### PR TITLE
feat: port Compare component from InspiraUI

### DIFF
--- a/src/lib/inspira/compare/Compare.svelte
+++ b/src/lib/inspira/compare/Compare.svelte
@@ -1,0 +1,301 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { cn } from '$lib/utils';
+	import StarField from './StarField.svelte';
+
+	interface Props {
+		firstImage?: string;
+		secondImage?: string;
+		firstImageAlt?: string;
+		secondImageAlt?: string;
+		class?: string;
+		firstContentClass?: string;
+		secondContentClass?: string;
+		initialSliderPercentage?: number;
+		slideMode?: 'hover' | 'drag';
+		showHandlebar?: boolean;
+		autoplay?: boolean;
+		autoplayDuration?: number;
+		onpercentagechange?: (percentage: number) => void;
+		ondragstart?: () => void;
+		ondragend?: () => void;
+		onhoverenter?: () => void;
+		onhoverleave?: () => void;
+		firstContent?: import('svelte').Snippet;
+		secondContent?: import('svelte').Snippet;
+		handle?: import('svelte').Snippet;
+	}
+
+	let {
+		firstImage = '',
+		secondImage = '',
+		firstImageAlt = 'First image',
+		secondImageAlt = 'Second image',
+		class: className = '',
+		firstContentClass = '',
+		secondContentClass = '',
+		initialSliderPercentage = 50,
+		slideMode = 'hover',
+		showHandlebar = true,
+		autoplay = false,
+		autoplayDuration = 5000,
+		onpercentagechange,
+		ondragstart,
+		ondragend,
+		onhoverenter,
+		onhoverleave,
+		firstContent,
+		secondContent,
+		handle
+	}: Props = $props();
+
+	let sliderRef: HTMLDivElement;
+	let sliderXPercent = $state(initialSliderPercentage);
+	let isDragging = $state(false);
+	let isMouseOver = $state(false);
+	let isInteracting = $state(false);
+	let autoplayRAF: number | null = null;
+
+	function startAutoplay(): void {
+		if (!autoplay || isMouseOver || isDragging) return;
+
+		const startTime = Date.now();
+		function animate(): void {
+			if (isMouseOver || isDragging) {
+				if (autoplayRAF) cancelAnimationFrame(autoplayRAF);
+				return;
+			}
+
+			const elapsedTime = Date.now() - startTime;
+			const progress = (elapsedTime % (autoplayDuration * 2)) / autoplayDuration;
+			const percentage = progress <= 1 ? progress * 100 : (2 - progress) * 100;
+
+			sliderXPercent = percentage;
+			onpercentagechange?.(percentage);
+			autoplayRAF = requestAnimationFrame(animate);
+		}
+
+		animate();
+	}
+
+	function stopAutoplay(): void {
+		if (autoplayRAF) {
+			cancelAnimationFrame(autoplayRAF);
+			autoplayRAF = null;
+		}
+	}
+
+	function mouseEnterHandler(): void {
+		isMouseOver = true;
+		onhoverenter?.();
+		if (autoplay) {
+			stopAutoplay();
+		}
+	}
+
+	function mouseLeaveHandler(): void {
+		isMouseOver = false;
+		isInteracting = false;
+		onhoverleave?.();
+
+		if (slideMode === 'hover') {
+			sliderXPercent = initialSliderPercentage;
+			onpercentagechange?.(initialSliderPercentage);
+		}
+		if (slideMode === 'drag') {
+			isDragging = false;
+		}
+
+		if (autoplay) {
+			startAutoplay();
+		}
+	}
+
+	function handleStart(): void {
+		if (slideMode === 'drag') {
+			isDragging = true;
+			isInteracting = true;
+			ondragstart?.();
+			stopAutoplay();
+		}
+	}
+
+	function handleEnd(): void {
+		if (slideMode === 'drag') {
+			isDragging = false;
+			isInteracting = false;
+			ondragend?.();
+			if (autoplay && !isMouseOver) {
+				startAutoplay();
+			}
+		}
+	}
+
+	function handleMove(clientX: number): void {
+		if (!sliderRef) return;
+
+		if (slideMode === 'hover' || (slideMode === 'drag' && isDragging)) {
+			isInteracting = true;
+			stopAutoplay();
+
+			const rect = sliderRef.getBoundingClientRect();
+			const x = clientX - rect.left;
+			const percent = (x / rect.width) * 100;
+
+			requestAnimationFrame(() => {
+				const newPercent = Math.max(0, Math.min(100, percent));
+				sliderXPercent = newPercent;
+				onpercentagechange?.(newPercent);
+			});
+		}
+	}
+
+	function handleMouseDown(_e: MouseEvent): void {
+		handleStart();
+	}
+
+	function handleMouseMove(e: MouseEvent): void {
+		handleMove(e.clientX);
+	}
+
+	function handleTouchStart(_e: TouchEvent): void {
+		if (!autoplay) handleStart();
+	}
+
+	function handleTouchEnd(): void {
+		if (!autoplay) handleEnd();
+	}
+
+	function handleTouchMove(e: TouchEvent): void {
+		if (!autoplay) handleMove(e.touches[0].clientX);
+	}
+
+	// Watch for initialSliderPercentage changes
+	$effect(() => {
+		sliderXPercent = initialSliderPercentage;
+	});
+
+	// Watch for autoplay changes
+	$effect(() => {
+		if (autoplay && !isMouseOver && !isDragging) {
+			startAutoplay();
+		} else {
+			stopAutoplay();
+		}
+	});
+
+	onMount(() => {
+		startAutoplay();
+		return () => {
+			stopAutoplay();
+		};
+	});
+</script>
+
+<div
+	bind:this={sliderRef}
+	class={cn('h-[400px] w-[400px] overflow-hidden', className)}
+	style:position="relative"
+	style:cursor={slideMode === 'drag' ? 'grab' : 'col-resize'}
+	onmousemove={handleMouseMove}
+	onmouseleave={mouseLeaveHandler}
+	onmouseenter={mouseEnterHandler}
+	onmousedown={handleMouseDown}
+	onmouseup={handleEnd}
+	ontouchstart={handleTouchStart}
+	ontouchend={handleTouchEnd}
+	ontouchmove={handleTouchMove}
+	role="slider"
+	aria-valuenow={sliderXPercent}
+	aria-valuemin={0}
+	aria-valuemax={100}
+	tabindex="0"
+>
+	<!-- Slider Line -->
+	<div
+		class="pointer-events-none absolute top-0 z-40 m-auto h-full w-px bg-gradient-to-b from-transparent from-5% via-indigo-500 to-transparent to-95%"
+		style:left="{sliderXPercent}%"
+	>
+		<!-- Decorative Effects -->
+		<div
+			class="absolute left-0 top-1/2 z-20 h-full w-36 -translate-y-1/2 bg-gradient-to-r from-indigo-400 via-transparent to-transparent opacity-50 [mask-image:radial-gradient(100px_at_left,white,transparent)]"
+		></div>
+		<div
+			class="absolute left-0 top-1/2 z-10 h-1/2 w-10 -translate-y-1/2 bg-gradient-to-r from-cyan-400 via-transparent to-transparent opacity-100 [mask-image:radial-gradient(50px_at_left,white,transparent)]"
+		></div>
+		<div
+			class="absolute -right-10 top-1/2 h-3/4 w-10 -translate-y-1/2 [mask-image:radial-gradient(100px_at_left,white,transparent)]"
+		>
+			<StarField starsCount={120} class="size-full" />
+		</div>
+
+		<!-- Custom Handle Slot -->
+		{#if handle}
+			{@render handle()}
+		{:else if showHandlebar}
+			<div
+				class="pointer-events-auto absolute -right-2.5 top-1/2 z-30 flex size-5 -translate-y-1/2 cursor-grab items-center justify-center rounded-md bg-white shadow-[0px_-1px_0px_0px_#FFFFFF40]"
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke-width="1.5"
+					stroke="currentColor"
+					class="size-4 text-black"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 12.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 18.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z"
+					/>
+				</svg>
+			</div>
+		{/if}
+	</div>
+
+	<!-- First Content -->
+	<div class="relative z-20 size-full overflow-hidden" style:pointer-events={isInteracting ? 'none' : 'auto'}>
+		<div
+			class={cn(
+				'absolute inset-0 z-20 h-full w-full flex-shrink-0 select-none overflow-hidden rounded-2xl',
+				firstContentClass
+			)}
+			style:clip-path="inset(0 {100 - sliderXPercent}% 0 0)"
+		>
+			{#if firstContent}
+				{@render firstContent()}
+			{:else if firstImage}
+				<img
+					alt={firstImageAlt}
+					src={firstImage}
+					class={cn(
+						'absolute inset-0 z-20 h-full w-full flex-shrink-0 select-none rounded-2xl object-cover',
+						firstContentClass
+					)}
+					draggable="false"
+				/>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Second Content -->
+	<div
+		class={cn(
+			'absolute left-0 top-0 z-[19] h-full w-full select-none rounded-2xl',
+			secondContentClass
+		)}
+		style:pointer-events={isInteracting ? 'none' : 'auto'}
+	>
+		{#if secondContent}
+			{@render secondContent()}
+		{:else if secondImage}
+			<img
+				alt={secondImageAlt}
+				src={secondImage}
+				class={cn('h-full w-full object-cover', secondContentClass)}
+				draggable="false"
+			/>
+		{/if}
+	</div>
+</div>

--- a/src/lib/inspira/compare/Compare.svelte
+++ b/src/lib/inspira/compare/Compare.svelte
@@ -150,7 +150,7 @@
 		}
 	}
 
-	function handleMouseDown(_e: MouseEvent): void {
+	function handleMouseDown(): void {
 		handleStart();
 	}
 
@@ -158,7 +158,7 @@
 		handleMove(e.clientX);
 	}
 
-	function handleTouchStart(_e: TouchEvent): void {
+	function handleTouchStart(): void {
 		if (!autoplay) handleStart();
 	}
 

--- a/src/lib/inspira/compare/README.md
+++ b/src/lib/inspira/compare/README.md
@@ -1,0 +1,101 @@
+# Compare
+
+A before/after image comparison slider with smooth interactions.
+
+## Source
+
+Ported from `vendor/inspira/ui/compare/Compare.vue`
+
+## Features
+
+- **Two slide modes**: `hover` (follows cursor) or `drag` (click and drag)
+- **Autoplay**: Automatic back-and-forth animation
+- **Custom content**: Supports images or custom snippets for both sides
+- **Decorative effects**: Includes gradient line, glow effects, and star field
+- **Touch support**: Works on mobile devices
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `firstImage` | `string` | `''` | URL of the first (left) image |
+| `secondImage` | `string` | `''` | URL of the second (right) image |
+| `firstImageAlt` | `string` | `'First image'` | Alt text for first image |
+| `secondImageAlt` | `string` | `'Second image'` | Alt text for second image |
+| `class` | `string` | `''` | Additional CSS classes |
+| `firstContentClass` | `string` | `''` | CSS classes for first content |
+| `secondContentClass` | `string` | `''` | CSS classes for second content |
+| `initialSliderPercentage` | `number` | `50` | Initial slider position (0-100) |
+| `slideMode` | `'hover' \| 'drag'` | `'hover'` | Interaction mode |
+| `showHandlebar` | `boolean` | `true` | Show the drag handle |
+| `autoplay` | `boolean` | `false` | Enable auto-animation |
+| `autoplayDuration` | `number` | `5000` | Duration of one autoplay cycle (ms) |
+
+## Events (Callbacks)
+
+| Callback | Type | Description |
+|----------|------|-------------|
+| `onpercentagechange` | `(percentage: number) => void` | Called when slider position changes |
+| `ondragstart` | `() => void` | Called when drag starts |
+| `ondragend` | `() => void` | Called when drag ends |
+| `onhoverenter` | `() => void` | Called when mouse enters |
+| `onhoverleave` | `() => void` | Called when mouse leaves |
+
+## Snippets
+
+| Snippet | Description |
+|---------|-------------|
+| `firstContent` | Custom content for the left side |
+| `secondContent` | Custom content for the right side |
+| `handle` | Custom handle element |
+
+## Usage
+
+```svelte
+<script>
+  import { Compare } from '$lib/inspira/compare';
+</script>
+
+<!-- Basic usage with images -->
+<Compare
+  firstImage="/before.jpg"
+  secondImage="/after.jpg"
+  class="rounded-lg"
+/>
+
+<!-- Drag mode -->
+<Compare
+  firstImage="/before.jpg"
+  secondImage="/after.jpg"
+  slideMode="drag"
+/>
+
+<!-- With autoplay -->
+<Compare
+  firstImage="/before.jpg"
+  secondImage="/after.jpg"
+  autoplay
+  autoplayDuration={3000}
+/>
+
+<!-- Custom content -->
+<Compare>
+  {#snippet firstContent()}
+    <div class="bg-blue-500 size-full flex items-center justify-center">
+      Before
+    </div>
+  {/snippet}
+  {#snippet secondContent()}
+    <div class="bg-red-500 size-full flex items-center justify-center">
+      After
+    </div>
+  {/snippet}
+</Compare>
+```
+
+## Porting Notes
+
+- Replaced Vue `emit` with callback props (`onpercentagechange`, etc.)
+- Replaced Vue slots with Svelte snippets
+- Replaced Nuxt Icon with inline SVG
+- Used Svelte 5 runes (`$state`, `$effect`, `$props`)

--- a/src/lib/inspira/compare/StarField.svelte
+++ b/src/lib/inspira/compare/StarField.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+
+	interface Props {
+		starsCount?: number;
+		class?: string;
+	}
+
+	let { starsCount = 130, class: className = '' }: Props = $props();
+
+	interface Star {
+		id: number;
+		top: string;
+		left: string;
+		size: number;
+		twinkleDuration: number;
+		driftDuration: number;
+		driftDirection: number;
+		opacityStart: number;
+		opacityEnd: number;
+	}
+
+	function random(min: number, max: number): number {
+		return Math.random() * (max - min) + min;
+	}
+
+	function randomSize(): number {
+		return Math.random() < 0.5 ? 1 : 2;
+	}
+
+	// Generate stars once on component creation
+	const stars: Star[] = Array.from({ length: starsCount }, (_, i): Star => ({
+		id: i,
+		top: `${random(0, 100)}%`,
+		left: `${random(0, 100)}%`,
+		size: randomSize(),
+		twinkleDuration: random(2, 4),
+		driftDuration: random(5, 10),
+		driftDirection: random(-50, 50),
+		opacityStart: random(0.1, 0.3),
+		opacityEnd: random(0.7, 1)
+	}));
+</script>
+
+<div class={cn('absolute inset-0 overflow-hidden', className)}>
+	{#each stars as star (star.id)}
+		<div
+			class="star absolute rounded-full bg-white"
+			style:top={star.top}
+			style:left={star.left}
+			style:width="{star.size}px"
+			style:height="{star.size}px"
+			style:--inspira-twinkle-duration="{star.twinkleDuration}s"
+			style:--inspira-drift-duration="{star.driftDuration}s"
+			style:--inspira-drift-direction="{star.driftDirection}px"
+			style:--inspira-opacity-start={star.opacityStart}
+			style:--inspira-opacity-end={star.opacityEnd}
+		></div>
+	{/each}
+</div>
+
+<style>
+	.star {
+		opacity: var(--inspira-opacity-start);
+		animation:
+			twinkle var(--inspira-twinkle-duration) ease-in-out infinite alternate,
+			drift var(--inspira-drift-duration) linear infinite;
+	}
+
+	@keyframes twinkle {
+		0% {
+			opacity: var(--inspira-opacity-start);
+		}
+		100% {
+			opacity: var(--inspira-opacity-end);
+		}
+	}
+
+	@keyframes drift {
+		0% {
+			transform: translate(0, 0);
+		}
+		25% {
+			transform: translate(var(--inspira-drift-direction), calc(var(--inspira-drift-direction) / 2));
+		}
+		50% {
+			transform: translate(
+				calc(var(--inspira-drift-direction) / 2),
+				var(--inspira-drift-direction)
+			);
+		}
+		75% {
+			transform: translate(
+				calc(var(--inspira-drift-direction) * -1),
+				calc(var(--inspira-drift-direction) / 2)
+			);
+		}
+		100% {
+			transform: translate(0, 0);
+		}
+	}
+</style>

--- a/src/lib/inspira/compare/index.ts
+++ b/src/lib/inspira/compare/index.ts
@@ -1,0 +1,2 @@
+export { default as Compare } from './Compare.svelte';
+export { default as StarField } from './StarField.svelte';

--- a/src/lib/inspira/index.ts
+++ b/src/lib/inspira/index.ts
@@ -9,6 +9,7 @@ export * from './animated-beam/index.js';
 export * from './animated-tooltip/index.js';
 export * from './bg-stars/index.js';
 export * from './border-beam/index.js';
+export * from './compare/index.js';
 export * from './rainbow-button/index.js';
 export * from './ripple-button/index.js';
 

--- a/src/lib/inspira/registry.ts
+++ b/src/lib/inspira/registry.ts
@@ -98,6 +98,14 @@ export const registry: Record<string, ComponentMeta> = {
 		status: 'done'
 	},
 
+	compare: {
+		name: 'Compare',
+		slug: 'compare',
+		description: 'Before/after image comparison slider with hover and drag modes',
+		category: 'media',
+		status: 'done'
+	},
+
 	'rainbow-button': {
 		name: 'RainbowButton',
 		slug: 'rainbow-button',

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -25,6 +25,12 @@
 			status: 'done' as const
 		},
 		{
+			name: 'Compare',
+			href: '/demo/compare',
+			description: 'Before/after image comparison slider with hover and drag modes',
+			status: 'done' as const
+		},
+		{
 			name: 'Dock',
 			href: '/demo/dock',
 			description: 'macOS-style dock with icon magnification on hover',

--- a/src/routes/demo/compare/+page.svelte
+++ b/src/routes/demo/compare/+page.svelte
@@ -39,7 +39,7 @@
 	<section class="mb-12">
 		<h2 class="mb-4 text-xl font-semibold">Drag Mode</h2>
 		<p class="mb-4 text-sm text-muted-foreground">
-			Click and drag to control the slider position. Set{' '}
+			Click and drag to control the slider position. Set
 			<code class="rounded bg-muted px-1.5 py-0.5">slideMode="drag"</code>.
 		</p>
 		<div class="flex justify-center rounded-lg border bg-card p-6">
@@ -78,7 +78,7 @@
 	<section class="mb-12">
 		<h2 class="mb-4 text-xl font-semibold">Custom Initial Position</h2>
 		<p class="mb-4 text-sm text-muted-foreground">
-			Set the starting position with{' '}
+			Set the starting position with
 			<code class="rounded bg-muted px-1.5 py-0.5">initialSliderPercentage</code>.
 		</p>
 		<div class="flex justify-center rounded-lg border bg-card p-6">
@@ -97,7 +97,7 @@
 	<section class="mb-12">
 		<h2 class="mb-4 text-xl font-semibold">Without Handlebar</h2>
 		<p class="mb-4 text-sm text-muted-foreground">
-			Hide the drag handle with{' '}
+			Hide the drag handle with
 			<code class="rounded bg-muted px-1.5 py-0.5">showHandlebar={'{'}false{'}'}</code>.
 		</p>
 		<div class="flex justify-center rounded-lg border bg-card p-6">

--- a/src/routes/demo/compare/+page.svelte
+++ b/src/routes/demo/compare/+page.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+	import { Compare } from '$lib/inspira/compare';
+
+	let currentPercentage = $state(50);
+</script>
+
+<svelte:head>
+	<title>Compare - Inspira Svelte</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl px-4 py-12">
+	<div class="mb-8">
+		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
+	</div>
+
+	<h1 class="mb-2 text-3xl font-bold">Compare</h1>
+	<p class="mb-8 text-muted-foreground">
+		A before/after image comparison slider with hover and drag modes, plus optional autoplay.
+	</p>
+
+	<!-- Basic Usage (Hover Mode) -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Basic Usage (Hover Mode)</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Move your mouse over the component to reveal the comparison. The slider follows your cursor.
+		</p>
+		<div class="flex justify-center rounded-lg border bg-card p-6">
+			<Compare
+				firstImage="https://images.unsplash.com/photo-1505765050516-f72dcac9c60e?w=800&q=80"
+				secondImage="https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=800&q=80"
+				firstImageAlt="Forest in autumn"
+				secondImageAlt="Mountains at sunrise"
+				class="rounded-lg"
+			/>
+		</div>
+	</section>
+
+	<!-- Drag Mode -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Drag Mode</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Click and drag to control the slider position. Set{' '}
+			<code class="rounded bg-muted px-1.5 py-0.5">slideMode="drag"</code>.
+		</p>
+		<div class="flex justify-center rounded-lg border bg-card p-6">
+			<Compare
+				firstImage="https://images.unsplash.com/photo-1682687220742-aba13b6e50ba?w=800&q=80"
+				secondImage="https://images.unsplash.com/photo-1682687221038-404670f09ef1?w=800&q=80"
+				firstImageAlt="Desert landscape"
+				secondImageAlt="Ocean view"
+				slideMode="drag"
+				class="rounded-lg"
+			/>
+		</div>
+	</section>
+
+	<!-- Autoplay -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Autoplay</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Enable automatic animation with <code class="rounded bg-muted px-1.5 py-0.5">autoplay</code>.
+			Hover to pause.
+		</p>
+		<div class="flex justify-center rounded-lg border bg-card p-6">
+			<Compare
+				firstImage="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80"
+				secondImage="https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?w=800&q=80"
+				firstImageAlt="Mountain peak"
+				secondImageAlt="Mountain range"
+				autoplay
+				autoplayDuration={3000}
+				class="rounded-lg"
+			/>
+		</div>
+	</section>
+
+	<!-- Custom Initial Position -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Custom Initial Position</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Set the starting position with{' '}
+			<code class="rounded bg-muted px-1.5 py-0.5">initialSliderPercentage</code>.
+		</p>
+		<div class="flex justify-center rounded-lg border bg-card p-6">
+			<Compare
+				firstImage="https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=800&q=80"
+				secondImage="https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?w=800&q=80"
+				firstImageAlt="Nature landscape"
+				secondImageAlt="Forest path"
+				initialSliderPercentage={25}
+				class="rounded-lg"
+			/>
+		</div>
+	</section>
+
+	<!-- Without Handlebar -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Without Handlebar</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Hide the drag handle with{' '}
+			<code class="rounded bg-muted px-1.5 py-0.5">showHandlebar={'{'}false{'}'}</code>.
+		</p>
+		<div class="flex justify-center rounded-lg border bg-card p-6">
+			<Compare
+				firstImage="https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=800&q=80"
+				secondImage="https://images.unsplash.com/photo-1433086966358-54859d0ed716?w=800&q=80"
+				firstImageAlt="Lake view"
+				secondImageAlt="Waterfall"
+				showHandlebar={false}
+				class="rounded-lg"
+			/>
+		</div>
+	</section>
+
+	<!-- With Event Callback -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">With Event Callback</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Track the slider position with the <code class="rounded bg-muted px-1.5 py-0.5">onpercentagechange</code> callback.
+		</p>
+		<div class="flex flex-col items-center gap-4 rounded-lg border bg-card p-6">
+			<Compare
+				firstImage="https://images.unsplash.com/photo-1426604966848-d7adac402bff?w=800&q=80"
+				secondImage="https://images.unsplash.com/photo-1472214103451-9374bd1c798e?w=800&q=80"
+				firstImageAlt="Mountain landscape"
+				secondImageAlt="Green valley"
+				onpercentagechange={(p) => (currentPercentage = p)}
+				class="rounded-lg"
+			/>
+			<p class="text-sm text-muted-foreground">
+				Current position: <span class="font-mono font-semibold text-foreground">{currentPercentage.toFixed(1)}%</span>
+			</p>
+		</div>
+	</section>
+
+	<!-- Custom Content -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Custom Content</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Use snippets to render custom content instead of images.
+		</p>
+		<div class="flex justify-center rounded-lg border bg-card p-6">
+			<Compare class="rounded-lg">
+				{#snippet firstContent()}
+					<div
+						class="flex size-full items-center justify-center bg-gradient-to-br from-violet-600 to-indigo-600"
+					>
+						<span class="text-2xl font-bold text-white">Before</span>
+					</div>
+				{/snippet}
+				{#snippet secondContent()}
+					<div
+						class="flex size-full items-center justify-center bg-gradient-to-br from-rose-600 to-orange-600"
+					>
+						<span class="text-2xl font-bold text-white">After</span>
+					</div>
+				{/snippet}
+			</Compare>
+		</div>
+	</section>
+
+	<!-- Different Sizes -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Different Sizes</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Customize dimensions with the <code class="rounded bg-muted px-1.5 py-0.5">class</code> prop.
+		</p>
+		<div class="flex flex-wrap justify-center gap-4 rounded-lg border bg-card p-6">
+			<Compare
+				firstImage="https://images.unsplash.com/photo-1540206395-68808572332f?w=800&q=80"
+				secondImage="https://images.unsplash.com/photo-1507400492013-162706c8c05e?w=800&q=80"
+				class="h-[200px] w-[300px] rounded-lg"
+			/>
+			<Compare
+				firstImage="https://images.unsplash.com/photo-1540206395-68808572332f?w=800&q=80"
+				secondImage="https://images.unsplash.com/photo-1507400492013-162706c8c05e?w=800&q=80"
+				class="h-[200px] w-[200px] rounded-lg"
+			/>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Port the Compare component from InspiraUI (Vue) to Svelte 5
- Add StarField helper component for decorative effects
- Create demo page showcasing all features

## Features
- **Hover mode**: Slider follows cursor position
- **Drag mode**: Click and drag to control slider
- **Autoplay**: Automatic back-and-forth animation with configurable duration
- **Custom content**: Support for snippets instead of images
- **Touch support**: Works on mobile devices
- **Decorative effects**: Gradient line, glow effects, and animated star field

## Test plan
- [ ] Visit `/demo/compare` to see all variations
- [ ] Test hover mode (default) - slider should follow cursor
- [ ] Test drag mode - click and drag to move slider
- [ ] Test autoplay - should animate automatically, pause on hover
- [ ] Test touch interactions on mobile
- [ ] Verify no TypeScript errors (`pnpm check`)