### PR TITLE
feat: port DirectionAwareHover component from InspiraUI

### DIFF
--- a/src/lib/inspira/direction-aware-hover/DirectionAwareHover.svelte
+++ b/src/lib/inspira/direction-aware-hover/DirectionAwareHover.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { cn } from '$lib/utils';
+	import { fade } from 'svelte/transition';
+
+	type Direction = 'top' | 'bottom' | 'left' | 'right';
+
+	interface Props {
+		imageUrl: string;
+		imageAlt?: string;
+		childrenClass?: string;
+		imageClass?: string;
+		class?: string;
+		children?: import('svelte').Snippet;
+	}
+
+	let {
+		imageUrl,
+		imageAlt = 'image',
+		childrenClass: childrenClassProp = '',
+		imageClass: imageClassProp = '',
+		class: className = '',
+		children
+	}: Props = $props();
+
+	let divRef: HTMLDivElement;
+	let direction = $state<Direction | null>(null);
+	let isTouched = $state(false);
+	let isMobile = $state(false);
+	let touchTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function detectMobile() {
+		isMobile =
+			window.matchMedia('(max-width: 768px)').matches || 'ontouchstart' in window;
+	}
+
+	function getDirection(ev: MouseEvent | { clientX: number; clientY: number }, obj: HTMLElement): number {
+		const { width: w, height: h, left, top } = obj.getBoundingClientRect();
+		const x = ev.clientX - left - (w / 2) * (w > h ? h / w : 1);
+		const y = ev.clientY - top - (h / 2) * (h > w ? w / h : 1);
+		const d = Math.round(Math.atan2(y, x) / 1.57079633 + 5) % 4;
+		return d;
+	}
+
+	function mapDirection(d: number): Direction {
+		switch (d) {
+			case 0:
+				return 'top';
+			case 1:
+				return 'right';
+			case 2:
+				return 'bottom';
+			case 3:
+				return 'left';
+			default:
+				return 'left';
+		}
+	}
+
+	function handleMouseEnter(event: MouseEvent) {
+		if (isMobile) return;
+		if (!divRef) return;
+
+		const fetchedDirection = getDirection(event, divRef);
+		direction = mapDirection(fetchedDirection);
+	}
+
+	function handleMouseLeave() {
+		if (isMobile) return;
+		direction = null;
+	}
+
+	function handleTouchStart(event: TouchEvent) {
+		if (!isMobile) return;
+
+		isTouched = true;
+
+		if (!divRef) return;
+		const touch = event.touches[0];
+		const fetchedDirection = getDirection(
+			{ clientX: touch.clientX, clientY: touch.clientY },
+			divRef
+		);
+		direction = mapDirection(fetchedDirection);
+
+		// Auto-hide after 3 seconds on mobile
+		if (touchTimer) clearTimeout(touchTimer);
+		touchTimer = setTimeout(() => {
+			handleTouchEnd();
+		}, 3000);
+	}
+
+	function handleTouchEnd() {
+		if (touchTimer) {
+			clearTimeout(touchTimer);
+			touchTimer = null;
+		}
+
+		setTimeout(() => {
+			direction = null;
+			isTouched = false;
+		}, 300);
+	}
+
+	let containerClass = $derived(
+		cn(
+			'group/card relative overflow-hidden rounded-lg bg-transparent transition-all duration-300',
+			'h-48 w-48',
+			'sm:h-64 sm:w-64',
+			'md:h-80 md:w-80',
+			'lg:h-96 lg:w-96',
+			'xl:h-[28rem] xl:w-[28rem]',
+			'touch-manipulation',
+			'active:scale-[0.98]',
+			'md:active:scale-100',
+			className
+		)
+	);
+
+	let imageClass = $derived(
+		cn(
+			'h-full w-full object-cover transition-transform duration-300',
+			'scale-125',
+			'sm:scale-[1.35]',
+			'md:scale-150',
+			imageClassProp
+		)
+	);
+
+	let childrenClass = $derived(
+		cn(
+			'absolute z-40 text-white transition-opacity duration-300',
+			'bottom-2 left-2 text-sm',
+			'sm:bottom-3 sm:left-3 sm:text-base',
+			'md:bottom-4 md:left-4 md:text-lg',
+			childrenClassProp
+		)
+	);
+
+	let overlayClass = $derived(() => {
+		const baseClasses = 'absolute inset-0 z-10 transition-all duration-300';
+		const backgroundClasses = 'bg-black/40 dark:bg-black/60';
+
+		let transformClasses = '';
+		switch (direction) {
+			case 'top':
+				transformClasses = '-translate-y-full group-hover/card:translate-y-0';
+				break;
+			case 'bottom':
+				transformClasses = 'translate-y-full group-hover/card:translate-y-0';
+				break;
+			case 'left':
+				transformClasses = '-translate-x-full group-hover/card:translate-x-0';
+				break;
+			case 'right':
+				transformClasses = 'translate-x-full group-hover/card:translate-x-0';
+				break;
+			default:
+				transformClasses = '';
+		}
+
+		return cn(baseClasses, backgroundClasses, transformClasses);
+	});
+
+	let imageContainerClass = $derived(
+		cn(
+			'relative size-full bg-gray-50 transition-transform duration-300 dark:bg-black',
+			{
+				'translate-y-2 md:translate-y-5': direction === 'top',
+				'-translate-y-2 md:-translate-y-5': direction === 'bottom',
+				'translate-x-2 md:translate-x-5': direction === 'left',
+				'-translate-x-2 md:-translate-x-5': direction === 'right'
+			}
+		)
+	);
+
+	onMount(() => {
+		detectMobile();
+		window.addEventListener('resize', detectMobile);
+
+		return () => {
+			window.removeEventListener('resize', detectMobile);
+			if (touchTimer) {
+				clearTimeout(touchTimer);
+			}
+		};
+	});
+</script>
+
+<div
+	bind:this={divRef}
+	class={containerClass}
+	onmouseenter={handleMouseEnter}
+	onmouseleave={handleMouseLeave}
+	ontouchstart={handleTouchStart}
+	ontouchend={handleTouchEnd}
+	role="figure"
+>
+	<div class="relative size-full overflow-hidden">
+		{#if direction !== null}
+			<div class={overlayClass()} transition:fade={{ duration: 300 }}></div>
+		{/if}
+
+		<div class={imageContainerClass}>
+			<img src={imageUrl} alt={imageAlt} class={imageClass} width="1000" height="1000" />
+		</div>
+
+		{#if direction !== null || isTouched}
+			<div class={childrenClass} transition:fade={{ duration: 300 }}>
+				{#if children}
+					{@render children()}
+				{/if}
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	/* Enhanced mobile touch targets */
+	@media (max-width: 768px) {
+		:global(.group\/card) {
+			min-height: 44px;
+			min-width: 44px;
+		}
+	}
+
+	/* Smooth transitions for reduced motion preference */
+	@media (prefers-reduced-motion: reduce) {
+		:global(*) {
+			transition-duration: 0.1s !important;
+		}
+	}
+</style>

--- a/src/lib/inspira/direction-aware-hover/DirectionAwareHover.svelte
+++ b/src/lib/inspira/direction-aware-hover/DirectionAwareHover.svelte
@@ -137,7 +137,7 @@
 		)
 	);
 
-	let overlayClass = $derived(() => {
+	let overlayClass = $derived.by(() => {
 		const baseClasses = 'absolute inset-0 z-10 transition-all duration-300';
 		const backgroundClasses = 'bg-black/40 dark:bg-black/60';
 

--- a/src/lib/inspira/direction-aware-hover/README.md
+++ b/src/lib/inspira/direction-aware-hover/README.md
@@ -1,0 +1,51 @@
+# DirectionAwareHover
+
+An image card that reveals an overlay sliding in from the direction the mouse entered.
+
+## Source
+
+Ported from `vendor/inspira/ui/direction-aware-hover/DirectionAwareHover.vue`
+
+## Features
+
+- **Direction detection**: Overlay slides in from the direction the cursor enters
+- **Image parallax**: Image shifts slightly opposite to the hover direction
+- **Touch support**: Tap on mobile to reveal, auto-hides after 3 seconds
+- **Responsive**: Scales from mobile to desktop with appropriate sizing
+- **Reduced motion**: Respects `prefers-reduced-motion`
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `imageUrl` | `string` | (required) | URL of the image to display |
+| `imageAlt` | `string` | `'image'` | Alt text for the image |
+| `class` | `string` | `''` | Additional CSS classes for the container |
+| `imageClass` | `string` | `''` | Additional CSS classes for the image |
+| `childrenClass` | `string` | `''` | Additional CSS classes for the content overlay |
+
+## Snippets
+
+| Snippet | Description |
+|---------|-------------|
+| `children` | Content to display on hover overlay |
+
+## Usage
+
+```svelte
+<script>
+  import { DirectionAwareHover } from '$lib/inspira/direction-aware-hover';
+</script>
+
+<DirectionAwareHover imageUrl="/photo.jpg">
+  <p class="font-bold">Title</p>
+  <p class="text-sm">Subtitle</p>
+</DirectionAwareHover>
+```
+
+## Porting Notes
+
+- Replaced Vue `Transition` with Svelte `transition:fade`
+- Replaced Vue computed with Svelte `$derived`
+- Extracted `mapDirection` helper to avoid repeated switch blocks
+- Used plain object for `getDirection` touch coordinates instead of constructing a `MouseEvent`

--- a/src/lib/inspira/direction-aware-hover/index.ts
+++ b/src/lib/inspira/direction-aware-hover/index.ts
@@ -1,0 +1,1 @@
+export { default as DirectionAwareHover } from './DirectionAwareHover.svelte';

--- a/src/lib/inspira/index.ts
+++ b/src/lib/inspira/index.ts
@@ -10,6 +10,7 @@ export * from './animated-tooltip/index.js';
 export * from './bg-stars/index.js';
 export * from './border-beam/index.js';
 export * from './compare/index.js';
+export * from './direction-aware-hover/index.js';
 export * from './rainbow-button/index.js';
 export * from './ripple-button/index.js';
 

--- a/src/lib/inspira/registry.ts
+++ b/src/lib/inspira/registry.ts
@@ -106,6 +106,14 @@ export const registry: Record<string, ComponentMeta> = {
 		status: 'done'
 	},
 
+	'direction-aware-hover': {
+		name: 'DirectionAwareHover',
+		slug: 'direction-aware-hover',
+		description: 'Image card with overlay that slides in from the mouse entry direction',
+		category: 'cards',
+		status: 'done'
+	},
+
 	'rainbow-button': {
 		name: 'RainbowButton',
 		slug: 'rainbow-button',

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -31,6 +31,12 @@
 			status: 'done' as const
 		},
 		{
+			name: 'DirectionAwareHover',
+			href: '/demo/direction-aware-hover',
+			description: 'Image card with overlay that slides in from the mouse entry direction',
+			status: 'done' as const
+		},
+		{
 			name: 'Dock',
 			href: '/demo/dock',
 			description: 'macOS-style dock with icon magnification on hover',

--- a/src/routes/demo/direction-aware-hover/+page.svelte
+++ b/src/routes/demo/direction-aware-hover/+page.svelte
@@ -39,21 +39,21 @@
 		<div class="flex flex-wrap justify-center gap-6 rounded-lg border bg-card p-8">
 			<DirectionAwareHover
 				imageUrl="https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=800&q=80"
-				class="h-64 w-64 md:h-64 md:w-64 lg:h-64 lg:w-64 xl:h-64 xl:w-64"
+				class="h-64 w-64"
 			>
 				<p class="text-lg font-bold">Nature</p>
 				<p class="text-sm font-normal">Sunlit valley</p>
 			</DirectionAwareHover>
 			<DirectionAwareHover
 				imageUrl="https://images.unsplash.com/photo-1682687220742-aba13b6e50ba?w=800&q=80"
-				class="h-64 w-64 md:h-64 md:w-64 lg:h-64 lg:w-64 xl:h-64 xl:w-64"
+				class="h-64 w-64"
 			>
 				<p class="text-lg font-bold">Desert</p>
 				<p class="text-sm font-normal">Golden dunes</p>
 			</DirectionAwareHover>
 			<DirectionAwareHover
 				imageUrl="https://images.unsplash.com/photo-1505765050516-f72dcac9c60e?w=800&q=80"
-				class="h-64 w-64 md:h-64 md:w-64 lg:h-64 lg:w-64 xl:h-64 xl:w-64"
+				class="h-64 w-64"
 			>
 				<p class="text-lg font-bold">Forest</p>
 				<p class="text-sm font-normal">Autumn colors</p>

--- a/src/routes/demo/direction-aware-hover/+page.svelte
+++ b/src/routes/demo/direction-aware-hover/+page.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { DirectionAwareHover } from '$lib/inspira/direction-aware-hover';
+</script>
+
+<svelte:head>
+	<title>DirectionAwareHover - Inspira Svelte</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl px-4 py-12">
+	<div class="mb-8">
+		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
+	</div>
+
+	<h1 class="mb-2 text-3xl font-bold">DirectionAwareHover</h1>
+	<p class="mb-8 text-muted-foreground">
+		An image card that reveals an overlay sliding in from the direction the mouse entered.
+	</p>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Basic Usage</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Hover from any edge to see the overlay slide in from that direction. The image shifts slightly on hover.
+		</p>
+		<div class="flex justify-center rounded-lg border bg-card p-8">
+			<DirectionAwareHover imageUrl="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80">
+				<p class="text-xl font-bold">Mountain Peak</p>
+				<p class="text-sm font-normal">Swiss Alps, Switzerland</p>
+			</DirectionAwareHover>
+		</div>
+	</section>
+
+	<!-- Multiple Cards -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Multiple Cards</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Works great in a grid layout. Try hovering from different directions on each card.
+		</p>
+		<div class="flex flex-wrap justify-center gap-6 rounded-lg border bg-card p-8">
+			<DirectionAwareHover
+				imageUrl="https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=800&q=80"
+				class="h-64 w-64 md:h-64 md:w-64 lg:h-64 lg:w-64 xl:h-64 xl:w-64"
+			>
+				<p class="text-lg font-bold">Nature</p>
+				<p class="text-sm font-normal">Sunlit valley</p>
+			</DirectionAwareHover>
+			<DirectionAwareHover
+				imageUrl="https://images.unsplash.com/photo-1682687220742-aba13b6e50ba?w=800&q=80"
+				class="h-64 w-64 md:h-64 md:w-64 lg:h-64 lg:w-64 xl:h-64 xl:w-64"
+			>
+				<p class="text-lg font-bold">Desert</p>
+				<p class="text-sm font-normal">Golden dunes</p>
+			</DirectionAwareHover>
+			<DirectionAwareHover
+				imageUrl="https://images.unsplash.com/photo-1505765050516-f72dcac9c60e?w=800&q=80"
+				class="h-64 w-64 md:h-64 md:w-64 lg:h-64 lg:w-64 xl:h-64 xl:w-64"
+			>
+				<p class="text-lg font-bold">Forest</p>
+				<p class="text-sm font-normal">Autumn colors</p>
+			</DirectionAwareHover>
+		</div>
+	</section>
+
+	<!-- Custom Content -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Custom Content</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			The overlay content is fully customizable via the default snippet.
+		</p>
+		<div class="flex justify-center rounded-lg border bg-card p-8">
+			<DirectionAwareHover imageUrl="https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=800&q=80">
+				<div class="space-y-2">
+					<p class="text-xl font-bold">Travel Photography</p>
+					<p class="text-sm text-white/80">Discover breathtaking landscapes from around the world.</p>
+					<div class="flex gap-2 pt-1">
+						<span class="rounded-full bg-white/20 px-2 py-0.5 text-xs backdrop-blur-sm">Nature</span>
+						<span class="rounded-full bg-white/20 px-2 py-0.5 text-xs backdrop-blur-sm">Travel</span>
+						<span class="rounded-full bg-white/20 px-2 py-0.5 text-xs backdrop-blur-sm">Photo</span>
+					</div>
+				</div>
+			</DirectionAwareHover>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Port the DirectionAwareHover component from InspiraUI (Vue) to Svelte 5
- Create demo page showcasing basic usage, grid layout, and custom content

## Features
- **Direction detection**: Overlay slides in from the edge the cursor enters (top/right/bottom/left)
- **Image parallax**: Slight image shift opposite to hover direction
- **Touch support**: Tap to reveal on mobile, auto-hides after 3 seconds
- **Responsive**: Scales from mobile to desktop
- **Reduced motion**: Respects `prefers-reduced-motion` preference

## Test plan
- [ ] Visit `/demo/direction-aware-hover` to see all variations
- [ ] Hover from different edges to verify direction detection
- [ ] Check overlay slides in from the correct direction
- [ ] Verify image shifts slightly on hover
- [ ] Test on mobile (tap to reveal, auto-hide after 3s)
- [ ] Verify no TypeScript errors (`pnpm check`)