### PR TITLE
fix: overlayClass runtime crash in DirectionAwareHover

### DIFF
--- a/src/lib/inspira/direction-aware-hover/DirectionAwareHover.svelte
+++ b/src/lib/inspira/direction-aware-hover/DirectionAwareHover.svelte
@@ -198,7 +198,7 @@
 >
 	<div class="relative size-full overflow-hidden">
 		{#if direction !== null}
-			<div class={overlayClass()} transition:fade={{ duration: 300 }}></div>
+			<div class={overlayClass} transition:fade={{ duration: 300 }}></div>
 		{/if}
 
 		<div class={imageContainerClass}>


### PR DESCRIPTION
## Summary
- Fix runtime crash in `DirectionAwareHover` caused by calling `overlayClass()` as a function after it was changed from `$derived(() => {...})` to `$derived.by(() => {...})`
- The previous Copilot review correctly identified the `$derived` misuse, but the fix only updated the declaration without updating the call site in the template
- Changed `overlayClass()` to `overlayClass` in the template since `$derived.by` already returns the computed string

## Root cause
`$derived(() => {...})` stored the arrow function itself, so `overlayClass()` in the template worked by calling it. After switching to `$derived.by(() => {...})`, the value became a string, making `overlayClass()` a runtime error.

## Test plan
- [ ] Visit `/demo/direction-aware-hover` and verify the component renders
- [ ] Hover from different edges to confirm the overlay slides in correctly
- [ ] No console errors
- [ ] `pnpm check` passes with 0 errors