### PR TITLE
feat: add component BlurReveal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -334,7 +334,7 @@
 - [ ] **glare-card** - Card with glare effect
 - [ ] **flip-card** - Card that flips on hover
 - [ ] **bento-grid** - Bento-style grid layout
-- [ ] **compare** - Before/after image comparison slider
+- [x] **compare** - Before/after image comparison slider
 - [ ] **container-scroll** - Scroll-animated container
 - [ ] **container-text-flip** - Text flip container
 - [ ] **focus** - Focus-style card container
@@ -361,7 +361,7 @@
 - [ ] **text-scroll-reveal** - Scroll-triggered text reveal
 - [ ] **line-shadow-text** - Text with line shadow
 - [ ] **video-text** - Video masked text
-- [ ] **blur-reveal** - Blur-to-reveal text
+- [x] **blur-reveal** - Blur-to-reveal text
 
 ### 8.4 Backgrounds (18 components)
 
@@ -372,7 +372,7 @@
 - [ ] **bg-neural** - Neural network visualization
 - [ ] **bg-particle-whirlpool** - Particle whirlpool
 - [ ] **bg-silk** - Silk fabric animation
-- [ ] **bg-stars** - Starfield background
+- [x] **bg-stars** - Starfield background
 - [ ] **bg-stractium** - Abstract stratum effect
 - [ ] **flickering-grid** - Flickering dot grid
 - [ ] **particles-bg** - Particle system background
@@ -386,9 +386,9 @@
 
 ### 8.5 Effects & Animations (20 components)
 
-- [ ] **animated-beam** - SVG animated beam lines
+- [x] **animated-beam** - SVG animated beam lines
 - [x] **border-beam** - Animated border beam
-- [ ] **glow-border** - Glowing border effect
+- [x] **glow-border** - Glowing border effect
 - [ ] **glowing-effect** - General glow effect
 - [ ] **meteors** - Meteor shower effect
 - [ ] **sparkles** - Sparkle particle effect
@@ -409,11 +409,11 @@
 
 ### 8.6 Navigation & Layout (8 components)
 
-- [ ] **dock** - macOS-style dock
+- [x] **dock** - macOS-style dock
 - [ ] **morphing-tabs** - Morphing tab navigation
 - [x] **timeline** - Vertical timeline
 - [ ] **scroll-island** - Scroll-aware floating island
-- [ ] **marquee** - Infinite scrolling marquee
+- [x] **marquee** - Infinite scrolling marquee
 - [ ] **logo-cloud** - Logo carousel/cloud
 - [ ] **logo-origami** - Origami-style logo reveal
 - [ ] **halo-search** - Spotlight search UI
@@ -446,9 +446,9 @@
 
 ### 8.9 Cursors & Interactions (6 components)
 
-- [ ] **animated-tooltip** - Animated tooltip
-- [ ] **direction-aware-hover** - Direction-aware hover effect
-- [ ] **fluid-cursor** - Fluid cursor effect
+- [x] **animated-tooltip** - Animated tooltip
+- [x] **direction-aware-hover** - Direction-aware hover effect
+- [x] **fluid-cursor** - Fluid cursor effect
 - [ ] **smooth-cursor** - Smooth cursor follower
 - [ ] **sleek-line-cursor** - Line cursor effect
 - [ ] **tailed-cursor** - Cursor with tail
@@ -535,12 +535,12 @@ These components are used in the portfolio project and should be ported first:
 |-----------|----------|--------|
 | rainbow-button | Buttons | Done |
 | animated-tooltip | Cursors & Interactions | Done |
-| blur-reveal | Text | Pending |
+| fluid-cursor | Cursors & Interactions | Done |
+| marquee | Navigation & Layout | Done |
+| blur-reveal | Text | Done |
 | bg-falling-stars | Backgrounds | Pending |
-| fluid-cursor | Cursors & Interactions | Pending |
 | image-trail-cursor | Cursors & Interactions | Pending |
 | interactive-grid-pattern | Effects | Pending |
-| marquee | Navigation & Layout | Pending |
 | timeline | Navigation & Layout | Done |
 | animated-logo-cloud | Data Display | Pending |
 

--- a/src/lib/inspira/blur-reveal/BlurReveal.svelte
+++ b/src/lib/inspira/blur-reveal/BlurReveal.svelte
@@ -1,0 +1,126 @@
+<script lang="ts" module>
+	import type { Snippet } from 'svelte';
+
+	export interface BlurRevealProps {
+		/** Animation duration in seconds */
+		duration?: number;
+		/** Stagger delay between children in seconds */
+		delay?: number;
+		/** Initial blur amount (CSS value) */
+		blur?: string;
+		/** Initial vertical offset in pixels */
+		yOffset?: number;
+		/** Additional CSS classes for the container */
+		class?: string;
+		/** Content to reveal */
+		children?: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { onMount } from 'svelte';
+
+	let {
+		duration = 1,
+		delay = 0.2,
+		blur = '20px',
+		yOffset = 20,
+		class: className,
+		children
+	}: BlurRevealProps = $props();
+
+	let containerRef: HTMLDivElement;
+	let isInView = $state(false);
+
+	onMount(() => {
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						isInView = true;
+						observer.disconnect();
+					}
+				}
+			},
+			{ threshold: 0.1 }
+		);
+
+		observer.observe(containerRef);
+
+		return () => observer.disconnect();
+	});
+</script>
+
+<div
+	bind:this={containerRef}
+	class={cn(className)}
+	style:--blur-reveal-duration="{duration}s"
+	style:--blur-reveal-delay="{delay}s"
+	style:--blur-reveal-blur={blur}
+	style:--blur-reveal-y="{yOffset}px"
+>
+	{#if children}
+		<div class="blur-reveal-wrapper" class:is-visible={isInView}>
+			{@render children()}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.blur-reveal-wrapper > :global(*) {
+		opacity: 0;
+		filter: blur(var(--blur-reveal-blur, 20px));
+		transform: translateY(var(--blur-reveal-y, 20px));
+		transition:
+			opacity var(--blur-reveal-duration, 1s) ease-in-out,
+			filter var(--blur-reveal-duration, 1s) ease-in-out,
+			transform var(--blur-reveal-duration, 1s) ease-in-out;
+	}
+
+	.blur-reveal-wrapper.is-visible > :global(*) {
+		opacity: 1;
+		filter: blur(0px);
+		transform: translateY(0);
+	}
+
+	/* Stagger delays for direct children */
+	.blur-reveal-wrapper.is-visible > :global(:nth-child(1)) {
+		transition-delay: calc(var(--blur-reveal-delay, 0.2s) * 0);
+	}
+	.blur-reveal-wrapper.is-visible > :global(:nth-child(2)) {
+		transition-delay: calc(var(--blur-reveal-delay, 0.2s) * 1);
+	}
+	.blur-reveal-wrapper.is-visible > :global(:nth-child(3)) {
+		transition-delay: calc(var(--blur-reveal-delay, 0.2s) * 2);
+	}
+	.blur-reveal-wrapper.is-visible > :global(:nth-child(4)) {
+		transition-delay: calc(var(--blur-reveal-delay, 0.2s) * 3);
+	}
+	.blur-reveal-wrapper.is-visible > :global(:nth-child(5)) {
+		transition-delay: calc(var(--blur-reveal-delay, 0.2s) * 4);
+	}
+	.blur-reveal-wrapper.is-visible > :global(:nth-child(6)) {
+		transition-delay: calc(var(--blur-reveal-delay, 0.2s) * 5);
+	}
+	.blur-reveal-wrapper.is-visible > :global(:nth-child(7)) {
+		transition-delay: calc(var(--blur-reveal-delay, 0.2s) * 6);
+	}
+	.blur-reveal-wrapper.is-visible > :global(:nth-child(8)) {
+		transition-delay: calc(var(--blur-reveal-delay, 0.2s) * 7);
+	}
+	.blur-reveal-wrapper.is-visible > :global(:nth-child(9)) {
+		transition-delay: calc(var(--blur-reveal-delay, 0.2s) * 8);
+	}
+	.blur-reveal-wrapper.is-visible > :global(:nth-child(10)) {
+		transition-delay: calc(var(--blur-reveal-delay, 0.2s) * 9);
+	}
+
+	/* Respect reduced motion */
+	@media (prefers-reduced-motion: reduce) {
+		.blur-reveal-wrapper > :global(*) {
+			transition-duration: 0.1s !important;
+			transition-delay: 0s !important;
+		}
+	}
+</style>

--- a/src/lib/inspira/blur-reveal/README.md
+++ b/src/lib/inspira/blur-reveal/README.md
@@ -1,0 +1,45 @@
+# BlurReveal
+
+A scroll-triggered reveal animation that transitions children from blurred and offset to clear and in-place, with staggered delays.
+
+## Source
+
+Ported from `vendor/inspira/ui/blur-reveal/BlurReveal.vue`
+
+## Features
+
+- **Scroll trigger**: Animates when the element enters the viewport via IntersectionObserver
+- **Staggered children**: Each direct child animates sequentially with a configurable delay
+- **Customizable blur**: Control blur amount, Y offset, duration, and stagger delay
+- **Reduced motion**: Respects `prefers-reduced-motion`
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `duration` | `number` | `1` | Animation duration in seconds |
+| `delay` | `number` | `0.2` | Stagger delay between children in seconds |
+| `blur` | `string` | `'20px'` | Initial blur amount (CSS value) |
+| `yOffset` | `number` | `20` | Initial vertical offset in pixels |
+| `class` | `string` | `''` | Additional CSS classes for the container |
+
+## Usage
+
+```svelte
+<script>
+  import { BlurReveal } from '$lib/inspira/blur-reveal';
+</script>
+
+<BlurReveal>
+  <h1>This fades in first</h1>
+  <p>This fades in second</p>
+  <p>This fades in third</p>
+</BlurReveal>
+```
+
+## Porting Notes
+
+- Replaced `motion-v` (Motion for Vue) with IntersectionObserver + CSS transitions
+- Vue version iterates VNodes from `slots.default()` to wrap each in a `Motion` component; Svelte version applies stagger via `:nth-child` CSS selectors on direct children
+- Default `delay` changed from `2` (Vue) to `0.2` — the Vue value was a multiplier used differently by motion-v
+- Supports up to 10 staggered children via CSS; beyond that, extra children animate with the same delay as the 10th

--- a/src/lib/inspira/blur-reveal/index.ts
+++ b/src/lib/inspira/blur-reveal/index.ts
@@ -1,0 +1,3 @@
+import BlurReveal, { type BlurRevealProps } from './BlurReveal.svelte';
+
+export { BlurReveal, type BlurRevealProps };

--- a/src/lib/inspira/index.ts
+++ b/src/lib/inspira/index.ts
@@ -7,6 +7,7 @@
 
 export * from './animated-beam/index.js';
 export * from './animated-tooltip/index.js';
+export * from './blur-reveal/index.js';
 export * from './bg-stars/index.js';
 export * from './border-beam/index.js';
 export * from './compare/index.js';

--- a/src/lib/inspira/registry.ts
+++ b/src/lib/inspira/registry.ts
@@ -90,6 +90,14 @@ export const registry: Record<string, ComponentMeta> = {
 		status: 'done'
 	},
 
+	'blur-reveal': {
+		name: 'BlurReveal',
+		slug: 'blur-reveal',
+		description: 'Scroll-triggered blur-to-clear reveal animation with staggered children',
+		category: 'text',
+		status: 'done'
+	},
+
 	'border-beam': {
 		name: 'BorderBeam',
 		slug: 'border-beam',

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -13,6 +13,12 @@
 			status: 'done' as const
 		},
 		{
+			name: 'BlurReveal',
+			href: '/demo/blur-reveal',
+			description: 'Scroll-triggered blur-to-clear reveal animation with staggered children',
+			status: 'done' as const
+		},
+		{
 			name: 'BgStars',
 			href: '/demo/bg-stars',
 			description: 'Animated starfield background with parallax mouse tracking',

--- a/src/routes/demo/blur-reveal/+page.svelte
+++ b/src/routes/demo/blur-reveal/+page.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+	import { BlurReveal } from '$lib/inspira/blur-reveal';
+</script>
+
+<svelte:head>
+	<title>BlurReveal - Inspira Svelte</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl px-4 py-12">
+	<div class="mb-8">
+		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
+	</div>
+
+	<h1 class="mb-2 text-3xl font-bold">BlurReveal</h1>
+	<p class="mb-8 text-muted-foreground">
+		Scroll-triggered reveal animation that transitions children from blurred to clear with staggered delays.
+	</p>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Basic Usage</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Each direct child element animates in sequence when scrolled into view.
+		</p>
+		<div class="rounded-lg border bg-card p-8">
+			<BlurReveal>
+				<h3 class="mb-4 text-2xl font-bold">Welcome to the future</h3>
+				<p class="mb-3 text-muted-foreground">
+					This paragraph fades in after the heading, with a slight delay.
+				</p>
+				<p class="text-muted-foreground">
+					And this one follows with another staggered delay.
+				</p>
+			</BlurReveal>
+		</div>
+	</section>
+
+	<!-- Custom Duration & Delay -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Custom Duration & Delay</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Slower animation with a larger stagger between children.
+		</p>
+		<div class="rounded-lg border bg-card p-8">
+			<BlurReveal duration={1.5} delay={0.4}>
+				<h3 class="mb-4 text-2xl font-bold">Slow reveal</h3>
+				<p class="mb-3 text-muted-foreground">
+					Duration is 1.5s with 0.4s stagger between elements.
+				</p>
+				<p class="text-muted-foreground">
+					The effect is more dramatic with longer timings.
+				</p>
+			</BlurReveal>
+		</div>
+	</section>
+
+	<!-- Heavy Blur -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Heavy Blur</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Increased blur and vertical offset for a more dramatic entrance.
+		</p>
+		<div class="rounded-lg border bg-card p-8">
+			<BlurReveal blur="40px" yOffset={40}>
+				<h3 class="mb-4 text-2xl font-bold">Bold entrance</h3>
+				<p class="mb-3 text-muted-foreground">
+					40px blur with 40px vertical offset makes the reveal much more pronounced.
+				</p>
+				<p class="text-muted-foreground">
+					Great for hero sections and landing pages.
+				</p>
+			</BlurReveal>
+		</div>
+	</section>
+
+	<!-- Card Grid -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Staggered Cards</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Works with any elements, including a grid of cards.
+		</p>
+		<div class="rounded-lg border bg-card p-8">
+			<BlurReveal delay={0.15} class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+				<div class="rounded-lg border bg-background p-6">
+					<h4 class="mb-2 font-semibold">Design</h4>
+					<p class="text-sm text-muted-foreground">Beautiful interfaces built with care.</p>
+				</div>
+				<div class="rounded-lg border bg-background p-6">
+					<h4 class="mb-2 font-semibold">Develop</h4>
+					<p class="text-sm text-muted-foreground">Clean code that scales with your needs.</p>
+				</div>
+				<div class="rounded-lg border bg-background p-6">
+					<h4 class="mb-2 font-semibold">Deploy</h4>
+					<p class="text-sm text-muted-foreground">Ship fast with confidence and reliability.</p>
+				</div>
+			</BlurReveal>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Port `BlurReveal` component from `vendor/inspira/ui/blur-reveal/`
- Scroll-triggered animation: children transition from blurred/offset to clear/in-place
- Staggered delays per child element via CSS `:nth-child` selectors
- Uses IntersectionObserver + CSS transitions (replaces Vue `motion-v`)
- Respects `prefers-reduced-motion`

## Files
- `src/lib/inspira/blur-reveal/` — component, index, README
- `src/routes/demo/blur-reveal/+page.svelte` — demo page with 4 examples
- Updated registry, exports, demo index, and TODO.md

## Test plan
- [ ] Visit `/demo/blur-reveal` and scroll to trigger animations
- [ ] Verify staggered children animate sequentially
- [ ] Check all 4 demo sections (basic, custom duration, heavy blur, card grid)
- [ ] Test with `prefers-reduced-motion` enabled