### PR TITLE
feat: add component Timeline

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -411,7 +411,7 @@
 
 - [ ] **dock** - macOS-style dock
 - [ ] **morphing-tabs** - Morphing tab navigation
-- [ ] **timeline** - Vertical timeline
+- [x] **timeline** - Vertical timeline
 - [ ] **scroll-island** - Scroll-aware floating island
 - [ ] **marquee** - Infinite scrolling marquee
 - [ ] **logo-cloud** - Logo carousel/cloud
@@ -541,7 +541,7 @@ These components are used in the portfolio project and should be ported first:
 | image-trail-cursor | Cursors & Interactions | Pending |
 | interactive-grid-pattern | Effects | Pending |
 | marquee | Navigation & Layout | Pending |
-| timeline | Navigation & Layout | Pending |
+| timeline | Navigation & Layout | Done |
 | animated-logo-cloud | Data Display | Pending |
 
 #### General Priority Order

--- a/src/lib/inspira/index.ts
+++ b/src/lib/inspira/index.ts
@@ -13,6 +13,7 @@ export * from './compare/index.js';
 export * from './direction-aware-hover/index.js';
 export * from './rainbow-button/index.js';
 export * from './ripple-button/index.js';
+export * from './timeline/index.js';
 
 // =============================================================================
 // Registry

--- a/src/lib/inspira/registry.ts
+++ b/src/lib/inspira/registry.ts
@@ -128,6 +128,14 @@ export const registry: Record<string, ComponentMeta> = {
 		description: 'Button with ripple click effect',
 		category: 'buttons',
 		status: 'done'
+	},
+
+	timeline: {
+		name: 'Timeline',
+		slug: 'timeline',
+		description: 'Vertical timeline with scroll-driven progress line and sticky labels',
+		category: 'navigation',
+		status: 'done'
 	}
 
 	// =========================================================================

--- a/src/lib/inspira/timeline/README.md
+++ b/src/lib/inspira/timeline/README.md
@@ -1,0 +1,60 @@
+# Timeline
+
+A vertical timeline with scroll-driven progress line and sticky labels.
+
+## Source
+
+Ported from `vendor/inspira/ui/timeline/Timeline.vue`
+
+## Features
+
+- **Scroll-driven progress**: Gradient line (purple → blue) grows as user scrolls
+- **Sticky labels**: Item labels stay visible while scrolling through content
+- **Dot indicators**: Visual markers on the timeline line
+- **Responsive**: Labels hidden on mobile, full layout on desktop
+- **ResizeObserver**: Recalculates height on layout changes
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `items` | `TimelineItem[]` | `[]` | Timeline entries with `id` and `label` |
+| `title` | `string` | — | Heading text above the timeline |
+| `description` | `string` | — | Subheading text |
+| `class` | `string` | `''` | Additional CSS classes |
+
+## Snippets
+
+| Snippet | Args | Description |
+|---------|------|-------------|
+| `content` | `(item: TimelineItem)` | Content rendered for each timeline entry |
+
+## Usage
+
+```svelte
+<script>
+  import { Timeline } from '$lib/inspira/timeline';
+
+  const items = [
+    { id: 'step-1', label: '2024' },
+    { id: 'step-2', label: '2023' },
+  ];
+</script>
+
+<Timeline {items} title="My Journey">
+  {#snippet content(item)}
+    {#if item.id === 'step-1'}
+      <p>First step content</p>
+    {:else if item.id === 'step-2'}
+      <p>Second step content</p>
+    {/if}
+  {/snippet}
+</Timeline>
+```
+
+## Porting Notes
+
+- Replaced `motion-v` `useScroll` / `useTransform` with a native scroll event listener
+- Replaced Vue named slots (`<slot :name="item.id">`) with a single `content` snippet that receives the item
+- Uses ResizeObserver to keep timeline height in sync
+- Uses theme tokens (`bg-background`, `text-foreground`) instead of hardcoded colors

--- a/src/lib/inspira/timeline/Timeline.svelte
+++ b/src/lib/inspira/timeline/Timeline.svelte
@@ -102,7 +102,7 @@
 	{/if}
 
 	<div bind:this={timelineRef} class="relative z-0 mx-auto max-w-7xl pb-20">
-		{#each items as item, index (item.id + index)}
+		{#each items as item, index (`${item.id}-${index}`)}
 			<div class="flex justify-start pt-10 md:gap-10 md:pt-40">
 				<!-- Sticky label -->
 				<div

--- a/src/lib/inspira/timeline/Timeline.svelte
+++ b/src/lib/inspira/timeline/Timeline.svelte
@@ -1,0 +1,147 @@
+<script lang="ts" module>
+	import type { Snippet } from 'svelte';
+
+	export interface TimelineItem {
+		id: string;
+		label: string;
+	}
+
+	export interface TimelineProps {
+		/** Timeline entries */
+		items?: TimelineItem[];
+		/** Heading text */
+		title?: string;
+		/** Subheading text */
+		description?: string;
+		/** Additional CSS classes for the outer wrapper */
+		class?: string;
+		/** Content snippet, called for each item */
+		content?: Snippet<[TimelineItem]>;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { onMount } from 'svelte';
+
+	let {
+		items = [],
+		title,
+		description,
+		class: className,
+		content
+	}: TimelineProps = $props();
+
+	let timelineRef: HTMLDivElement;
+	let timelineHeight = $state(0);
+	let scrollProgress = $state(0);
+
+	let progressHeight = $derived(scrollProgress * timelineHeight);
+	let progressOpacity = $derived(Math.min(scrollProgress / 0.1, 1));
+
+	function updateProgress() {
+		if (!timelineRef) return;
+
+		const rect = timelineRef.getBoundingClientRect();
+		const viewportHeight = window.innerHeight;
+
+		// Start tracking when top of timeline reaches 10% from top of viewport
+		const startOffset = viewportHeight * 0.1;
+		// End tracking when bottom of timeline reaches 50% of viewport
+		const endOffset = viewportHeight * 0.5;
+
+		const start = rect.top - startOffset;
+		const end = rect.bottom - endOffset;
+		const total = end - start;
+
+		if (total <= 0) {
+			scrollProgress = 0;
+			return;
+		}
+
+		const progress = -start / total;
+		scrollProgress = Math.max(0, Math.min(1, progress));
+	}
+
+	onMount(() => {
+		if (timelineRef) {
+			timelineHeight = timelineRef.getBoundingClientRect().height;
+		}
+
+		const resizeObserver = new ResizeObserver(() => {
+			if (timelineRef) {
+				timelineHeight = timelineRef.getBoundingClientRect().height;
+			}
+		});
+
+		resizeObserver.observe(timelineRef);
+		window.addEventListener('scroll', updateProgress, { passive: true });
+		updateProgress();
+
+		return () => {
+			resizeObserver.disconnect();
+			window.removeEventListener('scroll', updateProgress);
+		};
+	});
+</script>
+
+<div class={cn('w-full font-sans md:px-10', className)}>
+	{#if title || description}
+		<div class="mx-auto max-w-7xl px-4 py-20 md:px-8 lg:px-10">
+			{#if title}
+				<h2 class="mb-4 max-w-4xl text-lg text-foreground md:text-4xl">
+					{title}
+				</h2>
+			{/if}
+			{#if description}
+				<p class="max-w-sm text-sm text-muted-foreground md:text-base">
+					{description}
+				</p>
+			{/if}
+		</div>
+	{/if}
+
+	<div bind:this={timelineRef} class="relative z-0 mx-auto max-w-7xl pb-20">
+		{#each items as item, index (item.id + index)}
+			<div class="flex justify-start pt-10 md:gap-10 md:pt-40">
+				<!-- Sticky label -->
+				<div
+					class="sticky top-40 z-40 flex max-w-xs flex-col items-center self-start md:w-full md:flex-row lg:max-w-sm"
+				>
+					<div
+						class="absolute left-3 flex size-10 items-center justify-center rounded-full bg-background md:left-3"
+					>
+						<div
+							class="size-4 rounded-full border border-neutral-300 bg-neutral-200 p-2 dark:border-neutral-700 dark:bg-neutral-800"
+						/>
+					</div>
+					<h3
+						class="hidden text-xl font-bold text-neutral-500 md:block md:pl-20 md:text-5xl dark:text-neutral-500"
+					>
+						{item.label}
+					</h3>
+				</div>
+
+				<!-- Item content -->
+				<div class="w-full pl-20 pr-4 md:pl-4">
+					{#if content}
+						{@render content(item)}
+					{/if}
+				</div>
+			</div>
+		{/each}
+
+		<!-- Background line -->
+		<div
+			style:height="{timelineHeight}px"
+			class="absolute left-8 top-0 w-[2px] overflow-hidden bg-[linear-gradient(to_bottom,var(--tw-gradient-stops))] from-transparent from-0% via-neutral-200 to-transparent to-[99%] [mask-image:linear-gradient(to_bottom,transparent_0%,black_10%,black_90%,transparent_100%)] md:left-8 dark:via-neutral-700"
+		>
+			<!-- Animated progress line -->
+			<div
+				style:height="{progressHeight}px"
+				style:opacity={progressOpacity}
+				class="absolute inset-x-0 top-0 w-[2px] rounded-full bg-gradient-to-t from-purple-500 from-0% via-blue-500 via-10% to-transparent"
+			></div>
+		</div>
+	</div>
+</div>

--- a/src/lib/inspira/timeline/index.ts
+++ b/src/lib/inspira/timeline/index.ts
@@ -1,0 +1,3 @@
+import Timeline, { type TimelineProps, type TimelineItem } from './Timeline.svelte';
+
+export { Timeline, type TimelineProps, type TimelineItem };

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -71,6 +71,12 @@
 			href: '/demo/ripple-button',
 			description: 'Button with ripple click effect',
 			status: 'done' as const
+		},
+		{
+			name: 'Timeline',
+			href: '/demo/timeline',
+			description: 'Vertical timeline with scroll-driven progress line and sticky labels',
+			status: 'done' as const
 		}
 	];
 </script>

--- a/src/routes/demo/timeline/+page.svelte
+++ b/src/routes/demo/timeline/+page.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import { Timeline } from '$lib/inspira/timeline';
+
+	const items = [
+		{ id: 'early-2025', label: 'Early 2025' },
+		{ id: 'late-2024', label: 'Late 2024' },
+		{ id: 'mid-2024', label: 'Mid 2024' },
+		{ id: 'early-2024', label: 'Early 2024' }
+	];
+</script>
+
+<svelte:head>
+	<title>Timeline - Inspira Svelte</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl px-4 py-12">
+	<div class="mb-8">
+		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
+	</div>
+
+	<h1 class="mb-2 text-3xl font-bold">Timeline</h1>
+	<p class="mb-8 text-muted-foreground">
+		Vertical timeline with scroll-driven progress line and sticky labels.
+	</p>
+</div>
+
+<!-- Full-width timeline -->
+<Timeline
+	{items}
+	title="Changelog"
+	description="A history of updates and milestones."
+>
+	{#snippet content(item)}
+		{#if item.id === 'early-2025'}
+			<div class="space-y-4">
+				<h3 class="text-lg font-semibold text-foreground md:hidden">{item.label}</h3>
+				<div class="rounded-lg border bg-card p-4">
+					<h4 class="mb-2 font-semibold">New component library</h4>
+					<p class="text-sm text-muted-foreground">
+						Launched Inspira Svelte with 12+ ported components including AnimatedBeam,
+						Compare, DirectionAwareHover, and more.
+					</p>
+				</div>
+				<div class="rounded-lg border bg-card p-4">
+					<h4 class="mb-2 font-semibold">Timeline component</h4>
+					<p class="text-sm text-muted-foreground">
+						Added scroll-driven timeline with progress indicator and sticky labels.
+					</p>
+				</div>
+			</div>
+		{:else if item.id === 'late-2024'}
+			<div class="space-y-4">
+				<h3 class="text-lg font-semibold text-foreground md:hidden">{item.label}</h3>
+				<div class="rounded-lg border bg-card p-4">
+					<h4 class="mb-2 font-semibold">Project kickoff</h4>
+					<p class="text-sm text-muted-foreground">
+						Started porting InspiraUI components from Vue to idiomatic Svelte 5.
+						Established component template, registry system, and demo infrastructure.
+					</p>
+				</div>
+			</div>
+		{:else if item.id === 'mid-2024'}
+			<div class="space-y-4">
+				<h3 class="text-lg font-semibold text-foreground md:hidden">{item.label}</h3>
+				<div class="rounded-lg border bg-card p-4">
+					<h4 class="mb-2 font-semibold">Design exploration</h4>
+					<p class="text-sm text-muted-foreground">
+						Evaluated component libraries and identified InspiraUI as the source for
+						high-quality animation components. Prototyped initial ports.
+					</p>
+				</div>
+			</div>
+		{:else if item.id === 'early-2024'}
+			<div class="space-y-4">
+				<h3 class="text-lg font-semibold text-foreground md:hidden">{item.label}</h3>
+				<div class="rounded-lg border bg-card p-4">
+					<h4 class="mb-2 font-semibold">SvelteKit foundation</h4>
+					<p class="text-sm text-muted-foreground">
+						Set up the SvelteKit project with Tailwind CSS, shadcn-svelte, and TypeScript.
+						Configured the build pipeline and deployment.
+					</p>
+				</div>
+			</div>
+		{/if}
+	{/snippet}
+</Timeline>
+
+<div class="container mx-auto max-w-4xl px-4 py-12">
+	<p class="text-center text-sm text-muted-foreground">
+		Scroll up to see the progress line animate.
+	</p>
+</div>


### PR DESCRIPTION
## Summary
- Port `Timeline` component from `vendor/inspira/ui/timeline/`
- Vertical timeline with scroll-driven gradient progress line (purple → blue)
- Sticky labels that stay visible while scrolling through content
- Uses native scroll listener + ResizeObserver (replaces Vue `motion-v`)
- Content via `content` snippet receiving each `TimelineItem`

## Files
- `src/lib/inspira/timeline/` — component, index, README
- `src/routes/demo/timeline/+page.svelte` — demo page with changelog example
- Updated registry, exports, demo index, and TODO.md

## Test plan
- [ ] Visit `/demo/timeline` and scroll to see progress line animate
- [ ] Verify sticky labels stay visible while scrolling through content
- [ ] Check mobile layout (labels hidden, shown inline instead)
- [ ] Resize window to verify ResizeObserver recalculates height