### PR TITLE
feat: add component FallingStarsBg

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -368,7 +368,7 @@
 - [ ] **aurora-background** - Aurora borealis effect
 - [ ] **bg-black-hole** - Black hole animation
 - [ ] **bg-bubbles** - Floating bubbles
-- [ ] **bg-falling-stars** - Falling stars animation
+- [x] **bg-falling-stars** - Falling stars animation
 - [ ] **bg-neural** - Neural network visualization
 - [ ] **bg-particle-whirlpool** - Particle whirlpool
 - [ ] **bg-silk** - Silk fabric animation

--- a/src/lib/inspira/bg-falling-stars/FallingStarsBg.svelte
+++ b/src/lib/inspira/bg-falling-stars/FallingStarsBg.svelte
@@ -1,0 +1,167 @@
+<script lang="ts" module>
+	export interface FallingStarsBgProps {
+		/** Star color as hex string */
+		color?: string;
+		/** Number of stars */
+		count?: number;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import { onMount } from 'svelte';
+
+	interface Star {
+		x: number;
+		y: number;
+		z: number;
+		speed: number;
+	}
+
+	let {
+		color = '#FFF',
+		count = 200,
+		class: className = ''
+	}: FallingStarsBgProps = $props();
+
+	let canvas: HTMLCanvasElement;
+	let perspective = 0;
+	let stars: Star[] = [];
+	let ctx: CanvasRenderingContext2D | null = null;
+	let dpr = 1;
+	let rafId = 0;
+
+	function hexToRgb(hex: string) {
+		let h = (hex || '#000').replace(/^#/, '');
+		if (h.length === 3) {
+			h = h
+				.split('')
+				.map((c) => c + c)
+				.join('');
+		}
+		const bigint = parseInt(h, 16) || 0;
+		return {
+			r: (bigint >> 16) & 255,
+			g: (bigint >> 8) & 255,
+			b: bigint & 255
+		};
+	}
+
+	let cachedRgb = $derived(hexToRgb(color));
+
+	function resizeCanvas() {
+		if (!canvas) return;
+
+		dpr = window.devicePixelRatio || 1;
+		const width = Math.max(1, Math.floor(canvas.clientWidth));
+		const height = Math.max(1, Math.floor(canvas.clientHeight));
+
+		canvas.width = Math.floor(width * dpr);
+		canvas.height = Math.floor(height * dpr);
+		canvas.style.width = `${width}px`;
+		canvas.style.height = `${height}px`;
+
+		ctx = canvas.getContext('2d');
+		if (ctx) {
+			ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+		}
+
+		perspective = width / 2;
+	}
+
+	function drawStar(star: Star, width: number, height: number) {
+		if (!ctx) return;
+
+		const scale = perspective / (perspective + star.z);
+		const x2d = width / 2 + star.x * scale;
+		const y2d = height / 2 + star.y * scale;
+		const size = Math.max(scale * 3, 0.5);
+
+		const prevScale = perspective / (perspective + star.z + star.speed * 15);
+		const xPrev = width / 2 + star.x * prevScale;
+		const yPrev = height / 2 + star.y * prevScale;
+
+		const rgb = cachedRgb;
+
+		// Layered strokes from wide+faint to narrow+brighter to fake blur
+		const layerAlphas = [0.08, 0.14, 0.22];
+		for (let i = 0; i < layerAlphas.length; i++) {
+			ctx.beginPath();
+			ctx.strokeStyle = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${layerAlphas[i]})`;
+			ctx.lineWidth = size * (1.4 + i * 1.2);
+			ctx.moveTo(x2d, y2d);
+			ctx.lineTo(xPrev, yPrev);
+			ctx.stroke();
+		}
+
+		// Sharp center line
+		ctx.beginPath();
+		ctx.strokeStyle = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.6)`;
+		ctx.lineWidth = Math.max(1, size);
+		ctx.moveTo(x2d, y2d);
+		ctx.lineTo(xPrev, yPrev);
+		ctx.stroke();
+
+		// Dot
+		ctx.beginPath();
+		ctx.fillStyle = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 1)`;
+		ctx.arc(x2d, y2d, Math.max(0.5, size / 4), 0, Math.PI * 2);
+		ctx.fill();
+	}
+
+	function loop() {
+		if (!canvas) return;
+		if (!ctx) ctx = canvas.getContext('2d');
+		if (!ctx) return;
+
+		const width = canvas.clientWidth;
+		const height = canvas.clientHeight;
+
+		ctx.clearRect(0, 0, width, height);
+
+		for (let i = 0; i < stars.length; i++) {
+			const star = stars[i];
+			drawStar(star, width, height);
+
+			star.z -= star.speed;
+
+			if (star.z <= 0) {
+				star.z = width || 1;
+				star.x = (Math.random() - 0.5) * 2 * width;
+				star.y = (Math.random() - 0.5) * 2 * height;
+			}
+		}
+
+		rafId = requestAnimationFrame(loop);
+	}
+
+	onMount(() => {
+		resizeCanvas();
+
+		const cssWidth = canvas.clientWidth;
+		const cssHeight = canvas.clientHeight;
+		stars = [];
+		for (let i = 0; i < count; i++) {
+			stars.push({
+				x: (Math.random() - 0.5) * 2 * cssWidth,
+				y: (Math.random() - 0.5) * 2 * cssHeight,
+				z: Math.random() * (cssWidth || 1),
+				speed: Math.random() * 5 + 2
+			});
+		}
+
+		rafId = requestAnimationFrame(loop);
+
+		const resizeObserver = new ResizeObserver(() => resizeCanvas());
+		resizeObserver.observe(canvas);
+
+		return () => {
+			if (rafId) cancelAnimationFrame(rafId);
+			resizeObserver.disconnect();
+		};
+	});
+</script>
+
+<canvas bind:this={canvas} class={cn('absolute inset-0 h-full w-full', className)}></canvas>

--- a/src/lib/inspira/bg-falling-stars/README.md
+++ b/src/lib/inspira/bg-falling-stars/README.md
@@ -1,0 +1,26 @@
+# FallingStarsBg
+
+Canvas-based 3D starfield background with perspective projection, motion trails, and glow effects.
+
+## Source
+
+`vendor/inspira/ui/bg-falling-stars/FallingStarsBg.vue`
+
+## Props
+
+| Prop    | Type     | Default  | Description           |
+|---------|----------|----------|-----------------------|
+| `color` | `string` | `"#FFF"` | Star color (hex)      |
+| `count` | `number` | `200`    | Number of stars       |
+| `class` | `string` | `""`     | Additional CSS classes |
+
+## Porting Notes
+
+- Canvas rendering with `requestAnimationFrame` loop — no CSS/SVG animations.
+- 3D perspective: stars move toward camera with depth-based scaling (`perspective / (perspective + z)`).
+- Motion trails: lines drawn from previous to current projected position.
+- Glow layers: multiple strokes with decreasing opacity (`[0.08, 0.14, 0.22]`) plus a sharp center line and dot.
+- HiDPI: uses `devicePixelRatio` for crisp rendering on Retina displays.
+- Uses `ResizeObserver` instead of window resize listener for better responsiveness.
+- `$derived` used for cached RGB conversion so it updates reactively when `color` prop changes.
+- Cleanup: animation frame and resize observer are cleaned up on unmount via `onMount` return.

--- a/src/lib/inspira/bg-falling-stars/index.ts
+++ b/src/lib/inspira/bg-falling-stars/index.ts
@@ -1,0 +1,2 @@
+export { default as FallingStarsBg } from './FallingStarsBg.svelte';
+export type { FallingStarsBgProps } from './FallingStarsBg.svelte';

--- a/src/lib/inspira/index.ts
+++ b/src/lib/inspira/index.ts
@@ -8,6 +8,7 @@
 export * from './animated-beam/index.js';
 export * from './animated-tooltip/index.js';
 export * from './blur-reveal/index.js';
+export * from './bg-falling-stars/index.js';
 export * from './bg-stars/index.js';
 export * from './border-beam/index.js';
 export * from './compare/index.js';

--- a/src/lib/inspira/registry.ts
+++ b/src/lib/inspira/registry.ts
@@ -82,6 +82,14 @@ export const registry: Record<string, ComponentMeta> = {
 		status: 'done'
 	},
 
+	'bg-falling-stars': {
+		name: 'FallingStarsBg',
+		slug: 'bg-falling-stars',
+		description: 'Canvas-based 3D starfield with perspective projection, motion trails, and glow',
+		category: 'backgrounds',
+		status: 'done'
+	},
+
 	'animated-tooltip': {
 		name: 'AnimatedTooltip',
 		slug: 'animated-tooltip',

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -19,6 +19,12 @@
 			status: 'done' as const
 		},
 		{
+			name: 'BgFallingStars',
+			href: '/demo/bg-falling-stars',
+			description: 'Canvas-based 3D starfield with perspective projection, motion trails, and glow',
+			status: 'done' as const
+		},
+		{
 			name: 'BgStars',
 			href: '/demo/bg-stars',
 			description: 'Animated starfield background with parallax mouse tracking',

--- a/src/routes/demo/bg-falling-stars/+page.svelte
+++ b/src/routes/demo/bg-falling-stars/+page.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import { FallingStarsBg } from '$lib/inspira/bg-falling-stars';
+</script>
+
+<svelte:head>
+	<title>FallingStarsBg - Inspira Svelte</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl py-12 px-4">
+	<div class="mb-8">
+		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
+	</div>
+
+	<h1 class="text-3xl font-bold mb-2">FallingStarsBg</h1>
+	<p class="text-muted-foreground mb-8">
+		A canvas-based 3D starfield background with perspective projection, motion trails, and glow effects.
+	</p>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="relative rounded-lg border overflow-hidden bg-black h-[400px]">
+			<FallingStarsBg />
+			<div class="relative z-10 flex items-center justify-center h-full">
+				<h2 class="text-4xl font-bold text-white">Falling Stars</h2>
+			</div>
+		</div>
+	</section>
+
+	<!-- Custom Color -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Color</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Use <code class="rounded bg-muted px-1.5 py-0.5">color</code> to change the star color.
+		</p>
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+			<div class="relative rounded-lg border overflow-hidden bg-black h-[250px]">
+				<FallingStarsBg color="#60a5fa" />
+				<div class="relative z-10 flex items-center justify-center h-full">
+					<p class="text-blue-300">color="#60a5fa"</p>
+				</div>
+			</div>
+			<div class="relative rounded-lg border overflow-hidden bg-black h-[250px]">
+				<FallingStarsBg color="#f472b6" />
+				<div class="relative z-10 flex items-center justify-center h-full">
+					<p class="text-pink-300">color="#f472b6"</p>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- Custom Count -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Star Count</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Use <code class="rounded bg-muted px-1.5 py-0.5">count</code> to control the number of stars.
+		</p>
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+			<div class="relative rounded-lg border overflow-hidden bg-black h-[250px]">
+				<FallingStarsBg count={50} />
+				<div class="relative z-10 flex items-center justify-center h-full">
+					<p class="text-sm text-white/80">count=50 (sparse)</p>
+				</div>
+			</div>
+			<div class="relative rounded-lg border overflow-hidden bg-black h-[250px]">
+				<FallingStarsBg count={500} />
+				<div class="relative z-10 flex items-center justify-center h-full">
+					<p class="text-sm text-white/80">count=500 (dense)</p>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- Hero Example -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Hero Section Example</h2>
+		<div class="relative rounded-lg border overflow-hidden bg-black h-[500px]">
+			<FallingStarsBg color="#fbbf24" count={300} />
+			<div class="relative z-10 flex flex-col items-center justify-center h-full text-center px-4">
+				<h1 class="text-5xl md:text-6xl font-bold text-white mb-4">
+					Into the Void
+				</h1>
+				<p class="text-lg text-white/70 max-w-xl mb-8">
+					Watch the stars streak past as you hurtle through the cosmos at light speed.
+				</p>
+				<button class="px-6 py-3 bg-white text-black font-semibold rounded-lg hover:bg-white/90 transition-colors">
+					Launch
+				</button>
+			</div>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Port `vendor/inspira/ui/bg-falling-stars/FallingStarsBg.vue` to Svelte as a canvas-based 3D starfield background with perspective projection, motion trails, and glow effects
- Add demo page at `/demo/bg-falling-stars` with basic usage, custom color, custom count, and hero section examples
- Register component in registry, library exports, and demo index; mark as Done in TODO

## Test plan
- [x] `pnpm check` passes with no errors
- [x] Visit `/demo/bg-falling-stars` — stars animate with motion trails and glow
- [x] Resize browser window — canvas adapts via ResizeObserver
- [x] Verify custom `color` and `count` props work in demo variations
- [x] Demo index page lists BgFallingStars