### PR TITLE
feat: add component ImageTrailCursor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -452,7 +452,7 @@
 - [ ] **smooth-cursor** - Smooth cursor follower
 - [ ] **sleek-line-cursor** - Line cursor effect
 - [ ] **tailed-cursor** - Cursor with tail
-- [ ] **image-trail-cursor** - Image trail on cursor move
+- [x] **image-trail-cursor** - Image trail on cursor move
 
 ### 8.10 Media & Mockups (5 components)
 
@@ -538,8 +538,8 @@ These components are used in the portfolio project and should be ported first:
 | fluid-cursor | Cursors & Interactions | Done |
 | marquee | Navigation & Layout | Done |
 | blur-reveal | Text | Done |
-| bg-falling-stars | Backgrounds | Pending |
-| image-trail-cursor | Cursors & Interactions | Pending |
+| bg-falling-stars | Backgrounds | Done |
+| image-trail-cursor | Cursors & Interactions | Done |
 | interactive-grid-pattern | Effects | Pending |
 | timeline | Navigation & Layout | Done |
 | animated-logo-cloud | Data Display | Pending |

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^5.9.3",
 		"vite": "^7.2.6"
+	},
+	"dependencies": {
+		"gsap": "^3.14.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      gsap:
+        specifier: ^3.14.2
+        version: 3.14.2
     devDependencies:
       '@internationalized/date':
         specifier: ^3.10.1
@@ -618,6 +622,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gsap@3.14.2:
+    resolution: {integrity: sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -1312,6 +1319,8 @@ snapshots:
     optional: true
 
   graceful-fs@4.2.11: {}
+
+  gsap@3.14.2: {}
 
   inline-style-parser@0.2.7: {}
 

--- a/src/lib/inspira/image-trail-cursor/ImageTrailCursor.svelte
+++ b/src/lib/inspira/image-trail-cursor/ImageTrailCursor.svelte
@@ -1,0 +1,95 @@
+<script lang="ts" module>
+	import type { VariantType } from './trail-variants.js';
+
+	export interface ImageTrailCursorProps {
+		images?: string[];
+		variant?: VariantType;
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { cn } from '$lib/utils.js';
+	import { variantMap, type ImageTrailVariant } from './trail-variants.js';
+
+	let {
+		images = [],
+		variant = 'type1',
+		class: className = ''
+	}: ImageTrailCursorProps = $props();
+
+	let containerRef: HTMLDivElement;
+	let currentInstance: ImageTrailVariant | null = null;
+	let mounted = false;
+
+	function resetImageStyles() {
+		if (!containerRef) return;
+		const imgEls = containerRef.querySelectorAll<HTMLDivElement>('.content__img');
+		for (const el of imgEls) {
+			el.style.cssText = '';
+			const inner = el.querySelector<HTMLDivElement>('.content__img-inner');
+			if (inner) {
+				// Preserve background-image set by Svelte, only clear GSAP residue
+				const bgImage = inner.style.backgroundImage;
+				inner.style.cssText = '';
+				if (bgImage) inner.style.backgroundImage = bgImage;
+			}
+		}
+	}
+
+	function initializeVariant() {
+		if (!containerRef) return;
+
+		if (currentInstance) {
+			currentInstance.destroy();
+			currentInstance = null;
+		}
+
+		resetImageStyles();
+
+		const Variant = variantMap[variant] || variantMap.type1;
+		currentInstance = new Variant(containerRef);
+	}
+
+	onMount(() => {
+		initializeVariant();
+		mounted = true;
+
+		return () => {
+			if (currentInstance) {
+				currentInstance.destroy();
+				currentInstance = null;
+			}
+		};
+	});
+
+	$effect(() => {
+		// Track the variant prop
+		variant;
+
+		// Skip the first run (onMount handles initial setup)
+		if (!mounted) return;
+
+		initializeVariant();
+	});
+</script>
+
+<div
+	bind:this={containerRef}
+	class={cn(
+		'relative z-[100] h-full w-full overflow-visible rounded-lg bg-transparent',
+		className
+	)}
+>
+	{#each images as image, i (variant + i)}
+		<div
+			class="content__img absolute left-0 top-0 aspect-[1.1] w-[190px] overflow-hidden rounded-[15px] opacity-0 [will-change:transform,filter]"
+		>
+			<div
+				class="content__img-inner absolute left-[-10px] top-[-10px] h-[calc(100%+20px)] w-[calc(100%+20px)] bg-cover bg-center"
+				style="background-image: url({image})"
+			></div>
+		</div>
+	{/each}
+</div>

--- a/src/lib/inspira/image-trail-cursor/README.md
+++ b/src/lib/inspira/image-trail-cursor/README.md
@@ -1,0 +1,41 @@
+# ImageTrailCursor
+
+Cursor-following image trail effect with 8 animation variants. Images appear at the cursor position as you move the mouse, each variant providing a distinct visual style.
+
+## Source
+
+- **Vue**: `vendor/inspira/ui/image-trail-cursor/`
+- **Svelte**: `src/lib/inspira/image-trail-cursor/`
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `images` | `string[]` | `[]` | Array of image URLs for the trail |
+| `variant` | `VariantType` | `'type1'` | Animation variant (`type1` through `type8`) |
+| `class` | `string` | `''` | Additional CSS classes for the container |
+
+## Variants
+
+| Variant | Description |
+|---------|-------------|
+| `type1` | Basic fade & scale trail |
+| `type2` | Scale-up with brightness burst |
+| `type3` | Float-up exit with random x drift |
+| `type4` | Momentum-based drift with brightness/contrast |
+| `type5` | Rotation + momentum fling |
+| `type6` | Speed-reactive size, blur, grayscale |
+| `type7` | Stacking trail with visible queue |
+| `type8` | 3D perspective based on cursor position |
+
+## Dependencies
+
+- **GSAP** (`gsap`) — Required for animation timelines. First GSAP dependency in the project.
+
+## Porting Notes
+
+- Extracted a `BaseVariant` abstract class to eliminate ~800 lines of duplicated constructor/render/destroy boilerplate across the 8 variant classes.
+- Added proper `destroy()` methods (missing in vendor): cancels RAF, removes event listeners, kills GSAP tweens, cleans up `ImageItem` resize listeners.
+- Fixed `VariantType` to include `type8` (vendor TypeScript type stopped at `type7` but code had 8 variants).
+- Properly typed `variantMap` as `Record<VariantType, ...>` instead of `{ [key: string]: any }`.
+- The Svelte component resets inline styles before re-initializing on variant switch to prevent GSAP style residue.

--- a/src/lib/inspira/image-trail-cursor/index.ts
+++ b/src/lib/inspira/image-trail-cursor/index.ts
@@ -1,0 +1,3 @@
+export { default as ImageTrailCursor } from './ImageTrailCursor.svelte';
+export type { ImageTrailCursorProps } from './ImageTrailCursor.svelte';
+export type { VariantType } from './trail-variants.js';

--- a/src/lib/inspira/image-trail-cursor/trail-variants.ts
+++ b/src/lib/inspira/image-trail-cursor/trail-variants.ts
@@ -1,0 +1,809 @@
+import { gsap } from 'gsap';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type VariantType =
+	| 'type1'
+	| 'type2'
+	| 'type3'
+	| 'type4'
+	| 'type5'
+	| 'type6'
+	| 'type7'
+	| 'type8';
+
+export interface ImageTrailVariant {
+	destroy(): void;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function lerp(a: number, b: number, n: number): number {
+	return (1 - n) * a + n * b;
+}
+
+function getLocalPointerPos(e: MouseEvent | TouchEvent, rect: DOMRect): { x: number; y: number } {
+	let clientX = 0;
+	let clientY = 0;
+	if ('touches' in e && e.touches.length > 0) {
+		clientX = e.touches[0].clientX;
+		clientY = e.touches[0].clientY;
+	} else if ('clientX' in e) {
+		clientX = e.clientX;
+		clientY = e.clientY;
+	}
+	return {
+		x: clientX - rect.left,
+		y: clientY - rect.top
+	};
+}
+
+function getMouseDistance(p1: { x: number; y: number }, p2: { x: number; y: number }): number {
+	const dx = p1.x - p2.x;
+	const dy = p1.y - p2.y;
+	return Math.hypot(dx, dy);
+}
+
+function getNewPosition(position: number, offset: number, arr: ImageItem[]) {
+	const realOffset = Math.abs(offset) % arr.length;
+	if (position - realOffset >= 0) {
+		return position - realOffset;
+	} else {
+		return arr.length - (realOffset - position);
+	}
+}
+
+// =============================================================================
+// ImageItem
+// =============================================================================
+
+export class ImageItem {
+	public DOM: { el: HTMLDivElement; inner: HTMLDivElement | null } = {
+		el: null as unknown as HTMLDivElement,
+		inner: null
+	};
+	public defaultStyle: gsap.TweenVars = { scale: 1, x: 0, y: 0, opacity: 0 };
+	public rect: DOMRect | null = null;
+	private resizeHandler: (() => void) | null = null;
+
+	constructor(DOM_el: HTMLDivElement) {
+		this.DOM.el = DOM_el;
+		this.DOM.inner = this.DOM.el.querySelector('.content__img-inner');
+		this.getRect();
+		this.initEvents();
+	}
+
+	private initEvents() {
+		this.resizeHandler = () => {
+			gsap.set(this.DOM.el, this.defaultStyle);
+			this.getRect();
+		};
+		window.addEventListener('resize', this.resizeHandler);
+	}
+
+	private getRect() {
+		this.rect = this.DOM.el.getBoundingClientRect();
+	}
+
+	destroy() {
+		if (this.resizeHandler) {
+			window.removeEventListener('resize', this.resizeHandler);
+			this.resizeHandler = null;
+		}
+	}
+}
+
+// =============================================================================
+// Base class for shared variant logic
+// =============================================================================
+
+abstract class BaseVariant implements ImageTrailVariant {
+	protected container: HTMLDivElement;
+	protected DOM: { el: HTMLDivElement };
+	protected images: ImageItem[];
+	protected imagesTotal: number;
+	protected imgPosition: number;
+	protected zIndexVal: number;
+	protected activeImagesCount: number;
+	protected isIdle: boolean;
+	protected threshold: number;
+	protected mousePos: { x: number; y: number };
+	protected lastMousePos: { x: number; y: number };
+	protected cacheMousePos: { x: number; y: number };
+
+	private rafId: number | null = null;
+	private destroyed = false;
+	private handlePointerMove: ((ev: MouseEvent | TouchEvent) => void) | null = null;
+	private initRender: ((ev: MouseEvent | TouchEvent) => void) | null = null;
+
+	constructor(container: HTMLDivElement) {
+		this.container = container;
+		this.DOM = { el: container };
+		this.images = [...container.querySelectorAll('.content__img')].map(
+			(img) => new ImageItem(img as HTMLDivElement)
+		);
+		this.imagesTotal = this.images.length;
+		this.imgPosition = 0;
+		this.zIndexVal = 1;
+		this.activeImagesCount = 0;
+		this.isIdle = true;
+		this.threshold = 80;
+		this.mousePos = { x: 0, y: 0 };
+		this.lastMousePos = { x: 0, y: 0 };
+		this.cacheMousePos = { x: 0, y: 0 };
+
+		this.handlePointerMove = (ev: MouseEvent | TouchEvent) => {
+			const rect = this.container.getBoundingClientRect();
+			this.mousePos = getLocalPointerPos(ev, rect);
+		};
+		container.addEventListener('mousemove', this.handlePointerMove);
+		container.addEventListener('touchmove', this.handlePointerMove);
+
+		this.initRender = (ev: MouseEvent | TouchEvent) => {
+			const rect = this.container.getBoundingClientRect();
+			this.mousePos = getLocalPointerPos(ev, rect);
+			this.cacheMousePos = { ...this.mousePos };
+			this.rafId = requestAnimationFrame(() => this.render());
+			container.removeEventListener('mousemove', this.initRender as EventListener);
+			container.removeEventListener('touchmove', this.initRender as EventListener);
+		};
+		container.addEventListener('mousemove', this.initRender as EventListener);
+		container.addEventListener('touchmove', this.initRender as EventListener);
+	}
+
+	protected render() {
+		if (this.destroyed) return;
+		const distance = getMouseDistance(this.mousePos, this.lastMousePos);
+		this.updateCache();
+
+		if (distance > this.threshold) {
+			this.showNextImage();
+			this.lastMousePos = { ...this.mousePos };
+		}
+		if (this.isIdle && this.zIndexVal !== 1) {
+			this.zIndexVal = 1;
+		}
+		this.rafId = requestAnimationFrame(() => this.render());
+	}
+
+	protected updateCache() {
+		this.cacheMousePos.x = lerp(this.cacheMousePos.x, this.mousePos.x, 0.1);
+		this.cacheMousePos.y = lerp(this.cacheMousePos.y, this.mousePos.y, 0.1);
+	}
+
+	protected abstract showNextImage(): void;
+
+	protected onImageActivated() {
+		this.activeImagesCount++;
+		this.isIdle = false;
+	}
+
+	protected onImageDeactivated() {
+		this.activeImagesCount--;
+		if (this.activeImagesCount === 0) {
+			this.isIdle = true;
+		}
+	}
+
+	destroy() {
+		this.destroyed = true;
+
+		if (this.rafId !== null) {
+			cancelAnimationFrame(this.rafId);
+			this.rafId = null;
+		}
+
+		if (this.handlePointerMove) {
+			this.container.removeEventListener('mousemove', this.handlePointerMove);
+			this.container.removeEventListener('touchmove', this.handlePointerMove);
+		}
+		if (this.initRender) {
+			this.container.removeEventListener('mousemove', this.initRender as EventListener);
+			this.container.removeEventListener('touchmove', this.initRender as EventListener);
+		}
+
+		for (const img of this.images) {
+			gsap.killTweensOf(img.DOM.el);
+			if (img.DOM.inner) gsap.killTweensOf(img.DOM.inner);
+			img.destroy();
+		}
+	}
+}
+
+// =============================================================================
+// Variant 1 — Basic fade & scale trail
+// =============================================================================
+
+export class ImageTrailVariant1 extends BaseVariant {
+	protected showNextImage() {
+		++this.zIndexVal;
+		this.imgPosition = this.imgPosition < this.imagesTotal - 1 ? this.imgPosition + 1 : 0;
+		const img = this.images[this.imgPosition];
+
+		gsap.killTweensOf(img.DOM.el);
+		gsap
+			.timeline({
+				onStart: () => this.onImageActivated(),
+				onComplete: () => this.onImageDeactivated()
+			})
+			.fromTo(
+				img.DOM.el,
+				{
+					opacity: 1,
+					scale: 1,
+					zIndex: this.zIndexVal,
+					x: this.cacheMousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.cacheMousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				{
+					duration: 0.4,
+					ease: 'power1',
+					x: this.mousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.mousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				0
+			)
+			.to(
+				img.DOM.el,
+				{
+					duration: 0.4,
+					ease: 'power3',
+					opacity: 0,
+					scale: 0.2
+				},
+				0.4
+			);
+	}
+}
+
+// =============================================================================
+// Variant 2 — Scale-up with brightness burst
+// =============================================================================
+
+export class ImageTrailVariant2 extends BaseVariant {
+	protected showNextImage() {
+		++this.zIndexVal;
+		this.imgPosition = this.imgPosition < this.imagesTotal - 1 ? this.imgPosition + 1 : 0;
+		const img = this.images[this.imgPosition];
+
+		gsap.killTweensOf(img.DOM.el);
+		gsap
+			.timeline({
+				onStart: () => this.onImageActivated(),
+				onComplete: () => this.onImageDeactivated()
+			})
+			.fromTo(
+				img.DOM.el,
+				{
+					opacity: 1,
+					scale: 0,
+					zIndex: this.zIndexVal,
+					x: this.cacheMousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.cacheMousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				{
+					duration: 0.4,
+					ease: 'power1',
+					scale: 1,
+					x: this.mousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.mousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				0
+			)
+			.fromTo(
+				img.DOM.inner,
+				{ scale: 2.8, filter: 'brightness(250%)' },
+				{
+					duration: 0.4,
+					ease: 'power1',
+					scale: 1,
+					filter: 'brightness(100%)'
+				},
+				0
+			)
+			.to(
+				img.DOM.el,
+				{
+					duration: 0.4,
+					ease: 'power2',
+					opacity: 0,
+					scale: 0.2
+				},
+				0.45
+			);
+	}
+}
+
+// =============================================================================
+// Variant 3 — Float-up exit with random x drift
+// =============================================================================
+
+export class ImageTrailVariant3 extends BaseVariant {
+	protected showNextImage() {
+		++this.zIndexVal;
+		this.imgPosition = this.imgPosition < this.imagesTotal - 1 ? this.imgPosition + 1 : 0;
+		const img = this.images[this.imgPosition];
+
+		gsap.killTweensOf(img.DOM.el);
+		gsap
+			.timeline({
+				onStart: () => this.onImageActivated(),
+				onComplete: () => this.onImageDeactivated()
+			})
+			.fromTo(
+				img.DOM.el,
+				{
+					opacity: 1,
+					scale: 0,
+					zIndex: this.zIndexVal,
+					xPercent: 0,
+					yPercent: 0,
+					x: this.cacheMousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.cacheMousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				{
+					duration: 0.4,
+					ease: 'power1',
+					scale: 1,
+					x: this.mousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.mousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				0
+			)
+			.fromTo(
+				img.DOM.inner,
+				{ scale: 1.2 },
+				{
+					duration: 0.4,
+					ease: 'power1',
+					scale: 1
+				},
+				0
+			)
+			.to(
+				img.DOM.el,
+				{
+					duration: 0.6,
+					ease: 'power2',
+					opacity: 0,
+					scale: 0.2,
+					xPercent: () => gsap.utils.random(-30, 30),
+					yPercent: -200
+				},
+				0.6
+			);
+	}
+}
+
+// =============================================================================
+// Variant 4 — Momentum-based drift with brightness/contrast
+// =============================================================================
+
+export class ImageTrailVariant4 extends BaseVariant {
+	protected showNextImage() {
+		++this.zIndexVal;
+		this.imgPosition = this.imgPosition < this.imagesTotal - 1 ? this.imgPosition + 1 : 0;
+		const img = this.images[this.imgPosition];
+		gsap.killTweensOf(img.DOM.el);
+
+		let dx = this.mousePos.x - this.cacheMousePos.x;
+		let dy = this.mousePos.y - this.cacheMousePos.y;
+		const distance = Math.sqrt(dx * dx + dy * dy);
+		if (distance !== 0) {
+			dx /= distance;
+			dy /= distance;
+		}
+		dx *= distance / 100;
+		dy *= distance / 100;
+
+		gsap
+			.timeline({
+				onStart: () => this.onImageActivated(),
+				onComplete: () => this.onImageDeactivated()
+			})
+			.fromTo(
+				img.DOM.el,
+				{
+					opacity: 1,
+					scale: 0,
+					zIndex: this.zIndexVal,
+					x: this.cacheMousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.cacheMousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				{
+					duration: 0.4,
+					ease: 'power1',
+					scale: 1,
+					x: this.mousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.mousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				0
+			)
+			.fromTo(
+				img.DOM.inner,
+				{
+					scale: 2,
+					filter: `brightness(${Math.max((400 * distance) / 100, 100)}%) contrast(${Math.max(
+						(400 * distance) / 100,
+						100
+					)}%)`
+				},
+				{
+					duration: 0.4,
+					ease: 'power1',
+					scale: 1,
+					filter: 'brightness(100%) contrast(100%)'
+				},
+				0
+			)
+			.to(
+				img.DOM.el,
+				{
+					duration: 0.4,
+					ease: 'power3',
+					opacity: 0
+				},
+				0.4
+			)
+			.to(
+				img.DOM.el,
+				{
+					duration: 1.5,
+					ease: 'power4',
+					x: `+=${dx * 110}`,
+					y: `+=${dy * 110}`
+				},
+				0.05
+			);
+	}
+}
+
+// =============================================================================
+// Variant 5 — Rotation + momentum fling
+// =============================================================================
+
+export class ImageTrailVariant5 extends BaseVariant {
+	private lastAngle = 0;
+
+	protected showNextImage() {
+		let dx = this.mousePos.x - this.cacheMousePos.x;
+		let dy = this.mousePos.y - this.cacheMousePos.y;
+		let angle = Math.atan2(dy, dx) * (180 / Math.PI);
+		if (angle < 0) angle += 360;
+		if (angle > 90 && angle <= 270) angle += 180;
+		const isMovingClockwise = angle >= this.lastAngle;
+		this.lastAngle = angle;
+		const startAngle = isMovingClockwise ? angle - 10 : angle + 10;
+		const distance = Math.sqrt(dx * dx + dy * dy);
+		if (distance !== 0) {
+			dx /= distance;
+			dy /= distance;
+		}
+		dx *= distance / 150;
+		dy *= distance / 150;
+
+		++this.zIndexVal;
+		this.imgPosition = this.imgPosition < this.imagesTotal - 1 ? this.imgPosition + 1 : 0;
+		const img = this.images[this.imgPosition];
+		gsap.killTweensOf(img.DOM.el);
+
+		gsap
+			.timeline({
+				onStart: () => this.onImageActivated(),
+				onComplete: () => this.onImageDeactivated()
+			})
+			.fromTo(
+				img.DOM.el,
+				{
+					opacity: 1,
+					filter: 'brightness(80%)',
+					scale: 0.1,
+					zIndex: this.zIndexVal,
+					x: this.cacheMousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.cacheMousePos.y - (img.rect?.height ?? 0) / 2,
+					rotation: startAngle
+				},
+				{
+					duration: 1,
+					ease: 'power2',
+					scale: 1,
+					filter: 'brightness(100%)',
+					x: this.mousePos.x - (img.rect?.width ?? 0) / 2 + dx * 70,
+					y: this.mousePos.y - (img.rect?.height ?? 0) / 2 + dy * 70,
+					rotation: this.lastAngle
+				},
+				0
+			)
+			.to(
+				img.DOM.el,
+				{
+					duration: 0.4,
+					ease: 'expo',
+					opacity: 0
+				},
+				0.5
+			)
+			.to(
+				img.DOM.el,
+				{
+					duration: 1.5,
+					ease: 'power4',
+					x: `+=${dx * 120}`,
+					y: `+=${dy * 120}`
+				},
+				0.05
+			);
+	}
+}
+
+// =============================================================================
+// Variant 6 — Speed-reactive size, blur, grayscale
+// =============================================================================
+
+export class ImageTrailVariant6 extends BaseVariant {
+	protected updateCache() {
+		this.cacheMousePos.x = lerp(this.cacheMousePos.x, this.mousePos.x, 0.3);
+		this.cacheMousePos.y = lerp(this.cacheMousePos.y, this.mousePos.y, 0.3);
+	}
+
+	private mapSpeedToSize(speed: number, minSize: number, maxSize: number) {
+		const maxSpeed = 200;
+		return minSize + (maxSize - minSize) * Math.min(speed / maxSpeed, 1);
+	}
+
+	private mapSpeedToBrightness(speed: number, minB: number, maxB: number) {
+		const maxSpeed = 70;
+		return minB + (maxB - minB) * Math.min(speed / maxSpeed, 1);
+	}
+
+	private mapSpeedToBlur(speed: number, minBlur: number, maxBlur: number) {
+		const maxSpeed = 90;
+		return minBlur + (maxBlur - minBlur) * Math.min(speed / maxSpeed, 1);
+	}
+
+	private mapSpeedToGrayscale(speed: number, minG: number, maxG: number) {
+		const maxSpeed = 90;
+		return minG + (maxG - minG) * Math.min(speed / maxSpeed, 1);
+	}
+
+	protected showNextImage() {
+		const dx = this.mousePos.x - this.cacheMousePos.x;
+		const dy = this.mousePos.y - this.cacheMousePos.y;
+		const speed = Math.sqrt(dx * dx + dy * dy);
+
+		++this.zIndexVal;
+		this.imgPosition = this.imgPosition < this.imagesTotal - 1 ? this.imgPosition + 1 : 0;
+		const img = this.images[this.imgPosition];
+
+		const scaleFactor = this.mapSpeedToSize(speed, 0.3, 2);
+		const brightnessValue = this.mapSpeedToBrightness(speed, 0, 1.3);
+		const blurValue = this.mapSpeedToBlur(speed, 20, 0);
+		const grayscaleValue = this.mapSpeedToGrayscale(speed, 600, 0);
+
+		gsap.killTweensOf(img.DOM.el);
+		gsap
+			.timeline({
+				onStart: () => this.onImageActivated(),
+				onComplete: () => this.onImageDeactivated()
+			})
+			.fromTo(
+				img.DOM.el,
+				{
+					opacity: 1,
+					scale: 0,
+					zIndex: this.zIndexVal,
+					x: this.cacheMousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.cacheMousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				{
+					duration: 0.8,
+					ease: 'power3',
+					scale: scaleFactor,
+					filter: `grayscale(${grayscaleValue * 100}%) brightness(${
+						brightnessValue * 100
+					}%) blur(${blurValue}px)`,
+					x: this.mousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.mousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				0
+			)
+			.fromTo(
+				img.DOM.inner,
+				{ scale: 2 },
+				{
+					duration: 0.8,
+					ease: 'power3',
+					scale: 1
+				},
+				0
+			)
+			.to(
+				img.DOM.el,
+				{
+					duration: 0.4,
+					ease: 'power3.in',
+					opacity: 0,
+					scale: 0.2
+				},
+				0.45
+			);
+	}
+}
+
+// =============================================================================
+// Variant 7 — Stacking trail with visible queue
+// =============================================================================
+
+export class ImageTrailVariant7 extends BaseVariant {
+	private visibleImagesCount: number;
+	private visibleImagesTotal: number;
+
+	constructor(container: HTMLDivElement) {
+		super(container);
+		this.visibleImagesCount = 0;
+		this.visibleImagesTotal = 9;
+		this.visibleImagesTotal = Math.min(this.visibleImagesTotal, this.imagesTotal - 1);
+	}
+
+	protected updateCache() {
+		this.cacheMousePos.x = lerp(this.cacheMousePos.x, this.mousePos.x, 0.3);
+		this.cacheMousePos.y = lerp(this.cacheMousePos.y, this.mousePos.y, 0.3);
+	}
+
+	protected showNextImage() {
+		++this.zIndexVal;
+		this.imgPosition = this.imgPosition < this.imagesTotal - 1 ? this.imgPosition + 1 : 0;
+		const img = this.images[this.imgPosition];
+		++this.visibleImagesCount;
+
+		gsap.killTweensOf(img.DOM.el);
+		const scaleValue = gsap.utils.random(0.5, 1.6);
+
+		gsap
+			.timeline({
+				onStart: () => this.onImageActivated(),
+				onComplete: () => this.onImageDeactivated()
+			})
+			.fromTo(
+				img.DOM.el,
+				{
+					scale: scaleValue - Math.max(gsap.utils.random(0.2, 0.6), 0),
+					rotationZ: 0,
+					opacity: 1,
+					zIndex: this.zIndexVal,
+					x: this.cacheMousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.cacheMousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				{
+					duration: 0.4,
+					ease: 'power3',
+					scale: scaleValue,
+					rotationZ: gsap.utils.random(-3, 3),
+					x: this.mousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.mousePos.y - (img.rect?.height ?? 0) / 2
+				},
+				0
+			);
+
+		if (this.visibleImagesCount >= this.visibleImagesTotal) {
+			const lastInQueue = getNewPosition(this.imgPosition, this.visibleImagesTotal, this.images);
+			const oldImg = this.images[lastInQueue];
+			gsap.to(oldImg.DOM.el, {
+				duration: 0.4,
+				ease: 'power4',
+				opacity: 0,
+				scale: 1.3,
+				onComplete: () => {
+					if (this.activeImagesCount === 0) {
+						this.isIdle = true;
+					}
+				}
+			});
+		}
+	}
+}
+
+// =============================================================================
+// Variant 8 — 3D perspective based on cursor position
+// =============================================================================
+
+export class ImageTrailVariant8 extends BaseVariant {
+	private rotation: { x: number; y: number };
+	private cachedRotation: { x: number; y: number };
+	private zValue: number;
+	private cachedZValue: number;
+
+	constructor(container: HTMLDivElement) {
+		super(container);
+		this.rotation = { x: 0, y: 0 };
+		this.cachedRotation = { x: 0, y: 0 };
+		this.zValue = 0;
+		this.cachedZValue = 0;
+	}
+
+	protected showNextImage() {
+		const rect = this.container.getBoundingClientRect();
+		const centerX = rect.width / 2;
+		const centerY = rect.height / 2;
+		const relX = this.mousePos.x - centerX;
+		const relY = this.mousePos.y - centerY;
+
+		this.rotation.x = -(relY / centerY) * 30;
+		this.rotation.y = (relX / centerX) * 30;
+		this.cachedRotation = { ...this.rotation };
+
+		const distanceFromCenter = Math.sqrt(relX * relX + relY * relY);
+		const maxDistance = Math.sqrt(centerX * centerX + centerY * centerY);
+		const proportion = distanceFromCenter / maxDistance;
+		this.zValue = proportion * 1200 - 600;
+		this.cachedZValue = this.zValue;
+		const normalizedZ = (this.zValue + 600) / 1200;
+		const brightness = 0.2 + normalizedZ * 2.3;
+
+		++this.zIndexVal;
+		this.imgPosition = this.imgPosition < this.imagesTotal - 1 ? this.imgPosition + 1 : 0;
+		const img = this.images[this.imgPosition];
+		gsap.killTweensOf(img.DOM.el);
+
+		gsap
+			.timeline({
+				onStart: () => this.onImageActivated(),
+				onComplete: () => this.onImageDeactivated()
+			})
+			.set(this.DOM.el, { perspective: 1000 }, 0)
+			.fromTo(
+				img.DOM.el,
+				{
+					opacity: 1,
+					z: 0,
+					scale: 1 + this.cachedZValue / 1000,
+					zIndex: this.zIndexVal,
+					x: this.cacheMousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.cacheMousePos.y - (img.rect?.height ?? 0) / 2,
+					rotationX: this.cachedRotation.x,
+					rotationY: this.cachedRotation.y,
+					filter: `brightness(${brightness})`
+				},
+				{
+					duration: 1,
+					ease: 'expo',
+					scale: 1 + this.zValue / 1000,
+					x: this.mousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.mousePos.y - (img.rect?.height ?? 0) / 2,
+					rotationX: this.rotation.x,
+					rotationY: this.rotation.y
+				},
+				0
+			)
+			.to(
+				img.DOM.el,
+				{
+					duration: 0.4,
+					ease: 'power2',
+					opacity: 0,
+					z: -800
+				},
+				0.3
+			);
+	}
+}
+
+// =============================================================================
+// Variant Map
+// =============================================================================
+
+export const variantMap: Record<VariantType, new (container: HTMLDivElement) => ImageTrailVariant> =
+	{
+		type1: ImageTrailVariant1,
+		type2: ImageTrailVariant2,
+		type3: ImageTrailVariant3,
+		type4: ImageTrailVariant4,
+		type5: ImageTrailVariant5,
+		type6: ImageTrailVariant6,
+		type7: ImageTrailVariant7,
+		type8: ImageTrailVariant8
+	};

--- a/src/lib/inspira/index.ts
+++ b/src/lib/inspira/index.ts
@@ -11,6 +11,7 @@ export * from './blur-reveal/index.js';
 export * from './bg-stars/index.js';
 export * from './border-beam/index.js';
 export * from './compare/index.js';
+export * from './image-trail-cursor/index.js';
 export * from './direction-aware-hover/index.js';
 export * from './rainbow-button/index.js';
 export * from './ripple-button/index.js';

--- a/src/lib/inspira/registry.ts
+++ b/src/lib/inspira/registry.ts
@@ -114,6 +114,14 @@ export const registry: Record<string, ComponentMeta> = {
 		status: 'done'
 	},
 
+	'image-trail-cursor': {
+		name: 'ImageTrailCursor',
+		slug: 'image-trail-cursor',
+		description: 'Cursor-following image trail with 8 animation variants',
+		category: 'effects',
+		status: 'done'
+	},
+
 	'direction-aware-hover': {
 		name: 'DirectionAwareHover',
 		slug: 'direction-aware-hover',

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -55,6 +55,12 @@
 			status: 'done' as const
 		},
 		{
+			name: 'ImageTrailCursor',
+			href: '/demo/image-trail-cursor',
+			description: 'Cursor-following image trail with 8 animation variants',
+			status: 'done' as const
+		},
+		{
 			name: 'GlowBorder',
 			href: '/demo/glow-border',
 			description: 'Animated glowing border effect with gradient support',

--- a/src/routes/demo/image-trail-cursor/+page.svelte
+++ b/src/routes/demo/image-trail-cursor/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { ImageTrailCursor } from '$lib/inspira/image-trail-cursor';
+	import type { VariantType } from '$lib/inspira/image-trail-cursor';
+
+	const images = [
+		'https://picsum.photos/seed/trail1/400/440',
+		'https://picsum.photos/seed/trail2/400/440',
+		'https://picsum.photos/seed/trail3/400/440',
+		'https://picsum.photos/seed/trail4/400/440',
+		'https://picsum.photos/seed/trail5/400/440',
+		'https://picsum.photos/seed/trail6/400/440',
+		'https://picsum.photos/seed/trail7/400/440',
+		'https://picsum.photos/seed/trail8/400/440',
+		'https://picsum.photos/seed/trail9/400/440',
+		'https://picsum.photos/seed/trail10/400/440'
+	];
+
+	const variants: { type: VariantType; label: string; description: string }[] = [
+		{ type: 'type1', label: 'Type 1', description: 'Fade & scale' },
+		{ type: 'type2', label: 'Type 2', description: 'Brightness burst' },
+		{ type: 'type3', label: 'Type 3', description: 'Float-up exit' },
+		{ type: 'type4', label: 'Type 4', description: 'Momentum drift' },
+		{ type: 'type5', label: 'Type 5', description: 'Rotation fling' },
+		{ type: 'type6', label: 'Type 6', description: 'Speed-reactive' },
+		{ type: 'type7', label: 'Type 7', description: 'Stacking trail' },
+		{ type: 'type8', label: 'Type 8', description: '3D perspective' }
+	];
+
+	let selectedVariant: VariantType = $state('type1');
+</script>
+
+<svelte:head>
+	<title>ImageTrailCursor - Inspira Svelte</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl py-12 px-4">
+	<div class="mb-8">
+		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
+	</div>
+
+	<h1 class="text-3xl font-bold mb-2">ImageTrailCursor</h1>
+	<p class="text-muted-foreground mb-8">
+		Cursor-following image trail with 8 animation variants. Move your cursor inside the area below.
+	</p>
+
+	<!-- Variant Selector -->
+	<section class="mb-6">
+		<h2 class="text-xl font-semibold mb-4">Variant</h2>
+		<div class="flex flex-wrap gap-2">
+			{#each variants as v}
+				<button
+					class="rounded-lg border px-3 py-2 text-sm transition-colors {selectedVariant === v.type
+						? 'border-primary bg-primary text-primary-foreground'
+						: 'border-border bg-card hover:bg-accent'}"
+					onclick={() => (selectedVariant = v.type)}
+				>
+					<span class="font-medium">{v.label}</span>
+					<span class="ml-1 text-xs opacity-70">{v.description}</span>
+				</button>
+			{/each}
+		</div>
+	</section>
+
+	<!-- Interactive Area -->
+	<section class="mb-12">
+		<div class="relative rounded-lg border bg-card overflow-hidden h-[500px] cursor-crosshair">
+			<ImageTrailCursor {images} variant={selectedVariant} />
+			<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+				<p class="text-muted-foreground/50 text-lg select-none">Move your cursor here</p>
+			</div>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Add `ImageTrailCursor` component that displays a trail of images following the cursor
- Includes multiple trail variants (spring, fade, scatter, etc.)
- Adds demo page at `/demo/image-trail-cursor`

## Test plan
- [ ] Verify cursor trail renders on mouse move
- [ ] Test different trail variants
- [ ] Check cleanup on unmount
- [ ] Verify responsive behavior