### PR TITLE
feat: add component InteractiveGridPattern

### DIFF
--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -13,6 +13,7 @@ export * from './bg-stars/index.js';
 export * from './border-beam/index.js';
 export * from './compare/index.js';
 export * from './image-trail-cursor/index.js';
+export * from './interactive-grid-pattern/index.js';
 export * from './logo-cloud/index.js';
 export * from './direction-aware-hover/index.js';
 export * from './rainbow-button/index.js';

--- a/src/lib/fancy-ui/interactive-grid-pattern/InteractiveGridPattern.svelte
+++ b/src/lib/fancy-ui/interactive-grid-pattern/InteractiveGridPattern.svelte
@@ -1,0 +1,71 @@
+<script lang="ts" module>
+	export interface InteractiveGridPatternProps {
+		/** Additional CSS classes for the SVG container */
+		class?: string;
+		/** Additional CSS classes for individual squares */
+		squaresClassName?: string;
+		/** Width of each square in pixels */
+		width?: number;
+		/** Height of each square in pixels */
+		height?: number;
+		/** Grid dimensions [columns, rows] */
+		squares?: [number, number];
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let {
+		class: className,
+		squaresClassName,
+		width = 40,
+		height = 40,
+		squares = [24, 24] as [number, number]
+	}: InteractiveGridPatternProps = $props();
+
+	let hoveredSquare: number | null = $state(null);
+
+	const cols = $derived(squares[0]);
+	const rows = $derived(squares[1]);
+	const totalSquares = $derived(cols * rows);
+	const gridWidth = $derived(width * cols);
+	const gridHeight = $derived(height * rows);
+
+	function getX(index: number) {
+		return (index % cols) * width;
+	}
+
+	function getY(index: number) {
+		return Math.floor(index / cols) * height;
+	}
+</script>
+
+<svg
+	width={gridWidth}
+	height={gridHeight}
+	class={cn('absolute inset-0 h-full w-full border border-gray-400/30', className)}
+>
+	{#each { length: totalSquares } as _, index}
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<rect
+			x={getX(index)}
+			y={getY(index)}
+			{width}
+			{height}
+			class={cn(
+				'interactive-grid-square stroke-gray-400/30 transition-all duration-100 ease-in-out',
+				hoveredSquare === index ? 'fill-gray-300/30' : 'fill-transparent',
+				squaresClassName
+			)}
+			onmouseenter={() => (hoveredSquare = index)}
+			onmouseleave={() => (hoveredSquare = null)}
+		/>
+	{/each}
+</svg>
+
+<style>
+	.interactive-grid-square:not(:hover) {
+		transition-duration: 1000ms;
+	}
+</style>

--- a/src/lib/fancy-ui/interactive-grid-pattern/README.md
+++ b/src/lib/fancy-ui/interactive-grid-pattern/README.md
@@ -1,0 +1,31 @@
+# InteractiveGridPattern
+
+SVG grid of squares that highlight on hover with smooth fade transitions.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { InteractiveGridPattern } from '$lib/fancy-ui/interactive-grid-pattern';
+</script>
+
+<div class="relative h-96 w-full overflow-hidden">
+  <InteractiveGridPattern />
+</div>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `class` | `string` | - | Classes on the SVG container |
+| `squaresClassName` | `string` | - | Classes on individual rect elements |
+| `width` | `number` | `40` | Square width in pixels |
+| `height` | `number` | `40` | Square height in pixels |
+| `squares` | `[number, number]` | `[24, 24]` | Grid dimensions `[columns, rows]` |
+
+## Porting Notes
+
+- Vue source: `vendor/inspira/ui/interactive-grid-pattern/InteractiveGridPattern.vue`
+- Uses `$state` for hover tracking, Svelte 5 `onmouseenter`/`onmouseleave` handlers
+- CSS transition: 100ms on hover-in, 1000ms on hover-out via `:not(:hover)` selector

--- a/src/lib/fancy-ui/interactive-grid-pattern/index.ts
+++ b/src/lib/fancy-ui/interactive-grid-pattern/index.ts
@@ -1,0 +1,5 @@
+import InteractiveGridPattern, {
+	type InteractiveGridPatternProps
+} from './InteractiveGridPattern.svelte';
+
+export { InteractiveGridPattern, type InteractiveGridPatternProps };

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -130,6 +130,14 @@ export const registry: Record<string, ComponentMeta> = {
 		status: 'done'
 	},
 
+	'interactive-grid-pattern': {
+		name: 'InteractiveGridPattern',
+		slug: 'interactive-grid-pattern',
+		description: 'SVG grid of squares that highlight on hover with smooth fade transitions',
+		category: 'effects',
+		status: 'done'
+	},
+
 	'logo-cloud': {
 		name: 'LogoCloud',
 		slug: 'logo-cloud',

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -67,6 +67,12 @@
 			status: 'done' as const
 		},
 		{
+			name: 'InteractiveGridPattern',
+			href: '/demo/interactive-grid-pattern',
+			description: 'SVG grid of squares that highlight on hover with smooth fade transitions',
+			status: 'done' as const
+		},
+		{
 			name: 'LogoCloud',
 			href: '/demo/logo-cloud',
 			description: 'Logo display with animated marquee, static grid, and icon variants',

--- a/src/routes/demo/interactive-grid-pattern/+page.svelte
+++ b/src/routes/demo/interactive-grid-pattern/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { InteractiveGridPattern } from '$lib/fancy-ui/interactive-grid-pattern';
+</script>
+
+<svelte:head>
+	<title>InteractiveGridPattern - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl py-12 px-4">
+	<div class="mb-8">
+		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
+	</div>
+
+	<h1 class="text-3xl font-bold mb-2">InteractiveGridPattern</h1>
+	<p class="text-muted-foreground mb-8">
+		An SVG grid of squares that highlight on hover with a smooth fade-out transition.
+		Useful as an interactive background effect.
+	</p>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Default 24x24 grid with 40px squares. Hover over the grid to see the highlight effect.
+		</p>
+		<div class="rounded-lg border p-0 overflow-hidden">
+			<div class="relative flex h-96 w-full items-center justify-center overflow-hidden bg-neutral-950">
+				<InteractiveGridPattern
+					class="[mask-image:radial-gradient(400px_circle_at_center,white,transparent)]"
+				/>
+				<p class="z-10 text-lg font-medium text-neutral-400">Hover over the grid</p>
+			</div>
+		</div>
+	</section>
+
+	<!-- Colored Variant -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Colored Variant</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Customize square size and hover color via
+			<code class="rounded bg-muted px-1.5 py-0.5">squaresClassName</code>.
+		</p>
+		<div class="rounded-lg border p-0 overflow-hidden">
+			<div class="relative flex h-96 w-full items-center justify-center overflow-hidden bg-neutral-950">
+				<InteractiveGridPattern
+					width={30}
+					height={30}
+					squares={[30, 20]}
+					squaresClassName="hover:fill-blue-500/30"
+					class="[mask-image:radial-gradient(350px_circle_at_center,white,transparent)]"
+				/>
+				<p class="z-10 text-lg font-medium text-neutral-400">Blue hover effect</p>
+			</div>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Port `InteractiveGridPattern` from Vue (`vendor/inspira/ui/interactive-grid-pattern/`) to Svelte 5
- SVG grid of squares that highlight on hover with 100ms fade-in / 1000ms fade-out transitions
- Demo page with basic usage (radial mask, dark background) and colored variant (blue hover, smaller squares)

## Test plan
- [ ] `pnpm check` passes with no errors
- [ ] Visit `/demo/interactive-grid-pattern` — grid renders and squares highlight on hover
- [ ] Verify smooth fade-out transition (1s) when leaving a square
- [ ] Colored variant shows blue highlight with smaller 30px squares
- [ ] Component listed on `/demo` index page