### PR TITLE
feat: add component LogoCloud

### DIFF
--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -13,6 +13,7 @@ export * from './bg-stars/index.js';
 export * from './border-beam/index.js';
 export * from './compare/index.js';
 export * from './image-trail-cursor/index.js';
+export * from './logo-cloud/index.js';
 export * from './direction-aware-hover/index.js';
 export * from './rainbow-button/index.js';
 export * from './ripple-button/index.js';

--- a/src/lib/fancy-ui/logo-cloud/AnimatedLogoCloud.svelte
+++ b/src/lib/fancy-ui/logo-cloud/AnimatedLogoCloud.svelte
@@ -1,0 +1,64 @@
+<script lang="ts" module>
+	export interface Logo {
+		name: string;
+		path: string;
+	}
+
+	export interface AnimatedLogoCloudProps {
+		/** Additional CSS classes for the scrolling container */
+		class?: string;
+		/** Optional title displayed above the logos */
+		title?: string;
+		/** Array of logos with name and image path */
+		logos?: Logo[];
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let { class: className, title, logos = [] }: AnimatedLogoCloudProps = $props();
+</script>
+
+<div class="w-full py-12">
+	<div class="mx-auto w-full px-4 md:px-8">
+		{#if title}
+			<div class="text-center font-medium text-muted-foreground">
+				{title}
+			</div>
+		{/if}
+		<div
+			class={cn(
+				'logo-cloud-mask group relative mt-6 flex gap-6 overflow-hidden p-2',
+				className
+			)}
+		>
+			{#each { length: 5 } as _}
+				<div class="logo-cloud-scroll flex shrink-0 flex-row justify-around gap-6">
+					{#each logos as logo}
+						<img src={logo.path} alt={logo.name} class="h-10 w-28 px-2 brightness-0 dark:invert" />
+					{/each}
+				</div>
+			{/each}
+		</div>
+	</div>
+</div>
+
+<style>
+	.logo-cloud-mask {
+		mask-image: linear-gradient(to left, transparent 0%, black 20%, black 80%, transparent 95%);
+	}
+
+	.logo-cloud-scroll {
+		animation: logo-cloud-scroll 30s linear infinite;
+	}
+
+	@keyframes logo-cloud-scroll {
+		0% {
+			transform: translateX(0);
+		}
+		100% {
+			transform: translateX(calc(-100% - 1.5rem));
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/logo-cloud/IconLogoCloud.svelte
+++ b/src/lib/fancy-ui/logo-cloud/IconLogoCloud.svelte
@@ -1,0 +1,31 @@
+<script lang="ts" module>
+	export interface IconLogoCloudProps {
+		/** Additional CSS classes for the grid container */
+		class?: string;
+		/** Optional title displayed above the logos */
+		title?: string;
+		/** Array of logos with name and image path */
+		logos?: import('./AnimatedLogoCloud.svelte').Logo[];
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let { class: className, title, logos = [] }: IconLogoCloudProps = $props();
+</script>
+
+<div class="w-full py-12">
+	<div class="flex w-full flex-col items-center justify-center gap-6 px-4 md:px-8">
+		{#if title}
+			<div class="font-medium text-muted-foreground">
+				{title}
+			</div>
+		{/if}
+		<div class={cn('grid grid-cols-3 md:grid-cols-8 lg:grid-cols-8', className)}>
+			{#each logos as logo}
+				<img src={logo.path} alt={logo.name} class="h-7 w-12 px-2 brightness-0 dark:invert" />
+			{/each}
+		</div>
+	</div>
+</div>

--- a/src/lib/fancy-ui/logo-cloud/README.md
+++ b/src/lib/fancy-ui/logo-cloud/README.md
@@ -1,0 +1,42 @@
+# LogoCloud
+
+Logo display components in three variants: animated marquee, static grid, and compact icon grid.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { AnimatedLogoCloud, StaticLogoCloud, IconLogoCloud } from '$lib/fancy-ui/logo-cloud';
+
+  const logos = [
+    { name: 'Vercel', path: '/logos/vercel.svg' },
+    { name: 'Next.js', path: '/logos/nextjs.svg' },
+  ];
+</script>
+
+<AnimatedLogoCloud title="Trusted by" {logos} />
+<StaticLogoCloud title="Our Partners" {logos} />
+<IconLogoCloud title="Built with" {logos} />
+```
+
+## Variants
+
+| Component | Description |
+|-----------|-------------|
+| `AnimatedLogoCloud` | Infinite horizontal scroll with fade mask |
+| `StaticLogoCloud` | Responsive grid layout |
+| `IconLogoCloud` | Compact icon-sized grid |
+
+## Props (shared)
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `class` | `string` | - | Classes on the container |
+| `title` | `string` | - | Optional heading text |
+| `logos` | `Logo[]` | `[]` | Array of `{ name, path }` objects |
+
+## Porting Notes
+
+- Vue source: `vendor/inspira/ui/logo-cloud/`
+- Images use `brightness-0 dark:invert` for monochrome display that adapts to theme
+- Animated variant duplicates logos 5x for seamless infinite scroll

--- a/src/lib/fancy-ui/logo-cloud/StaticLogoCloud.svelte
+++ b/src/lib/fancy-ui/logo-cloud/StaticLogoCloud.svelte
@@ -1,0 +1,31 @@
+<script lang="ts" module>
+	export interface StaticLogoCloudProps {
+		/** Additional CSS classes for the grid container */
+		class?: string;
+		/** Optional title displayed above the logos */
+		title?: string;
+		/** Array of logos with name and image path */
+		logos?: import('./AnimatedLogoCloud.svelte').Logo[];
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let { class: className, title, logos = [] }: StaticLogoCloudProps = $props();
+</script>
+
+<div class="w-full py-12">
+	<div class="flex w-full flex-col items-center justify-center gap-4 px-4 md:px-8">
+		{#if title}
+			<div class="font-medium uppercase text-muted-foreground">
+				{title}
+			</div>
+		{/if}
+		<div class={cn('grid grid-cols-3 gap-x-4 md:grid-cols-5 lg:grid-cols-8', className)}>
+			{#each logos as logo}
+				<img src={logo.path} alt={logo.name} class="h-10 w-28 px-2 brightness-0 dark:invert" />
+			{/each}
+		</div>
+	</div>
+</div>

--- a/src/lib/fancy-ui/logo-cloud/index.ts
+++ b/src/lib/fancy-ui/logo-cloud/index.ts
@@ -1,0 +1,13 @@
+import AnimatedLogoCloud, { type AnimatedLogoCloudProps, type Logo } from './AnimatedLogoCloud.svelte';
+import StaticLogoCloud, { type StaticLogoCloudProps } from './StaticLogoCloud.svelte';
+import IconLogoCloud, { type IconLogoCloudProps } from './IconLogoCloud.svelte';
+
+export {
+	AnimatedLogoCloud,
+	StaticLogoCloud,
+	IconLogoCloud,
+	type AnimatedLogoCloudProps,
+	type StaticLogoCloudProps,
+	type IconLogoCloudProps,
+	type Logo
+};

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -130,6 +130,14 @@ export const registry: Record<string, ComponentMeta> = {
 		status: 'done'
 	},
 
+	'logo-cloud': {
+		name: 'LogoCloud',
+		slug: 'logo-cloud',
+		description: 'Logo display with animated marquee, static grid, and icon variants',
+		category: 'data-display',
+		status: 'done'
+	},
+
 	'direction-aware-hover': {
 		name: 'DirectionAwareHover',
 		slug: 'direction-aware-hover',

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -67,6 +67,12 @@
 			status: 'done' as const
 		},
 		{
+			name: 'LogoCloud',
+			href: '/demo/logo-cloud',
+			description: 'Logo display with animated marquee, static grid, and icon variants',
+			status: 'done' as const
+		},
+		{
 			name: 'GlowBorder',
 			href: '/demo/glow-border',
 			description: 'Animated glowing border effect with gradient support',

--- a/src/routes/demo/logo-cloud/+page.svelte
+++ b/src/routes/demo/logo-cloud/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { AnimatedLogoCloud, StaticLogoCloud, IconLogoCloud } from '$lib/fancy-ui/logo-cloud';
+
+	const logos = [
+		{ name: 'Vercel', path: 'https://svgl.app/library/vercel_wordmark.svg' },
+		{ name: 'Next.js', path: 'https://svgl.app/library/nextjs_icon_dark.svg' },
+		{ name: 'Supabase', path: 'https://svgl.app/library/supabase_wordmark.svg' },
+		{ name: 'Tailwind CSS', path: 'https://svgl.app/library/tailwindcss.svg' },
+		{ name: 'Prisma', path: 'https://svgl.app/library/prisma.svg' },
+		{ name: 'TypeScript', path: 'https://svgl.app/library/typescript.svg' },
+		{ name: 'Stripe', path: 'https://svgl.app/library/stripe_wordmark.svg' },
+		{ name: 'Svelte', path: 'https://svgl.app/library/svelte.svg' }
+	];
+</script>
+
+<svelte:head>
+	<title>LogoCloud - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl py-12 px-4">
+	<div class="mb-8">
+		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground"
+			>&larr; Back to components</a
+		>
+	</div>
+
+	<h1 class="text-3xl font-bold mb-2">LogoCloud</h1>
+	<p class="text-muted-foreground mb-8">
+		Logo display components in three variants: animated infinite scroll, static grid, and compact
+		icon grid. Logos automatically adapt to light/dark theme.
+	</p>
+
+	<!-- Animated -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Animated (Marquee)</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Infinite horizontal scroll with edge fade mask. Logos are duplicated 5x for seamless
+			looping.
+		</p>
+		<div class="rounded-lg border bg-card overflow-hidden">
+			<AnimatedLogoCloud title="Trusted by the best" {logos} />
+		</div>
+	</section>
+
+	<!-- Static Grid -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Static Grid</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Responsive grid layout. 3 columns on mobile, 5 on tablet, 8 on desktop.
+		</p>
+		<div class="rounded-lg border bg-card overflow-hidden">
+			<StaticLogoCloud title="Our partners" {logos} />
+		</div>
+	</section>
+
+	<!-- Icon Grid -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Icon Grid</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Compact variant with smaller logos, suited for tooling or tech stack displays.
+		</p>
+		<div class="rounded-lg border bg-card overflow-hidden">
+			<IconLogoCloud title="Built with" {logos} />
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Port `LogoCloud` from Vue (`vendor/inspira/ui/logo-cloud/`) to Svelte 5
- Three variants: `AnimatedLogoCloud` (infinite marquee scroll), `StaticLogoCloud` (responsive grid), `IconLogoCloud` (compact icon grid)
- All share the same `Logo` type (`{ name, path }`) and support `class` / `title` props
- Logos use `brightness-0 dark:invert` for automatic light/dark theme adaptation

## Test plan
- [ ] `pnpm check` passes with no errors
- [ ] Visit `/demo/logo-cloud` — all three variants render
- [ ] Animated variant scrolls infinitely with edge fade mask
- [ ] Static and icon grids are responsive across breakpoints
- [ ] Logos adapt to dark/light theme