### PR TITLE
feat: add ShimmerButton component

### DIFF
--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -17,6 +17,7 @@ export * from './logo-cloud/index.js';
 export * from './direction-aware-hover/index.js';
 export * from './rainbow-button/index.js';
 export * from './ripple-button/index.js';
+export * from './shimmer-button/index.js';
 export * from './timeline/index.js';
 
 // =============================================================================

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -162,6 +162,14 @@ export const registry: Record<string, ComponentMeta> = {
 		status: 'done'
 	},
 
+	'shimmer-button': {
+		name: 'ShimmerButton',
+		slug: 'shimmer-button',
+		description: 'Button with a rotating conic-gradient shimmer border effect',
+		category: 'buttons',
+		status: 'done'
+	},
+
 	timeline: {
 		name: 'Timeline',
 		slug: 'timeline',

--- a/src/lib/fancy-ui/shimmer-button/README.md
+++ b/src/lib/fancy-ui/shimmer-button/README.md
@@ -1,0 +1,10 @@
+# ShimmerButton
+
+## Changes from Vue version
+
+- Pure CSS animation, no JS state needed
+- Props use `$props()` with Svelte 5 syntax
+- Scoped keyframes (`shimmer-slide`, `spin-around`) via `<style>` block
+- CSS variables set via inline `style` attribute
+- Uses `{@render children?.()}` for slot content
+- Spreads `...restProps` for native button attributes

--- a/src/lib/fancy-ui/shimmer-button/ShimmerButton.svelte
+++ b/src/lib/fancy-ui/shimmer-button/ShimmerButton.svelte
@@ -1,0 +1,111 @@
+<script lang="ts" module>
+	import type { Snippet } from 'svelte';
+	import type { HTMLButtonAttributes } from 'svelte/elements';
+
+	type BaseProps = {
+		/** Shimmer highlight color */
+		shimmerColor?: string;
+		/** Thickness of the shimmer border */
+		shimmerSize?: string;
+		/** Button border radius */
+		borderRadius?: string;
+		/** Duration of the shimmer animation cycle */
+		shimmerDuration?: string;
+		/** Button background color */
+		background?: string;
+		/** Custom CSS class */
+		class?: string;
+		/** Button content */
+		children?: Snippet;
+	};
+
+	export type ShimmerButtonProps = BaseProps & Omit<HTMLButtonAttributes, keyof BaseProps>;
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let {
+		class: className,
+		shimmerColor = '#ffffff',
+		shimmerSize = '0.05em',
+		borderRadius = '100px',
+		shimmerDuration = '3s',
+		background = 'rgba(0, 0, 0, 1)',
+		children,
+		...restProps
+	}: ShimmerButtonProps = $props();
+
+	const styleVars = $derived(
+		`--spread: 90deg; --shimmer-color: ${shimmerColor}; --radius: ${borderRadius}; --speed: ${shimmerDuration}; --cut: ${shimmerSize}; --bg: ${background}`
+	);
+</script>
+
+<button
+	class={cn(
+		'shimmer-button group relative z-0 flex cursor-pointer items-center justify-center overflow-hidden whitespace-nowrap border border-white/10 px-6 py-3 text-white [background:var(--bg)] [border-radius:var(--radius)] dark:text-black',
+		'transform-gpu transition-transform duration-300 ease-in-out active:translate-y-px',
+		className
+	)}
+	style={styleVars}
+	{...restProps}
+>
+	<!-- Shimmer layer -->
+	<div class="-z-30 absolute inset-0 overflow-visible blur-[2px] [container-type:size]">
+		<div class="shimmer-slide absolute inset-0 h-[100cqh] [aspect-ratio:1] [border-radius:0] [mask:none]">
+			<div
+				class="spin-around absolute -inset-full w-auto rotate-0 [background:conic-gradient(from_calc(270deg-(var(--spread)*0.5)),transparent_0,var(--shimmer-color)_var(--spread),transparent_var(--spread))] [translate:0_0]"
+			></div>
+		</div>
+	</div>
+
+	<!-- Content -->
+	{@render children?.()}
+
+	<!-- Inner shadow overlay -->
+	<div
+		class={cn(
+			'insert-0 absolute size-full',
+			'rounded-2xl px-4 py-1.5 text-sm font-medium shadow-[inset_0_-8px_10px_#ffffff1f]',
+			'transform-gpu transition-all duration-300 ease-in-out',
+			'group-hover:shadow-[inset_0_-6px_10px_#ffffff3f]',
+			'group-active:shadow-[inset_0_-10px_10px_#ffffff3f]'
+		)}
+	></div>
+
+	<!-- Background fill -->
+	<div class="absolute -z-20 [background:var(--bg)] [border-radius:var(--radius)] [inset:var(--cut)]"></div>
+</button>
+
+<style>
+	@keyframes shimmer-slide {
+		to {
+			transform: translate(calc(100cqw - 100%), 0);
+		}
+	}
+
+	@keyframes spin-around {
+		0% {
+			transform: translateZ(0) rotate(0);
+		}
+		15%,
+		35% {
+			transform: translateZ(0) rotate(90deg);
+		}
+		65%,
+		85% {
+			transform: translateZ(0) rotate(270deg);
+		}
+		100% {
+			transform: translateZ(0) rotate(360deg);
+		}
+	}
+
+	.shimmer-slide {
+		animation: shimmer-slide var(--speed) ease-in-out infinite alternate;
+	}
+
+	.spin-around {
+		animation: spin-around calc(var(--speed) * 2) infinite linear;
+	}
+</style>

--- a/src/lib/fancy-ui/shimmer-button/index.ts
+++ b/src/lib/fancy-ui/shimmer-button/index.ts
@@ -1,0 +1,3 @@
+import ShimmerButton, { type ShimmerButtonProps } from './ShimmerButton.svelte';
+
+export { ShimmerButton, type ShimmerButtonProps };

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -97,6 +97,12 @@
 			status: 'done' as const
 		},
 		{
+			name: 'ShimmerButton',
+			href: '/demo/shimmer-button',
+			description: 'Button with a rotating conic-gradient shimmer border effect',
+			status: 'done' as const
+		},
+		{
 			name: 'Timeline',
 			href: '/demo/timeline',
 			description: 'Vertical timeline with scroll-driven progress line and sticky labels',

--- a/src/routes/demo/shimmer-button/+page.svelte
+++ b/src/routes/demo/shimmer-button/+page.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	import { ShimmerButton } from '$lib/fancy-ui/shimmer-button';
+</script>
+
+<svelte:head>
+	<title>ShimmerButton - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl py-12 px-4">
+	<div class="mb-8">
+		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
+	</div>
+
+	<h1 class="text-3xl font-bold mb-2">ShimmerButton</h1>
+	<p class="text-muted-foreground mb-8">
+		A button with a rotating conic-gradient shimmer effect around its border.
+	</p>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="rounded-lg border bg-card p-6 flex justify-center">
+			<ShimmerButton>Shimmer</ShimmerButton>
+		</div>
+	</section>
+
+	<!-- Shimmer Colors -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Shimmer Colors</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Change the shimmer highlight with the <code class="rounded bg-muted px-1.5 py-0.5">shimmerColor</code> prop.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap justify-center gap-4">
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton shimmerColor="#ffffff">White</ShimmerButton>
+				<span class="text-xs text-muted-foreground">#ffffff</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton shimmerColor="#60a5fa">Blue</ShimmerButton>
+				<span class="text-xs text-muted-foreground">#60a5fa</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton shimmerColor="#f472b6">Pink</ShimmerButton>
+				<span class="text-xs text-muted-foreground">#f472b6</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton shimmerColor="#4ade80">Green</ShimmerButton>
+				<span class="text-xs text-muted-foreground">#4ade80</span>
+			</div>
+		</div>
+	</section>
+
+	<!-- Animation Speed -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Animation Speed</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Control the shimmer speed with the <code class="rounded bg-muted px-1.5 py-0.5">shimmerDuration</code> prop.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap justify-center gap-4">
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton shimmerDuration="1.5s">Fast (1.5s)</ShimmerButton>
+				<span class="text-xs text-muted-foreground">shimmerDuration="1.5s"</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton shimmerDuration="3s">Default (3s)</ShimmerButton>
+				<span class="text-xs text-muted-foreground">shimmerDuration="3s"</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton shimmerDuration="6s">Slow (6s)</ShimmerButton>
+				<span class="text-xs text-muted-foreground">shimmerDuration="6s"</span>
+			</div>
+		</div>
+	</section>
+
+	<!-- Shimmer Size -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Shimmer Size</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Adjust the border thickness with the <code class="rounded bg-muted px-1.5 py-0.5">shimmerSize</code> prop.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap justify-center gap-4">
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton shimmerSize="0.03em">Thin</ShimmerButton>
+				<span class="text-xs text-muted-foreground">0.03em</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton shimmerSize="0.05em">Default</ShimmerButton>
+				<span class="text-xs text-muted-foreground">0.05em</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton shimmerSize="0.1em">Thick</ShimmerButton>
+				<span class="text-xs text-muted-foreground">0.1em</span>
+			</div>
+		</div>
+	</section>
+
+	<!-- Custom Background -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Background</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Set a custom background with the <code class="rounded bg-muted px-1.5 py-0.5">background</code> prop.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap justify-center gap-4">
+			<ShimmerButton background="rgba(59, 130, 246, 0.8)" shimmerColor="#93c5fd">
+				Blue
+			</ShimmerButton>
+			<ShimmerButton background="rgba(139, 92, 246, 0.8)" shimmerColor="#c4b5fd">
+				Purple
+			</ShimmerButton>
+			<ShimmerButton background="rgba(20, 83, 45, 0.9)" shimmerColor="#86efac">
+				Green
+			</ShimmerButton>
+		</div>
+	</section>
+
+	<!-- Border Radius -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Border Radius</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Change the shape with the <code class="rounded bg-muted px-1.5 py-0.5">borderRadius</code> prop.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap justify-center gap-4">
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton borderRadius="8px">Rounded</ShimmerButton>
+				<span class="text-xs text-muted-foreground">8px</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton borderRadius="100px">Pill (default)</ShimmerButton>
+				<span class="text-xs text-muted-foreground">100px</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<ShimmerButton borderRadius="0px">Square</ShimmerButton>
+				<span class="text-xs text-muted-foreground">0px</span>
+			</div>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Port ShimmerButton from Vue to Svelte 5 with CSS-only conic-gradient shimmer animation
- Props: `shimmerColor`, `shimmerSize`, `borderRadius`, `shimmerDuration`, `background`
- Demo page at `/demo/shimmer-button` with color, speed, size, background, and radius variations

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm test` — all tests pass
- [ ] Visit `/demo/shimmer-button` — shimmer animates smoothly
- [ ] Verify dark mode rendering