### PR TITLE
feat: add component GradientButton

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -321,8 +321,8 @@
 ### 8.1 Buttons (6 components)
 
 - [x] **rainbow-button** - Animated rainbow gradient border button
-- [ ] **gradient-button** - Button with gradient background
-- [ ] **shimmer-button** - Button with shimmer effect
+- [x] **gradient-button** - Button with gradient background
+- [x] **shimmer-button** - Button with shimmer effect
 - [x] **ripple-button** - Button with ripple click effect
 - [ ] **interactive-hover-button** - Button with hover interactions
 - [ ] **neon-border** - Button/container with neon glow border
@@ -404,7 +404,7 @@
 - [ ] **svg-mask** - SVG masking effects
 - [ ] **animate-grid** - Animated grid
 - [ ] **infinite-grid** - Infinite scrolling grid
-- [ ] **interactive-grid-pattern** - Interactive grid
+- [x] **interactive-grid-pattern** - Interactive grid
 - [ ] **shader-toy** - Shader effects
 
 ### 8.6 Navigation & Layout (8 components)
@@ -414,7 +414,7 @@
 - [x] **timeline** - Vertical timeline
 - [ ] **scroll-island** - Scroll-aware floating island
 - [x] **marquee** - Infinite scrolling marquee
-- [ ] **logo-cloud** - Logo carousel/cloud
+- [x] **logo-cloud** - Logo carousel/cloud
 - [ ] **logo-origami** - Origami-style logo reveal
 - [ ] **halo-search** - Spotlight search UI
 
@@ -540,9 +540,9 @@ These components are used in the portfolio project and should be ported first:
 | blur-reveal | Text | Done |
 | bg-falling-stars | Backgrounds | Done |
 | image-trail-cursor | Cursors & Interactions | Done |
-| interactive-grid-pattern | Effects | Pending |
+| interactive-grid-pattern | Effects | Done |
 | timeline | Navigation & Layout | Done |
-| animated-logo-cloud | Data Display | Pending |
+| animated-logo-cloud | Data Display | Done |
 
 #### General Priority Order
 

--- a/src/lib/fancy-ui/gradient-button/GradientButton.svelte
+++ b/src/lib/fancy-ui/gradient-button/GradientButton.svelte
@@ -65,12 +65,14 @@
 	.gradient-button {
 		padding: var(--gb-border-width);
 		border-radius: var(--gb-border-radius);
+		isolation: isolate;
 	}
 
 	.gradient-border {
 		content: '';
 		position: absolute;
 		inset: -200%;
+		z-index: -1;
 		background: conic-gradient(var(--gb-colors));
 		animation: rotate-gradient var(--gb-duration) linear infinite;
 		filter: blur(var(--gb-blur));
@@ -79,7 +81,6 @@
 	.gradient-content {
 		border-radius: var(--gb-border-radius);
 		background-color: var(--gb-bg-color);
-		z-index: 0;
 	}
 
 	@keyframes rotate-gradient {

--- a/src/lib/fancy-ui/gradient-button/GradientButton.svelte
+++ b/src/lib/fancy-ui/gradient-button/GradientButton.svelte
@@ -46,7 +46,7 @@
 
 <button
 	class={cn(
-		'gradient-button relative flex min-w-28 min-h-10 items-center justify-center overflow-hidden',
+		'gradient-button relative flex cursor-pointer min-w-28 min-h-10 items-center justify-center overflow-hidden',
 		className
 	)}
 	style={styleVars}

--- a/src/lib/fancy-ui/gradient-button/GradientButton.svelte
+++ b/src/lib/fancy-ui/gradient-button/GradientButton.svelte
@@ -1,0 +1,93 @@
+<script lang="ts" module>
+	import type { Snippet } from 'svelte';
+	import type { HTMLButtonAttributes } from 'svelte/elements';
+
+	type BaseProps = {
+		/** Gradient colors for the conic-gradient border */
+		colors?: string[];
+		/** Animation duration in milliseconds */
+		duration?: number;
+		/** Border width in pixels */
+		borderWidth?: number;
+		/** Border radius in pixels */
+		borderRadius?: number;
+		/** Blur amount for the gradient in pixels */
+		blur?: number;
+		/** Background color of the button content area */
+		bgColor?: string;
+		/** Custom CSS class */
+		class?: string;
+		/** Button content */
+		children?: Snippet;
+	};
+
+	export type GradientButtonProps = BaseProps & Omit<HTMLButtonAttributes, keyof BaseProps>;
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let {
+		class: className,
+		colors = ['#FF0000', '#FFA500', '#FFFF00', '#008000', '#0000FF', '#4B0082', '#EE82EE', '#FF0000'],
+		duration = 2500,
+		borderWidth = 2,
+		borderRadius = 8,
+		blur = 4,
+		bgColor = '#000',
+		children,
+		...restProps
+	}: GradientButtonProps = $props();
+
+	const styleVars = $derived(
+		`--gb-colors: ${colors.join(', ')}; --gb-duration: ${duration}ms; --gb-border-width: ${borderWidth}px; --gb-border-radius: ${borderRadius}px; --gb-blur: ${blur}px; --gb-bg-color: ${bgColor}`
+	);
+</script>
+
+<button
+	class={cn(
+		'gradient-button relative flex min-w-28 min-h-10 items-center justify-center overflow-hidden',
+		className
+	)}
+	style={styleVars}
+	{...restProps}
+>
+	<!-- Rotating conic-gradient pseudo-element -->
+	<span class="gradient-border" aria-hidden="true"></span>
+
+	<!-- Content area -->
+	<span class="gradient-content inline-flex size-full items-center justify-center px-4 py-2">
+		{@render children?.()}
+	</span>
+</button>
+
+<style>
+	.gradient-button {
+		padding: var(--gb-border-width);
+		border-radius: var(--gb-border-radius);
+	}
+
+	.gradient-border {
+		content: '';
+		position: absolute;
+		inset: -200%;
+		background: conic-gradient(var(--gb-colors));
+		animation: rotate-gradient var(--gb-duration) linear infinite;
+		filter: blur(var(--gb-blur));
+	}
+
+	.gradient-content {
+		border-radius: var(--gb-border-radius);
+		background-color: var(--gb-bg-color);
+		z-index: 0;
+	}
+
+	@keyframes rotate-gradient {
+		0% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/gradient-button/README.md
+++ b/src/lib/fancy-ui/gradient-button/README.md
@@ -1,0 +1,10 @@
+# GradientButton
+
+## Changes from Vue version
+
+- Uses a real `<span>` element instead of `::before` pseudo-element for the rotating gradient (avoids scoped style issues with pseudo-elements in Svelte)
+- CSS variables set via inline `style` attribute instead of Vue's `v-bind()` in `<style>`
+- Props use `$props()` with Svelte 5 syntax
+- Uses `{@render children?.()}` for slot content
+- Spreads `...restProps` for native button attributes
+- `aria-hidden="true"` on the decorative gradient span

--- a/src/lib/fancy-ui/gradient-button/index.ts
+++ b/src/lib/fancy-ui/gradient-button/index.ts
@@ -1,0 +1,3 @@
+import GradientButton, { type GradientButtonProps } from './GradientButton.svelte';
+
+export { GradientButton, type GradientButtonProps };

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -85,6 +85,12 @@
 			status: 'done' as const
 		},
 		{
+			name: 'GradientButton',
+			href: '/demo/gradient-button',
+			description: 'Button with a rotating conic-gradient rainbow border effect',
+			status: 'done' as const
+		},
+		{
 			name: 'Marquee',
 			href: '/demo/marquee',
 			description: 'Infinite scrolling component for text, images, or cards',

--- a/src/routes/demo/gradient-button/+page.svelte
+++ b/src/routes/demo/gradient-button/+page.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+	import { GradientButton } from '$lib/fancy-ui/gradient-button';
+</script>
+
+<svelte:head>
+	<title>GradientButton - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl py-12 px-4">
+	<div class="mb-8">
+		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
+	</div>
+
+	<h1 class="text-3xl font-bold mb-2">GradientButton</h1>
+	<p class="text-muted-foreground mb-8">
+		A button with a rotating conic-gradient rainbow border and blur effect.
+	</p>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="rounded-lg border bg-card p-6 flex justify-center">
+			<GradientButton class="text-white font-medium">Click me</GradientButton>
+		</div>
+	</section>
+
+	<!-- Custom Colors -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Colors</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Change the gradient with the <code class="rounded bg-muted px-1.5 py-0.5">colors</code> prop.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap justify-center gap-4">
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton
+					colors={['#3b82f6', '#8b5cf6', '#3b82f6']}
+					class="text-white font-medium"
+				>
+					Blue → Purple
+				</GradientButton>
+				<span class="text-xs text-muted-foreground">Blue / Purple</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton
+					colors={['#f43f5e', '#fb923c', '#f43f5e']}
+					class="text-white font-medium"
+				>
+					Rose → Orange
+				</GradientButton>
+				<span class="text-xs text-muted-foreground">Rose / Orange</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton
+					colors={['#10b981', '#06b6d4', '#10b981']}
+					class="text-white font-medium"
+				>
+					Emerald → Cyan
+				</GradientButton>
+				<span class="text-xs text-muted-foreground">Emerald / Cyan</span>
+			</div>
+		</div>
+	</section>
+
+	<!-- Border Width & Blur -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Border Width &amp; Blur</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Adjust thickness with <code class="rounded bg-muted px-1.5 py-0.5">borderWidth</code> and softness with <code class="rounded bg-muted px-1.5 py-0.5">blur</code>.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap justify-center gap-4">
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton borderWidth={1} blur={2} class="text-white font-medium">
+					Thin & Sharp
+				</GradientButton>
+				<span class="text-xs text-muted-foreground">1px / 2px blur</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton borderWidth={2} blur={4} class="text-white font-medium">
+					Default
+				</GradientButton>
+				<span class="text-xs text-muted-foreground">2px / 4px blur</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton borderWidth={4} blur={8} class="text-white font-medium">
+					Thick & Soft
+				</GradientButton>
+				<span class="text-xs text-muted-foreground">4px / 8px blur</span>
+			</div>
+		</div>
+	</section>
+
+	<!-- Animation Speed -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Animation Speed</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Control the rotation speed with the <code class="rounded bg-muted px-1.5 py-0.5">duration</code> prop (in ms).
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap justify-center gap-4">
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton duration={1000} class="text-white font-medium">Fast</GradientButton>
+				<span class="text-xs text-muted-foreground">1000ms</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton duration={2500} class="text-white font-medium">Default</GradientButton>
+				<span class="text-xs text-muted-foreground">2500ms</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton duration={5000} class="text-white font-medium">Slow</GradientButton>
+				<span class="text-xs text-muted-foreground">5000ms</span>
+			</div>
+		</div>
+	</section>
+
+	<!-- Border Radius -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Border Radius</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Change the shape with the <code class="rounded bg-muted px-1.5 py-0.5">borderRadius</code> prop.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap justify-center gap-4">
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton borderRadius={0} class="text-white font-medium">Square</GradientButton>
+				<span class="text-xs text-muted-foreground">0px</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton borderRadius={8} class="text-white font-medium">Rounded</GradientButton>
+				<span class="text-xs text-muted-foreground">8px (default)</span>
+			</div>
+			<div class="flex flex-col items-center gap-2">
+				<GradientButton borderRadius={100} class="text-white font-medium">Pill</GradientButton>
+				<span class="text-xs text-muted-foreground">100px</span>
+			</div>
+		</div>
+	</section>
+
+	<!-- Background Color -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Background Color</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Set the content area background with the <code class="rounded bg-muted px-1.5 py-0.5">bgColor</code> prop.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap justify-center gap-4">
+			<GradientButton bgColor="#000" class="text-white font-medium">Black (default)</GradientButton>
+			<GradientButton bgColor="#1e293b" class="text-white font-medium">Slate</GradientButton>
+			<GradientButton bgColor="#18181b" class="text-white font-medium">Zinc</GradientButton>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary

- Port `GradientButton` from `vendor/inspira/ui/gradient-button/GradientButton.vue` to Svelte 5
- Rotating conic-gradient rainbow border with configurable colors, duration, blur, border width/radius, and background color
- Demo page at `/demo/gradient-button` with 6 variation sections
- Update TODO.md checkboxes for gradient-button, shimmer-button, interactive-grid-pattern, and logo-cloud

## Test plan

- [ ] `pnpm check` passes (0 errors)
- [ ] `/demo/gradient-button` renders correctly
- [ ] Gradient rotates continuously, blur is visible
- [ ] Custom colors, border width, blur, duration, radius, and bgColor props work
- [ ] Button accepts native HTML button attributes via `...restProps`