### PR TITLE
feat: add InteractiveHoverButton component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ This is a reimplementation project, not a line-by-line translation.
 - Prefer shadcn-svelte primitives from `$lib/components/ui`.
 - Prefer theme tokens (`bg-background`, `text-foreground`, `bg-primary`) over hardcoded colors.
 - Do NOT include `Co-Authored-By` lines in git commits.
+- Do NOT reference vendor source paths in component READMEs (no `## Source` section pointing to `vendor/…`).
 
 ## Svelte 5 conventions
 - Use `$state()` for reactive state (replaces `let` + reactivity)

--- a/TODO.md
+++ b/TODO.md
@@ -324,7 +324,7 @@
 - [x] **gradient-button** - Button with gradient background
 - [x] **shimmer-button** - Button with shimmer effect
 - [x] **ripple-button** - Button with ripple click effect
-- [ ] **interactive-hover-button** - Button with hover interactions
+- [x] **interactive-hover-button** - Button with hover interactions
 - [ ] **neon-border** - Button/container with neon glow border
 
 ### 8.2 Cards & Containers (12 components)

--- a/src/lib/fancy-ui/interactive-hover-button/InteractiveHoverButton.svelte
+++ b/src/lib/fancy-ui/interactive-hover-button/InteractiveHoverButton.svelte
@@ -1,0 +1,76 @@
+<script lang="ts" module>
+	import type { Snippet } from 'svelte';
+	import type { HTMLButtonAttributes } from 'svelte/elements';
+
+	type BaseProps = {
+		/** Button label text */
+		text?: string;
+		/** Custom CSS class */
+		class?: string;
+		/** Button content (overrides text prop) */
+		children?: Snippet;
+	};
+
+	export type InteractiveHoverButtonProps = BaseProps &
+		Omit<HTMLButtonAttributes, keyof BaseProps>;
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let {
+		text = 'Button',
+		class: className,
+		children,
+		...restProps
+	}: InteractiveHoverButtonProps = $props();
+</script>
+
+<button
+	class={cn(
+		'group relative w-auto cursor-pointer overflow-hidden rounded-full border bg-background p-2 px-6 text-center font-semibold',
+		className
+	)}
+	{...restProps}
+>
+	<div class="flex items-center gap-2">
+		<div
+			class="size-2 rounded-lg bg-primary transition-all duration-300 group-hover:scale-[100.8]"
+		></div>
+		<span
+			class="inline-block transition-all duration-300 group-hover:translate-x-12 group-hover:opacity-0"
+		>
+			{#if children}
+				{@render children()}
+			{:else}
+				{text}
+			{/if}
+		</span>
+	</div>
+
+	<div
+		class="absolute top-0 z-10 flex size-full translate-x-12 items-center justify-center gap-2 text-primary-foreground opacity-0 transition-all duration-300 group-hover:-translate-x-5 group-hover:opacity-100"
+	>
+		<span>
+			{#if children}
+				{@render children()}
+			{:else}
+				{text}
+			{/if}
+		</span>
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		>
+			<path d="M5 12h14" />
+			<path d="m12 5 7 7-7 7" />
+		</svg>
+	</div>
+</button>

--- a/src/lib/fancy-ui/interactive-hover-button/InteractiveHoverButton.test.ts
+++ b/src/lib/fancy-ui/interactive-hover-button/InteractiveHoverButton.test.ts
@@ -1,0 +1,75 @@
+import { render, screen, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import InteractiveHoverButton from './InteractiveHoverButton.svelte';
+
+describe('InteractiveHoverButton', () => {
+	afterEach(cleanup);
+
+	it('renders a button element', () => {
+		render(InteractiveHoverButton);
+		expect(screen.getByRole('button')).toBeInTheDocument();
+	});
+
+	it('renders default text "Button" when no text prop is provided', () => {
+		render(InteractiveHoverButton);
+		const button = screen.getByRole('button');
+		expect(button).toHaveTextContent('Button');
+	});
+
+	it('renders custom text from the text prop', () => {
+		render(InteractiveHoverButton, { props: { text: 'Get Started' } });
+		const button = screen.getByRole('button');
+		expect(button).toHaveTextContent('Get Started');
+	});
+
+	it('displays the text twice (initial + hover overlay)', () => {
+		render(InteractiveHoverButton, { props: { text: 'Subscribe' } });
+		const matches = screen.getAllByText('Subscribe');
+		expect(matches).toHaveLength(2);
+	});
+
+	it('renders the arrow SVG icon', () => {
+		render(InteractiveHoverButton);
+		const button = screen.getByRole('button');
+		const svg = button.querySelector('svg');
+		expect(svg).toBeInTheDocument();
+		expect(svg?.querySelectorAll('path')).toHaveLength(2);
+	});
+
+	it('applies custom class names', () => {
+		render(InteractiveHoverButton, { props: { class: 'my-custom-class' } });
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('my-custom-class');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		render(InteractiveHoverButton, { props: { class: 'extra' } });
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('overflow-hidden');
+		expect(button.className).toContain('rounded-full');
+	});
+
+	it('forwards native button attributes', () => {
+		render(InteractiveHoverButton, {
+			props: { disabled: true, type: 'submit', 'aria-label': 'Sign up' }
+		});
+		const button = screen.getByRole('button');
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute('type', 'submit');
+		expect(button).toHaveAttribute('aria-label', 'Sign up');
+	});
+
+	it('contains the dot element with bg-primary class', () => {
+		render(InteractiveHoverButton);
+		const button = screen.getByRole('button');
+		const dot = button.querySelector('.bg-primary');
+		expect(dot).toBeInTheDocument();
+	});
+
+	it('has hover overlay with translate and opacity classes', () => {
+		render(InteractiveHoverButton);
+		const button = screen.getByRole('button');
+		const overlay = button.querySelector('.translate-x-12.opacity-0');
+		expect(overlay).toBeInTheDocument();
+	});
+});

--- a/src/lib/fancy-ui/interactive-hover-button/README.md
+++ b/src/lib/fancy-ui/interactive-hover-button/README.md
@@ -1,0 +1,28 @@
+# InteractiveHoverButton
+
+Button with a hover animation: text slides out to the right while an arrow and duplicate text slide in from the right. A small `bg-primary` dot scales up to fill the button background.
+
+## Props
+
+| Prop       | Type     | Default    | Description                         |
+|------------|----------|------------|-------------------------------------|
+| `text`     | `string` | `"Button"` | Button label text                   |
+| `class`    | `string` | `""`       | Additional CSS classes              |
+| `children` | Snippet  | -          | Optional content (overrides `text`) |
+
+Also accepts all standard `<button>` attributes via `...restProps`.
+
+## Animation details
+
+All animations are pure CSS via Tailwind `group-hover` utilities, no JS required:
+
+- **Dot**: `scale-1` -> `scale-[100.8]` fills the button background with `bg-primary`
+- **Initial text**: slides right (`translate-x-12`) and fades out (`opacity-0`)
+- **Hover text + arrow**: slides in from right (`-translate-x-5`) and fades in (`opacity-100`)
+- All transitions use `duration-300`
+
+## Porting notes
+
+- Direct port, no structural changes needed
+- Inline SVG arrow (no Lucide dependency)
+- Uses theme tokens: `bg-background`, `bg-primary`, `text-primary-foreground`

--- a/src/lib/fancy-ui/interactive-hover-button/index.ts
+++ b/src/lib/fancy-ui/interactive-hover-button/index.ts
@@ -1,0 +1,5 @@
+import InteractiveHoverButton, {
+	type InteractiveHoverButtonProps
+} from './InteractiveHoverButton.svelte';
+
+export { InteractiveHoverButton, type InteractiveHoverButtonProps };

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -73,6 +73,12 @@
 			status: 'done' as const
 		},
 		{
+			name: 'InteractiveHoverButton',
+			href: '/demo/interactive-hover-button',
+			description: 'Button with hover animation: text slides out, arrow slides in, dot fills background',
+			status: 'done' as const
+		},
+		{
 			name: 'LogoCloud',
 			href: '/demo/logo-cloud',
 			description: 'Logo display with animated marquee, static grid, and icon variants',

--- a/src/routes/demo/interactive-hover-button/+page.svelte
+++ b/src/routes/demo/interactive-hover-button/+page.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { InteractiveHoverButton } from '$lib/fancy-ui/interactive-hover-button';
+</script>
+
+<svelte:head>
+	<title>InteractiveHoverButton - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">InteractiveHoverButton</h1>
+	<p class="text-muted-foreground mb-8">
+		Button with hover animation: text slides out while an arrow slides in, and a dot scales up to
+		fill the background.
+	</p>
+
+	<!-- Basic Example -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="border rounded-lg p-6 bg-card flex items-center justify-center">
+			<InteractiveHoverButton />
+		</div>
+	</section>
+
+	<!-- Custom Text -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Text</h2>
+		<div class="border rounded-lg p-6 bg-card flex items-center justify-center gap-4">
+			<InteractiveHoverButton text="Get Started" />
+			<InteractiveHoverButton text="Learn More" />
+			<InteractiveHoverButton text="Subscribe" />
+		</div>
+	</section>
+
+	<!-- Custom Styling -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Styling</h2>
+		<div class="border rounded-lg p-6 bg-card flex items-center justify-center gap-4">
+			<InteractiveHoverButton
+				text="Danger"
+				class="border-red-500/30 [&_div>.size-2]:bg-red-500 [&>div:last-child]:text-white"
+			/>
+			<InteractiveHoverButton
+				text="Success"
+				class="border-green-500/30 [&_div>.size-2]:bg-green-500 [&>div:last-child]:text-white"
+			/>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary

- Port `InteractiveHoverButton` from `vendor/inspira/ui/interactive-hover-button/InteractiveHoverButton.vue` to Svelte 5
- Pure CSS hover animation using Tailwind `group-hover` utilities (no JS animation logic)
- On hover: dot scales to fill background with `bg-primary`, text slides out, replacement text + arrow slides in
- Includes demo page at `/demo/interactive-hover-button` with basic, custom text, and custom styling examples
- Adds 10 unit tests covering rendering, props, attribute forwarding, and animation structure

## Test plan

- [x] `pnpm check` passes (0 errors)
- [x] `pnpm test` passes (10 tests)
- [x] Demo page renders correctly at `/demo/interactive-hover-button`
- [x] Hover animation works in dark and light mode
- [x] Visual review of hover animation smoothness