### PR TITLE
feat: add demo layout with sidebar navigation

### DIFF
--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -7,7 +7,7 @@
 <button
 	onclick={() => themeState.toggleTheme()}
 	aria-label={themeState.isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-	class="fixed top-4 right-4 z-50 flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
+	class="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
 >
 	{#if themeState.isDark}
 		<svg

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -184,15 +184,63 @@ export const registry: Record<string, ComponentMeta> = {
 		description: 'Vertical timeline with scroll-driven progress line and sticky labels',
 		category: 'navigation',
 		status: 'done'
+	},
+
+	'bg-stars': {
+		name: 'StarsBackground',
+		slug: 'bg-stars',
+		description: 'Animated starfield background with parallax mouse tracking',
+		category: 'backgrounds',
+		status: 'done'
+	},
+
+	dock: {
+		name: 'Dock',
+		slug: 'dock',
+		description: 'macOS-style dock with icon magnification on hover',
+		category: 'navigation',
+		status: 'done'
+	},
+
+	'fluid-cursor': {
+		name: 'FluidCursor',
+		slug: 'fluid-cursor',
+		description: 'WebGL fluid simulation that follows cursor movement',
+		category: 'effects',
+		status: 'done'
+	},
+
+	'glow-border': {
+		name: 'GlowBorder',
+		slug: 'glow-border',
+		description: 'Animated glowing border effect with gradient support',
+		category: 'effects',
+		status: 'done'
+	},
+
+	'gradient-button': {
+		name: 'GradientButton',
+		slug: 'gradient-button',
+		description: 'Button with a rotating conic-gradient rainbow border effect',
+		category: 'buttons',
+		status: 'done'
+	},
+
+	'interactive-hover-button': {
+		name: 'InteractiveHoverButton',
+		slug: 'interactive-hover-button',
+		description: 'Button with interactive hover effect revealing alternate content',
+		category: 'buttons',
+		status: 'done'
+	},
+
+	marquee: {
+		name: 'Marquee',
+		slug: 'marquee',
+		description: 'Infinite scrolling component for text, images, or cards',
+		category: 'layout',
+		status: 'done'
 	}
-
-	// =========================================================================
-	// In Progress - Currently being ported
-	// =========================================================================
-
-	// =========================================================================
-	// Planned - Identified for porting
-	// =========================================================================
 };
 
 // =============================================================================

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
 	import './layout.css';
 	import AnimatedFavicon from '$lib/components/AnimatedFavicon.svelte';
-	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
 
 	let { children } = $props();
 </script>
 
 <AnimatedFavicon />
-<ThemeToggle />
 {@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import { RainbowButton } from '$lib/fancy-ui';
+	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
 </script>
 
 <svelte:head>
 	<title>FancyUI</title>
 </svelte:head>
+
+<div class="fixed top-4 right-4 z-50">
+	<ThemeToggle />
+</div>
 
 <div class="flex min-h-screen flex-col items-center justify-center px-4">
 	<div class="text-center">

--- a/src/routes/demo/+layout.svelte
+++ b/src/routes/demo/+layout.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+	import {
+		categories,
+		categoryLabels,
+		getComponentsGroupedByCategory,
+		getComponent
+	} from '$lib/fancy-ui/registry.js';
+
+	let { children } = $props();
+
+	let sidebarOpen = $state(false);
+
+	const grouped = getComponentsGroupedByCategory();
+
+	// Derive current component slug from URL
+	let currentSlug = $derived.by(() => {
+		const path = $page.url.pathname;
+		const match = path.match(/^\/demo\/([^/]+)/);
+		return match ? match[1] : null;
+	});
+
+	let currentComponent = $derived(currentSlug ? getComponent(currentSlug) : null);
+
+	function closeSidebar() {
+		sidebarOpen = false;
+	}
+</script>
+
+<!-- Mobile overlay -->
+{#if sidebarOpen}
+	<button
+		class="fixed inset-0 z-40 bg-black/50 lg:hidden"
+		onclick={closeSidebar}
+		aria-label="Close sidebar"
+	></button>
+{/if}
+
+<!-- Sidebar -->
+<aside
+	class="fixed top-0 left-0 z-50 flex h-full w-64 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground transition-transform duration-300 lg:translate-x-0 {sidebarOpen
+		? 'translate-x-0'
+		: '-translate-x-full'}"
+>
+	<!-- Sidebar header -->
+	<div class="flex h-14 shrink-0 items-center border-b border-sidebar-border px-4">
+		<a href="/demo" class="text-lg font-semibold tracking-tight" onclick={closeSidebar}>
+			FancyUI
+		</a>
+	</div>
+
+	<!-- Sidebar nav -->
+	<nav class="flex-1 overflow-y-auto px-3 py-4">
+		{#each categories as category}
+			{@const items = grouped[category]}
+			{#if items.length > 0}
+				<div class="mb-4">
+					<h3
+						class="mb-1 px-2 text-xs font-semibold uppercase tracking-wider text-sidebar-foreground/50"
+					>
+						{categoryLabels[category]}
+					</h3>
+					<ul>
+						{#each items as comp}
+							{@const isActive = currentSlug === comp.slug}
+							<li>
+								<a
+									href="/demo/{comp.slug}"
+									onclick={closeSidebar}
+									class="block rounded-md px-2 py-1.5 text-sm transition-colors {isActive
+										? 'bg-sidebar-accent font-medium text-sidebar-accent-foreground'
+										: 'text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground'}"
+								>
+									{comp.name}
+								</a>
+							</li>
+						{/each}
+					</ul>
+				</div>
+			{/if}
+		{/each}
+	</nav>
+</aside>
+
+<!-- Main area -->
+<div class="lg:pl-64">
+	<!-- Header -->
+	<header
+		class="sticky top-0 z-30 flex h-14 items-center gap-3 border-b border-border bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+	>
+		<!-- Mobile hamburger -->
+		<button
+			class="flex h-9 w-9 items-center justify-center rounded-md border border-border text-foreground lg:hidden"
+			onclick={() => (sidebarOpen = !sidebarOpen)}
+			aria-label="Toggle sidebar"
+		>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="18"
+				height="18"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<line x1="4" x2="20" y1="12" y2="12" />
+				<line x1="4" x2="20" y1="6" y2="6" />
+				<line x1="4" x2="20" y1="18" y2="18" />
+			</svg>
+		</button>
+
+		<!-- Breadcrumbs -->
+		<nav class="flex items-center gap-1.5 text-sm">
+			<a href="/demo" class="text-muted-foreground hover:text-foreground transition-colors">
+				Components
+			</a>
+			{#if currentComponent}
+				<span class="text-muted-foreground/50">/</span>
+				<span class="font-medium text-foreground">{currentComponent.name}</span>
+			{/if}
+		</nav>
+
+		<!-- Spacer -->
+		<div class="flex-1"></div>
+
+		<!-- Theme toggle -->
+		<ThemeToggle />
+	</header>
+
+	<!-- Page content -->
+	<main>
+		{@render children()}
+	</main>
+</div>

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -1,132 +1,14 @@
 <script lang="ts">
-	const components = [
-		{
-			name: 'AnimatedBeam',
-			href: '/demo/animated-beam',
-			description: 'Animated SVG beams connecting elements with gradient effects',
-			status: 'done' as const
-		},
-		{
-			name: 'AnimatedTooltip',
-			href: '/demo/animated-tooltip',
-			description: 'Avatar row with animated tooltips that follow mouse movement',
-			status: 'done' as const
-		},
-		{
-			name: 'BlurReveal',
-			href: '/demo/blur-reveal',
-			description: 'Scroll-triggered blur-to-clear reveal animation with staggered children',
-			status: 'done' as const
-		},
-		{
-			name: 'BgFallingStars',
-			href: '/demo/bg-falling-stars',
-			description: 'Canvas-based 3D starfield with perspective projection, motion trails, and glow',
-			status: 'done' as const
-		},
-		{
-			name: 'BgStars',
-			href: '/demo/bg-stars',
-			description: 'Animated starfield background with parallax mouse tracking',
-			status: 'done' as const
-		},
-		{
-			name: 'BorderBeam',
-			href: '/demo/border-beam',
-			description: 'Animated beam effect that travels around borders',
-			status: 'done' as const
-		},
-		{
-			name: 'Compare',
-			href: '/demo/compare',
-			description: 'Before/after image comparison slider with hover and drag modes',
-			status: 'done' as const
-		},
-		{
-			name: 'DirectionAwareHover',
-			href: '/demo/direction-aware-hover',
-			description: 'Image card with overlay that slides in from the mouse entry direction',
-			status: 'done' as const
-		},
-		{
-			name: 'Dock',
-			href: '/demo/dock',
-			description: 'macOS-style dock with icon magnification on hover',
-			status: 'done' as const
-		},
-		{
-			name: 'FluidCursor',
-			href: '/demo/fluid-cursor',
-			description: 'WebGL fluid simulation that follows cursor movement',
-			status: 'done' as const
-		},
-		{
-			name: 'ImageTrailCursor',
-			href: '/demo/image-trail-cursor',
-			description: 'Cursor-following image trail with 8 animation variants',
-			status: 'done' as const
-		},
-		{
-			name: 'InteractiveGridPattern',
-			href: '/demo/interactive-grid-pattern',
-			description: 'SVG grid of squares that highlight on hover with smooth fade transitions',
-			status: 'done' as const
-		},
-		{
-			name: 'InteractiveHoverButton',
-			href: '/demo/interactive-hover-button',
-			description: 'Button with hover animation: text slides out, arrow slides in, dot fills background',
-			status: 'done' as const
-		},
-		{
-			name: 'LogoCloud',
-			href: '/demo/logo-cloud',
-			description: 'Logo display with animated marquee, static grid, and icon variants',
-			status: 'done' as const
-		},
-		{
-			name: 'GlowBorder',
-			href: '/demo/glow-border',
-			description: 'Animated glowing border effect with gradient support',
-			status: 'done' as const
-		},
-		{
-			name: 'GradientButton',
-			href: '/demo/gradient-button',
-			description: 'Button with a rotating conic-gradient rainbow border effect',
-			status: 'done' as const
-		},
-		{
-			name: 'Marquee',
-			href: '/demo/marquee',
-			description: 'Infinite scrolling component for text, images, or cards',
-			status: 'done' as const
-		},
-		{
-			name: 'RainbowButton',
-			href: '/demo/rainbow-button',
-			description: 'Animated button with a rainbow gradient border effect',
-			status: 'done' as const
-		},
-		{
-			name: 'RippleButton',
-			href: '/demo/ripple-button',
-			description: 'Button with ripple click effect',
-			status: 'done' as const
-		},
-		{
-			name: 'ShimmerButton',
-			href: '/demo/shimmer-button',
-			description: 'Button with a rotating conic-gradient shimmer border effect',
-			status: 'done' as const
-		},
-		{
-			name: 'Timeline',
-			href: '/demo/timeline',
-			description: 'Vertical timeline with scroll-driven progress line and sticky labels',
-			status: 'done' as const
-		}
-	];
+	import {
+		categories,
+		categoryLabels,
+		categoryDescriptions,
+		getComponentsGroupedByCategory,
+		getStats
+	} from '$lib/fancy-ui/registry.js';
+
+	const grouped = getComponentsGroupedByCategory();
+	const stats = getStats();
 </script>
 
 <svelte:head>
@@ -134,58 +16,67 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<h1 class="text-4xl font-bold mb-2">FancyUI</h1>
+	<h1 class="text-4xl font-bold mb-2">Components</h1>
 	<p class="text-muted-foreground mb-8">
-		Svelte ports of FancyUI components. Click on any component to see it in action.
+		{stats.done} components ported to Svelte 5. Click on any component to see it in action.
 	</p>
 
-	<div class="grid gap-4">
-		{#each components as component}
-			<a
-				href={component.href}
-				class="group flex items-center justify-between rounded-lg border bg-card p-4 transition-colors hover:bg-accent"
-			>
-				<div>
-					<h2 class="font-semibold group-hover:text-accent-foreground">
-						{component.name}
-					</h2>
-					<p class="text-sm text-muted-foreground">{component.description}</p>
+	{#each categories as category}
+		{@const items = grouped[category]}
+		{#if items.length > 0}
+			<section class="mb-10">
+				<h2 class="text-xl font-semibold mb-1">{categoryLabels[category]}</h2>
+				<p class="text-sm text-muted-foreground mb-4">{categoryDescriptions[category]}</p>
+				<div class="grid gap-3">
+					{#each items as component}
+						<a
+							href="/demo/{component.slug}"
+							class="group flex items-center justify-between rounded-lg border bg-card p-4 transition-colors hover:bg-accent"
+						>
+							<div>
+								<h3 class="font-semibold group-hover:text-accent-foreground">
+									{component.name}
+								</h3>
+								<p class="text-sm text-muted-foreground">{component.description}</p>
+							</div>
+							<div class="flex items-center gap-2">
+								{#if component.status === 'done'}
+									<span
+										class="rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-600 dark:text-green-400"
+									>
+										Done
+									</span>
+								{:else if component.status === 'in-progress'}
+									<span
+										class="rounded-full bg-yellow-500/10 px-2 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400"
+									>
+										In Progress
+									</span>
+								{:else}
+									<span
+										class="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+									>
+										Planned
+									</span>
+								{/if}
+								<svg
+									class="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-1"
+									fill="none"
+									stroke="currentColor"
+									viewBox="0 0 24 24"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M9 5l7 7-7 7"
+									/>
+								</svg>
+							</div>
+						</a>
+					{/each}
 				</div>
-				<div class="flex items-center gap-2">
-					{#if component.status === 'done'}
-						<span
-							class="rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-600 dark:text-green-400"
-						>
-							Done
-						</span>
-					{:else if component.status === 'in-progress'}
-						<span
-							class="rounded-full bg-yellow-500/10 px-2 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400"
-						>
-							In Progress
-						</span>
-					{:else}
-						<span
-							class="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
-						>
-							Planned
-						</span>
-					{/if}
-					<svg
-						class="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-1"
-						fill="none"
-						stroke="currentColor"
-						viewBox="0 0 24 24"
-					>
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width="2"
-							d="M9 5l7 7-7 7"
-						/>
-					</svg>
-				</div>
-			</a>
-		{/each}
-	</div>
+			</section>
+		{/if}
+	{/each}
 </div>

--- a/src/routes/demo/animated-tooltip/+page.svelte
+++ b/src/routes/demo/animated-tooltip/+page.svelte
@@ -55,10 +55,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl px-4 py-12">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="mb-2 text-3xl font-bold">AnimatedTooltip</h1>
 	<p class="mb-8 text-muted-foreground">
 		A row of avatar images with animated tooltips that follow mouse movement.

--- a/src/routes/demo/bg-falling-stars/+page.svelte
+++ b/src/routes/demo/bg-falling-stars/+page.svelte
@@ -7,10 +7,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">FallingStarsBg</h1>
 	<p class="text-muted-foreground mb-8">
 		A canvas-based 3D starfield background with perspective projection, motion trails, and glow effects.

--- a/src/routes/demo/bg-stars/+page.svelte
+++ b/src/routes/demo/bg-stars/+page.svelte
@@ -7,10 +7,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">StarsBackground</h1>
 	<p class="text-muted-foreground mb-8">
 		An animated starfield background with parallax mouse tracking. Stars scroll upward at different speeds creating depth.

--- a/src/routes/demo/blur-reveal/+page.svelte
+++ b/src/routes/demo/blur-reveal/+page.svelte
@@ -7,10 +7,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl px-4 py-12">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="mb-2 text-3xl font-bold">BlurReveal</h1>
 	<p class="mb-8 text-muted-foreground">
 		Scroll-triggered reveal animation that transitions children from blurred to clear with staggered delays.

--- a/src/routes/demo/border-beam/+page.svelte
+++ b/src/routes/demo/border-beam/+page.svelte
@@ -7,10 +7,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">BorderBeam</h1>
 	<p class="text-muted-foreground mb-8">
 		An animated beam effect that travels around the border of a container.

--- a/src/routes/demo/compare/+page.svelte
+++ b/src/routes/demo/compare/+page.svelte
@@ -9,10 +9,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl px-4 py-12">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="mb-2 text-3xl font-bold">Compare</h1>
 	<p class="mb-8 text-muted-foreground">
 		A before/after image comparison slider with hover and drag modes, plus optional autoplay.

--- a/src/routes/demo/direction-aware-hover/+page.svelte
+++ b/src/routes/demo/direction-aware-hover/+page.svelte
@@ -7,10 +7,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl px-4 py-12">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="mb-2 text-3xl font-bold">DirectionAwareHover</h1>
 	<p class="mb-8 text-muted-foreground">
 		An image card that reveals an overlay sliding in from the direction the mouse entered.

--- a/src/routes/demo/dock/+page.svelte
+++ b/src/routes/demo/dock/+page.svelte
@@ -7,10 +7,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">Dock</h1>
 	<p class="text-muted-foreground mb-8">
 		A macOS-style dock with icon magnification on hover. Icons grow larger as the cursor approaches them.

--- a/src/routes/demo/glow-border/+page.svelte
+++ b/src/routes/demo/glow-border/+page.svelte
@@ -7,10 +7,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">GlowBorder</h1>
 	<p class="text-muted-foreground mb-8">
 		An animated glowing border effect. Place inside an element with

--- a/src/routes/demo/gradient-button/+page.svelte
+++ b/src/routes/demo/gradient-button/+page.svelte
@@ -7,10 +7,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">GradientButton</h1>
 	<p class="text-muted-foreground mb-8">
 		A button with a rotating conic-gradient rainbow border and blur effect.

--- a/src/routes/demo/image-trail-cursor/+page.svelte
+++ b/src/routes/demo/image-trail-cursor/+page.svelte
@@ -34,10 +34,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">ImageTrailCursor</h1>
 	<p class="text-muted-foreground mb-8">
 		Cursor-following image trail with 8 animation variants. Move your cursor inside the area below.

--- a/src/routes/demo/interactive-grid-pattern/+page.svelte
+++ b/src/routes/demo/interactive-grid-pattern/+page.svelte
@@ -7,10 +7,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">InteractiveGridPattern</h1>
 	<p class="text-muted-foreground mb-8">
 		An SVG grid of squares that highlight on hover with a smooth fade-out transition.

--- a/src/routes/demo/logo-cloud/+page.svelte
+++ b/src/routes/demo/logo-cloud/+page.svelte
@@ -18,12 +18,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground"
-			>&larr; Back to components</a
-		>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">LogoCloud</h1>
 	<p class="text-muted-foreground mb-8">
 		Logo display components in three variants: animated infinite scroll, static grid, and compact

--- a/src/routes/demo/rainbow-button/+page.svelte
+++ b/src/routes/demo/rainbow-button/+page.svelte
@@ -9,10 +9,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">RainbowButton</h1>
 	<p class="text-muted-foreground mb-8">
 		An animated button with a rainbow gradient border that continuously animates around the button.

--- a/src/routes/demo/ripple-button/+page.svelte
+++ b/src/routes/demo/ripple-button/+page.svelte
@@ -7,10 +7,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">RippleButton</h1>
 	<p class="text-muted-foreground mb-8">
 		A button with a Material Design-inspired ripple effect on click.

--- a/src/routes/demo/shimmer-button/+page.svelte
+++ b/src/routes/demo/shimmer-button/+page.svelte
@@ -7,10 +7,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl py-12 px-4">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="text-3xl font-bold mb-2">ShimmerButton</h1>
 	<p class="text-muted-foreground mb-8">
 		A button with a rotating conic-gradient shimmer effect around its border.

--- a/src/routes/demo/timeline/+page.svelte
+++ b/src/routes/demo/timeline/+page.svelte
@@ -14,10 +14,6 @@
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl px-4 py-12">
-	<div class="mb-8">
-		<a href="/demo" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to components</a>
-	</div>
-
 	<h1 class="mb-2 text-3xl font-bold">Timeline</h1>
 	<p class="mb-8 text-muted-foreground">
 		Vertical timeline with scroll-driven progress line and sticky labels.


### PR DESCRIPTION
## Summary

- Add shared layout for `/demo/*` pages with sidebar navigation and sticky header
- Sidebar displays components grouped by category, sourced from the registry
- Header includes breadcrumbs, mobile hamburger menu, and theme toggle
- Add 7 missing components to registry (now 21 total)
- Remove manual "Back to components" links from 17 demo pages

## Test plan

- [ ] Visit `/demo` — sidebar visible with all components grouped by category
- [ ] Click a component in sidebar — navigates and highlights active item
- [ ] Breadcrumbs show "Components / ComponentName"
- [ ] Mobile: sidebar hidden, hamburger opens slide-over with overlay
- [ ] ThemeToggle works in header and on landing page
- [ ] Full-width pages (FluidCursor, Timeline) not broken by layout