### PR TITLE
feat: port Meteors, FlickeringGrid, NeonBorder, ColourfulText + tests

### DIFF
--- a/src/lib/fancy-ui/border-beam/BorderBeam.test.ts
+++ b/src/lib/fancy-ui/border-beam/BorderBeam.test.ts
@@ -1,0 +1,74 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import BorderBeam from './BorderBeam.svelte';
+
+describe('BorderBeam', () => {
+	afterEach(cleanup);
+
+	it('renders a div element', () => {
+		const { container } = render(BorderBeam);
+		const div = container.querySelector('.border-beam');
+		expect(div).toBeInTheDocument();
+	});
+
+	it('applies default CSS custom properties', () => {
+		const { container } = render(BorderBeam);
+		const div = container.querySelector('.border-beam') as HTMLElement;
+		const style = div.getAttribute('style') ?? '';
+		expect(style).toContain('--border-beam-size: 200');
+		expect(style).toContain('--border-beam-duration: 15s');
+		expect(style).toContain('--border-beam-anchor: 90');
+		expect(style).toContain('--border-beam-border-width: 1.5');
+		expect(style).toContain('--border-beam-color-from: #ffaa40');
+		expect(style).toContain('--border-beam-color-to: #9c40ff');
+		expect(style).toContain('--border-beam-delay: 0s');
+	});
+
+	it('applies custom size', () => {
+		const { container } = render(BorderBeam, { props: { size: 300 } });
+		const div = container.querySelector('.border-beam') as HTMLElement;
+		expect(div.getAttribute('style')).toContain('--border-beam-size: 300');
+	});
+
+	it('applies custom duration', () => {
+		const { container } = render(BorderBeam, { props: { duration: 5 } });
+		const div = container.querySelector('.border-beam') as HTMLElement;
+		expect(div.getAttribute('style')).toContain('--border-beam-duration: 5s');
+	});
+
+	it('applies custom colors', () => {
+		const { container } = render(BorderBeam, {
+			props: { colorFrom: '#ff0000', colorTo: '#00ff00' }
+		});
+		const div = container.querySelector('.border-beam') as HTMLElement;
+		const style = div.getAttribute('style') ?? '';
+		expect(style).toContain('--border-beam-color-from: #ff0000');
+		expect(style).toContain('--border-beam-color-to: #00ff00');
+	});
+
+	it('applies custom delay', () => {
+		const { container } = render(BorderBeam, { props: { delay: 3 } });
+		const div = container.querySelector('.border-beam') as HTMLElement;
+		expect(div.getAttribute('style')).toContain('--border-beam-delay: 3s');
+	});
+
+	it('applies custom borderWidth', () => {
+		const { container } = render(BorderBeam, { props: { borderWidth: 3 } });
+		const div = container.querySelector('.border-beam') as HTMLElement;
+		expect(div.getAttribute('style')).toContain('--border-beam-border-width: 3');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(BorderBeam, { props: { class: 'my-beam' } });
+		const div = container.querySelector('.border-beam');
+		expect(div?.className).toContain('my-beam');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		const { container } = render(BorderBeam, { props: { class: 'extra' } });
+		const div = container.querySelector('.border-beam');
+		expect(div?.className).toContain('pointer-events-none');
+		expect(div?.className).toContain('absolute');
+		expect(div?.className).toContain('inset-0');
+	});
+});

--- a/src/lib/fancy-ui/colourful-text/ColourfulText.svelte
+++ b/src/lib/fancy-ui/colourful-text/ColourfulText.svelte
@@ -1,0 +1,75 @@
+<script lang="ts" module>
+	/**
+	 * ColourfulText - Per-character color animation
+	 *
+	 * Each character is individually animated with shuffled colors.
+	 * Colors reshuffle every 5 seconds with staggered CSS transitions.
+	 * Pure CSS implementation (no motion library dependency).
+	 */
+	export interface ColourfulTextProps {
+		/** Text to animate */
+		text: string;
+		/** Array of colors to cycle through */
+		colors?: string[];
+		/** Initial color before animation */
+		startColor?: string;
+		/** Transition duration in seconds for each character */
+		duration?: number;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { onMount } from 'svelte';
+
+	let {
+		text,
+		colors = [
+			'rgb(131, 179, 32)',
+			'rgb(47, 195, 106)',
+			'rgb(42, 169, 210)',
+			'rgb(4, 112, 202)',
+			'rgb(107, 10, 255)',
+			'rgb(183, 0, 218)',
+			'rgb(218, 0, 171)',
+			'rgb(230, 64, 92)',
+			'rgb(232, 98, 63)',
+			'rgb(249, 129, 47)'
+		],
+		startColor = 'rgb(255, 255, 255)',
+		duration = 0.5,
+		class: className
+	}: ColourfulTextProps = $props();
+
+	let currentColors = $state<string[]>([]);
+
+	function shuffleColors() {
+		currentColors = [...colors].sort(() => 0.5 - Math.random());
+	}
+
+	// Initialize with shuffled colors
+	shuffleColors();
+
+	onMount(() => {
+		const intervalId = setInterval(() => {
+			if (document.visibilityState === 'visible') {
+				shuffleColors();
+			}
+		}, 5000);
+
+		return () => clearInterval(intervalId);
+	});
+
+	const chars = $derived(text.split(''));
+</script>
+
+<span class={cn('colourful-text inline-flex', className)}>
+	{#each chars as char, i (i)}
+		<span
+			class="colourful-char inline-block"
+			style="color:{currentColors[i % currentColors.length] ?? startColor};transition:color {duration}s ease {i * 0.05}s,opacity {duration}s ease {i * 0.05}s,transform {duration}s ease {i * 0.05}s,filter {duration}s ease {i * 0.05}s"
+		>{char === ' ' ? '\u00A0' : char}</span>
+	{/each}
+</span>

--- a/src/lib/fancy-ui/colourful-text/ColourfulText.test.ts
+++ b/src/lib/fancy-ui/colourful-text/ColourfulText.test.ts
@@ -1,0 +1,59 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import ColourfulText from './ColourfulText.svelte';
+
+describe('ColourfulText', () => {
+	afterEach(cleanup);
+
+	it('renders one span per character', () => {
+		const { container } = render(ColourfulText, { props: { text: 'Hello' } });
+		const chars = container.querySelectorAll('.colourful-char');
+		expect(chars.length).toBe(5);
+	});
+
+	it('renders the correct text content', () => {
+		const { container } = render(ColourfulText, { props: { text: 'ABC' } });
+		const wrapper = container.querySelector('.colourful-text');
+		expect(wrapper?.textContent).toBe('ABC');
+	});
+
+	it('renders spaces as non-breaking spaces', () => {
+		const { container } = render(ColourfulText, { props: { text: 'A B' } });
+		const chars = container.querySelectorAll('.colourful-char');
+		expect(chars.length).toBe(3);
+		expect(chars[1].textContent).toBe('\u00A0');
+	});
+
+	it('applies color styles to each character', () => {
+		const { container } = render(ColourfulText, { props: { text: 'Hi' } });
+		const chars = container.querySelectorAll('.colourful-char');
+		chars.forEach((char) => {
+			const style = (char as HTMLElement).getAttribute('style') ?? '';
+			expect(style).toContain('color:');
+			expect(style).toContain('transition:');
+		});
+	});
+
+	it('applies staggered transition delays', () => {
+		const { container } = render(ColourfulText, { props: { text: 'AB', duration: 0.5 } });
+		const chars = container.querySelectorAll('.colourful-char');
+		const style0 = (chars[0] as HTMLElement).getAttribute('style') ?? '';
+		const style1 = (chars[1] as HTMLElement).getAttribute('style') ?? '';
+		expect(style0).toContain('0s');
+		expect(style1).toContain('0.05s');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(ColourfulText, {
+			props: { text: 'Hi', class: 'my-colourful' }
+		});
+		const wrapper = container.querySelector('.colourful-text');
+		expect(wrapper?.className).toContain('my-colourful');
+	});
+
+	it('renders an empty wrapper for empty text', () => {
+		const { container } = render(ColourfulText, { props: { text: '' } });
+		const chars = container.querySelectorAll('.colourful-char');
+		expect(chars.length).toBe(0);
+	});
+});

--- a/src/lib/fancy-ui/colourful-text/README.md
+++ b/src/lib/fancy-ui/colourful-text/README.md
@@ -1,0 +1,21 @@
+# ColourfulText
+
+Per-character color animation. Each character is individually animated with shuffled colors that reshuffle every 5 seconds. Pure CSS transitions — no motion library dependency.
+
+## Props
+
+| Prop         | Type       | Default                    | Description                              |
+| ------------ | ---------- | -------------------------- | ---------------------------------------- |
+| `text`       | `string`   | **required**               | Text to animate                          |
+| `colors`     | `string[]` | 10 rainbow colors          | Array of colors to cycle through         |
+| `startColor` | `string`   | `'rgb(255, 255, 255)'`     | Initial color before animation           |
+| `duration`   | `number`   | `0.5`                      | Transition duration per character (secs) |
+| `class`      | `string`   | `''`                       | Additional CSS classes                   |
+
+## Usage
+
+```svelte
+<h1 class="text-4xl font-bold">
+  Make things <ColourfulText text="colourful" />
+</h1>
+```

--- a/src/lib/fancy-ui/colourful-text/index.ts
+++ b/src/lib/fancy-ui/colourful-text/index.ts
@@ -1,0 +1,3 @@
+import ColourfulText, { type ColourfulTextProps } from './ColourfulText.svelte';
+
+export { ColourfulText, type ColourfulTextProps };

--- a/src/lib/fancy-ui/flickering-grid/FlickeringGrid.svelte
+++ b/src/lib/fancy-ui/flickering-grid/FlickeringGrid.svelte
@@ -1,0 +1,154 @@
+<script lang="ts" module>
+	/**
+	 * FlickeringGrid - Canvas-based grid with flickering opacity squares
+	 *
+	 * Uses ResizeObserver, IntersectionObserver, and requestAnimationFrame
+	 * for performant rendering with automatic pause when off-screen.
+	 */
+	export interface FlickeringGridProps {
+		/** Size of each grid square in pixels */
+		squareSize?: number;
+		/** Gap between squares in pixels */
+		gridGap?: number;
+		/** Probability of a square changing opacity each second (0-1) */
+		flickerChance?: number;
+		/** Color of the squares (hex format) */
+		color?: string;
+		/** Maximum opacity of squares (0-1) */
+		maxOpacity?: number;
+		/** Fixed width in pixels (defaults to container width) */
+		width?: number;
+		/** Fixed height in pixels (defaults to container height) */
+		height?: number;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { onMount } from 'svelte';
+
+	let {
+		squareSize = 4,
+		gridGap = 6,
+		flickerChance = 0.3,
+		color = '#000000',
+		maxOpacity = 0.3,
+		width,
+		height,
+		class: className
+	}: FlickeringGridProps = $props();
+
+	let containerEl: HTMLDivElement;
+	let canvasEl: HTMLCanvasElement;
+
+	function hexToRgba(hex: string): string {
+		const clean = hex.replace(/^#/, '');
+		const bigint = Number.parseInt(clean, 16);
+		const r = (bigint >> 16) & 255;
+		const g = (bigint >> 8) & 255;
+		const b = bigint & 255;
+		return `rgba(${r}, ${g}, ${b},`;
+	}
+
+	onMount(() => {
+		const ctx = canvasEl.getContext('2d');
+		if (!ctx) return;
+
+		let isInView = false;
+		let animationFrameId: number | undefined;
+		let lastTime = 0;
+		let cols = 0;
+		let rows = 0;
+		let squares: Float32Array;
+		let dpr = 1;
+
+		function setupCanvas(w: number, h: number) {
+			dpr = window.devicePixelRatio || 1;
+			canvasEl.width = w * dpr;
+			canvasEl.height = h * dpr;
+			canvasEl.style.width = `${w}px`;
+			canvasEl.style.height = `${h}px`;
+
+			cols = Math.floor(w / (squareSize + gridGap));
+			rows = Math.floor(h / (squareSize + gridGap));
+
+			squares = new Float32Array(cols * rows);
+			for (let i = 0; i < squares.length; i++) {
+				squares[i] = Math.random() * maxOpacity;
+			}
+		}
+
+		function updateSquares(deltaTime: number) {
+			for (let i = 0; i < squares.length; i++) {
+				if (Math.random() < flickerChance * deltaTime) {
+					squares[i] = Math.random() * maxOpacity;
+				}
+			}
+		}
+
+		function drawGrid() {
+			const colorPrefix = hexToRgba(color);
+			ctx!.clearRect(0, 0, canvasEl.width, canvasEl.height);
+			for (let i = 0; i < cols; i++) {
+				for (let j = 0; j < rows; j++) {
+					const opacity = squares[i * rows + j];
+					ctx!.fillStyle = `${colorPrefix}${opacity})`;
+					ctx!.fillRect(
+						i * (squareSize + gridGap) * dpr,
+						j * (squareSize + gridGap) * dpr,
+						squareSize * dpr,
+						squareSize * dpr
+					);
+				}
+			}
+		}
+
+		function updateCanvasSize() {
+			const w = width ?? containerEl.clientWidth;
+			const h = height ?? containerEl.clientHeight;
+			setupCanvas(w, h);
+		}
+
+		function animate(time: number) {
+			if (!isInView) return;
+
+			const deltaTime = (time - lastTime) / 1000;
+			lastTime = time;
+
+			updateSquares(deltaTime);
+			drawGrid();
+			animationFrameId = requestAnimationFrame(animate);
+		}
+
+		updateCanvasSize();
+
+		const resizeObserver = new ResizeObserver(() => {
+			updateCanvasSize();
+		});
+
+		const intersectionObserver = new IntersectionObserver(
+			([entry]) => {
+				isInView = entry.isIntersecting;
+				if (isInView) {
+					animationFrameId = requestAnimationFrame(animate);
+				}
+			},
+			{ threshold: 0 }
+		);
+
+		resizeObserver.observe(containerEl);
+		intersectionObserver.observe(canvasEl);
+
+		return () => {
+			if (animationFrameId) cancelAnimationFrame(animationFrameId);
+			resizeObserver.disconnect();
+			intersectionObserver.disconnect();
+		};
+	});
+</script>
+
+<div bind:this={containerEl} class={cn('h-full w-full', className)}>
+	<canvas bind:this={canvasEl} class="pointer-events-none"></canvas>
+</div>

--- a/src/lib/fancy-ui/flickering-grid/FlickeringGrid.test.ts
+++ b/src/lib/fancy-ui/flickering-grid/FlickeringGrid.test.ts
@@ -1,0 +1,38 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import FlickeringGrid from './FlickeringGrid.svelte';
+
+describe('FlickeringGrid', () => {
+	afterEach(cleanup);
+
+	it('renders a container div', () => {
+		const { container } = render(FlickeringGrid);
+		const div = container.querySelector('div');
+		expect(div).toBeInTheDocument();
+	});
+
+	it('renders a canvas element inside the container', () => {
+		const { container } = render(FlickeringGrid);
+		const canvas = container.querySelector('canvas');
+		expect(canvas).toBeInTheDocument();
+	});
+
+	it('canvas has pointer-events-none class', () => {
+		const { container } = render(FlickeringGrid);
+		const canvas = container.querySelector('canvas');
+		expect(canvas?.className).toContain('pointer-events-none');
+	});
+
+	it('applies custom class names to the container', () => {
+		const { container } = render(FlickeringGrid, { props: { class: 'my-grid' } });
+		const div = container.querySelector('div');
+		expect(div?.className).toContain('my-grid');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		const { container } = render(FlickeringGrid, { props: { class: 'extra' } });
+		const div = container.querySelector('div');
+		expect(div?.className).toContain('w-full');
+		expect(div?.className).toContain('h-full');
+	});
+});

--- a/src/lib/fancy-ui/flickering-grid/README.md
+++ b/src/lib/fancy-ui/flickering-grid/README.md
@@ -1,0 +1,24 @@
+# FlickeringGrid
+
+Canvas-based grid of squares with flickering opacity. Uses ResizeObserver, IntersectionObserver, and requestAnimationFrame for performant rendering with automatic pause when off-screen.
+
+## Props
+
+| Prop            | Type     | Default      | Description                                     |
+| --------------- | -------- | ------------ | ----------------------------------------------- |
+| `squareSize`    | `number` | `4`          | Size of each grid square in pixels               |
+| `gridGap`       | `number` | `6`          | Gap between squares in pixels                    |
+| `flickerChance` | `number` | `0.3`        | Probability of opacity change per second (0-1)   |
+| `color`         | `string` | `'#000000'`  | Color of the squares (hex format)                |
+| `maxOpacity`    | `number` | `0.3`        | Maximum opacity of squares (0-1)                 |
+| `width`         | `number` | `undefined`  | Fixed width (defaults to container width)        |
+| `height`        | `number` | `undefined`  | Fixed height (defaults to container height)      |
+| `class`         | `string` | `''`         | Additional CSS classes                           |
+
+## Usage
+
+```svelte
+<div class="h-64 w-full">
+  <FlickeringGrid color="#6366f1" maxOpacity={0.5} flickerChance={0.2} />
+</div>
+```

--- a/src/lib/fancy-ui/flickering-grid/index.ts
+++ b/src/lib/fancy-ui/flickering-grid/index.ts
@@ -1,0 +1,3 @@
+import FlickeringGrid, { type FlickeringGridProps } from './FlickeringGrid.svelte';
+
+export { FlickeringGrid, type FlickeringGridProps };

--- a/src/lib/fancy-ui/gradient-button/GradientButton.test.ts
+++ b/src/lib/fancy-ui/gradient-button/GradientButton.test.ts
@@ -1,0 +1,76 @@
+import { render, screen, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import GradientButton from './GradientButton.svelte';
+
+describe('GradientButton', () => {
+	afterEach(cleanup);
+
+	it('renders a button element', () => {
+		render(GradientButton);
+		expect(screen.getByRole('button')).toBeInTheDocument();
+	});
+
+	it('applies default CSS custom properties', () => {
+		render(GradientButton);
+		const button = screen.getByRole('button');
+		const style = button.getAttribute('style') ?? '';
+		expect(style).toContain('--gb-duration: 2500ms');
+		expect(style).toContain('--gb-border-width: 2px');
+		expect(style).toContain('--gb-border-radius: 8px');
+		expect(style).toContain('--gb-blur: 4px');
+		expect(style).toContain('--gb-bg-color: #000');
+	});
+
+	it('applies custom colors', () => {
+		render(GradientButton, { props: { colors: ['#ff0000', '#00ff00'] } });
+		const button = screen.getByRole('button');
+		expect(button.getAttribute('style')).toContain('--gb-colors: #ff0000, #00ff00');
+	});
+
+	it('applies custom duration', () => {
+		render(GradientButton, { props: { duration: 5000 } });
+		const button = screen.getByRole('button');
+		expect(button.getAttribute('style')).toContain('--gb-duration: 5000ms');
+	});
+
+	it('applies custom borderWidth', () => {
+		render(GradientButton, { props: { borderWidth: 4 } });
+		const button = screen.getByRole('button');
+		expect(button.getAttribute('style')).toContain('--gb-border-width: 4px');
+	});
+
+	it('applies custom class names', () => {
+		render(GradientButton, { props: { class: 'my-gradient' } });
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('my-gradient');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		render(GradientButton, { props: { class: 'extra' } });
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('gradient-button');
+		expect(button.className).toContain('overflow-hidden');
+	});
+
+	it('contains gradient-border span', () => {
+		render(GradientButton);
+		const button = screen.getByRole('button');
+		const border = button.querySelector('.gradient-border');
+		expect(border).toBeInTheDocument();
+		expect(border).toHaveAttribute('aria-hidden', 'true');
+	});
+
+	it('contains gradient-content span', () => {
+		render(GradientButton);
+		const button = screen.getByRole('button');
+		const content = button.querySelector('.gradient-content');
+		expect(content).toBeInTheDocument();
+	});
+
+	it('forwards native button attributes', () => {
+		render(GradientButton, { props: { disabled: true, type: 'submit' } });
+		const button = screen.getByRole('button');
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute('type', 'submit');
+	});
+});

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -20,6 +20,10 @@ export * from './rainbow-button/index.js';
 export * from './ripple-button/index.js';
 export * from './shimmer-button/index.js';
 export * from './timeline/index.js';
+export * from './meteors/index.js';
+export * from './flickering-grid/index.js';
+export * from './neon-border/index.js';
+export * from './colourful-text/index.js';
 
 // =============================================================================
 // Registry

--- a/src/lib/fancy-ui/meteors/Meteors.svelte
+++ b/src/lib/fancy-ui/meteors/Meteors.svelte
@@ -30,7 +30,7 @@
 {#each meteors as meteor, i (i)}
 	<span
 		class={cn(
-			'meteor pointer-events-none absolute top-0 h-0.5 w-0.5 rounded-full bg-slate-500 shadow-[0_0_0_1px_#ffffff10]',
+			'meteor pointer-events-none absolute top-0 h-0.5 w-0.5 rounded-full bg-slate-500 opacity-0 shadow-[0_0_0_1px_#ffffff10]',
 			"before:absolute before:top-1/2 before:h-px before:w-[50px] before:-translate-y-1/2 before:bg-gradient-to-r before:from-slate-500 before:to-transparent before:content-['']",
 			className
 		)}

--- a/src/lib/fancy-ui/meteors/Meteors.svelte
+++ b/src/lib/fancy-ui/meteors/Meteors.svelte
@@ -1,0 +1,59 @@
+<script lang="ts" module>
+	/**
+	 * Meteors - Animated meteor shower effect
+	 *
+	 * Generates N span elements with randomized positions, delays, and durations
+	 * that animate diagonally across the container.
+	 */
+	export interface MeteorsProps {
+		/** Number of meteors to render */
+		count?: number;
+		/** Additional CSS classes applied to each meteor */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let { count = 20, class: className }: MeteorsProps = $props();
+
+	const meteors = $derived(
+		Array.from({ length: count }, () => ({
+			left: `${Math.floor(Math.random() * 800 - 400)}px`,
+			animationDelay: `${(Math.random() * 0.6 + 0.2).toFixed(2)}s`,
+			animationDuration: `${Math.floor(Math.random() * 8 + 2)}s`
+		}))
+	);
+</script>
+
+{#each meteors as meteor, i (i)}
+	<span
+		class={cn(
+			'meteor pointer-events-none absolute top-0 h-0.5 w-0.5 rounded-full bg-slate-500 shadow-[0_0_0_1px_#ffffff10]',
+			"before:absolute before:top-1/2 before:h-px before:w-[50px] before:-translate-y-1/2 before:bg-gradient-to-r before:from-slate-500 before:to-transparent before:content-['']",
+			className
+		)}
+		style="left:{meteor.left};animation-delay:{meteor.animationDelay};animation-duration:{meteor.animationDuration}"
+	></span>
+{/each}
+
+<style>
+	@keyframes meteor-fall {
+		0% {
+			transform: rotate(215deg) translateX(0);
+			opacity: 1;
+		}
+		70% {
+			opacity: 1;
+		}
+		100% {
+			transform: rotate(215deg) translateX(-500px);
+			opacity: 0;
+		}
+	}
+
+	.meteor {
+		animation: meteor-fall 5s linear infinite;
+	}
+</style>

--- a/src/lib/fancy-ui/meteors/Meteors.test.ts
+++ b/src/lib/fancy-ui/meteors/Meteors.test.ts
@@ -1,0 +1,51 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import Meteors from './Meteors.svelte';
+
+describe('Meteors', () => {
+	afterEach(cleanup);
+
+	it('renders the default number of meteor spans (20)', () => {
+		const { container } = render(Meteors);
+		const spans = container.querySelectorAll('span.meteor');
+		expect(spans.length).toBe(20);
+	});
+
+	it('renders a custom count of meteors', () => {
+		const { container } = render(Meteors, { props: { count: 5 } });
+		const spans = container.querySelectorAll('span.meteor');
+		expect(spans.length).toBe(5);
+	});
+
+	it('renders zero meteors when count is 0', () => {
+		const { container } = render(Meteors, { props: { count: 0 } });
+		const spans = container.querySelectorAll('span.meteor');
+		expect(spans.length).toBe(0);
+	});
+
+	it('applies custom class names to each meteor', () => {
+		const { container } = render(Meteors, { props: { count: 3, class: 'my-custom-class' } });
+		const spans = container.querySelectorAll('span.meteor');
+		spans.forEach((span) => {
+			expect(span.className).toContain('my-custom-class');
+		});
+	});
+
+	it('each meteor has a style attribute with left, animation-delay, and animation-duration', () => {
+		const { container } = render(Meteors, { props: { count: 3 } });
+		const spans = container.querySelectorAll('span.meteor');
+		spans.forEach((span) => {
+			const style = span.getAttribute('style') ?? '';
+			expect(style).toContain('left:');
+			expect(style).toContain('animation-delay:');
+			expect(style).toContain('animation-duration:');
+		});
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		const { container } = render(Meteors, { props: { count: 1, class: 'extra' } });
+		const span = container.querySelector('span.meteor')!;
+		expect(span.className).toContain('absolute');
+		expect(span.className).toContain('rounded-full');
+	});
+});

--- a/src/lib/fancy-ui/meteors/README.md
+++ b/src/lib/fancy-ui/meteors/README.md
@@ -1,0 +1,18 @@
+# Meteors
+
+Animated meteor shower effect. Generates N span elements with randomized positions, delays, and durations that animate diagonally across the container.
+
+## Props
+
+| Prop    | Type     | Default | Description                          |
+| ------- | -------- | ------- | ------------------------------------ |
+| `count` | `number` | `20`    | Number of meteors to render          |
+| `class` | `string` | `''`    | Additional CSS classes on each meteor |
+
+## Usage
+
+```svelte
+<div class="relative h-64 w-full overflow-hidden bg-black">
+  <Meteors count={30} />
+</div>
+```

--- a/src/lib/fancy-ui/meteors/index.ts
+++ b/src/lib/fancy-ui/meteors/index.ts
@@ -1,0 +1,3 @@
+import Meteors, { type MeteorsProps } from './Meteors.svelte';
+
+export { Meteors, type MeteorsProps };

--- a/src/lib/fancy-ui/neon-border/NeonBorder.svelte
+++ b/src/lib/fancy-ui/neon-border/NeonBorder.svelte
@@ -1,0 +1,139 @@
+<script lang="ts" module>
+	import type { Snippet } from 'svelte';
+
+	/**
+	 * NeonBorder - Dual-color neon glow border effect
+	 *
+	 * Two gradient layers with blur and drop-shadow create a bicolor neon effect.
+	 * Optional rotation animation with half or full coverage.
+	 */
+	export interface NeonBorderProps {
+		/** First neon color */
+		color1?: string;
+		/** Second neon color */
+		color2?: string;
+		/** Animation type: none (static), half (50% coverage), full (100% coverage) */
+		animationType?: 'none' | 'half' | 'full';
+		/** Animation duration in seconds */
+		duration?: number;
+		/** Additional CSS classes */
+		class?: string;
+		/** Content */
+		children?: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let {
+		color1 = '#0496ff',
+		color2 = '#ff0a54',
+		animationType = 'half',
+		duration = 6,
+		class: className,
+		children
+	}: NeonBorderProps = $props();
+
+	function getWidth(type: 'none' | 'half' | 'full'): number {
+		switch (type) {
+			case 'none':
+				return 12;
+			case 'half':
+				return 50;
+			case 'full':
+				return 100;
+		}
+	}
+
+	const styleVars = $derived(
+		`--neon-duration: ${duration}s; --neon-color1: ${color1}; --neon-color2: ${color2}; --neon-width: ${getWidth(animationType)}%`
+	);
+
+	const animated = $derived(animationType !== 'none');
+</script>
+
+<div
+	class={cn(
+		'neon-border-container relative inline-block h-10 w-full max-w-sm overflow-hidden rounded-lg p-px z-10',
+		className
+	)}
+	style={styleVars}
+>
+	<div
+		class={cn('neon-layer-one rounded-lg', animated && 'neon-animated')}
+	></div>
+	<div
+		class={cn('neon-layer-two rounded-lg', animated && 'neon-animated')}
+	></div>
+	{@render children?.()}
+</div>
+
+<style>
+	.neon-layer-one {
+		position: absolute;
+		overflow: hidden;
+		width: 100%;
+		height: 100%;
+		filter: blur(1px) drop-shadow(0 0 12px var(--neon-color1));
+		z-index: -1;
+		inset: 0;
+	}
+
+	.neon-layer-one::before {
+		content: '';
+		position: absolute;
+		overflow: hidden;
+		top: 0;
+		left: 0;
+		width: var(--neon-width);
+		height: 100%;
+		background: linear-gradient(
+			135deg,
+			var(--neon-color1),
+			var(--neon-color1),
+			transparent,
+			transparent
+		);
+	}
+
+	.neon-layer-two {
+		position: absolute;
+		overflow: hidden;
+		width: 100%;
+		height: 100%;
+		filter: blur(1px) drop-shadow(0 0 12px var(--neon-color2));
+		z-index: -1;
+		inset: 0;
+	}
+
+	.neon-layer-two::before {
+		content: '';
+		position: absolute;
+		bottom: 0;
+		right: 0;
+		overflow: hidden;
+		width: var(--neon-width);
+		height: 100%;
+		background: linear-gradient(
+			135deg,
+			transparent,
+			transparent,
+			var(--neon-color2),
+			var(--neon-color2)
+		);
+	}
+
+	@keyframes neon-rotate {
+		0% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(360deg);
+		}
+	}
+
+	.neon-animated {
+		animation: neon-rotate var(--neon-duration) linear infinite;
+	}
+</style>

--- a/src/lib/fancy-ui/neon-border/NeonBorder.test.ts
+++ b/src/lib/fancy-ui/neon-border/NeonBorder.test.ts
@@ -1,0 +1,79 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import NeonBorder from './NeonBorder.svelte';
+
+describe('NeonBorder', () => {
+	afterEach(cleanup);
+
+	it('renders a container div', () => {
+		const { container } = render(NeonBorder);
+		const wrapper = container.querySelector('.neon-border-container');
+		expect(wrapper).toBeInTheDocument();
+	});
+
+	it('renders two neon layer divs', () => {
+		const { container } = render(NeonBorder);
+		const layerOne = container.querySelector('.neon-layer-one');
+		const layerTwo = container.querySelector('.neon-layer-two');
+		expect(layerOne).toBeInTheDocument();
+		expect(layerTwo).toBeInTheDocument();
+	});
+
+	it('applies animation class when animationType is not "none"', () => {
+		const { container } = render(NeonBorder, { props: { animationType: 'half' } });
+		const layerOne = container.querySelector('.neon-layer-one');
+		expect(layerOne?.className).toContain('neon-animated');
+	});
+
+	it('does not apply animation class when animationType is "none"', () => {
+		const { container } = render(NeonBorder, { props: { animationType: 'none' } });
+		const layerOne = container.querySelector('.neon-layer-one');
+		expect(layerOne?.className).not.toContain('neon-animated');
+	});
+
+	it('sets CSS custom properties from props', () => {
+		const { container } = render(NeonBorder, {
+			props: { color1: '#ff0000', color2: '#00ff00', duration: 10 }
+		});
+		const wrapper = container.querySelector('.neon-border-container') as HTMLElement;
+		const style = wrapper.getAttribute('style') ?? '';
+		expect(style).toContain('--neon-color1: #ff0000');
+		expect(style).toContain('--neon-color2: #00ff00');
+		expect(style).toContain('--neon-duration: 10s');
+	});
+
+	it('sets neon-width to 50% for half animation type', () => {
+		const { container } = render(NeonBorder, { props: { animationType: 'half' } });
+		const wrapper = container.querySelector('.neon-border-container') as HTMLElement;
+		const style = wrapper.getAttribute('style') ?? '';
+		expect(style).toContain('--neon-width: 50%');
+	});
+
+	it('sets neon-width to 100% for full animation type', () => {
+		const { container } = render(NeonBorder, { props: { animationType: 'full' } });
+		const wrapper = container.querySelector('.neon-border-container') as HTMLElement;
+		const style = wrapper.getAttribute('style') ?? '';
+		expect(style).toContain('--neon-width: 100%');
+	});
+
+	it('sets neon-width to 12% for none animation type', () => {
+		const { container } = render(NeonBorder, { props: { animationType: 'none' } });
+		const wrapper = container.querySelector('.neon-border-container') as HTMLElement;
+		const style = wrapper.getAttribute('style') ?? '';
+		expect(style).toContain('--neon-width: 12%');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(NeonBorder, { props: { class: 'custom-neon' } });
+		const wrapper = container.querySelector('.neon-border-container');
+		expect(wrapper?.className).toContain('custom-neon');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		const { container } = render(NeonBorder, { props: { class: 'extra' } });
+		const wrapper = container.querySelector('.neon-border-container');
+		expect(wrapper?.className).toContain('relative');
+		expect(wrapper?.className).toContain('overflow-hidden');
+		expect(wrapper?.className).toContain('rounded-lg');
+	});
+});

--- a/src/lib/fancy-ui/neon-border/README.md
+++ b/src/lib/fancy-ui/neon-border/README.md
@@ -1,0 +1,27 @@
+# NeonBorder
+
+Dual-color neon glow border effect. Two gradient layers with blur and drop-shadow create a bicolor neon effect with optional rotation animation.
+
+## Props
+
+| Prop             | Type                            | Default     | Description                        |
+| ---------------- | ------------------------------- | ----------- | ---------------------------------- |
+| `color1`         | `string`                        | `'#0496ff'` | First neon color                   |
+| `color2`         | `string`                        | `'#ff0a54'` | Second neon color                  |
+| `animationType`  | `'none' \| 'half' \| 'full'`   | `'half'`    | Animation coverage type            |
+| `duration`       | `number`                        | `6`         | Animation duration in seconds      |
+| `class`          | `string`                        | `''`        | Additional CSS classes             |
+
+## Slots
+
+- **default** — Content rendered inside the neon border
+
+## Usage
+
+```svelte
+<NeonBorder color1="#0496ff" color2="#ff0a54" animationType="half">
+  <div class="bg-background rounded-lg px-4 py-2 text-center">
+    Neon content
+  </div>
+</NeonBorder>
+```

--- a/src/lib/fancy-ui/neon-border/index.ts
+++ b/src/lib/fancy-ui/neon-border/index.ts
@@ -1,0 +1,3 @@
+import NeonBorder, { type NeonBorderProps } from './NeonBorder.svelte';
+
+export { NeonBorder, type NeonBorderProps };

--- a/src/lib/fancy-ui/rainbow-button/RainbowButton.test.ts
+++ b/src/lib/fancy-ui/rainbow-button/RainbowButton.test.ts
@@ -1,0 +1,62 @@
+import { render, screen, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import RainbowButton from './RainbowButton.svelte';
+
+describe('RainbowButton', () => {
+	afterEach(cleanup);
+
+	it('renders a button element by default', () => {
+		render(RainbowButton);
+		expect(screen.getByRole('button')).toBeInTheDocument();
+	});
+
+	it('renders an anchor element when href is provided', () => {
+		render(RainbowButton, { props: { href: '/test' } });
+		expect(screen.getByRole('link')).toBeInTheDocument();
+	});
+
+	it('applies the href to the anchor element', () => {
+		render(RainbowButton, { props: { href: '/test' } });
+		expect(screen.getByRole('link')).toHaveAttribute('href', '/test');
+	});
+
+	it('sets the --rainbow-speed CSS custom property', () => {
+		render(RainbowButton, { props: { speed: 5 } });
+		const button = screen.getByRole('button');
+		expect(button.getAttribute('style')).toContain('--rainbow-speed: 5s');
+	});
+
+	it('uses default speed of 2s', () => {
+		render(RainbowButton);
+		const button = screen.getByRole('button');
+		expect(button.getAttribute('style')).toContain('--rainbow-speed: 2s');
+	});
+
+	it('applies custom class names', () => {
+		render(RainbowButton, { props: { class: 'my-custom' } });
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('my-custom');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		render(RainbowButton, { props: { class: 'extra' } });
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('rainbow-button');
+		expect(button.className).toContain('rounded-xl');
+	});
+
+	it('supports disabled state on button', () => {
+		render(RainbowButton, { props: { disabled: true } });
+		expect(screen.getByRole('button')).toBeDisabled();
+	});
+
+	it('sets type="button" by default', () => {
+		render(RainbowButton);
+		expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+	});
+
+	it('allows custom type attribute', () => {
+		render(RainbowButton, { props: { type: 'submit' } });
+		expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+	});
+});

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -240,6 +240,38 @@ export const registry: Record<string, ComponentMeta> = {
 		description: 'Infinite scrolling component for text, images, or cards',
 		category: 'layout',
 		status: 'done'
+	},
+
+	meteors: {
+		name: 'Meteors',
+		slug: 'meteors',
+		description: 'Animated meteor shower effect with randomized positions and delays',
+		category: 'effects',
+		status: 'done'
+	},
+
+	'flickering-grid': {
+		name: 'FlickeringGrid',
+		slug: 'flickering-grid',
+		description: 'Canvas-based grid of squares with flickering opacity',
+		category: 'backgrounds',
+		status: 'done'
+	},
+
+	'neon-border': {
+		name: 'NeonBorder',
+		slug: 'neon-border',
+		description: 'Dual-color neon glow border effect with optional rotation animation',
+		category: 'effects',
+		status: 'done'
+	},
+
+	'colourful-text': {
+		name: 'ColourfulText',
+		slug: 'colourful-text',
+		description: 'Per-character color animation with shuffling colors',
+		category: 'text',
+		status: 'done'
 	}
 };
 

--- a/src/lib/fancy-ui/shimmer-button/ShimmerButton.test.ts
+++ b/src/lib/fancy-ui/shimmer-button/ShimmerButton.test.ts
@@ -1,0 +1,79 @@
+import { render, screen, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import ShimmerButton from './ShimmerButton.svelte';
+
+describe('ShimmerButton', () => {
+	afterEach(cleanup);
+
+	it('renders a button element', () => {
+		render(ShimmerButton);
+		expect(screen.getByRole('button')).toBeInTheDocument();
+	});
+
+	it('applies default CSS custom properties', () => {
+		render(ShimmerButton);
+		const button = screen.getByRole('button');
+		const style = button.getAttribute('style') ?? '';
+		expect(style).toContain('--shimmer-color: #ffffff');
+		expect(style).toContain('--speed: 3s');
+		expect(style).toContain('--bg: rgba(0, 0, 0, 1)');
+	});
+
+	it('applies custom shimmerColor', () => {
+		render(ShimmerButton, { props: { shimmerColor: '#ff0000' } });
+		const button = screen.getByRole('button');
+		expect(button.getAttribute('style')).toContain('--shimmer-color: #ff0000');
+	});
+
+	it('applies custom background', () => {
+		render(ShimmerButton, { props: { background: 'rgba(0, 0, 255, 0.5)' } });
+		const button = screen.getByRole('button');
+		expect(button.getAttribute('style')).toContain('--bg: rgba(0, 0, 255, 0.5)');
+	});
+
+	it('applies custom shimmerDuration', () => {
+		render(ShimmerButton, { props: { shimmerDuration: '5s' } });
+		const button = screen.getByRole('button');
+		expect(button.getAttribute('style')).toContain('--speed: 5s');
+	});
+
+	it('applies custom borderRadius', () => {
+		render(ShimmerButton, { props: { borderRadius: '8px' } });
+		const button = screen.getByRole('button');
+		expect(button.getAttribute('style')).toContain('--radius: 8px');
+	});
+
+	it('applies custom class names', () => {
+		render(ShimmerButton, { props: { class: 'my-shimmer' } });
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('my-shimmer');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		render(ShimmerButton, { props: { class: 'extra' } });
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('shimmer-button');
+		expect(button.className).toContain('overflow-hidden');
+	});
+
+	it('contains shimmer layer div', () => {
+		render(ShimmerButton);
+		const button = screen.getByRole('button');
+		const shimmerLayer = button.querySelector('.shimmer-slide');
+		expect(shimmerLayer).toBeInTheDocument();
+	});
+
+	it('contains spin-around element', () => {
+		render(ShimmerButton);
+		const button = screen.getByRole('button');
+		const spinAround = button.querySelector('.spin-around');
+		expect(spinAround).toBeInTheDocument();
+	});
+
+	it('forwards native button attributes', () => {
+		render(ShimmerButton, { props: { disabled: true, 'aria-label': 'Submit' } });
+		const button = screen.getByRole('button');
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute('aria-label', 'Submit');
+	});
+});

--- a/src/routes/demo/colourful-text/+page.svelte
+++ b/src/routes/demo/colourful-text/+page.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import { ColourfulText } from '$lib/fancy-ui/colourful-text';
+</script>
+
+<svelte:head>
+	<title>ColourfulText - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">ColourfulText</h1>
+	<p class="text-muted-foreground mb-8">
+		Per-character color animation with shuffling colors every 5 seconds.
+	</p>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="rounded-lg border bg-card p-6">
+			<div class="mx-auto flex items-center justify-center rounded-xl bg-slate-950 p-12">
+				<h2 class="text-4xl font-bold text-white">
+					Make things <ColourfulText text="colourful" />
+				</h2>
+			</div>
+		</div>
+	</section>
+
+	<!-- Custom Colors -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Colors</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Pass a custom <code class="rounded bg-muted px-1.5 py-0.5">colors</code> array.
+		</p>
+		<div class="rounded-lg border bg-card p-6">
+			<div class="mx-auto flex items-center justify-center rounded-xl bg-slate-950 p-12">
+				<h2 class="text-4xl font-bold text-white">
+					<ColourfulText
+						text="Ocean Vibes"
+						colors={['#0ea5e9', '#06b6d4', '#14b8a6', '#3b82f6', '#6366f1']}
+					/>
+				</h2>
+			</div>
+		</div>
+	</section>
+
+	<!-- Different Durations -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Transition Speed</h2>
+		<div class="rounded-lg border bg-card p-6 space-y-6">
+			<div class="flex items-center justify-center rounded-xl bg-slate-950 p-8">
+				<div class="text-center">
+					<p class="text-xs text-slate-500 mb-2">Fast (0.2s)</p>
+					<h2 class="text-3xl font-bold">
+						<ColourfulText text="Lightning" duration={0.2} />
+					</h2>
+				</div>
+			</div>
+			<div class="flex items-center justify-center rounded-xl bg-slate-950 p-8">
+				<div class="text-center">
+					<p class="text-xs text-slate-500 mb-2">Slow (1.5s)</p>
+					<h2 class="text-3xl font-bold">
+						<ColourfulText text="Smooth Flow" duration={1.5} />
+					</h2>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- Longer Text -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Longer Text</h2>
+		<div class="rounded-lg border bg-card p-6">
+			<div class="mx-auto flex items-center justify-center rounded-xl bg-slate-950 p-12">
+				<p class="text-2xl font-semibold text-center">
+					<ColourfulText text="Every character gets its own colour!" />
+				</p>
+			</div>
+		</div>
+	</section>
+</div>

--- a/src/routes/demo/flickering-grid/+page.svelte
+++ b/src/routes/demo/flickering-grid/+page.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import { FlickeringGrid } from '$lib/fancy-ui/flickering-grid';
+</script>
+
+<svelte:head>
+	<title>FlickeringGrid - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">FlickeringGrid</h1>
+	<p class="text-muted-foreground mb-8">
+		Canvas-based grid of squares with flickering opacity. Automatically pauses when off-screen.
+	</p>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="rounded-lg border bg-card p-6">
+			<div class="mx-auto h-64 w-full max-w-md overflow-hidden rounded-xl border bg-background">
+				<FlickeringGrid />
+			</div>
+		</div>
+	</section>
+
+	<!-- Custom Colors -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Colors</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Use the <code class="rounded bg-muted px-1.5 py-0.5">color</code> prop with a hex value.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap gap-6 justify-center">
+			<div class="h-48 w-56 overflow-hidden rounded-xl border bg-background">
+				<FlickeringGrid color="#6366f1" maxOpacity={0.5} />
+			</div>
+			<div class="h-48 w-56 overflow-hidden rounded-xl border bg-background">
+				<FlickeringGrid color="#ef4444" maxOpacity={0.4} />
+			</div>
+			<div class="h-48 w-56 overflow-hidden rounded-xl border bg-background">
+				<FlickeringGrid color="#22c55e" maxOpacity={0.4} />
+			</div>
+		</div>
+	</section>
+
+	<!-- Grid Size Variations -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Grid Size Variations</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Adjust <code class="rounded bg-muted px-1.5 py-0.5">squareSize</code> and
+			<code class="rounded bg-muted px-1.5 py-0.5">gridGap</code>.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap gap-6 justify-center">
+			<div class="h-48 w-56 overflow-hidden rounded-xl border bg-background">
+				<FlickeringGrid squareSize={2} gridGap={2} maxOpacity={0.4} />
+			</div>
+			<div class="h-48 w-56 overflow-hidden rounded-xl border bg-background">
+				<FlickeringGrid squareSize={8} gridGap={4} maxOpacity={0.3} />
+			</div>
+		</div>
+	</section>
+
+	<!-- Flicker Speed -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Flicker Speed</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Control how often squares change with <code class="rounded bg-muted px-1.5 py-0.5">flickerChance</code>.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap gap-6 justify-center">
+			<div class="h-48 w-56 overflow-hidden rounded-xl border bg-background">
+				<FlickeringGrid flickerChance={0.05} maxOpacity={0.4} />
+			</div>
+			<div class="h-48 w-56 overflow-hidden rounded-xl border bg-background">
+				<FlickeringGrid flickerChance={0.8} maxOpacity={0.4} />
+			</div>
+		</div>
+	</section>
+</div>

--- a/src/routes/demo/meteors/+page.svelte
+++ b/src/routes/demo/meteors/+page.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { Meteors } from '$lib/fancy-ui/meteors';
+</script>
+
+<svelte:head>
+	<title>Meteors - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">Meteors</h1>
+	<p class="text-muted-foreground mb-8">
+		Animated meteor shower effect with randomized positions, delays, and durations.
+	</p>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="rounded-lg border bg-card p-6">
+			<div class="relative mx-auto h-64 w-full max-w-md overflow-hidden rounded-xl border bg-slate-950 p-6 flex items-center justify-center">
+				<p class="text-center text-white z-10">Default (20 meteors)</p>
+				<Meteors />
+			</div>
+		</div>
+	</section>
+
+	<!-- Custom Count -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Count</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Control the number of meteors with the <code class="rounded bg-muted px-1.5 py-0.5">count</code> prop.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap gap-6 justify-center">
+			<div class="relative h-48 w-56 overflow-hidden rounded-xl border bg-slate-950 p-4 flex items-center justify-center">
+				<p class="text-xs text-white text-center z-10">5 meteors</p>
+				<Meteors count={5} />
+			</div>
+			<div class="relative h-48 w-56 overflow-hidden rounded-xl border bg-slate-950 p-4 flex items-center justify-center">
+				<p class="text-xs text-white text-center z-10">40 meteors</p>
+				<Meteors count={40} />
+			</div>
+		</div>
+	</section>
+
+	<!-- Card Example -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Card with Meteors</h2>
+		<div class="rounded-lg border bg-card p-6">
+			<div class="relative mx-auto w-full max-w-sm overflow-hidden rounded-2xl border border-slate-800 bg-slate-950 p-8 shadow-xl">
+				<Meteors count={15} />
+				<div class="relative z-10">
+					<h3 class="text-lg font-bold text-white mb-2">Shooting Stars</h3>
+					<p class="text-sm text-slate-400">
+						A beautiful meteor shower effect for dark-themed cards and hero sections.
+					</p>
+				</div>
+			</div>
+		</div>
+	</section>
+</div>

--- a/src/routes/demo/neon-border/+page.svelte
+++ b/src/routes/demo/neon-border/+page.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import { NeonBorder } from '$lib/fancy-ui/neon-border';
+</script>
+
+<svelte:head>
+	<title>NeonBorder - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">NeonBorder</h1>
+	<p class="text-muted-foreground mb-8">
+		Dual-color neon glow border effect with optional rotation animation.
+	</p>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="rounded-lg border bg-card p-6 flex justify-center">
+			<NeonBorder>
+				<div class="flex h-full w-full items-center justify-center rounded-lg bg-background px-6 py-2">
+					<span class="text-sm font-medium">Neon Border</span>
+				</div>
+			</NeonBorder>
+		</div>
+	</section>
+
+	<!-- Animation Types -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Animation Types</h2>
+		<p class="text-sm text-muted-foreground mb-4">
+			Control coverage with <code class="rounded bg-muted px-1.5 py-0.5">animationType</code>.
+		</p>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap gap-6 justify-center">
+			<NeonBorder animationType="none" class="max-w-[200px]">
+				<div class="flex h-full w-full items-center justify-center rounded-lg bg-background px-4 py-2">
+					<span class="text-xs">none (static)</span>
+				</div>
+			</NeonBorder>
+			<NeonBorder animationType="half" class="max-w-[200px]">
+				<div class="flex h-full w-full items-center justify-center rounded-lg bg-background px-4 py-2">
+					<span class="text-xs">half</span>
+				</div>
+			</NeonBorder>
+			<NeonBorder animationType="full" class="max-w-[200px]">
+				<div class="flex h-full w-full items-center justify-center rounded-lg bg-background px-4 py-2">
+					<span class="text-xs">full</span>
+				</div>
+			</NeonBorder>
+		</div>
+	</section>
+
+	<!-- Custom Colors -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Colors</h2>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap gap-6 justify-center">
+			<NeonBorder color1="#22c55e" color2="#3b82f6" class="max-w-[200px]">
+				<div class="flex h-full w-full items-center justify-center rounded-lg bg-background px-4 py-2">
+					<span class="text-xs">Green → Blue</span>
+				</div>
+			</NeonBorder>
+			<NeonBorder color1="#f59e0b" color2="#ef4444" class="max-w-[200px]">
+				<div class="flex h-full w-full items-center justify-center rounded-lg bg-background px-4 py-2">
+					<span class="text-xs">Amber → Red</span>
+				</div>
+			</NeonBorder>
+			<NeonBorder color1="#a855f7" color2="#ec4899" class="max-w-[200px]">
+				<div class="flex h-full w-full items-center justify-center rounded-lg bg-background px-4 py-2">
+					<span class="text-xs">Purple → Pink</span>
+				</div>
+			</NeonBorder>
+		</div>
+	</section>
+
+	<!-- Speed Variations -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Speed Variations</h2>
+		<div class="rounded-lg border bg-card p-6 flex flex-wrap gap-6 justify-center">
+			<NeonBorder duration={2} class="max-w-[200px]">
+				<div class="flex h-full w-full items-center justify-center rounded-lg bg-background px-4 py-2">
+					<span class="text-xs">Fast (2s)</span>
+				</div>
+			</NeonBorder>
+			<NeonBorder duration={6} class="max-w-[200px]">
+				<div class="flex h-full w-full items-center justify-center rounded-lg bg-background px-4 py-2">
+					<span class="text-xs">Default (6s)</span>
+				</div>
+			</NeonBorder>
+			<NeonBorder duration={15} class="max-w-[200px]">
+				<div class="flex h-full w-full items-center justify-center rounded-lg bg-background px-4 py-2">
+					<span class="text-xs">Slow (15s)</span>
+				</div>
+			</NeonBorder>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Port 4 new components: **Meteors**, **FlickeringGrid**, **NeonBorder**, **ColourfulText**
- Add unit tests for these 4 + 4 existing components (**RainbowButton**, **ShimmerButton**, **GradientButton**, **BorderBeam**)
- Update registry and index with all 4 new components
- Fix Tailwind v4 double-rotation bug (individual `rotate` property stacking with `transform` in keyframes)

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm vitest run` — 78 tests pass (9/9 component suites)
- [ ] Visual review of demo pages: `/demo/meteors`, `/demo/flickering-grid`, `/demo/neon-border`, `/demo/colourful-text`