### PR TITLE
test: add unit tests for all 16 remaining components

### DIFF
--- a/src/lib/fancy-ui/animated-beam/AnimatedBeam.test.ts
+++ b/src/lib/fancy-ui/animated-beam/AnimatedBeam.test.ts
@@ -1,0 +1,51 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import AnimatedBeam from './AnimatedBeam.svelte';
+
+describe('AnimatedBeam', () => {
+	afterEach(cleanup);
+
+	it('renders an svg element', () => {
+		const { container } = render(AnimatedBeam);
+		const svg = container.querySelector('svg');
+		expect(svg).toBeInTheDocument();
+	});
+
+	it('svg has pointer-events-none class', () => {
+		const { container } = render(AnimatedBeam);
+		const svg = container.querySelector('svg');
+		expect(svg?.className.baseVal).toContain('pointer-events-none');
+	});
+
+	it('renders two path elements', () => {
+		const { container } = render(AnimatedBeam);
+		const paths = container.querySelectorAll('path');
+		expect(paths.length).toBe(2);
+	});
+
+	it('renders a linearGradient in defs', () => {
+		const { container } = render(AnimatedBeam);
+		const gradient = container.querySelector('linearGradient');
+		expect(gradient).toBeInTheDocument();
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(AnimatedBeam, { props: { class: 'my-beam' } });
+		const svg = container.querySelector('svg');
+		expect(svg?.className.baseVal).toContain('my-beam');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		const { container } = render(AnimatedBeam, { props: { class: 'extra' } });
+		const svg = container.querySelector('svg');
+		expect(svg?.className.baseVal).toContain('pointer-events-none');
+		expect(svg?.className.baseVal).toContain('absolute');
+		expect(svg?.className.baseVal).toContain('transform-gpu');
+	});
+
+	it('svg has fill="none" attribute', () => {
+		const { container } = render(AnimatedBeam);
+		const svg = container.querySelector('svg');
+		expect(svg).toHaveAttribute('fill', 'none');
+	});
+});

--- a/src/lib/fancy-ui/animated-tooltip/AnimatedTooltip.test.ts
+++ b/src/lib/fancy-ui/animated-tooltip/AnimatedTooltip.test.ts
@@ -1,0 +1,65 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import AnimatedTooltip from './AnimatedTooltip.svelte';
+
+const mockItems = [
+	{ id: 1, name: 'Alice', designation: 'Engineer', image: '/alice.jpg' },
+	{ id: 2, name: 'Bob', designation: 'Designer', image: '/bob.jpg' }
+];
+
+describe('AnimatedTooltip', () => {
+	afterEach(cleanup);
+
+	it('renders one avatar image per item', () => {
+		const { container } = render(AnimatedTooltip, { props: { items: mockItems } });
+		const imgs = container.querySelectorAll('img');
+		expect(imgs.length).toBe(2);
+	});
+
+	it('sets correct alt text on images', () => {
+		const { container } = render(AnimatedTooltip, { props: { items: mockItems } });
+		const imgs = container.querySelectorAll('img');
+		expect(imgs[0]).toHaveAttribute('alt', 'Alice');
+		expect(imgs[1]).toHaveAttribute('alt', 'Bob');
+	});
+
+	it('sets correct src on images', () => {
+		const { container } = render(AnimatedTooltip, { props: { items: mockItems } });
+		const imgs = container.querySelectorAll('img');
+		expect(imgs[0]).toHaveAttribute('src', '/alice.jpg');
+		expect(imgs[1]).toHaveAttribute('src', '/bob.jpg');
+	});
+
+	it('renders a flex container', () => {
+		const { container } = render(AnimatedTooltip, { props: { items: mockItems } });
+		const wrapper = container.firstElementChild as HTMLElement;
+		expect(wrapper?.className).toContain('flex');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(AnimatedTooltip, {
+			props: { items: mockItems, class: 'custom' }
+		});
+		const wrapper = container.firstElementChild as HTMLElement;
+		expect(wrapper?.className).toContain('custom');
+	});
+
+	it('renders empty when items is empty', () => {
+		const { container } = render(AnimatedTooltip, { props: { items: [] } });
+		const imgs = container.querySelectorAll('img');
+		expect(imgs.length).toBe(0);
+	});
+
+	it('each item wrapper has group class', () => {
+		const { container } = render(AnimatedTooltip, { props: { items: mockItems } });
+		const groups = container.querySelectorAll('.group');
+		expect(groups.length).toBe(2);
+	});
+
+	it('images have rounded-full class', () => {
+		const { container } = render(AnimatedTooltip, { props: { items: mockItems } });
+		const imgs = container.querySelectorAll('img');
+		expect(imgs[0]?.className).toContain('rounded-full');
+		expect(imgs[1]?.className).toContain('rounded-full');
+	});
+});

--- a/src/lib/fancy-ui/bg-falling-stars/FallingStarsBg.test.ts
+++ b/src/lib/fancy-ui/bg-falling-stars/FallingStarsBg.test.ts
@@ -1,0 +1,56 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import FallingStarsBg from './FallingStarsBg.svelte';
+
+describe('FallingStarsBg', () => {
+	beforeEach(() => {
+		// Mock ResizeObserver (not available in jsdom) - must be a class
+		global.ResizeObserver = class {
+			observe = vi.fn();
+			unobserve = vi.fn();
+			disconnect = vi.fn();
+		};
+	});
+
+	afterEach(cleanup);
+
+	it('renders a canvas element', () => {
+		const { container } = render(FallingStarsBg);
+		const canvas = container.querySelector('canvas');
+		expect(canvas).toBeInTheDocument();
+	});
+
+	it('canvas has absolute positioning class', () => {
+		const { container } = render(FallingStarsBg);
+		const canvas = container.querySelector('canvas');
+		expect(canvas?.className).toContain('absolute');
+	});
+
+	it('canvas has inset-0 class', () => {
+		const { container } = render(FallingStarsBg);
+		const canvas = container.querySelector('canvas');
+		expect(canvas?.className).toContain('inset-0');
+	});
+
+	it('canvas has full width and height classes', () => {
+		const { container } = render(FallingStarsBg);
+		const canvas = container.querySelector('canvas');
+		expect(canvas?.className).toContain('h-full');
+		expect(canvas?.className).toContain('w-full');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(FallingStarsBg, { props: { class: 'my-stars' } });
+		const canvas = container.querySelector('canvas');
+		expect(canvas?.className).toContain('my-stars');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		const { container } = render(FallingStarsBg, { props: { class: 'extra' } });
+		const canvas = container.querySelector('canvas');
+		expect(canvas?.className).toContain('absolute');
+		expect(canvas?.className).toContain('inset-0');
+		expect(canvas?.className).toContain('h-full');
+		expect(canvas?.className).toContain('w-full');
+	});
+});

--- a/src/lib/fancy-ui/bg-stars/StarsBackground.test.ts
+++ b/src/lib/fancy-ui/bg-stars/StarsBackground.test.ts
@@ -1,0 +1,50 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import StarsBackground from './StarsBackground.svelte';
+
+describe('StarsBackground', () => {
+	afterEach(cleanup);
+
+	it('renders a container div', () => {
+		const { container } = render(StarsBackground);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div).toBeInTheDocument();
+	});
+
+	it('has overflow-hidden class', () => {
+		const { container } = render(StarsBackground);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('overflow-hidden');
+	});
+
+	it('renders three star layers', () => {
+		const { container } = render(StarsBackground);
+		const layers = container.querySelectorAll('.star-layer');
+		expect(layers.length).toBe(3);
+	});
+
+	it('renders six star fields (2 per layer)', () => {
+		const { container } = render(StarsBackground);
+		const fields = container.querySelectorAll('.star-field');
+		expect(fields.length).toBe(6);
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(StarsBackground, { props: { class: 'my-stars' } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('my-stars');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		const { container } = render(StarsBackground, { props: { class: 'extra' } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('overflow-hidden');
+		expect(div?.className).toContain('size-full');
+	});
+
+	it('has radial gradient background class', () => {
+		const { container } = render(StarsBackground);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('bg-[radial-gradient');
+	});
+});

--- a/src/lib/fancy-ui/blur-reveal/BlurReveal.test.ts
+++ b/src/lib/fancy-ui/blur-reveal/BlurReveal.test.ts
@@ -1,0 +1,54 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import BlurReveal from './BlurReveal.svelte';
+
+describe('BlurReveal', () => {
+	beforeEach(() => {
+		// Mock IntersectionObserver (not available in jsdom) - must be a class
+		global.IntersectionObserver = class {
+			observe = vi.fn();
+			unobserve = vi.fn();
+			disconnect = vi.fn();
+		} as unknown as typeof IntersectionObserver;
+	});
+
+	afterEach(cleanup);
+
+	it('renders a container div', () => {
+		const { container } = render(BlurReveal);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div).toBeInTheDocument();
+	});
+
+	it('sets default CSS custom properties', () => {
+		const { container } = render(BlurReveal);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div.style.getPropertyValue('--blur-reveal-duration')).toBe('1s');
+		expect(div.style.getPropertyValue('--blur-reveal-delay')).toBe('0.2s');
+		expect(div.style.getPropertyValue('--blur-reveal-blur')).toBe('20px');
+		expect(div.style.getPropertyValue('--blur-reveal-y')).toBe('20px');
+	});
+
+	it('sets CSS custom properties from props', () => {
+		const { container } = render(BlurReveal, {
+			props: { duration: 2, delay: 0.5, blur: '10px', yOffset: 30 }
+		});
+		const div = container.firstElementChild as HTMLElement;
+		expect(div.style.getPropertyValue('--blur-reveal-duration')).toBe('2s');
+		expect(div.style.getPropertyValue('--blur-reveal-delay')).toBe('0.5s');
+		expect(div.style.getPropertyValue('--blur-reveal-blur')).toBe('10px');
+		expect(div.style.getPropertyValue('--blur-reveal-y')).toBe('30px');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(BlurReveal, { props: { class: 'my-reveal' } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('my-reveal');
+	});
+
+	it('does not render blur-reveal-wrapper without children', () => {
+		const { container } = render(BlurReveal);
+		const wrapper = container.querySelector('.blur-reveal-wrapper');
+		expect(wrapper).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/fancy-ui/compare/Compare.test.ts
+++ b/src/lib/fancy-ui/compare/Compare.test.ts
@@ -1,0 +1,66 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import Compare from './Compare.svelte';
+
+describe('Compare', () => {
+	afterEach(cleanup);
+
+	it('renders a container with role="slider"', () => {
+		const { container } = render(Compare);
+		const slider = container.querySelector('[role="slider"]');
+		expect(slider).toBeInTheDocument();
+	});
+
+	it('has overflow-hidden class', () => {
+		const { container } = render(Compare);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('overflow-hidden');
+	});
+
+	it('renders image elements when image props are provided', () => {
+		const { container } = render(Compare, {
+			props: { firstImage: '/a.jpg', secondImage: '/b.jpg' }
+		});
+		const imgs = container.querySelectorAll('img');
+		expect(imgs.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it('sets correct src and alt on first image', () => {
+		const { container } = render(Compare, {
+			props: { firstImage: '/a.jpg', firstImageAlt: 'Before' }
+		});
+		const imgs = container.querySelectorAll('img');
+		const firstImg = Array.from(imgs).find((img) => img.getAttribute('alt') === 'Before');
+		expect(firstImg).toHaveAttribute('src', '/a.jpg');
+	});
+
+	it('sets correct src and alt on second image', () => {
+		const { container } = render(Compare, {
+			props: { secondImage: '/b.jpg', secondImageAlt: 'After' }
+		});
+		const imgs = container.querySelectorAll('img');
+		const secondImg = Array.from(imgs).find((img) => img.getAttribute('alt') === 'After');
+		expect(secondImg).toHaveAttribute('src', '/b.jpg');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(Compare, { props: { class: 'my-compare' } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('my-compare');
+	});
+
+	it('has aria-valuenow set to initial slider percentage', () => {
+		const { container } = render(Compare, {
+			props: { initialSliderPercentage: 75 }
+		});
+		const slider = container.querySelector('[role="slider"]');
+		expect(slider).toHaveAttribute('aria-valuenow', '75');
+	});
+
+	it('has aria-valuemin and aria-valuemax attributes', () => {
+		const { container } = render(Compare);
+		const slider = container.querySelector('[role="slider"]');
+		expect(slider).toHaveAttribute('aria-valuemin', '0');
+		expect(slider).toHaveAttribute('aria-valuemax', '100');
+	});
+});

--- a/src/lib/fancy-ui/direction-aware-hover/DirectionAwareHover.test.ts
+++ b/src/lib/fancy-ui/direction-aware-hover/DirectionAwareHover.test.ts
@@ -1,0 +1,88 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import DirectionAwareHover from './DirectionAwareHover.svelte';
+
+describe('DirectionAwareHover', () => {
+	beforeEach(() => {
+		// Mock window.matchMedia (not available in jsdom)
+		Object.defineProperty(window, 'matchMedia', {
+			writable: true,
+			value: vi.fn().mockImplementation((query: string) => ({
+				matches: false,
+				media: query,
+				onchange: null,
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				dispatchEvent: vi.fn()
+			}))
+		});
+	});
+
+	afterEach(cleanup);
+
+	it('renders a figure container', () => {
+		const { container } = render(DirectionAwareHover, {
+			props: { imageUrl: '/test.jpg' }
+		});
+		const figure = container.querySelector('[role="figure"]');
+		expect(figure).toBeInTheDocument();
+	});
+
+	it('renders an image with correct src', () => {
+		const { container } = render(DirectionAwareHover, {
+			props: { imageUrl: '/test.jpg' }
+		});
+		const img = container.querySelector('img');
+		expect(img).toHaveAttribute('src', '/test.jpg');
+	});
+
+	it('renders an image with correct alt', () => {
+		const { container } = render(DirectionAwareHover, {
+			props: { imageUrl: '/test.jpg', imageAlt: 'My image' }
+		});
+		const img = container.querySelector('img');
+		expect(img).toHaveAttribute('alt', 'My image');
+	});
+
+	it('uses default alt text', () => {
+		const { container } = render(DirectionAwareHover, {
+			props: { imageUrl: '/test.jpg' }
+		});
+		const img = container.querySelector('img');
+		expect(img).toHaveAttribute('alt', 'image');
+	});
+
+	it('has overflow-hidden class on the container', () => {
+		const { container } = render(DirectionAwareHover, {
+			props: { imageUrl: '/test.jpg' }
+		});
+		const figure = container.querySelector('[role="figure"]') as HTMLElement;
+		expect(figure?.className).toContain('overflow-hidden');
+	});
+
+	it('has rounded-lg class on the container', () => {
+		const { container } = render(DirectionAwareHover, {
+			props: { imageUrl: '/test.jpg' }
+		});
+		const figure = container.querySelector('[role="figure"]') as HTMLElement;
+		expect(figure?.className).toContain('rounded-lg');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(DirectionAwareHover, {
+			props: { imageUrl: '/test.jpg', class: 'custom-hover' }
+		});
+		const figure = container.querySelector('[role="figure"]') as HTMLElement;
+		expect(figure?.className).toContain('custom-hover');
+	});
+
+	it('image has object-cover class', () => {
+		const { container } = render(DirectionAwareHover, {
+			props: { imageUrl: '/test.jpg' }
+		});
+		const img = container.querySelector('img');
+		expect(img?.className).toContain('object-cover');
+	});
+});

--- a/src/lib/fancy-ui/dock/Dock.test.ts
+++ b/src/lib/fancy-ui/dock/Dock.test.ts
@@ -1,0 +1,61 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import Dock from './Dock.svelte';
+
+describe('Dock', () => {
+	afterEach(cleanup);
+
+	it('renders a toolbar element', () => {
+		const { container } = render(Dock);
+		const toolbar = container.querySelector('[role="toolbar"]');
+		expect(toolbar).toBeInTheDocument();
+	});
+
+	it('has backdrop-blur-md class', () => {
+		const { container } = render(Dock);
+		const toolbar = container.querySelector('[role="toolbar"]') as HTMLElement;
+		expect(toolbar?.className).toContain('backdrop-blur-md');
+	});
+
+	it('has rounded-2xl class', () => {
+		const { container } = render(Dock);
+		const toolbar = container.querySelector('[role="toolbar"]') as HTMLElement;
+		expect(toolbar?.className).toContain('rounded-2xl');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(Dock, { props: { class: 'my-dock' } });
+		const toolbar = container.querySelector('[role="toolbar"]') as HTMLElement;
+		expect(toolbar?.className).toContain('my-dock');
+	});
+
+	it('uses vertical layout when orientation is vertical', () => {
+		const { container } = render(Dock, { props: { orientation: 'vertical' } });
+		const toolbar = container.querySelector('[role="toolbar"]') as HTMLElement;
+		expect(toolbar?.className).toContain('flex-col');
+	});
+
+	it('applies items-end class for bottom direction', () => {
+		const { container } = render(Dock, { props: { direction: 'bottom' } });
+		const toolbar = container.querySelector('[role="toolbar"]') as HTMLElement;
+		expect(toolbar?.className).toContain('items-end');
+	});
+
+	it('applies items-start class for top direction', () => {
+		const { container } = render(Dock, { props: { direction: 'top' } });
+		const toolbar = container.querySelector('[role="toolbar"]') as HTMLElement;
+		expect(toolbar?.className).toContain('items-start');
+	});
+
+	it('applies items-center class for middle direction (default)', () => {
+		const { container } = render(Dock);
+		const toolbar = container.querySelector('[role="toolbar"]') as HTMLElement;
+		expect(toolbar?.className).toContain('items-center');
+	});
+
+	it('has flex class for layout', () => {
+		const { container } = render(Dock);
+		const toolbar = container.querySelector('[role="toolbar"]') as HTMLElement;
+		expect(toolbar?.className).toContain('flex');
+	});
+});

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
@@ -1,0 +1,49 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import FluidCursor from './FluidCursor.svelte';
+
+describe('FluidCursor', () => {
+	afterEach(cleanup);
+
+	it('renders a container div', () => {
+		const { container } = render(FluidCursor);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div).toBeInTheDocument();
+	});
+
+	it('renders a canvas element', () => {
+		const { container } = render(FluidCursor);
+		const canvas = container.querySelector('canvas');
+		expect(canvas).toBeInTheDocument();
+	});
+
+	it('canvas has id="fluid"', () => {
+		const { container } = render(FluidCursor);
+		const canvas = container.querySelector('canvas#fluid');
+		expect(canvas).toBeInTheDocument();
+	});
+
+	it('container has pointer-events-none class', () => {
+		const { container } = render(FluidCursor);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('pointer-events-none');
+	});
+
+	it('container has fixed positioning class', () => {
+		const { container } = render(FluidCursor);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('fixed');
+	});
+
+	it('container has z-50 class', () => {
+		const { container } = render(FluidCursor);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('z-50');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(FluidCursor, { props: { class: 'my-fluid' } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('my-fluid');
+	});
+});

--- a/src/lib/fancy-ui/glow-border/GlowBorder.test.ts
+++ b/src/lib/fancy-ui/glow-border/GlowBorder.test.ts
@@ -1,0 +1,67 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import GlowBorder from './GlowBorder.svelte';
+
+describe('GlowBorder', () => {
+	afterEach(cleanup);
+
+	it('renders a div element', () => {
+		const { container } = render(GlowBorder);
+		const div = container.querySelector('.animate-glow');
+		expect(div).toBeInTheDocument();
+	});
+
+	it('has pointer-events-none class', () => {
+		const { container } = render(GlowBorder);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('pointer-events-none');
+	});
+
+	it('has absolute and inset-0 classes', () => {
+		const { container } = render(GlowBorder);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('absolute');
+		expect(div?.className).toContain('inset-0');
+	});
+
+	it('includes border-radius in inline style', () => {
+		const { container } = render(GlowBorder, { props: { borderRadius: 20 } });
+		const div = container.firstElementChild as HTMLElement;
+		const style = div.getAttribute('style') ?? '';
+		expect(style).toContain('border-radius');
+	});
+
+	it('includes duration CSS var in style', () => {
+		const { container } = render(GlowBorder, { props: { duration: 5 } });
+		const div = container.firstElementChild as HTMLElement;
+		const style = div.getAttribute('style') ?? '';
+		expect(style).toContain('--glow-duration: 5s');
+	});
+
+	it('includes border-width CSS var in style', () => {
+		const { container } = render(GlowBorder, { props: { borderWidth: 4 } });
+		const div = container.firstElementChild as HTMLElement;
+		const style = div.getAttribute('style') ?? '';
+		expect(style).toContain('--glow-border-width: 4px');
+	});
+
+	it('includes border-radius CSS var in style', () => {
+		const { container } = render(GlowBorder, { props: { borderRadius: 16 } });
+		const div = container.firstElementChild as HTMLElement;
+		const style = div.getAttribute('style') ?? '';
+		expect(style).toContain('--glow-border-radius: 16px');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(GlowBorder, { props: { class: 'my-glow' } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('my-glow');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		const { container } = render(GlowBorder, { props: { class: 'extra' } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('pointer-events-none');
+		expect(div?.className).toContain('absolute');
+	});
+});

--- a/src/lib/fancy-ui/image-trail-cursor/ImageTrailCursor.test.ts
+++ b/src/lib/fancy-ui/image-trail-cursor/ImageTrailCursor.test.ts
@@ -1,0 +1,48 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import ImageTrailCursor from './ImageTrailCursor.svelte';
+
+describe('ImageTrailCursor', () => {
+	afterEach(cleanup);
+
+	it('renders a container div', () => {
+		const { container } = render(ImageTrailCursor);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div).toBeInTheDocument();
+	});
+
+	it('renders one content__img per image', () => {
+		const { container } = render(ImageTrailCursor, {
+			props: { images: ['/a.jpg', '/b.jpg', '/c.jpg'] }
+		});
+		const imgs = container.querySelectorAll('.content__img');
+		expect(imgs.length).toBe(3);
+	});
+
+	it('renders content__img-inner with background-image', () => {
+		const { container } = render(ImageTrailCursor, {
+			props: { images: ['/test.jpg'] }
+		});
+		const inner = container.querySelector('.content__img-inner') as HTMLElement;
+		expect(inner).toBeInTheDocument();
+		expect(inner?.style.backgroundImage).toContain('/test.jpg');
+	});
+
+	it('renders empty when no images provided', () => {
+		const { container } = render(ImageTrailCursor, { props: { images: [] } });
+		const imgs = container.querySelectorAll('.content__img');
+		expect(imgs.length).toBe(0);
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(ImageTrailCursor, { props: { class: 'my-trail' } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('my-trail');
+	});
+
+	it('preserves base classes', () => {
+		const { container } = render(ImageTrailCursor, { props: { class: 'extra' } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('relative');
+	});
+});

--- a/src/lib/fancy-ui/interactive-grid-pattern/InteractiveGridPattern.test.ts
+++ b/src/lib/fancy-ui/interactive-grid-pattern/InteractiveGridPattern.test.ts
@@ -1,0 +1,48 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import InteractiveGridPattern from './InteractiveGridPattern.svelte';
+
+describe('InteractiveGridPattern', () => {
+	afterEach(cleanup);
+
+	it('renders an SVG element', () => {
+		const { container } = render(InteractiveGridPattern, { props: { squares: [3, 3] } });
+		const svg = container.querySelector('svg');
+		expect(svg).toBeInTheDocument();
+	});
+
+	it('renders correct number of rect elements', () => {
+		const { container } = render(InteractiveGridPattern, { props: { squares: [4, 3] } });
+		const rects = container.querySelectorAll('rect');
+		expect(rects.length).toBe(12);
+	});
+
+	it('renders default 24x24 grid', () => {
+		const { container } = render(InteractiveGridPattern);
+		const rects = container.querySelectorAll('rect');
+		expect(rects.length).toBe(576);
+	});
+
+	it('each rect has interactive-grid-square class', () => {
+		const { container } = render(InteractiveGridPattern, { props: { squares: [2, 2] } });
+		const rects = container.querySelectorAll('.interactive-grid-square');
+		expect(rects.length).toBe(4);
+	});
+
+	it('applies custom class names to SVG', () => {
+		const { container } = render(InteractiveGridPattern, {
+			props: { squares: [2, 2], class: 'my-grid' }
+		});
+		const svg = container.querySelector('svg');
+		expect(svg?.getAttribute('class')).toContain('my-grid');
+	});
+
+	it('sets correct SVG dimensions based on props', () => {
+		const { container } = render(InteractiveGridPattern, {
+			props: { squares: [5, 3], width: 50, height: 30 }
+		});
+		const svg = container.querySelector('svg');
+		expect(svg).toHaveAttribute('width', '250');
+		expect(svg).toHaveAttribute('height', '90');
+	});
+});

--- a/src/lib/fancy-ui/logo-cloud/AnimatedLogoCloud.test.ts
+++ b/src/lib/fancy-ui/logo-cloud/AnimatedLogoCloud.test.ts
@@ -1,0 +1,58 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import { AnimatedLogoCloud } from './index';
+
+const mockLogos = [
+	{ name: 'Svelte', path: '/svelte.svg' },
+	{ name: 'React', path: '/react.svg' }
+];
+
+describe('AnimatedLogoCloud', () => {
+	afterEach(cleanup);
+
+	it('renders a container div', () => {
+		const { container } = render(AnimatedLogoCloud, { props: { logos: mockLogos } });
+		const mask = container.querySelector('.logo-cloud-mask');
+		expect(mask).toBeInTheDocument();
+	});
+
+	it('renders 5 scroll groups', () => {
+		const { container } = render(AnimatedLogoCloud, { props: { logos: mockLogos } });
+		const scrolls = container.querySelectorAll('.logo-cloud-scroll');
+		expect(scrolls.length).toBe(5);
+	});
+
+	it('renders correct number of logo images per group', () => {
+		const { container } = render(AnimatedLogoCloud, { props: { logos: mockLogos } });
+		const firstGroup = container.querySelector('.logo-cloud-scroll');
+		const imgs = firstGroup?.querySelectorAll('img');
+		expect(imgs?.length).toBe(2);
+	});
+
+	it('sets correct alt on logo images', () => {
+		const { container } = render(AnimatedLogoCloud, { props: { logos: mockLogos } });
+		const img = container.querySelector('img');
+		expect(img).toHaveAttribute('alt', 'Svelte');
+	});
+
+	it('renders title when provided', () => {
+		const { container } = render(AnimatedLogoCloud, {
+			props: { logos: mockLogos, title: 'Our Partners' }
+		});
+		expect(container.textContent).toContain('Our Partners');
+	});
+
+	it('does not render title when not provided', () => {
+		const { container } = render(AnimatedLogoCloud, { props: { logos: mockLogos } });
+		const titleDiv = container.querySelector('.text-center');
+		expect(titleDiv).not.toBeInTheDocument();
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(AnimatedLogoCloud, {
+			props: { logos: mockLogos, class: 'custom-cloud' }
+		});
+		const mask = container.querySelector('.logo-cloud-mask');
+		expect(mask?.className).toContain('custom-cloud');
+	});
+});

--- a/src/lib/fancy-ui/marquee/Marquee.test.ts
+++ b/src/lib/fancy-ui/marquee/Marquee.test.ts
@@ -1,0 +1,55 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import Marquee from './Marquee.svelte';
+
+describe('Marquee', () => {
+	afterEach(cleanup);
+
+	it('renders a container div', () => {
+		const { container } = render(Marquee);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div).toBeInTheDocument();
+	});
+
+	it('has overflow-hidden class', () => {
+		const { container } = render(Marquee);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('overflow-hidden');
+	});
+
+	it('renders default 4 repeat groups', () => {
+		const { container } = render(Marquee);
+		const groups = container.querySelectorAll('.animate-marquee');
+		expect(groups.length).toBe(4);
+	});
+
+	it('renders custom repeat count', () => {
+		const { container } = render(Marquee, { props: { repeat: 2 } });
+		const groups = container.querySelectorAll('.animate-marquee');
+		expect(groups.length).toBe(2);
+	});
+
+	it('uses vertical animation class when vertical', () => {
+		const { container } = render(Marquee, { props: { vertical: true } });
+		const groups = container.querySelectorAll('.animate-marquee-vertical');
+		expect(groups.length).toBe(4);
+	});
+
+	it('uses flex-col when vertical', () => {
+		const { container } = render(Marquee, { props: { vertical: true } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('flex-col');
+	});
+
+	it('sets animation-direction to reverse when reverse prop is true', () => {
+		const { container } = render(Marquee, { props: { reverse: true } });
+		const group = container.querySelector('.animate-marquee') as HTMLElement;
+		expect(group?.style.animationDirection).toBe('reverse');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(Marquee, { props: { class: 'my-marquee' } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('my-marquee');
+	});
+});

--- a/src/lib/fancy-ui/ripple-button/RippleButton.test.ts
+++ b/src/lib/fancy-ui/ripple-button/RippleButton.test.ts
@@ -1,0 +1,50 @@
+import { render, screen, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import RippleButton from './RippleButton.svelte';
+
+describe('RippleButton', () => {
+	afterEach(cleanup);
+
+	it('renders a button element', () => {
+		render(RippleButton);
+		expect(screen.getByRole('button')).toBeInTheDocument();
+	});
+
+	it('has overflow-hidden class', () => {
+		render(RippleButton);
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('overflow-hidden');
+	});
+
+	it('has rounded-lg class', () => {
+		render(RippleButton);
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('rounded-lg');
+	});
+
+	it('sets --ripple-duration CSS custom property', () => {
+		render(RippleButton, { props: { duration: 800 } });
+		const button = screen.getByRole('button');
+		expect(button.getAttribute('style')).toContain('--ripple-duration: 800ms');
+	});
+
+	it('applies custom class names', () => {
+		render(RippleButton, { props: { class: 'my-ripple' } });
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('my-ripple');
+	});
+
+	it('preserves base classes when custom class is added', () => {
+		render(RippleButton, { props: { class: 'extra' } });
+		const button = screen.getByRole('button');
+		expect(button.className).toContain('overflow-hidden');
+		expect(button.className).toContain('rounded-lg');
+	});
+
+	it('forwards native button attributes', () => {
+		render(RippleButton, { props: { disabled: true, 'aria-label': 'Click me' } });
+		const button = screen.getByRole('button');
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute('aria-label', 'Click me');
+	});
+});

--- a/src/lib/fancy-ui/timeline/Timeline.test.ts
+++ b/src/lib/fancy-ui/timeline/Timeline.test.ts
@@ -1,0 +1,74 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import Timeline from './Timeline.svelte';
+
+const mockItems = [
+	{ id: 'one', label: '2020' },
+	{ id: 'two', label: '2021' },
+	{ id: 'three', label: '2022' }
+];
+
+describe('Timeline', () => {
+	beforeEach(() => {
+		// Mock ResizeObserver (not available in jsdom) - must be a class
+		global.ResizeObserver = class {
+			observe = vi.fn();
+			unobserve = vi.fn();
+			disconnect = vi.fn();
+		};
+	});
+
+	afterEach(cleanup);
+
+	it('renders a container div', () => {
+		const { container } = render(Timeline);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div).toBeInTheDocument();
+	});
+
+	it('has w-full class', () => {
+		const { container } = render(Timeline);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('w-full');
+	});
+
+	it('renders title when provided', () => {
+		const { container } = render(Timeline, { props: { title: 'My Timeline' } });
+		const h2 = container.querySelector('h2');
+		expect(h2).toBeInTheDocument();
+		expect(h2?.textContent).toBe('My Timeline');
+	});
+
+	it('renders description when provided', () => {
+		const { container } = render(Timeline, {
+			props: { title: 'Title', description: 'My description' }
+		});
+		const p = container.querySelector('p');
+		expect(p?.textContent).toBe('My description');
+	});
+
+	it('does not render header section when no title or description', () => {
+		const { container } = render(Timeline);
+		const h2 = container.querySelector('h2');
+		expect(h2).not.toBeInTheDocument();
+	});
+
+	it('renders one entry per item', () => {
+		const { container } = render(Timeline, { props: { items: mockItems } });
+		const labels = container.querySelectorAll('h3');
+		expect(labels.length).toBe(3);
+	});
+
+	it('displays item labels', () => {
+		const { container } = render(Timeline, { props: { items: mockItems } });
+		const labels = container.querySelectorAll('h3');
+		expect(labels[0].textContent).toBe('2020');
+		expect(labels[1].textContent).toBe('2021');
+	});
+
+	it('applies custom class names', () => {
+		const { container } = render(Timeline, { props: { class: 'my-timeline' } });
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain('my-timeline');
+	});
+});


### PR DESCRIPTION
## Summary
- Add unit tests for all 16 components that were missing tests
- Covers: AnimatedBeam, AnimatedTooltip, FallingStarsBg, StarsBackground, BlurReveal, Compare, DirectionAwareHover, Dock, FluidCursor, GlowBorder, ImageTrailCursor, InteractiveGridPattern, AnimatedLogoCloud, Marquee, RippleButton, Timeline
- 116 new tests, bringing total to 194 across 25 suites

## Test plan
- [x] `pnpm vitest run` — 194 tests pass (25/25 component suites)