### PR TITLE
fix: darken dark mode to true black

### DIFF
--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -94,7 +94,7 @@ function applyTheme() {
 	// Update meta theme-color for mobile browsers
 	const metaThemeColor = document.querySelector('meta[name="theme-color"]');
 	if (metaThemeColor) {
-		metaThemeColor.setAttribute('content', resolved === 'dark' ? '#0f172a' : '#ffffff');
+		metaThemeColor.setAttribute('content', resolved === 'dark' ? '#0a0a0a' : '#ffffff');
 	}
 }
 

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -75,36 +75,36 @@
 }
 
 .dark {
-  --background: oklch(0.129 0.042 264.695);
+  --background: oklch(0.05 0 0);
   --foreground: oklch(0.984 0.003 247.858);
-  --card: oklch(0.208 0.042 265.755);
+  --card: oklch(0.1 0.005 265);
   --card-foreground: oklch(0.984 0.003 247.858);
-  --popover: oklch(0.208 0.042 265.755);
+  --popover: oklch(0.1 0.005 265);
   --popover-foreground: oklch(0.984 0.003 247.858);
   --primary: oklch(0.929 0.013 255.508);
-  --primary-foreground: oklch(0.208 0.042 265.755);
-  --secondary: oklch(0.279 0.041 260.031);
+  --primary-foreground: oklch(0.05 0 0);
+  --secondary: oklch(0.15 0.005 260);
   --secondary-foreground: oklch(0.984 0.003 247.858);
-  --muted: oklch(0.279 0.041 260.031);
+  --muted: oklch(0.15 0.005 260);
   --muted-foreground: oklch(0.704 0.04 256.788);
-  --accent: oklch(0.279 0.041 260.031);
+  --accent: oklch(0.15 0.005 260);
   --accent-foreground: oklch(0.984 0.003 247.858);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
+  --border: oklch(1 0 0 / 8%);
+  --input: oklch(1 0 0 / 10%);
   --ring: oklch(0.551 0.027 264.364);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.208 0.042 265.755);
+  --sidebar: oklch(0.07 0.005 265);
   --sidebar-foreground: oklch(0.984 0.003 247.858);
   --sidebar-primary: oklch(0.488 0.243 264.376);
   --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.279 0.041 260.031);
+  --sidebar-accent: oklch(0.15 0.005 260);
   --sidebar-accent-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-border: oklch(1 0 0 / 8%);
   --sidebar-ring: oklch(0.551 0.027 264.364);
 }
 


### PR DESCRIPTION
## Summary
- Replace dark blue-ish backgrounds with near-black/neutral values
- Background: `oklch(0.05)` (was `oklch(0.129)`)
- Cards/popovers: `oklch(0.1)` (was `oklch(0.208)`)
- Secondary/muted/accent: `oklch(0.15)` (was `oklch(0.279)`)
- Sidebar: `oklch(0.07)` (was `oklch(0.208)`)
- Reduced chroma to near-zero for neutral black (no blue tint)
- Updated meta theme-color to `#0a0a0a`

## Test plan
- [x] Visual verification in dark mode — backgrounds are true black
- [x] Text contrast preserved (foreground colors unchanged)
- [x] Cards/sidebar still visually distinct from background