### PR TITLE
feat: port 8 cards & containers components

### DIFF
--- a/src/lib/fancy-ui/book/Book.svelte
+++ b/src/lib/fancy-ui/book/Book.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import {
+		BOOK_RADIUS_MAP as radiusMap,
+		BOOK_SIZE_MAP as sizeMap,
+		BOOK_COLOR_MAP as colorMap,
+		BOOK_SHADOW_SIZE_MAP as shadowSizeMap,
+		type BookRadius,
+		type BookSize,
+		type BookColor,
+		type BookShadowSize
+	} from './index.js';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		class?: string;
+		duration?: number;
+		color?: BookColor;
+		isStatic?: boolean;
+		size?: BookSize;
+		radius?: BookRadius;
+		shadowSize?: BookShadowSize;
+		children?: Snippet;
+	}
+
+	let {
+		class: className = '',
+		duration = 1000,
+		color = 'zinc',
+		isStatic = false,
+		size = 'md',
+		radius = 'md',
+		shadowSize = 'lg',
+		children
+	}: Props = $props();
+
+	let computedGradient = $derived(colorMap[color] || colorMap.zinc);
+</script>
+
+<div
+	class={cn(
+		'z-10 group [perspective:800px] w-min [--shadowColor:#bbb] dark:[--shadowColor:#111]',
+		className
+	)}
+>
+	<div
+		style="width: {sizeMap[size].width}; transition: transform {duration}ms ease"
+		class={cn(
+			'relative aspect-[3/4] [transform-style:preserve-3d]',
+			isStatic
+				? '[transform:rotateY(-30deg)]'
+				: '[transform:rotateY(0deg)] group-hover:[transform:rotateY(-30deg)]',
+			radiusMap[radius]
+		)}
+	>
+		<!-- Front face -->
+		<div
+			class="absolute inset-y-0 overflow-hidden size-full left-0 text-white flex flex-col justify-end p-6 bg-gradient-to-tr {computedGradient.from} {computedGradient.to} {radiusMap[radius]}"
+			style="transform: translateZ(25px); box-shadow: 5px 5px 20px var(--shadowColor);"
+		>
+			<div
+				class="absolute left-0 top-0 h-full"
+				style="min-width: 8.2%; background: linear-gradient(90deg, hsla(0, 0%, 100%, 0), hsla(0, 0%, 100%, 0) 12%, hsla(0, 0%, 100%, .25) 29.25%, hsla(0, 0%, 100%, 0) 50.5%, hsla(0, 0%, 100%, 0) 75.25%, hsla(0, 0%, 100%, .25) 91%, hsla(0, 0%, 100%, 0)), linear-gradient(90deg, rgba(0, 0, 0, .03), rgba(0, 0, 0, .1) 12%, transparent 30%, rgba(0, 0, 0, .02) 50%, rgba(0, 0, 0, .2) 73.5%, rgba(0, 0, 0, .5) 75.25%, rgba(0, 0, 0, .15) 85.25%, transparent); opacity: 0.2;"
+			></div>
+			<div class="pl-1">
+				{#if children}
+					{@render children()}
+				{/if}
+			</div>
+		</div>
+
+		<!-- Spine -->
+		<div
+			class="absolute left-0 bg-white"
+			style="top: 3px; bottom: 3px; width: 48px; transform: translateX({sizeMap[size].spineTranslation}) rotateY(90deg); background: linear-gradient(90deg, rgba(255,255,255,1) 50%, rgba(249,249,249,1) 50%);"
+		></div>
+
+		<!-- Back face -->
+		<div
+			class="absolute inset-y-0 overflow-hidden size-full left-0 text-white flex flex-col justify-end p-6 bg-gradient-to-tr {computedGradient.from} {computedGradient.to} {radiusMap[radius]}"
+			style="transform: translateZ(-25px); box-shadow: {shadowSizeMap[shadowSize]};"
+		></div>
+	</div>
+</div>

--- a/src/lib/fancy-ui/book/Book.test.ts
+++ b/src/lib/fancy-ui/book/Book.test.ts
@@ -1,0 +1,56 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import Book from './Book.svelte';
+
+describe('Book', () => {
+	afterEach(cleanup);
+
+	it('renders the component', () => {
+		const { container } = render(Book);
+		const wrapper = container.querySelector('.group');
+		expect(wrapper).toBeInTheDocument();
+	});
+
+	it('has perspective class', () => {
+		const { container } = render(Book);
+		const wrapper = container.querySelector('.group');
+		expect(wrapper?.className).toContain('[perspective:800px]');
+	});
+
+	it('applies default size (md = 220px)', () => {
+		const { container } = render(Book);
+		const inner = container.querySelector('.group > div') as HTMLElement;
+		expect(inner?.style.width).toBe('220px');
+	});
+
+	it('applies custom size', () => {
+		const { container } = render(Book, { props: { size: 'lg' } });
+		const inner = container.querySelector('.group > div') as HTMLElement;
+		expect(inner?.style.width).toBe('260px');
+	});
+
+	it('applies static transform when isStatic', () => {
+		const { container } = render(Book, { props: { isStatic: true } });
+		const inner = container.querySelector('.group > div');
+		expect(inner?.className).toContain('[transform:rotateY(-30deg)]');
+		expect(inner?.className).not.toContain('group-hover');
+	});
+
+	it('applies hover transform by default', () => {
+		const { container } = render(Book);
+		const inner = container.querySelector('.group > div');
+		expect(inner?.className).toContain('group-hover:[transform:rotateY(-30deg)]');
+	});
+
+	it('applies custom class', () => {
+		const { container } = render(Book, { props: { class: 'my-book' } });
+		const wrapper = container.querySelector('.group');
+		expect(wrapper?.className).toContain('my-book');
+	});
+
+	it('renders spine element', () => {
+		const { container } = render(Book);
+		const spine = container.querySelector('[style*="rotateY(90deg)"]');
+		expect(spine).toBeInTheDocument();
+	});
+});

--- a/src/lib/fancy-ui/book/BookDescription.svelte
+++ b/src/lib/fancy-ui/book/BookDescription.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		class?: string;
+		children?: Snippet;
+	}
+
+	let { class: className = '', children }: Props = $props();
+</script>
+
+<p class={cn('select-none text-xs/relaxed', className)}>
+	{#if children}
+		{@render children()}
+	{/if}
+</p>

--- a/src/lib/fancy-ui/book/BookHeader.svelte
+++ b/src/lib/fancy-ui/book/BookHeader.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		class?: string;
+		children?: Snippet;
+	}
+
+	let { class: className = '', children }: Props = $props();
+</script>
+
+<div class={cn('flex gap-2 flex-wrap', className)}>
+	{#if children}
+		{@render children()}
+	{/if}
+</div>

--- a/src/lib/fancy-ui/book/BookTitle.svelte
+++ b/src/lib/fancy-ui/book/BookTitle.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		class?: string;
+		children?: Snippet;
+	}
+
+	let { class: className = '', children }: Props = $props();
+</script>
+
+<h1 class={cn('font-bold select-none mt-3 mb-1 text-balance', className)}>
+	{#if children}
+		{@render children()}
+	{/if}
+</h1>

--- a/src/lib/fancy-ui/book/README.md
+++ b/src/lib/fancy-ui/book/README.md
@@ -1,0 +1,34 @@
+# Book
+
+A 3D book component with cover, spine, and back face. Opens on hover with a smooth rotation animation.
+
+## Components
+
+- `Book` — Main container with 3D perspective
+- `BookHeader` — Flex container for tags/badges
+- `BookTitle` — Bold heading for the book title
+- `BookDescription` — Small text for description
+
+## Props (Book)
+
+| Prop         | Type           | Default  | Description                    |
+| ------------ | -------------- | -------- | ------------------------------ |
+| `color`      | `BookColor`    | `"zinc"` | Gradient color (22 options)    |
+| `size`       | `BookSize`     | `"md"`   | Width (sm/md/lg/xl)            |
+| `radius`     | `BookRadius`   | `"md"`   | Border radius                  |
+| `shadowSize` | `BookShadowSize` | `"lg"` | Back shadow size               |
+| `duration`   | `number`       | `1000`   | Transition duration in ms      |
+| `isStatic`   | `boolean`      | `false`  | Always show opened state       |
+| `class`      | `string`       | `""`     | Additional CSS classes         |
+
+## Usage
+
+```svelte
+<Book color="blue" size="md">
+  <BookHeader>
+    <span class="rounded bg-white/20 px-2 py-0.5 text-xs">New</span>
+  </BookHeader>
+  <BookTitle>My Book Title</BookTitle>
+  <BookDescription>A short description of the book.</BookDescription>
+</Book>
+```

--- a/src/lib/fancy-ui/book/index.ts
+++ b/src/lib/fancy-ui/book/index.ts
@@ -1,0 +1,55 @@
+export const BOOK_RADIUS_MAP = {
+	sm: 'rounded-sm',
+	md: 'rounded-md',
+	lg: 'rounded-lg',
+	xl: 'rounded-xl'
+} as const;
+
+export const BOOK_SIZE_MAP = {
+	sm: { width: '180px', spineTranslation: '152px' },
+	md: { width: '220px', spineTranslation: '192px' },
+	lg: { width: '260px', spineTranslation: '232px' },
+	xl: { width: '300px', spineTranslation: '272px' }
+} as const;
+
+export const BOOK_SHADOW_SIZE_MAP = {
+	sm: '-5px 0 15px 5px var(--shadowColor)',
+	md: '-7px 0 25px 7px var(--shadowColor)',
+	lg: '-10px 0 35px 10px var(--shadowColor)',
+	xl: '-12px 0 45px 12px var(--shadowColor)'
+} as const;
+
+export const BOOK_COLOR_MAP = {
+	slate: { from: 'from-slate-900', to: 'to-slate-700' },
+	gray: { from: 'from-gray-900', to: 'to-gray-700' },
+	zinc: { from: 'from-zinc-900', to: 'to-zinc-700' },
+	neutral: { from: 'from-neutral-900', to: 'to-neutral-700' },
+	stone: { from: 'from-stone-900', to: 'to-stone-700' },
+	red: { from: 'from-red-900', to: 'to-red-700' },
+	orange: { from: 'from-orange-900', to: 'to-orange-700' },
+	amber: { from: 'from-amber-900', to: 'to-amber-700' },
+	yellow: { from: 'from-yellow-900', to: 'to-yellow-700' },
+	lime: { from: 'from-lime-900', to: 'to-lime-700' },
+	green: { from: 'from-green-900', to: 'to-green-700' },
+	emerald: { from: 'from-emerald-900', to: 'to-emerald-700' },
+	teal: { from: 'from-teal-900', to: 'to-teal-700' },
+	cyan: { from: 'from-cyan-900', to: 'to-cyan-700' },
+	sky: { from: 'from-sky-900', to: 'to-sky-700' },
+	blue: { from: 'from-blue-900', to: 'to-blue-700' },
+	indigo: { from: 'from-indigo-900', to: 'to-indigo-700' },
+	violet: { from: 'from-violet-900', to: 'to-violet-700' },
+	purple: { from: 'from-purple-900', to: 'to-purple-700' },
+	fuchsia: { from: 'from-fuchsia-900', to: 'to-fuchsia-700' },
+	pink: { from: 'from-pink-900', to: 'to-pink-700' },
+	rose: { from: 'from-rose-900', to: 'to-rose-700' }
+} as const;
+
+export type BookColor = keyof typeof BOOK_COLOR_MAP;
+export type BookSize = keyof typeof BOOK_SIZE_MAP;
+export type BookRadius = keyof typeof BOOK_RADIUS_MAP;
+export type BookShadowSize = keyof typeof BOOK_SHADOW_SIZE_MAP;
+
+export { default as Book } from './Book.svelte';
+export { default as BookHeader } from './BookHeader.svelte';
+export { default as BookTitle } from './BookTitle.svelte';
+export { default as BookDescription } from './BookDescription.svelte';

--- a/src/lib/fancy-ui/container-scroll/ContainerScroll.svelte
+++ b/src/lib/fancy-ui/container-scroll/ContainerScroll.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import { onMount } from 'svelte';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		class?: string;
+		titleContent?: Snippet;
+		cardContent?: Snippet;
+	}
+
+	let { class: className = '', titleContent, cardContent }: Props = $props();
+
+	let containerRef: HTMLDivElement;
+	let isMobile = $state(false);
+	let scrollYProgress = $state(0);
+
+	let scaleDimensions = $derived(isMobile ? [0.7, 0.9] : [1.05, 1]);
+	let rotate = $derived(20 * (1 - scrollYProgress));
+	let scale = $derived(scaleDimensions[0] + (scaleDimensions[1] - scaleDimensions[0]) * scrollYProgress);
+	let translateY = $derived(-100 * scrollYProgress);
+
+	function updateIsMobile() {
+		isMobile = window.innerWidth <= 768;
+	}
+
+	function updateScroll() {
+		if (!containerRef) return;
+		const rect = containerRef.getBoundingClientRect();
+		const windowHeight = window.innerHeight;
+		const progress = 1 - Math.max(0, rect.bottom - window.scrollY) / windowHeight;
+		scrollYProgress = Math.max(0, Math.min(1, progress));
+	}
+
+	onMount(() => {
+		updateIsMobile();
+		updateScroll();
+
+		window.addEventListener('resize', updateIsMobile);
+		window.addEventListener('scroll', updateScroll, { passive: true });
+		window.addEventListener('resize', updateScroll, { passive: true });
+
+		return () => {
+			window.removeEventListener('resize', updateIsMobile);
+			window.removeEventListener('scroll', updateScroll);
+			window.removeEventListener('resize', updateScroll);
+		};
+	});
+</script>
+
+<div
+	bind:this={containerRef}
+	class={cn(
+		'relative flex h-[60rem] items-center justify-center p-2 md:h-[80rem] md:p-20',
+		className
+	)}
+>
+	<div class="relative w-full py-10 md:py-40" style="perspective: 1000px">
+		<!-- Title -->
+		<div
+			style="transform: translateY({translateY}px)"
+			class="mx-auto max-w-5xl text-center"
+		>
+			{#if titleContent}
+				{@render titleContent()}
+			{/if}
+		</div>
+
+		<!-- Card -->
+		<div
+			style="transform: rotateX({rotate}deg) scale({scale}); box-shadow: 0 0 #0000004d, 0 9px 20px #0000004a, 0 37px 37px #00000042, 0 84px 50px #00000026, 0 149px 60px #0000000a, 0 233px 65px #00000003;"
+			class="mx-auto -mt-12 h-[30rem] w-full max-w-5xl rounded-[30px] border-4 border-[#6C6C6C] bg-[#222222] p-2 shadow-2xl md:h-[40rem] md:p-6"
+		>
+			<div
+				class="size-full overflow-hidden rounded-2xl bg-gray-100 md:rounded-2xl md:p-4 dark:bg-zinc-900"
+			>
+				{#if cardContent}
+					{@render cardContent()}
+				{/if}
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/lib/fancy-ui/container-scroll/ContainerScroll.test.ts
+++ b/src/lib/fancy-ui/container-scroll/ContainerScroll.test.ts
@@ -1,0 +1,38 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import ContainerScroll from './ContainerScroll.svelte';
+
+describe('ContainerScroll', () => {
+	afterEach(cleanup);
+
+	it('renders the component', () => {
+		const { container } = render(ContainerScroll);
+		const wrapper = container.firstElementChild;
+		expect(wrapper).toBeInTheDocument();
+	});
+
+	it('has perspective container', () => {
+		const { container } = render(ContainerScroll);
+		const perspectiveDiv = container.querySelector('[style*="perspective: 1000px"]');
+		expect(perspectiveDiv).toBeInTheDocument();
+	});
+
+	it('renders card container', () => {
+		const { container } = render(ContainerScroll);
+		const card = container.querySelector('.rounded-\\[30px\\]');
+		expect(card).toBeInTheDocument();
+	});
+
+	it('applies custom class', () => {
+		const { container } = render(ContainerScroll, { props: { class: 'my-scroll' } });
+		const wrapper = container.firstElementChild;
+		expect(wrapper?.className).toContain('my-scroll');
+	});
+
+	it('has initial rotation transform', () => {
+		const { container } = render(ContainerScroll);
+		const card = container.querySelector('.rounded-\\[30px\\]') as HTMLElement;
+		const style = card?.getAttribute('style') ?? '';
+		expect(style).toContain('rotateX(');
+	});
+});

--- a/src/lib/fancy-ui/container-scroll/README.md
+++ b/src/lib/fancy-ui/container-scroll/README.md
@@ -1,0 +1,28 @@
+# ContainerScroll
+
+A scroll-driven animation container that rotates and scales a card from a tilted perspective to flat as the user scrolls.
+
+## Props
+
+| Prop    | Type     | Default | Description            |
+| ------- | -------- | ------- | ---------------------- |
+| `class` | `string` | `""`    | Additional CSS classes |
+
+## Snippets
+
+- `titleContent` — Title section (translates up on scroll)
+- `cardContent` — Card content (rotates and scales on scroll)
+
+## Usage
+
+```svelte
+<ContainerScroll>
+  {#snippet titleContent()}
+    <h2 class="text-4xl font-bold">Scroll Animation</h2>
+    <p class="text-muted-foreground">Scroll down to see the effect</p>
+  {/snippet}
+  {#snippet cardContent()}
+    <img src="/screenshot.png" alt="Demo" class="size-full object-cover" />
+  {/snippet}
+</ContainerScroll>
+```

--- a/src/lib/fancy-ui/container-scroll/index.ts
+++ b/src/lib/fancy-ui/container-scroll/index.ts
@@ -1,0 +1,1 @@
+export { default as ContainerScroll } from './ContainerScroll.svelte';

--- a/src/lib/fancy-ui/container-text-flip/ContainerTextFlip.svelte
+++ b/src/lib/fancy-ui/container-text-flip/ContainerTextFlip.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import { onMount } from 'svelte';
+
+	interface Props {
+		words?: string[];
+		interval?: number;
+		animationDuration?: number;
+		class?: string;
+		textClass?: string;
+	}
+
+	let {
+		words = ['better', 'modern', 'beautiful', 'awesome'],
+		interval = 3000,
+		animationDuration = 700,
+		class: className = '',
+		textClass = ''
+	}: Props = $props();
+
+	let currentWordIndex = $state(0);
+	let currentWord = $derived(words[currentWordIndex] ?? '');
+	let letters = $derived(currentWord.split(''));
+
+	onMount(() => {
+		const id = setInterval(() => {
+			currentWordIndex = (currentWordIndex + 1) % words.length;
+		}, interval);
+
+		return () => clearInterval(id);
+	});
+</script>
+
+<p
+	class={cn(
+		'relative inline-block rounded-lg pt-2 pb-3 px-4 text-center text-4xl font-bold text-black md:text-7xl dark:text-white',
+		'[background:linear-gradient(to_bottom,#f3f4f6,#e5e7eb)]',
+		'shadow-[inset_0_-1px_#d1d5db,inset_0_0_0_1px_#d1d5db,_0_4px_8px_#d1d5db]',
+		'dark:[background:linear-gradient(to_bottom,#374151,#1f2937)]',
+		'dark:shadow-[inset_0_-1px_#10171e,inset_0_0_0_1px_hsla(205,89%,46%,.24),_0_4px_8px_#00000052]',
+		className
+	)}
+>
+	<span class={cn('inline-block', textClass)}>
+		<span class="inline-block">
+			{#key currentWord}
+				{#each letters as letter, index}
+					<span
+						class="text-flip-letter inline-block"
+						style="animation-delay: {index * 0.02}s; animation-duration: {animationDuration}ms;"
+					>{letter === ' ' ? '\u00A0' : letter}</span>
+				{/each}
+			{/key}
+		</span>
+	</span>
+</p>
+
+<style>
+	:global {
+		@keyframes text-flip-in {
+			0% {
+				opacity: 0;
+				filter: blur(10px);
+			}
+			100% {
+				opacity: 1;
+				filter: blur(0px);
+			}
+		}
+	}
+
+	.text-flip-letter {
+		animation: text-flip-in ease-in-out forwards;
+		opacity: 0;
+		filter: blur(10px);
+	}
+</style>

--- a/src/lib/fancy-ui/container-text-flip/ContainerTextFlip.test.ts
+++ b/src/lib/fancy-ui/container-text-flip/ContainerTextFlip.test.ts
@@ -1,0 +1,50 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import ContainerTextFlip from './ContainerTextFlip.svelte';
+
+describe('ContainerTextFlip', () => {
+	afterEach(cleanup);
+
+	it('renders the component', () => {
+		const { container } = render(ContainerTextFlip);
+		const el = container.querySelector('p');
+		expect(el).toBeInTheDocument();
+	});
+
+	it('renders first word by default', () => {
+		const { container } = render(ContainerTextFlip, {
+			props: { words: ['hello', 'world'] }
+		});
+		const letters = container.querySelectorAll('.text-flip-letter');
+		const text = Array.from(letters)
+			.map((l) => l.textContent)
+			.join('');
+		expect(text).toBe('hello');
+	});
+
+	it('applies custom class', () => {
+		const { container } = render(ContainerTextFlip, { props: { class: 'my-flip' } });
+		const el = container.querySelector('p');
+		expect(el?.className).toContain('my-flip');
+	});
+
+	it('renders letters with staggered animation delay', () => {
+		const { container } = render(ContainerTextFlip, {
+			props: { words: ['abc'] }
+		});
+		const letters = container.querySelectorAll('.text-flip-letter');
+		expect(letters.length).toBe(3);
+		const firstDelay = (letters[0] as HTMLElement).style.animationDelay;
+		const secondDelay = (letters[1] as HTMLElement).style.animationDelay;
+		expect(firstDelay).toBe('0s');
+		expect(secondDelay).toBe('0.02s');
+	});
+
+	it('applies custom animation duration', () => {
+		const { container } = render(ContainerTextFlip, {
+			props: { words: ['hi'], animationDuration: 500 }
+		});
+		const letter = container.querySelector('.text-flip-letter') as HTMLElement;
+		expect(letter.style.animationDuration).toBe('500ms');
+	});
+});

--- a/src/lib/fancy-ui/container-text-flip/README.md
+++ b/src/lib/fancy-ui/container-text-flip/README.md
@@ -1,0 +1,22 @@
+# ContainerTextFlip
+
+A text container that cycles through words with per-character blur-to-clear animation.
+
+## Props
+
+| Prop                | Type       | Default                                    | Description               |
+| ------------------- | ---------- | ------------------------------------------ | ------------------------- |
+| `words`             | `string[]` | `["better","modern","beautiful","awesome"]` | Words to cycle through    |
+| `interval`          | `number`   | `3000`                                     | Time between words (ms)   |
+| `animationDuration` | `number`   | `700`                                      | Letter animation (ms)     |
+| `class`             | `string`   | `""`                                       | Additional CSS classes    |
+| `textClass`         | `string`   | `""`                                       | CSS classes for text span |
+
+## Usage
+
+```svelte
+<ContainerTextFlip
+  words={["stunning", "brilliant", "amazing"]}
+  interval={2500}
+/>
+```

--- a/src/lib/fancy-ui/container-text-flip/index.ts
+++ b/src/lib/fancy-ui/container-text-flip/index.ts
@@ -1,0 +1,1 @@
+export { default as ContainerTextFlip } from './ContainerTextFlip.svelte';

--- a/src/lib/fancy-ui/flip-card/FlipCard.svelte
+++ b/src/lib/fancy-ui/flip-card/FlipCard.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		rotate?: 'x' | 'y';
+		class?: string;
+		children?: Snippet;
+		back?: Snippet;
+	}
+
+	let { rotate = 'y', class: className = '', children, back }: Props = $props();
+
+	const rotationClass = {
+		x: ['group-hover:[transform:rotateX(180deg)]', '[transform:rotateX(180deg)]'],
+		y: ['group-hover:[transform:rotateY(180deg)]', '[transform:rotateY(180deg)]']
+	} as const;
+
+	let rotation = $derived(rotationClass[rotate]);
+</script>
+
+<div class={cn('group h-72 w-56 [perspective:1000px]', className)}>
+	<div
+		class={cn(
+			'relative h-full rounded-2xl transition-all duration-500 [transform-style:preserve-3d]',
+			rotation[0]
+		)}
+	>
+		<!-- Front -->
+		<div
+			class="absolute size-full overflow-hidden rounded-2xl border [backface-visibility:hidden]"
+		>
+			{#if children}
+				{@render children()}
+			{/if}
+		</div>
+
+		<!-- Back -->
+		<div
+			class={cn(
+				'absolute h-full w-full overflow-hidden rounded-2xl border bg-black/80 p-4 text-slate-200 [backface-visibility:hidden]',
+				rotation[1]
+			)}
+		>
+			{#if back}
+				{@render back()}
+			{/if}
+		</div>
+	</div>
+</div>

--- a/src/lib/fancy-ui/flip-card/FlipCard.test.ts
+++ b/src/lib/fancy-ui/flip-card/FlipCard.test.ts
@@ -1,0 +1,43 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import FlipCard from './FlipCard.svelte';
+
+describe('FlipCard', () => {
+	afterEach(cleanup);
+
+	it('renders the component', () => {
+		const { container } = render(FlipCard);
+		const wrapper = container.querySelector('.group');
+		expect(wrapper).toBeInTheDocument();
+	});
+
+	it('has perspective class', () => {
+		const { container } = render(FlipCard);
+		const wrapper = container.querySelector('.group');
+		expect(wrapper?.className).toContain('[perspective:1000px]');
+	});
+
+	it('defaults to Y-axis rotation', () => {
+		const { container } = render(FlipCard);
+		const inner = container.querySelector('.group > div');
+		expect(inner?.className).toContain('rotateY(180deg)');
+	});
+
+	it('supports X-axis rotation', () => {
+		const { container } = render(FlipCard, { props: { rotate: 'x' } });
+		const inner = container.querySelector('.group > div');
+		expect(inner?.className).toContain('rotateX(180deg)');
+	});
+
+	it('applies custom class', () => {
+		const { container } = render(FlipCard, { props: { class: 'my-card' } });
+		const wrapper = container.querySelector('.group');
+		expect(wrapper?.className).toContain('my-card');
+	});
+
+	it('renders front and back faces', () => {
+		const { container } = render(FlipCard);
+		const faces = container.querySelectorAll('[class*="backface-visibility"]');
+		expect(faces.length).toBe(2);
+	});
+});

--- a/src/lib/fancy-ui/flip-card/README.md
+++ b/src/lib/fancy-ui/flip-card/README.md
@@ -1,0 +1,26 @@
+# FlipCard
+
+A card that flips to reveal back content on hover, using pure CSS 3D transforms.
+
+## Props
+
+| Prop     | Type         | Default | Description                     |
+| -------- | ------------ | ------- | ------------------------------- |
+| `rotate` | `"x" \| "y"` | `"y"`   | Axis of rotation                |
+| `class`  | `string`     | `""`    | Additional CSS classes          |
+
+## Snippets
+
+- `children` — Front face content
+- `back` — Back face content
+
+## Usage
+
+```svelte
+<FlipCard>
+  <img src="/front.jpg" alt="Front" class="size-full object-cover" />
+  {#snippet back()}
+    <p>Back content here</p>
+  {/snippet}
+</FlipCard>
+```

--- a/src/lib/fancy-ui/flip-card/index.ts
+++ b/src/lib/fancy-ui/flip-card/index.ts
@@ -1,0 +1,1 @@
+export { default as FlipCard } from './FlipCard.svelte';

--- a/src/lib/fancy-ui/focus/Focus.svelte
+++ b/src/lib/fancy-ui/focus/Focus.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import { onMount, tick } from 'svelte';
+
+	interface Props {
+		sentence?: string;
+		manualMode?: boolean;
+		blurAmount?: number;
+		borderColor?: string;
+		animationDuration?: number;
+		pauseBetweenAnimations?: number;
+		class?: string;
+	}
+
+	let {
+		sentence = 'Inspira Focus',
+		manualMode = false,
+		blurAmount = 5,
+		borderColor = 'green',
+		animationDuration = 0.5,
+		pauseBetweenAnimations = 1,
+		class: className = ''
+	}: Props = $props();
+
+	let words = $derived(sentence.split(' '));
+	let containerRef: HTMLDivElement;
+	let wordElements: HTMLSpanElement[] = $state([]);
+	let currentIndex = $state(0);
+	let focusRect = $state({ x: 0, y: 0, width: 0, height: 0 });
+
+	function updateFocusRect() {
+		const wordEl = wordElements[currentIndex];
+		if (!wordEl || !containerRef) return;
+		const parentRect = containerRef.getBoundingClientRect();
+		const wordRect = wordEl.getBoundingClientRect();
+		focusRect = {
+			x: wordRect.left - parentRect.left,
+			y: wordRect.top - parentRect.top,
+			width: wordRect.width,
+			height: wordRect.height
+		};
+	}
+
+	function handleMouseEnter(index: number) {
+		if (manualMode) {
+			currentIndex = index;
+		}
+	}
+
+	function handleMouseLeave() {
+		if (manualMode) {
+			currentIndex = 0;
+		}
+	}
+
+	$effect(() => {
+		// Track currentIndex to update rect
+		currentIndex;
+		tick().then(updateFocusRect);
+	});
+
+	onMount(() => {
+		updateFocusRect();
+
+		if (!manualMode) {
+			const intervalMs = animationDuration * 1000 + pauseBetweenAnimations * 1000;
+			const id = setInterval(() => {
+				currentIndex = (currentIndex + 1) % words.length;
+			}, intervalMs);
+			return () => clearInterval(id);
+		}
+	});
+</script>
+
+<div bind:this={containerRef} class={cn('focus-container', className)}>
+	{#each words as word, index}
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<span
+			bind:this={wordElements[index]}
+			class="focus-word"
+			class:manual={manualMode}
+			class:active={index === currentIndex && !manualMode}
+			style="filter: {index === currentIndex ? 'blur(0px)' : `blur(${blurAmount}px)`}; transition: filter {animationDuration}s ease; --border-color: {borderColor};"
+			onmouseenter={() => handleMouseEnter(index)}
+			onmouseleave={handleMouseLeave}
+		>
+			{word}
+		</span>
+	{/each}
+
+	<div
+		class="focus-frame"
+		style="transform: translate({focusRect.x}px, {focusRect.y}px); width: {focusRect.width}px; height: {focusRect.height}px; opacity: {currentIndex >= 0 ? 1 : 0}; transition: all {animationDuration}s ease; --border-color: {borderColor};"
+	>
+		<span class="corner top-left"></span>
+		<span class="corner top-right"></span>
+		<span class="corner bottom-left"></span>
+		<span class="corner bottom-right"></span>
+	</div>
+</div>
+
+<style>
+	.focus-container {
+		position: relative;
+		display: flex;
+		gap: 1em;
+		justify-content: center;
+		align-items: center;
+		flex-wrap: wrap;
+	}
+
+	.focus-word {
+		position: relative;
+		font-size: 3rem;
+		font-weight: 900;
+		cursor: pointer;
+		transition:
+			filter 0.3s ease,
+			color 0.3s ease;
+	}
+
+	.focus-word.active {
+		filter: blur(0);
+	}
+
+	.focus-frame {
+		position: absolute;
+		top: 0;
+		left: 0;
+		pointer-events: none;
+		box-sizing: content-box;
+		border: none;
+	}
+
+	.corner {
+		position: absolute;
+		width: 1rem;
+		height: 1rem;
+		border: 3px solid var(--border-color, #fff);
+		filter: drop-shadow(0px 0px 4px var(--border-color, #fff));
+		border-radius: 3px;
+		transition: none;
+	}
+
+	.top-left {
+		top: -10px;
+		left: -10px;
+		border-right: none;
+		border-bottom: none;
+	}
+
+	.top-right {
+		top: -10px;
+		right: -10px;
+		border-left: none;
+		border-bottom: none;
+	}
+
+	.bottom-left {
+		bottom: -10px;
+		left: -10px;
+		border-right: none;
+		border-top: none;
+	}
+
+	.bottom-right {
+		bottom: -10px;
+		right: -10px;
+		border-left: none;
+		border-top: none;
+	}
+</style>

--- a/src/lib/fancy-ui/focus/Focus.test.ts
+++ b/src/lib/fancy-ui/focus/Focus.test.ts
@@ -1,0 +1,54 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import Focus from './Focus.svelte';
+
+describe('Focus', () => {
+	afterEach(cleanup);
+
+	it('renders the component', () => {
+		const { container } = render(Focus);
+		const wrapper = container.querySelector('.focus-container');
+		expect(wrapper).toBeInTheDocument();
+	});
+
+	it('splits sentence into words', () => {
+		const { container } = render(Focus, { props: { sentence: 'Hello World Test' } });
+		const words = container.querySelectorAll('.focus-word');
+		expect(words.length).toBe(3);
+	});
+
+	it('renders default sentence', () => {
+		const { container } = render(Focus);
+		const words = container.querySelectorAll('.focus-word');
+		expect(words.length).toBe(2); // "Inspira" "Focus"
+	});
+
+	it('renders focus frame with corners', () => {
+		const { container } = render(Focus);
+		const frame = container.querySelector('.focus-frame');
+		expect(frame).toBeInTheDocument();
+		const corners = container.querySelectorAll('.corner');
+		expect(corners.length).toBe(4);
+	});
+
+	it('applies custom border color', () => {
+		const { container } = render(Focus, { props: { borderColor: 'red' } });
+		const word = container.querySelector('.focus-word') as HTMLElement;
+		expect(word.style.getPropertyValue('--border-color')).toBe('red');
+	});
+
+	it('applies custom class', () => {
+		const { container } = render(Focus, { props: { class: 'my-focus' } });
+		const wrapper = container.querySelector('.focus-container');
+		expect(wrapper?.className).toContain('my-focus');
+	});
+
+	it('blurs non-active words', () => {
+		const { container } = render(Focus, {
+			props: { sentence: 'A B', blurAmount: 8 }
+		});
+		const words = container.querySelectorAll('.focus-word');
+		// Second word should be blurred
+		expect((words[1] as HTMLElement).style.filter).toBe('blur(8px)');
+	});
+});

--- a/src/lib/fancy-ui/focus/README.md
+++ b/src/lib/fancy-ui/focus/README.md
@@ -1,0 +1,21 @@
+# Focus
+
+A text component that cycles through words, focusing on one at a time with a decorative frame. Non-focused words are blurred.
+
+## Props
+
+| Prop                     | Type      | Default          | Description                    |
+| ------------------------ | --------- | ---------------- | ------------------------------ |
+| `sentence`               | `string`  | `"Inspira Focus"` | Sentence to split into words   |
+| `manualMode`             | `boolean` | `false`          | Focus on hover instead of auto |
+| `blurAmount`             | `number`  | `5`              | Blur amount for unfocused words (px) |
+| `borderColor`            | `string`  | `"green"`        | Corner bracket border color    |
+| `animationDuration`      | `number`  | `0.5`            | Animation duration in seconds  |
+| `pauseBetweenAnimations` | `number`  | `1`              | Pause between words in seconds |
+| `class`                  | `string`  | `""`             | Additional CSS classes         |
+
+## Usage
+
+```svelte
+<Focus sentence="Create stunning interfaces" borderColor="cyan" />
+```

--- a/src/lib/fancy-ui/focus/index.ts
+++ b/src/lib/fancy-ui/focus/index.ts
@@ -1,0 +1,1 @@
+export { default as Focus } from './Focus.svelte';

--- a/src/lib/fancy-ui/glare-card/GlareCard.svelte
+++ b/src/lib/fancy-ui/glare-card/GlareCard.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		class?: string;
+		children?: Snippet;
+	}
+
+	let { class: className = '', children }: Props = $props();
+
+	let isPointerInside = $state(false);
+	let refElement: HTMLDivElement;
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+	let glare = $state({ x: 50, y: 50 });
+	let background = $state({ x: 50, y: 50 });
+	let rotate = $state({ x: 0, y: 0 });
+
+	let cssVars = $derived(
+		`--m-x:${glare.x}%;--m-y:${glare.y}%;--r-x:${rotate.x}deg;--r-y:${rotate.y}deg;--bg-x:${background.x}%;--bg-y:${background.y}%;--duration:300ms;--foil-size:100%;--opacity:0;--radius:48px;--easing:ease;--transition:var(--duration) var(--easing);`
+	);
+
+	function handlePointerMove(event: PointerEvent) {
+		const rotateFactor = 0.4;
+		const rect = refElement?.getBoundingClientRect();
+		if (rect) {
+			const position = {
+				x: event.clientX - rect.left,
+				y: event.clientY - rect.top
+			};
+			const percentage = {
+				x: (100 / rect.width) * position.x,
+				y: (100 / rect.height) * position.y
+			};
+			const delta = {
+				x: percentage.x - 50,
+				y: percentage.y - 50
+			};
+			background.x = 50 + percentage.x / 4 - 12.5;
+			background.y = 50 + percentage.y / 3 - 16.67;
+			rotate.x = -(delta.x / 3.5) * rotateFactor;
+			rotate.y = (delta.y / 2) * rotateFactor;
+			glare.x = percentage.x;
+			glare.y = percentage.y;
+		}
+	}
+
+	function handlePointerEnter() {
+		isPointerInside = true;
+		if (timeoutId) clearTimeout(timeoutId);
+		timeoutId = setTimeout(() => {
+			if (isPointerInside && refElement) {
+				refElement.style.setProperty('--duration', '0s');
+			}
+		}, 300);
+	}
+
+	function handlePointerLeave() {
+		isPointerInside = false;
+		if (timeoutId) clearTimeout(timeoutId);
+		if (refElement) {
+			refElement.style.removeProperty('--duration');
+			rotate = { x: 0, y: 0 };
+		}
+	}
+</script>
+
+<div
+	bind:this={refElement}
+	class="glare-container relative isolate w-[320px] transition-transform will-change-transform [aspect-ratio:17/21] [contain:layout_style] [perspective:600px] duration-[var(--duration)] ease-[var(--easing)] delay-[var(--delay)]"
+	style={cssVars}
+	onpointermove={handlePointerMove}
+	onpointerenter={handlePointerEnter}
+	onpointerleave={handlePointerLeave}
+>
+	<div
+		class="grid h-full origin-center overflow-hidden rounded-lg border border-slate-800 transition-transform will-change-transform [transform:rotateY(var(--r-x))_rotateX(var(--r-y))] hover:filter-none hover:[--duration:200ms] hover:[--easing:linear] hover:[--opacity:0.6] duration-[var(--duration)] ease-[var(--easing)] delay-[var(--delay)]"
+	>
+		<div
+			class="grid size-full mix-blend-soft-light [clip-path:inset(0_0_0_0_round_var(--radius))] [grid-area:1/1]"
+		>
+			<div class={cn('size-full bg-slate-950', className)}>
+				{#if children}
+					{@render children()}
+				{/if}
+			</div>
+		</div>
+		<div
+			class="will-change-background grid size-full opacity-[var(--opacity)] mix-blend-soft-light transition-opacity [background:radial-gradient(farthest-corner_circle_at_var(--m-x)_var(--m-y),_rgba(255,255,255,0.8)_10%,_rgba(255,255,255,0.65)_20%,_rgba(255,255,255,0)_90%)] [clip-path:inset(0_0_1px_0_round_var(--radius))] [grid-area:1/1] duration-[var(--duration)] ease-[var(--easing)] delay-[var(--delay)]"
+		></div>
+		<div
+			class="glare-foil relative grid size-full opacity-[var(--opacity)] mix-blend-color-dodge transition-opacity will-change-[background] [background-blend-mode:hue_hue_hue_overlay] [background:var(--pattern),_var(--rainbow),_var(--diagonal),_var(--shade)] [clip-path:inset(0_0_1px_0_round_var(--radius))] [grid-area:1/1] after:bg-[inherit] after:mix-blend-exclusion after:content-[''] after:[background-blend-mode:soft-light,_hue,_hard-light] after:[background-position:center,_0%_var(--bg-y),_calc(var(--bg-x)*_-1)_calc(var(--bg-y)*_-1),_var(--bg-x)_var(--bg-y)] after:[background-size:var(--foil-size),_200%_400%,_800%,_200%] after:[grid-area:1/1]"
+		></div>
+	</div>
+</div>
+
+<style>
+	.glare-foil {
+		--step: 5%;
+		--foil-svg: url("data:image/svg+xml,%3Csvg width='26' height='26' viewBox='0 0 26 26' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2.99994 3.419C2.99994 3.419 21.6142 7.43646 22.7921 12.153C23.97 16.8695 3.41838 23.0306 3.41838 23.0306' stroke='white' stroke-width='5' stroke-miterlimit='3.86874' stroke-linecap='round' style='mix-blend-mode:darken'/%3E%3C/svg%3E");
+		--pattern: var(--foil-svg) center/100% no-repeat;
+		--rainbow: repeating-linear-gradient(
+				0deg,
+				rgb(255, 119, 115) calc(var(--step) * 1),
+				rgba(255, 237, 95, 1) calc(var(--step) * 2),
+				rgba(168, 255, 95, 1) calc(var(--step) * 3),
+				rgba(131, 255, 247, 1) calc(var(--step) * 4),
+				rgba(120, 148, 255, 1) calc(var(--step) * 5),
+				rgb(216, 117, 255) calc(var(--step) * 6),
+				rgb(255, 119, 115) calc(var(--step) * 7)
+			)
+			0% var(--bg-y) / 200% 700% no-repeat;
+		--diagonal: repeating-linear-gradient(
+				128deg,
+				#0e152e 0%,
+				hsl(180, 10%, 60%) 3.8%,
+				hsl(180, 10%, 60%) 4.5%,
+				hsl(180, 10%, 60%) 5.2%,
+				#0e152e 10%,
+				#0e152e 12%
+			)
+			var(--bg-x) var(--bg-y) / 300% no-repeat;
+		--shade: radial-gradient(
+				farthest-corner circle at var(--m-x) var(--m-y),
+				rgba(255, 255, 255, 0.1) 12%,
+				rgba(255, 255, 255, 0.15) 20%,
+				rgba(255, 255, 255, 0.25) 120%
+			)
+			var(--bg-x) var(--bg-y) / 300% no-repeat;
+		background-blend-mode: hue, hue, hue, overlay;
+	}
+</style>

--- a/src/lib/fancy-ui/glare-card/GlareCard.test.ts
+++ b/src/lib/fancy-ui/glare-card/GlareCard.test.ts
@@ -1,0 +1,47 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import GlareCard from './GlareCard.svelte';
+
+describe('GlareCard', () => {
+	afterEach(cleanup);
+
+	it('renders the component', () => {
+		const { container } = render(GlareCard);
+		const wrapper = container.querySelector('.glare-container');
+		expect(wrapper).toBeInTheDocument();
+	});
+
+	it('has perspective class', () => {
+		const { container } = render(GlareCard);
+		const wrapper = container.querySelector('.glare-container');
+		expect(wrapper?.className).toContain('[perspective:600px]');
+	});
+
+	it('has correct aspect ratio', () => {
+		const { container } = render(GlareCard);
+		const wrapper = container.querySelector('.glare-container');
+		expect(wrapper?.className).toContain('[aspect-ratio:17/21]');
+	});
+
+	it('sets CSS custom properties', () => {
+		const { container } = render(GlareCard);
+		const wrapper = container.querySelector('.glare-container') as HTMLElement;
+		const style = wrapper.getAttribute('style') ?? '';
+		expect(style).toContain('--m-x');
+		expect(style).toContain('50%');
+		expect(style).toContain('--r-x');
+		expect(style).toContain('0deg');
+	});
+
+	it('applies custom class', () => {
+		const { container } = render(GlareCard, { props: { class: 'my-glare' } });
+		const content = container.querySelector('.my-glare');
+		expect(content).toBeInTheDocument();
+	});
+
+	it('renders foil layer', () => {
+		const { container } = render(GlareCard);
+		const foil = container.querySelector('.glare-foil');
+		expect(foil).toBeInTheDocument();
+	});
+});

--- a/src/lib/fancy-ui/glare-card/README.md
+++ b/src/lib/fancy-ui/glare-card/README.md
@@ -1,0 +1,24 @@
+# GlareCard
+
+A holographic trading card effect with mouse-tracking glare, rainbow foil, and 3D rotation.
+
+## Props
+
+| Prop    | Type     | Default | Description            |
+| ------- | -------- | ------- | ---------------------- |
+| `class` | `string` | `""`    | Additional CSS classes |
+
+## Snippets
+
+- `children` — Card content
+
+## Usage
+
+```svelte
+<GlareCard>
+  <div class="flex flex-col items-center justify-center h-full p-6 text-white">
+    <h3 class="text-xl font-bold">Holographic</h3>
+    <p class="text-sm">Move your mouse around</p>
+  </div>
+</GlareCard>
+```

--- a/src/lib/fancy-ui/glare-card/index.ts
+++ b/src/lib/fancy-ui/glare-card/index.ts
@@ -1,0 +1,1 @@
+export { default as GlareCard } from './GlareCard.svelte';

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -33,6 +33,14 @@ export * from './box-reveal/index.js';
 export * from './card-3d/index.js';
 export * from './card-spotlight/index.js';
 export * from './bento-grid/index.js';
+export * from './flip-card/index.js';
+export * from './book/index.js';
+export * from './glare-card/index.js';
+export * from './text-reveal-card/index.js';
+export * from './container-scroll/index.js';
+export * from './container-text-flip/index.js';
+export * from './focus/index.js';
+export * from './liquid-glass/index.js';
 
 // =============================================================================
 // Registry

--- a/src/lib/fancy-ui/liquid-glass/LiquidGlass.svelte
+++ b/src/lib/fancy-ui/liquid-glass/LiquidGlass.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import { onMount } from 'svelte';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		radius?: number;
+		border?: number;
+		lightness?: number;
+		displace?: number;
+		blend?: string;
+		xChannel?: 'R' | 'G' | 'B';
+		yChannel?: 'R' | 'G' | 'B';
+		alpha?: number;
+		blur?: number;
+		rOffset?: number;
+		gOffset?: number;
+		bOffset?: number;
+		scale?: number;
+		frost?: number;
+		class?: string;
+		containerClass?: string;
+		children?: Snippet;
+	}
+
+	let {
+		radius = 16,
+		border: borderProp = 0.07,
+		lightness = 50,
+		displace,
+		blend = 'difference',
+		xChannel = 'R',
+		yChannel = 'B',
+		alpha = 0.93,
+		blur = 11,
+		rOffset = 0,
+		gOffset = 10,
+		bOffset = 20,
+		scale = -180,
+		frost = 0.05,
+		class: className = '',
+		containerClass = '',
+		children
+	}: Props = $props();
+
+	let liquidGlassRoot: HTMLDivElement;
+	let dimensions = $state({ width: 0, height: 0 });
+	let filterId = $state('');
+
+	let displacementImage = $derived.by(() => {
+		const brd = Math.min(dimensions.width, dimensions.height) * (borderProp * 0.5);
+
+		return `<svg viewBox="0 0 ${dimensions.width} ${dimensions.height}" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="red-${filterId}" x1="100%" y1="0%" x2="0%" y2="0%"><stop offset="0%" stop-color="#0000"/><stop offset="100%" stop-color="red"/></linearGradient><linearGradient id="blue-${filterId}" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#0000"/><stop offset="100%" stop-color="blue"/></linearGradient></defs><rect x="0" y="0" width="${dimensions.width}" height="${dimensions.height}" fill="black"/><rect x="0" y="0" width="${dimensions.width}" height="${dimensions.height}" rx="${radius}" fill="url(#red-${filterId})"/><rect x="0" y="0" width="${dimensions.width}" height="${dimensions.height}" rx="${radius}" fill="url(#blue-${filterId})" style="mix-blend-mode:${blend}"/><rect x="${brd}" y="${brd}" width="${dimensions.width - brd * 2}" height="${dimensions.height - brd * 2}" rx="${radius}" fill="hsl(0 0% ${lightness}% / ${alpha})" style="filter:blur(${blur}px)"/></svg>`;
+	});
+
+	let displacementDataUri = $derived(`data:image/svg+xml,${encodeURIComponent(displacementImage)}`);
+
+	let backdropStyle = $derived(
+		filterId
+			? `--frost:${frost};border-radius:${radius}px;backdrop-filter:url(#displacementFilter-${filterId});`
+			: `--frost:${frost};border-radius:${radius}px;`
+	);
+
+	onMount(() => {
+		filterId = `lg-${Math.random().toString(36).slice(2, 8)}`;
+
+		if (!liquidGlassRoot) return;
+
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (!entry) return;
+
+			let width = 0;
+			let height = 0;
+
+			if (entry.borderBoxSize && entry.borderBoxSize.length) {
+				width = entry.borderBoxSize[0]!.inlineSize;
+				height = entry.borderBoxSize[0]!.blockSize;
+			} else if (entry.contentRect) {
+				width = entry.contentRect.width;
+				height = entry.contentRect.height;
+			}
+
+			dimensions = { width, height };
+		});
+
+		observer.observe(liquidGlassRoot);
+
+		return () => observer.disconnect();
+	});
+</script>
+
+<div
+	bind:this={liquidGlassRoot}
+	class={cn('liquid-glass-effect', containerClass)}
+	style={backdropStyle}
+>
+	<div class={cn('liquid-glass-slot', className)}>
+		{#if children}
+			{@render children()}
+		{/if}
+	</div>
+
+	{#if filterId}
+		<svg class="liquid-glass-filter" xmlns="http://www.w3.org/2000/svg">
+			<defs>
+				<filter id="displacementFilter-{filterId}" color-interpolation-filters="sRGB">
+					<feImage
+						x="0"
+						y="0"
+						width="100%"
+						height="100%"
+						href={displacementDataUri}
+						result="map"
+					/>
+					<feDisplacementMap
+						in="SourceGraphic"
+						in2="map"
+						xChannelSelector={xChannel}
+						yChannelSelector={yChannel}
+						scale={scale + rOffset}
+						result="dispRed"
+					/>
+					<feColorMatrix
+						in="dispRed"
+						type="matrix"
+						values="1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0"
+						result="red"
+					/>
+					<feDisplacementMap
+						in="SourceGraphic"
+						in2="map"
+						xChannelSelector={xChannel}
+						yChannelSelector={yChannel}
+						scale={scale + gOffset}
+						result="dispGreen"
+					/>
+					<feColorMatrix
+						in="dispGreen"
+						type="matrix"
+						values="0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 1 0"
+						result="green"
+					/>
+					<feDisplacementMap
+						in="SourceGraphic"
+						in2="map"
+						xChannelSelector={xChannel}
+						yChannelSelector={yChannel}
+						scale={scale + bOffset}
+						result="dispBlue"
+					/>
+					<feColorMatrix
+						in="dispBlue"
+						type="matrix"
+						values="0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 1 0"
+						result="blue"
+					/>
+					<feBlend in="red" in2="green" mode="screen" result="rg" />
+					<feBlend in="rg" in2="blue" mode="screen" result="output" />
+					{#if displace !== undefined}
+						<feGaussianBlur stdDeviation={displace} />
+					{/if}
+				</filter>
+			</defs>
+		</svg>
+	{/if}
+</div>
+
+<style>
+	.liquid-glass-effect {
+		position: fixed;
+		display: block;
+		opacity: 1;
+		border-radius: inherit;
+		background: light-dark(
+			hsl(0 0% 100% / var(--frost, 0)),
+			hsl(0 0% 0% / var(--frost, 0))
+		);
+		box-shadow:
+			0 0 2px 1px
+				light-dark(
+					color-mix(in oklch, canvasText, #0000 85%),
+					color-mix(in oklch, canvasText, #0000 90%)
+				)
+				inset,
+			0 0 10px 4px
+				light-dark(
+					color-mix(in oklch, canvasText, #0000 90%),
+					color-mix(in oklch, canvasText, #0000 95%)
+				)
+				inset,
+			0px 4px 16px rgba(17, 17, 26, 0.05),
+			0px 8px 24px rgba(17, 17, 26, 0.05),
+			0px 16px 56px rgba(17, 17, 26, 0.05),
+			0px 4px 16px rgba(17, 17, 26, 0.05) inset,
+			0px 8px 24px rgba(17, 17, 26, 0.05) inset,
+			0px 16px 56px rgba(17, 17, 26, 0.05) inset;
+	}
+
+	.liquid-glass-slot {
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+		border-radius: inherit;
+	}
+
+	.liquid-glass-filter {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		pointer-events: none;
+	}
+</style>

--- a/src/lib/fancy-ui/liquid-glass/LiquidGlass.test.ts
+++ b/src/lib/fancy-ui/liquid-glass/LiquidGlass.test.ts
@@ -1,0 +1,57 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import LiquidGlass from './LiquidGlass.svelte';
+
+describe('LiquidGlass', () => {
+	beforeEach(() => {
+		// Mock ResizeObserver (not available in jsdom)
+		vi.stubGlobal(
+			'ResizeObserver',
+			class {
+				observe = vi.fn();
+				unobserve = vi.fn();
+				disconnect = vi.fn();
+			}
+		);
+	});
+
+	afterEach(cleanup);
+
+	it('renders the component', () => {
+		const { container } = render(LiquidGlass);
+		const wrapper = container.querySelector('.liquid-glass-effect');
+		expect(wrapper).toBeInTheDocument();
+	});
+
+	it('renders slot container', () => {
+		const { container } = render(LiquidGlass);
+		const slot = container.querySelector('.liquid-glass-slot');
+		expect(slot).toBeInTheDocument();
+	});
+
+	it('applies custom container class', () => {
+		const { container } = render(LiquidGlass, { props: { containerClass: 'my-container' } });
+		const wrapper = container.querySelector('.liquid-glass-effect');
+		expect(wrapper?.className).toContain('my-container');
+	});
+
+	it('applies custom class to slot container', () => {
+		const { container } = render(LiquidGlass, { props: { class: 'my-slot' } });
+		const slot = container.querySelector('.liquid-glass-slot');
+		expect(slot?.className).toContain('my-slot');
+	});
+
+	it('sets frost CSS variable', () => {
+		const { container } = render(LiquidGlass, { props: { frost: 0.1 } });
+		const wrapper = container.querySelector('.liquid-glass-effect') as HTMLElement;
+		expect(wrapper.getAttribute('style')).toContain('--frost');
+		expect(wrapper.getAttribute('style')).toContain('0.1');
+	});
+
+	it('sets border radius', () => {
+		const { container } = render(LiquidGlass, { props: { radius: 24 } });
+		const wrapper = container.querySelector('.liquid-glass-effect') as HTMLElement;
+		expect(wrapper.getAttribute('style')).toContain('border-radius');
+		expect(wrapper.getAttribute('style')).toContain('24px');
+	});
+});

--- a/src/lib/fancy-ui/liquid-glass/README.md
+++ b/src/lib/fancy-ui/liquid-glass/README.md
@@ -1,0 +1,34 @@
+# LiquidGlass
+
+A glass-like visual effect using SVG filters for chromatic displacement, creating a liquid glass refraction look. Uses `backdrop-filter` with an inline SVG displacement map.
+
+## Props
+
+| Prop             | Type          | Default        | Description                          |
+| ---------------- | ------------- | -------------- | ------------------------------------ |
+| `radius`         | `number`      | `16`           | Border radius in px                  |
+| `border`         | `number`      | `0.07`         | Border thickness factor              |
+| `lightness`      | `number`      | `50`           | HSL lightness of fill                |
+| `displace`       | `number`      | —              | Gaussian blur std deviation          |
+| `blend`          | `string`      | `"difference"` | SVG blend mode                       |
+| `xChannel`       | `"R"\|"G"\|"B"` | `"R"`          | X displacement channel               |
+| `yChannel`       | `"R"\|"G"\|"B"` | `"B"`          | Y displacement channel               |
+| `alpha`          | `number`      | `0.93`         | Fill opacity                         |
+| `blur`           | `number`      | `11`           | Inner blur                           |
+| `rOffset`        | `number`      | `0`            | Red channel offset                   |
+| `gOffset`        | `number`      | `10`           | Green channel offset                 |
+| `bOffset`        | `number`      | `20`           | Blue channel offset                  |
+| `scale`          | `number`      | `-180`         | Displacement scale                   |
+| `frost`          | `number`      | `0.05`         | Frosted overlay opacity              |
+| `class`          | `string`      | `""`           | CSS classes for inner container      |
+| `containerClass` | `string`      | `""`           | CSS classes for outer container      |
+
+## Usage
+
+```svelte
+<LiquidGlass containerClass="w-64 h-40">
+  <div class="p-4 text-white">Glass content</div>
+</LiquidGlass>
+```
+
+**Note**: This component uses `position: fixed` and `backdrop-filter` with SVG filters. Place it over content to see the refraction effect.

--- a/src/lib/fancy-ui/liquid-glass/index.ts
+++ b/src/lib/fancy-ui/liquid-glass/index.ts
@@ -1,0 +1,1 @@
+export { default as LiquidGlass } from './LiquidGlass.svelte';

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -344,6 +344,70 @@ export const registry: Record<string, ComponentMeta> = {
 		description: 'Bento-style grid layout with slot-based and props-based card variants',
 		category: 'cards',
 		status: 'done'
+	},
+
+	'flip-card': {
+		name: 'FlipCard',
+		slug: 'flip-card',
+		description: 'Card that flips to reveal back content on hover using CSS 3D transforms',
+		category: 'cards',
+		status: 'done'
+	},
+
+	book: {
+		name: 'Book',
+		slug: 'book',
+		description: '3D book component with cover, spine, and back face that opens on hover',
+		category: 'cards',
+		status: 'done'
+	},
+
+	'glare-card': {
+		name: 'GlareCard',
+		slug: 'glare-card',
+		description: 'Holographic trading card effect with mouse-tracking glare and rainbow foil',
+		category: 'cards',
+		status: 'done'
+	},
+
+	'text-reveal-card': {
+		name: 'TextRevealCard',
+		slug: 'text-reveal-card',
+		description: 'Card that reveals text on horizontal mouse drag with animated star particles',
+		category: 'cards',
+		status: 'done'
+	},
+
+	'container-scroll': {
+		name: 'ContainerScroll',
+		slug: 'container-scroll',
+		description: 'Scroll-driven animation that rotates and scales a card from tilted to flat',
+		category: 'layout',
+		status: 'done'
+	},
+
+	'container-text-flip': {
+		name: 'ContainerTextFlip',
+		slug: 'container-text-flip',
+		description: 'Text container that cycles through words with per-character blur animation',
+		category: 'text',
+		status: 'done'
+	},
+
+	focus: {
+		name: 'Focus',
+		slug: 'focus',
+		description: 'Text component that cycles focus through words with blur and corner frame',
+		category: 'text',
+		status: 'done'
+	},
+
+	'liquid-glass': {
+		name: 'LiquidGlass',
+		slug: 'liquid-glass',
+		description: 'Glass-like visual effect using SVG filters for chromatic displacement',
+		category: 'effects',
+		status: 'done'
 	}
 };
 

--- a/src/lib/fancy-ui/text-reveal-card/README.md
+++ b/src/lib/fancy-ui/text-reveal-card/README.md
@@ -1,0 +1,36 @@
+# TextRevealCard
+
+A card that reveals text as the user drags their mouse horizontally. Features animated stars in the background.
+
+## Components
+
+- `TextRevealCard` — Main card with mouse/touch reveal
+- `TextRevealStars` — Animated floating star dots
+
+## Props (TextRevealCard)
+
+| Prop         | Type     | Default | Description                 |
+| ------------ | -------- | ------- | --------------------------- |
+| `starsCount` | `number` | `130`   | Number of star dots         |
+| `starsClass` | `string` | `""`    | CSS classes for star dots   |
+| `class`      | `string` | `""`    | Additional CSS classes      |
+
+## Snippets
+
+- `children` — Header content above the reveal area
+- `text` — The revealed text (shown on mouse drag)
+- `revealText` — The base text (always visible)
+
+## Usage
+
+```svelte
+<TextRevealCard>
+  <p class="text-lg font-bold text-white">Hover to reveal</p>
+  {#snippet text()}
+    <p class="text-4xl font-bold text-white">Revealed!</p>
+  {/snippet}
+  {#snippet revealText()}
+    <p class="text-4xl font-bold text-white/20">Hidden text</p>
+  {/snippet}
+</TextRevealCard>
+```

--- a/src/lib/fancy-ui/text-reveal-card/TextRevealCard.svelte
+++ b/src/lib/fancy-ui/text-reveal-card/TextRevealCard.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import TextRevealStars from './TextRevealStars.svelte';
+	import type { Snippet } from 'svelte';
+	import { onMount } from 'svelte';
+
+	interface Props {
+		class?: string;
+		starsCount?: number;
+		starsClass?: string;
+		children?: Snippet;
+		text?: Snippet;
+		revealText?: Snippet;
+	}
+
+	let {
+		class: className = '',
+		starsCount = 130,
+		starsClass = '',
+		children,
+		text,
+		revealText
+	}: Props = $props();
+
+	let cardRef: HTMLDivElement;
+	let widthPercentage = $state(0);
+	let isMouseOver = $state(false);
+
+	let rotateDeg = $derived((widthPercentage - 50) * 0.1);
+
+	function mouseMoveHandler(event: MouseEvent) {
+		event.preventDefault();
+		if (cardRef) {
+			const rect = cardRef.getBoundingClientRect();
+			const relativeX = event.clientX - rect.left;
+			widthPercentage = (relativeX / rect.width) * 100;
+		}
+	}
+
+	function mouseLeaveHandler() {
+		isMouseOver = false;
+		setTimeout(() => {
+			if (!isMouseOver) {
+				widthPercentage = 0;
+			}
+		}, 100);
+	}
+
+	function mouseEnterHandler() {
+		isMouseOver = true;
+	}
+
+	function touchMoveHandler(event: TouchEvent) {
+		event.preventDefault();
+		if (cardRef) {
+			const rect = cardRef.getBoundingClientRect();
+			const relativeX = event.touches[0]!.clientX - rect.left;
+			widthPercentage = (relativeX / rect.width) * 100;
+		}
+	}
+</script>
+
+<div
+	bind:this={cardRef}
+	class={cn(
+		'relative w-full max-w-[40rem] overflow-hidden rounded-lg border border-white/[0.08] bg-[#1d1c20] p-4 md:p-8 sm:p-6',
+		className
+	)}
+	role="presentation"
+	onmouseenter={mouseEnterHandler}
+	onmouseleave={mouseLeaveHandler}
+	onmousemove={mouseMoveHandler}
+	ontouchstart={mouseEnterHandler}
+	ontouchend={mouseLeaveHandler}
+	ontouchmove={touchMoveHandler}
+>
+	{#if children}
+		{@render children()}
+	{/if}
+
+	<div class="relative flex h-40 items-center overflow-hidden">
+		<!-- Reveal layer -->
+		<div
+			style="width: 100%; opacity: {widthPercentage > 0 ? 1 : 0}; clip-path: inset(0 {100 - widthPercentage}% 0 0); transition: {isMouseOver ? 'none' : 'all 0.4s ease-out'};"
+			class="absolute z-20 bg-[#1d1c20] will-change-transform"
+		>
+			{#if text}
+				{@render text()}
+			{/if}
+		</div>
+
+		<!-- Reveal line -->
+		<div
+			style="left: {widthPercentage}%; transform: rotate({rotateDeg}deg); opacity: {widthPercentage > 0 ? 1 : 0}; transition: {isMouseOver ? 'none' : 'all 0.4s ease-out'};"
+			class="absolute z-50 h-40 w-[8px] bg-gradient-to-b from-transparent via-neutral-800 to-transparent will-change-transform"
+		></div>
+
+		<!-- Background text + stars -->
+		<div
+			class="overflow-hidden [mask-image:linear-gradient(to_bottom,transparent,white,transparent)]"
+		>
+			{#if revealText}
+				{@render revealText()}
+			{/if}
+			<TextRevealStars {starsCount} class={starsClass} />
+		</div>
+	</div>
+</div>

--- a/src/lib/fancy-ui/text-reveal-card/TextRevealCard.test.ts
+++ b/src/lib/fancy-ui/text-reveal-card/TextRevealCard.test.ts
@@ -1,0 +1,38 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import TextRevealCard from './TextRevealCard.svelte';
+
+describe('TextRevealCard', () => {
+	afterEach(cleanup);
+
+	it('renders the component', () => {
+		const { container } = render(TextRevealCard);
+		const card = container.querySelector('.bg-\\[\\#1d1c20\\]');
+		expect(card).toBeInTheDocument();
+	});
+
+	it('applies custom class', () => {
+		const { container } = render(TextRevealCard, { props: { class: 'my-reveal' } });
+		const card = container.firstElementChild;
+		expect(card?.className).toContain('my-reveal');
+	});
+
+	it('renders reveal line', () => {
+		const { container } = render(TextRevealCard);
+		const line = container.querySelector('.via-neutral-800');
+		expect(line).toBeInTheDocument();
+	});
+
+	it('renders stars container', () => {
+		const { container } = render(TextRevealCard);
+		// Stars are rendered inside the component
+		const starsContainer = container.querySelector('.absolute.inset-0');
+		expect(starsContainer).toBeInTheDocument();
+	});
+
+	it('starts with 0% width', () => {
+		const { container } = render(TextRevealCard);
+		const revealLayer = container.querySelector('.z-20') as HTMLElement;
+		expect(revealLayer?.style.opacity).toBe('0');
+	});
+});

--- a/src/lib/fancy-ui/text-reveal-card/TextRevealStars.svelte
+++ b/src/lib/fancy-ui/text-reveal-card/TextRevealStars.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+
+	interface Props {
+		starsCount?: number;
+		class?: string;
+	}
+
+	let { starsCount = 130, class: className = '' }: Props = $props();
+
+	interface StarData {
+		top: string;
+		left: string;
+		targetTop: string;
+		targetLeft: string;
+		opacity: number;
+		duration: number;
+	}
+
+	function randomMove() {
+		return Math.random() * 4 - 2;
+	}
+
+	function random() {
+		return Math.random();
+	}
+
+	// Generate star data reactively based on starsCount
+	let stars: StarData[] = $derived(Array.from({ length: starsCount }, () => ({
+		top: `calc(${random() * 100}% + ${randomMove()}px)`,
+		left: `calc(${random() * 100}% + ${randomMove()}px)`,
+		targetTop: `calc(${random() * 100}% + ${randomMove()}px)`,
+		targetLeft: `calc(${random() * 100}% + ${randomMove()}px)`,
+		opacity: random(),
+		duration: random() * 10 + 20
+	})));
+</script>
+
+<div class="absolute inset-0">
+	{#each stars as star}
+		<span
+			class={cn(
+				'inline-block absolute w-0.5 h-0.5 bg-white rounded-full z-[1] star-animate',
+				className
+			)}
+			style="top:{star.top};left:{star.left};--target-top:{star.targetTop};--target-left:{star.targetLeft};--star-opacity:{star.opacity};animation-duration:{star.duration}s;"
+		></span>
+	{/each}
+</div>
+
+<style>
+	:global {
+		@keyframes star-drift {
+			0% {
+				opacity: 0;
+				transform: scale(1);
+			}
+			50% {
+				opacity: var(--star-opacity, 0.5);
+				transform: scale(1.2);
+			}
+			100% {
+				opacity: 0;
+				transform: scale(0);
+				top: var(--target-top);
+				left: var(--target-left);
+			}
+		}
+	}
+
+	.star-animate {
+		animation: star-drift linear infinite;
+	}
+</style>

--- a/src/lib/fancy-ui/text-reveal-card/index.ts
+++ b/src/lib/fancy-ui/text-reveal-card/index.ts
@@ -1,0 +1,2 @@
+export { default as TextRevealCard } from './TextRevealCard.svelte';
+export { default as TextRevealStars } from './TextRevealStars.svelte';

--- a/src/routes/demo/book/+page.svelte
+++ b/src/routes/demo/book/+page.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import {
+		Book,
+		BookHeader,
+		BookTitle,
+		BookDescription,
+		type BookColor,
+		type BookSize
+	} from '$lib/fancy-ui/book';
+
+	const colors: BookColor[] = ['blue', 'purple', 'emerald', 'rose', 'amber'];
+	const sizes: BookSize[] = ['sm', 'md', 'lg', 'xl'];
+</script>
+
+<svelte:head>
+	<title>Book - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">Book</h1>
+	<p class="text-muted-foreground mb-8">
+		A 3D book component with cover, spine, and back face that opens on hover.
+	</p>
+
+	<!-- Basic Example -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="flex justify-center border rounded-lg p-10 bg-card">
+			<Book>
+				<BookHeader>
+					<span class="rounded bg-white/20 px-2 py-0.5 text-xs">Fiction</span>
+				</BookHeader>
+				<BookTitle>The Great Gatsby</BookTitle>
+				<BookDescription>
+					A story of the mysteriously wealthy Jay Gatsby and his love for Daisy Buchanan.
+				</BookDescription>
+			</Book>
+		</div>
+	</section>
+
+	<!-- Colors -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Color Variants</h2>
+		<div class="flex flex-wrap justify-center gap-8 border rounded-lg p-10 bg-card">
+			{#each colors as bookColor}
+				<Book color={bookColor}>
+					<BookTitle>{bookColor}</BookTitle>
+					<BookDescription>Color variant</BookDescription>
+				</Book>
+			{/each}
+		</div>
+	</section>
+
+	<!-- Sizes -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Sizes</h2>
+		<div class="flex flex-wrap items-end justify-center gap-8 border rounded-lg p-10 bg-card">
+			{#each sizes as bookSize}
+				<Book size={bookSize} color="indigo">
+					<BookTitle>{bookSize}</BookTitle>
+					<BookDescription>Size variant</BookDescription>
+				</Book>
+			{/each}
+		</div>
+	</section>
+
+	<!-- Static -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Static (always open)</h2>
+		<div class="flex justify-center border rounded-lg p-10 bg-card">
+			<Book isStatic color="teal">
+				<BookHeader>
+					<span class="rounded bg-white/20 px-2 py-0.5 text-xs">Static</span>
+				</BookHeader>
+				<BookTitle>Always Open</BookTitle>
+				<BookDescription>This book is always in the opened state.</BookDescription>
+			</Book>
+		</div>
+	</section>
+</div>

--- a/src/routes/demo/container-scroll/+page.svelte
+++ b/src/routes/demo/container-scroll/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { ContainerScroll } from '$lib/fancy-ui/container-scroll';
+</script>
+
+<svelte:head>
+	<title>ContainerScroll - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">ContainerScroll</h1>
+	<p class="text-muted-foreground mb-8">
+		A scroll-driven animation that rotates and scales a card from a tilted perspective to flat.
+		Scroll down to see the effect.
+	</p>
+
+	<ContainerScroll>
+		{#snippet titleContent()}
+			<h2 class="text-4xl font-semibold text-foreground dark:text-white">
+				Unleash the power of <br />
+				<span class="mt-1 text-4xl font-bold leading-none md:text-[6rem]">Scroll Animations</span>
+			</h2>
+		{/snippet}
+		{#snippet cardContent()}
+			<div
+				class="flex size-full flex-col items-center justify-center bg-gradient-to-br from-violet-500 to-purple-700 p-8 text-white"
+			>
+				<h3 class="text-3xl font-bold">Your Content Here</h3>
+				<p class="mt-4 max-w-md text-center text-lg text-white/80">
+					This card rotates from 20 degrees to 0 as you scroll. It also scales smoothly
+					to create a dramatic reveal effect.
+				</p>
+			</div>
+		{/snippet}
+	</ContainerScroll>
+</div>

--- a/src/routes/demo/container-text-flip/+page.svelte
+++ b/src/routes/demo/container-text-flip/+page.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { ContainerTextFlip } from '$lib/fancy-ui/container-text-flip';
+</script>
+
+<svelte:head>
+	<title>ContainerTextFlip - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">ContainerTextFlip</h1>
+	<p class="text-muted-foreground mb-8">
+		A text container that cycles through words with per-character blur-to-clear animation.
+	</p>
+
+	<!-- Basic Example -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="flex justify-center border rounded-lg p-10 bg-card">
+			<div class="flex items-center gap-4">
+				<span class="text-4xl md:text-7xl font-bold text-foreground">Build</span>
+				<ContainerTextFlip />
+			</div>
+		</div>
+	</section>
+
+	<!-- Custom Words -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Words</h2>
+		<div class="flex justify-center border rounded-lg p-10 bg-card">
+			<div class="flex items-center gap-4">
+				<span class="text-4xl md:text-7xl font-bold text-foreground">Make it</span>
+				<ContainerTextFlip words={['stunning', 'brilliant', 'perfect', 'legendary']} />
+			</div>
+		</div>
+	</section>
+
+	<!-- Fast Animation -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Fast Interval</h2>
+		<div class="flex justify-center border rounded-lg p-10 bg-card">
+			<ContainerTextFlip
+				words={['fast', 'quick', 'rapid', 'swift']}
+				interval={1500}
+				animationDuration={400}
+			/>
+		</div>
+	</section>
+</div>

--- a/src/routes/demo/flip-card/+page.svelte
+++ b/src/routes/demo/flip-card/+page.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import { FlipCard } from '$lib/fancy-ui/flip-card';
+</script>
+
+<svelte:head>
+	<title>FlipCard - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">FlipCard</h1>
+	<p class="text-muted-foreground mb-8">
+		A card that flips to reveal back content on hover using CSS 3D transforms.
+	</p>
+
+	<!-- Basic Example -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage (Y-axis)</h2>
+		<div class="flex justify-center border rounded-lg p-6 bg-card">
+			<FlipCard>
+				<div
+					class="flex size-full items-center justify-center bg-gradient-to-br from-purple-500 to-pink-500"
+				>
+					<p class="text-2xl font-bold text-white">Front</p>
+				</div>
+				{#snippet back()}
+					<div class="flex size-full flex-col items-center justify-center">
+						<p class="text-lg font-semibold">Back Side</p>
+						<p class="mt-2 text-sm text-slate-400">Hover to flip</p>
+					</div>
+				{/snippet}
+			</FlipCard>
+		</div>
+	</section>
+
+	<!-- X-axis rotation -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">X-axis Rotation</h2>
+		<div class="flex justify-center border rounded-lg p-6 bg-card">
+			<FlipCard rotate="x">
+				<div
+					class="flex size-full items-center justify-center bg-gradient-to-br from-cyan-500 to-blue-500"
+				>
+					<p class="text-2xl font-bold text-white">Front</p>
+				</div>
+				{#snippet back()}
+					<div class="flex size-full flex-col items-center justify-center">
+						<p class="text-lg font-semibold">Flipped vertically!</p>
+						<p class="mt-2 text-sm text-slate-400">rotate="x"</p>
+					</div>
+				{/snippet}
+			</FlipCard>
+		</div>
+	</section>
+
+	<!-- Multiple cards -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Multiple Cards</h2>
+		<div class="flex flex-wrap justify-center gap-6 border rounded-lg p-6 bg-card">
+			{#each ['from-rose-500 to-orange-500', 'from-emerald-500 to-teal-500', 'from-violet-500 to-indigo-500'] as gradient, i}
+				<FlipCard>
+					<div
+						class="flex size-full items-center justify-center bg-gradient-to-br {gradient}"
+					>
+						<p class="text-2xl font-bold text-white">Card {i + 1}</p>
+					</div>
+					{#snippet back()}
+						<div class="flex size-full flex-col items-center justify-center">
+							<p class="text-lg font-semibold">Details #{i + 1}</p>
+							<p class="mt-2 text-sm text-slate-400">More info here</p>
+						</div>
+					{/snippet}
+				</FlipCard>
+			{/each}
+		</div>
+	</section>
+</div>

--- a/src/routes/demo/focus/+page.svelte
+++ b/src/routes/demo/focus/+page.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { Focus } from '$lib/fancy-ui/focus';
+</script>
+
+<svelte:head>
+	<title>Focus - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">Focus</h1>
+	<p class="text-muted-foreground mb-8">
+		A text component that cycles through words, focusing on one at a time with a decorative
+		frame. Non-focused words are blurred.
+	</p>
+
+	<!-- Basic Example -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Auto Mode (default)</h2>
+		<div class="flex justify-center border rounded-lg p-10 bg-card">
+			<Focus sentence="Build beautiful interfaces easily" />
+		</div>
+	</section>
+
+	<!-- Custom Colors -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Border Color</h2>
+		<div class="flex justify-center border rounded-lg p-10 bg-card">
+			<Focus sentence="Design with confidence" borderColor="cyan" />
+		</div>
+	</section>
+
+	<!-- Manual Mode -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Manual Mode (hover)</h2>
+		<div class="flex justify-center border rounded-lg p-10 bg-card">
+			<Focus sentence="Hover over each word" manualMode borderColor="orange" />
+		</div>
+	</section>
+
+	<!-- High Blur -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">High Blur Amount</h2>
+		<div class="flex justify-center border rounded-lg p-10 bg-card">
+			<Focus
+				sentence="Strong blur effect here"
+				blurAmount={10}
+				borderColor="red"
+				animationDuration={0.3}
+				pauseBetweenAnimations={0.5}
+			/>
+		</div>
+	</section>
+</div>

--- a/src/routes/demo/glare-card/+page.svelte
+++ b/src/routes/demo/glare-card/+page.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { GlareCard } from '$lib/fancy-ui/glare-card';
+</script>
+
+<svelte:head>
+	<title>GlareCard - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">GlareCard</h1>
+	<p class="text-muted-foreground mb-8">
+		A holographic trading card effect with mouse-tracking glare, rainbow foil, and 3D rotation.
+	</p>
+
+	<!-- Basic Example -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="flex justify-center border rounded-lg p-10 bg-card">
+			<GlareCard>
+				<div class="flex size-full flex-col items-center justify-center p-6 text-white">
+					<h3 class="text-2xl font-bold">Holographic</h3>
+					<p class="mt-2 text-sm text-slate-300">Move your mouse to see the effect</p>
+				</div>
+			</GlareCard>
+		</div>
+	</section>
+
+	<!-- With Image -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">With Image Content</h2>
+		<div class="flex justify-center border rounded-lg p-10 bg-card">
+			<GlareCard>
+				<img
+					src="https://images.unsplash.com/photo-1517336714731-489689fd1ca8?w=400&h=500&fit=crop"
+					alt="Laptop"
+					class="size-full object-cover"
+				/>
+			</GlareCard>
+		</div>
+	</section>
+
+	<!-- Multiple -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Multiple Cards</h2>
+		<div class="flex flex-wrap justify-center gap-8 border rounded-lg p-10 bg-card">
+			{#each ['Fire', 'Water', 'Earth'] as element, i}
+				<GlareCard>
+					<div
+						class="flex size-full flex-col items-center justify-center p-6 text-white"
+					>
+						<span class="text-4xl mb-2">{['🔥', '💧', '🌍'][i]}</span>
+						<h3 class="text-xl font-bold">{element}</h3>
+						<p class="mt-1 text-xs text-slate-400">Elemental Card</p>
+					</div>
+				</GlareCard>
+			{/each}
+		</div>
+	</section>
+</div>

--- a/src/routes/demo/liquid-glass/+page.svelte
+++ b/src/routes/demo/liquid-glass/+page.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import { LiquidGlass } from '$lib/fancy-ui/liquid-glass';
+</script>
+
+<svelte:head>
+	<title>LiquidGlass - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">LiquidGlass</h1>
+	<p class="text-muted-foreground mb-8">
+		A glass-like visual effect using SVG filters for chromatic displacement, creating a liquid
+		glass refraction look.
+	</p>
+
+	<!-- Demo with background content -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="relative border rounded-lg p-10 bg-card overflow-hidden" style="min-height: 400px;">
+			<!-- Background content -->
+			<div class="flex flex-wrap gap-4 p-8">
+				<div class="h-20 w-32 rounded-lg bg-gradient-to-br from-purple-500 to-pink-500"></div>
+				<div class="h-20 w-32 rounded-lg bg-gradient-to-br from-cyan-500 to-blue-500"></div>
+				<div class="h-20 w-32 rounded-lg bg-gradient-to-br from-green-500 to-emerald-500"></div>
+				<div class="h-20 w-32 rounded-lg bg-gradient-to-br from-orange-500 to-red-500"></div>
+				<p class="w-full text-lg text-foreground">
+					This is some background text that the liquid glass effect will distort and refract.
+					Move or resize the glass element to see the displacement in action.
+				</p>
+				<div class="h-20 w-32 rounded-lg bg-gradient-to-br from-violet-500 to-indigo-500"></div>
+				<div class="h-20 w-32 rounded-lg bg-gradient-to-br from-amber-500 to-yellow-500"></div>
+			</div>
+
+			<!-- Glass overlay -->
+			<LiquidGlass
+				containerClass="!absolute !inset-x-8 !top-16 !bottom-auto h-48 z-10"
+				radius={20}
+				frost={0.08}
+			>
+				<div class="flex items-center justify-center h-full text-foreground font-semibold text-lg">
+					Liquid Glass Effect
+				</div>
+			</LiquidGlass>
+		</div>
+		<p class="mt-2 text-sm text-muted-foreground">
+			Note: The liquid glass uses <code>backdrop-filter</code> with SVG displacement maps.
+			Best viewed in Chromium-based browsers.
+		</p>
+	</section>
+
+	<!-- Props showcase -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">High Frost</h2>
+		<div class="relative border rounded-lg p-10 bg-card overflow-hidden" style="min-height: 300px;">
+			<div class="grid grid-cols-3 gap-4 p-4">
+				{#each Array(9) as _, i}
+					<div
+						class="h-16 rounded bg-gradient-to-r from-rose-400 to-violet-400"
+						style="opacity: {0.5 + (i * 0.05)}"
+					></div>
+				{/each}
+			</div>
+
+			<LiquidGlass
+				containerClass="!absolute inset-8 z-10"
+				frost={0.2}
+				radius={24}
+			>
+				<div class="flex items-center justify-center h-full text-foreground font-medium">
+					frost = 0.2
+				</div>
+			</LiquidGlass>
+		</div>
+	</section>
+</div>

--- a/src/routes/demo/text-reveal-card/+page.svelte
+++ b/src/routes/demo/text-reveal-card/+page.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { TextRevealCard } from '$lib/fancy-ui/text-reveal-card';
+</script>
+
+<svelte:head>
+	<title>TextRevealCard - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">TextRevealCard</h1>
+	<p class="text-muted-foreground mb-8">
+		A card that reveals text as the user moves their mouse horizontally, with animated star
+		particles.
+	</p>
+
+	<!-- Basic Example -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="flex justify-center border rounded-lg p-6 bg-card">
+			<TextRevealCard>
+				<p class="mb-4 text-lg font-bold text-white">Move your mouse to reveal</p>
+				{#snippet text()}
+					<p
+						class="bg-clip-text text-transparent bg-gradient-to-b from-white to-neutral-300 text-[2rem] md:text-[3rem] font-bold py-6"
+					>
+						I know the secret
+					</p>
+				{/snippet}
+				{#snippet revealText()}
+					<p
+						class="text-[2rem] md:text-[3rem] font-bold text-white/10 py-6"
+					>
+						Hover me to see
+					</p>
+				{/snippet}
+			</TextRevealCard>
+		</div>
+	</section>
+
+	<!-- Custom Stars -->
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Fewer Stars</h2>
+		<div class="flex justify-center border rounded-lg p-6 bg-card">
+			<TextRevealCard starsCount={40}>
+				<p class="mb-4 text-sm text-neutral-400">Fewer stars, same effect</p>
+				{#snippet text()}
+					<p
+						class="bg-clip-text text-transparent bg-gradient-to-b from-white to-neutral-300 text-[2rem] md:text-[3rem] font-bold py-6"
+					>
+						Less is more
+					</p>
+				{/snippet}
+				{#snippet revealText()}
+					<p
+						class="text-[2rem] md:text-[3rem] font-bold text-white/10 py-6"
+					>
+						Minimalist
+					</p>
+				{/snippet}
+			</TextRevealCard>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Port **FlipCard**: CSS 3D flip on hover with X/Y axis support
- Port **Book** (+ BookHeader, BookTitle, BookDescription): 3D book with cover, spine, back face, 22 color variants, 4 sizes
- Port **GlareCard**: Holographic trading card with mouse-tracking glare, rainbow foil, and 3D rotation
- Port **TextRevealCard** (+ TextRevealStars): Mouse-drag text reveal with animated star particles
- Port **ContainerScroll**: Scroll-driven 3D rotation and scale animation (merged 3 Vue sub-components into 1)
- Port **ContainerTextFlip**: Word cycling with per-character blur-to-clear animation
- Port **Focus**: Word-by-word focus cycling with blur and decorative corner frame brackets
- Port **LiquidGlass**: SVG filter displacement map for chromatic glass refraction effect

Each component includes: Svelte component, `index.ts` barrel export, `README.md`, unit tests, and demo page at `/demo/<component>`.

Registry (`registry.ts`) and barrel exports (`index.ts`) updated with all 8 components.

## Test plan
- [x] `pnpm check` — no new TypeScript errors (pre-existing errors unchanged)
- [x] `pnpm test` — all new component tests pass
- [x] Visit `/demo/flip-card` — card flips on hover (Y and X axis variants)
- [x] Visit `/demo/book` — 3D book opens on hover, color/size/static variants work
- [x] Visit `/demo/glare-card` — holographic glare follows mouse, foil effect visible
- [x] Visit `/demo/text-reveal-card` — mouse drag reveals text with star animation
- [x] Visit `/demo/container-scroll` — card rotates/scales on scroll
- [x] Visit `/demo/container-text-flip` — words cycle with blur animation
- [ ] Visit `/demo/focus` — words cycle with focus frame, manual mode works on hover
- [ ] Visit `/demo/liquid-glass` — glass refraction effect over background content
- [ ] Verify dark/light mode appearance on all demos