### PR TITLE
fix: align portfolio Hero and Contact with design

### DIFF
--- a/src/lib/portfolio/sections/Contact.svelte
+++ b/src/lib/portfolio/sections/Contact.svelte
@@ -1,32 +1,15 @@
-<script lang="ts">
-	import ContactForm from '$lib/portfolio/ContactForm.svelte';
-</script>
-
 <footer id="contact" class="border-t border-border/40 py-16 px-6">
 	<div class="max-w-4xl mx-auto">
 		<div class="flex flex-col items-center justify-center text-center space-y-8">
 			<div class="space-y-4">
-				<div class="flex flex-col items-center space-y-4">
-					<h2
-						class="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-foreground"
-					>
-						Let's Connect
-					</h2>
-				</div>
+				<h2
+					class="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-foreground"
+				>
+					Let's Connect
+				</h2>
 				<p class="text-lg text-muted-foreground max-w-2xl">
-					Ready to collaborate on your next project or just want to say hello?
+					Ready to collaborate on your next project or just want to say hi?
 				</p>
-			</div>
-
-			<div class="w-full max-w-lg">
-				<ContactForm />
-			</div>
-
-			<!-- Divider -->
-			<div class="flex items-center w-full max-w-md">
-				<div class="flex-1 border-t border-border/40"></div>
-				<span class="px-4 text-sm text-muted-foreground">or reach out directly</span>
-				<div class="flex-1 border-t border-border/40"></div>
 			</div>
 
 			<!-- Contact Links -->

--- a/src/lib/portfolio/sections/Hero.svelte
+++ b/src/lib/portfolio/sections/Hero.svelte
@@ -39,6 +39,8 @@
 	<!-- Interactive Grid Pattern Background -->
 	{#if showInteractiveElements}
 		<InteractiveGridPattern
+			width={80}
+			height={80}
 			class="[mask-image:radial-gradient(500px_circle_at_center,white,transparent)] inset-0 h-full opacity-30"
 		/>
 	{/if}
@@ -49,8 +51,8 @@
 			Rama Herbin
 		</h1>
 
-		<BlurReveal delay={0.2} duration={0.75} class="space-y-6">
-			<h2 class="text-xl sm:text-2xl lg:text-3xl font-medium text-muted-foreground">
+		<BlurReveal delay={0.2} duration={0.75} class="space-y-8">
+			<h2 class="text-xl sm:text-2xl lg:text-3xl font-medium text-neutral-400">
 				Front-End & UI Engineer
 			</h2>
 

--- a/src/routes/portfolio/+page.svelte
+++ b/src/routes/portfolio/+page.svelte
@@ -5,7 +5,6 @@
 	import Projects from '$lib/portfolio/sections/Projects.svelte';
 	import Testimonials from '$lib/portfolio/sections/Testimonials.svelte';
 	import Passions from '$lib/portfolio/sections/Passions.svelte';
-	import Creative from '$lib/portfolio/sections/Creative.svelte';
 	import Contact from '$lib/portfolio/sections/Contact.svelte';
 	import Footer from '$lib/portfolio/sections/Footer.svelte';
 </script>
@@ -31,7 +30,6 @@
 	<Projects />
 	<Testimonials />
 	<Passions />
-	<Creative />
 	<Contact />
 	<Footer />
 </div>


### PR DESCRIPTION
## Summary
- **Contact section**: Removed ContactForm and "or reach out directly" divider, keeping only the 3 contact buttons (Email, LinkedIn, GitHub) to match the design
- **Creative section**: Removed from page composition (absent in design)
- **Hero grid**: Increased InteractiveGridPattern cell size from 40px to 80px to match design proportions
- **Hero subtitle**: Changed "Front-End & UI Engineer" color to `text-neutral-400` (neutral grey instead of muted-foreground) and increased vertical spacing (`space-y-8`)

## Test plan
- [ ] Verify Hero section grid pattern matches design visually
- [ ] Verify Contact section shows only heading + 3 buttons + location
- [ ] Verify Creative section is no longer rendered
- [ ] Check responsive layout on mobile