### PR TITLE
feat: site builder Phase 1 — JSON page renderer

### DIFF
--- a/BUILDER.md
+++ b/BUILDER.md
@@ -1,0 +1,382 @@
+# CMS / Site Builder — Plan
+
+## Overview
+
+A custom git-based visual site builder integrated into the FancyUI component library. It renders pages from JSON documents using the existing 50+ ported Svelte 5 components, with a drag-and-drop editor for composing pages visually.
+
+**Audience:** Admin deployed (accessible in prod, with auth)
+**Storage:** Local filesystem first, GitHub API later
+**Approach:** Custom builder (no existing CMS supports Svelte 5 snippets + FancyUI props)
+
+---
+
+## Architecture
+
+```
+content/pages/*.json          → Page documents (git-tracked)
+src/lib/builder/              → Core library (types, registry, renderer, utils)
+src/routes/pages/[slug]/      → Public page rendering
+src/routes/builder/           → Visual editor (protected)
+src/routes/api/builder/       → Storage API endpoints (protected)
+```
+
+### Page Document Format
+
+Each page = a JSON file in `content/pages/`:
+
+```json
+{
+  "version": 1,
+  "meta": { "title": "...", "slug": "...", "status": "draft|published", ... },
+  "body": [
+    {
+      "id": "nanoid-12",
+      "type": "_section",
+      "props": { "padding": "py-16 px-4" },
+      "children": [
+        { "id": "...", "type": "sparkles-text", "props": { "text": "Hello" } }
+      ]
+    }
+  ]
+}
+```
+
+### Component Types
+
+- **Layout primitives** (prefixed `_`): `_section`, `_container`, `_grid`, `_flex`, `_text`, `_image`, `_spacer`
+- **FancyUI components**: 15+ components with full prop schemas (BorderBeam, GlowBorder, Meteors, ShimmerButton, RainbowButton, Marquee, Ripple, SparklesText, ColourfulText, NumberTicker, FlipWords, CardSpotlight, NeonBorder, LetterPullup, BoxReveal)
+- **Adapters**: Wrappers for multi-snippet components (FlipCard, BentoGridItem, ContainerScroll, ShimmerButton, RainbowButton)
+
+### Editor Layout (Phase 2+)
+
+```
++----------------------------------------------------------+
+|  TopBar: [←] Page Title | Breakpoints | Save | Publish   |
++--------+--------------------------------+----------------+
+| LEFT   |         CENTER CANVAS          |    RIGHT       |
+| 240px  |   Live preview of page tree    |    320px       |
+| Palette|   Click = select               | Props editor   |
+| drag-  |   Blue border = selected       | for selected   |
+| gable  |   Dashed = drop zone           | block          |
++--------+--------------------------------+----------------+
+| Layer tree (hierarchical)               |                |
++-----------------------------------------+----------------+
+```
+
+---
+
+## Phases
+
+### Phase 1: Infrastructure Core ✅
+
+**Status: DONE**
+
+Types, registry, renderer, utilities, and public page route.
+
+#### Files Created
+
+```
+src/lib/builder/
+├── index.ts                              # Barrel export
+├── types/
+│   ├── page.ts                           # PageDocument, BlockNode, PageMeta
+│   ├── registry.ts                       # PropSchema (7 variants), BuilderComponentMeta
+│   └── index.ts
+├── registry/
+│   ├── builder-registry.ts               # 22 components (7 primitives + 15 FancyUI)
+│   └── index.ts
+├── renderer/
+│   ├── component-map.ts                  # slug → Svelte component map
+│   ├── BlockRenderer.svelte              # Recursive renderer
+│   ├── PageRenderer.svelte               # Full page renderer
+│   ├── index.ts
+│   ├── primitives/
+│   │   ├── Section.svelte
+│   │   ├── Container.svelte
+│   │   ├── Grid.svelte
+│   │   ├── Flex.svelte
+│   │   ├── Text.svelte
+│   │   ├── Image.svelte
+│   │   └── Spacer.svelte
+│   └── adapters/
+│       ├── ShimmerButtonAdapter.svelte
+│       ├── RainbowButtonAdapter.svelte
+│       ├── FlipCardAdapter.svelte
+│       ├── BentoGridItemAdapter.svelte
+│       └── ContainerScrollAdapter.svelte
+└── utils/
+    ├── id.ts                             # createBlockId() (nanoid)
+    ├── tree.ts                           # findNode, removeNode, insertNode, moveNode, ...
+    └── index.ts
+
+src/routes/pages/[slug]/
+├── +page.server.ts                       # Loads JSON from content/pages/
+└── +page.svelte                          # Renders with PageRenderer
+
+content/
+├── pages/test.json                       # Test page (6 sections, all component types)
+├── _drafts/
+└── _templates/
+```
+
+#### Verification
+
+- `/pages/test` → renders all sections correctly (200 OK)
+- `/pages/nonexistent` → 404
+- `pnpm check` → 0 new errors
+
+#### Dependencies Added
+
+- `nanoid` (runtime)
+- `@types/node` (dev)
+
+---
+
+### Phase 2: Editor UI
+
+**Status: TODO**
+
+Visual editor with 3 panels: palette, canvas, property panel.
+
+#### Deliverables
+
+- **Editor state store** (`src/lib/builder/stores/editor.svelte.ts`)
+  - Selected block ID, page document (reactive), undo/redo stack
+  - Svelte 5 runes (`$state`, `$derived`) + context (`setContext`/`getContext`)
+- **EditorLayout.svelte** — 3-panel responsive layout
+- **TopBar.svelte** — page title, breakpoint toggle, save/publish buttons
+- **ComponentPalette.svelte** + **PaletteItem.svelte** — browsable list of components grouped by category
+- **Canvas.svelte** — live preview area, click to select blocks
+- **BlockWrapper.svelte** — wraps each block in the canvas with selection border + toolbar (move up/down, delete)
+- **PropertyPanel.svelte** — edits props of the selected block
+- **Prop editors** (5 types): StringEditor, NumberEditor, BooleanEditor, ColorEditor, SelectEditor
+- **LayerTree.svelte** — hierarchical view of the block tree
+
+#### Files
+
+```
+src/lib/builder/
+├── stores/
+│   └── editor.svelte.ts
+├── editor/
+│   ├── EditorLayout.svelte
+│   ├── TopBar.svelte
+│   ├── ComponentPalette.svelte
+│   ├── PaletteItem.svelte
+│   ├── Canvas.svelte
+│   ├── BlockWrapper.svelte
+│   ├── PropertyPanel.svelte
+│   ├── LayerTree.svelte
+│   └── props/
+│       ├── StringEditor.svelte
+│       ├── NumberEditor.svelte
+│       ├── BooleanEditor.svelte
+│       ├── ColorEditor.svelte
+│       └── SelectEditor.svelte
+
+src/routes/builder/
+├── +layout.svelte
+├── +page.svelte                          # Dashboard / page list
+└── [slug]/
+    ├── +page.svelte                      # Editor for a specific page
+    └── +page.ts                          # Load page data
+```
+
+---
+
+### Phase 3: Drag-and-Drop
+
+**Status: TODO**
+
+Integration of `svelte-dnd-action` for visual block reordering.
+
+#### Deliverables
+
+- **Palette → Canvas**: drag a component from the palette to create a new BlockNode with default props
+- **Canvas → Canvas**: reorder/reparent blocks via nested `use:dndzone`
+- **Layer tree reorder**: drag blocks in the layer tree
+- **Drop zone validation**: enforce `allowedChildTypes` / `allowedParentTypes`
+- **Visual indicators**: dashed borders for drop zones, placeholders during drag
+
+#### Dependency
+
+| Package | Size | Usage |
+|---------|------|-------|
+| `svelte-dnd-action` | ~8KB gz | Drag-and-drop |
+
+---
+
+### Phase 4: Live Preview
+
+**Status: TODO**
+
+Wire reactive updates between editor state and the canvas.
+
+#### Deliverables
+
+- **Reactive canvas**: modifying props in the property panel instantly updates the preview
+- **Edit/Interact toggle**: `pointer-events: none` on components in edit mode, `pointer-events: auto` in interact mode
+- **Responsive preview**: CSS zoom for mobile/tablet/desktop breakpoints
+- **Inline text editing**: double-click a `_text` block to edit content directly
+
+---
+
+### Phase 5: Storage + Auth
+
+**Status: TODO**
+
+Persist pages and protect the editor.
+
+#### Deliverables
+
+- **PageStorage interface** (`src/lib/builder/storage/types.ts`)
+  - `list()`, `get(slug)`, `save(page)`, `delete(slug)`, `publish(slug)`
+- **Local filesystem implementation** (`storage/local.ts`)
+  - API routes: `POST /api/builder/pages`, `GET/PUT/DELETE /api/builder/pages/[slug]`
+  - Publish: `POST /api/builder/publish` (git add + commit + push)
+- **IndexedDB drafts** (`storage/draft-store.ts`)
+  - Auto-save every 5s to IndexedDB (client-side)
+  - Recover unsaved changes on reload
+- **Dashboard** (`/builder` page)
+  - List all pages with status, last modified, actions
+  - Create new page, duplicate, delete
+- **GitHub OAuth** authentication
+  - Login flow via `arctic` library
+  - `hooks.server.ts` middleware protecting `/builder/**` and `/api/builder/**`
+  - Session in httpOnly cookie
+  - Whitelist of authorized GitHub usernames
+
+#### Dependencies
+
+| Package | Size | Usage |
+|---------|------|-------|
+| `arctic` | ~15KB | GitHub OAuth |
+| `idb` (optional) | ~1.2KB | Typed IndexedDB wrapper |
+
+#### Files
+
+```
+src/lib/builder/storage/
+├── types.ts                              # PageStorage interface
+├── local.ts                              # Filesystem implementation
+├── github.ts                             # GitHub API implementation (later)
+└── draft-store.ts                        # IndexedDB auto-save
+
+src/routes/api/builder/
+├── pages/+server.ts                      # GET (list), POST (create)
+├── pages/[slug]/+server.ts               # GET, PUT, DELETE
+└── publish/+server.ts                    # POST (git commit + push)
+
+src/hooks.server.ts                       # Auth middleware
+```
+
+---
+
+### Phase 6: Polish
+
+**Status: TODO**
+
+UX refinements and completeness.
+
+#### Deliverables
+
+- **Undo/Redo** — command stack in editor store, Cmd+Z / Cmd+Shift+Z
+- **Copy/Paste** — Cmd+C / Cmd+V on selected blocks
+- **Keyboard shortcuts** — Cmd+S (save), Delete/Backspace (remove block), arrow keys (navigate tree)
+- **Page templates** — starter templates in `content/_templates/` (blank, landing, portfolio)
+- **Version history UI** — git log viewer showing page change history
+- **Complete registry** — expand from 15 to ~35 builder-compatible components
+- **SEO/Meta editor** — edit title, description, OG tags in the property panel
+- **Tests** — unit tests for tree utils, renderer, storage
+
+---
+
+### Phase 7: Preview Iframe
+
+**Status: TODO**
+
+Replace inline canvas rendering with an isolated iframe for pixel-perfect preview.
+
+#### Deliverables
+
+- **Preview route** (`/builder/preview`) — renders a PageDocument in isolation
+- **PostMessage bridge** — editor sends JSON state to iframe on each change
+- **CSS isolation** — editor styles cannot leak into the preview
+- **Native responsive** — resize the iframe element for mobile/tablet/desktop
+- **Shareable preview URL** — link to preview a draft page
+
+---
+
+## File Structure (Complete)
+
+```
+src/lib/builder/
+├── index.ts
+├── types/
+│   ├── page.ts
+│   ├── registry.ts
+│   └── index.ts
+├── registry/
+│   ├── builder-registry.ts
+│   └── index.ts
+├── renderer/
+│   ├── component-map.ts
+│   ├── BlockRenderer.svelte
+│   ├── PageRenderer.svelte
+│   ├── index.ts
+│   ├── primitives/ (7 files)
+│   └── adapters/ (5 files)
+├── editor/
+│   ├── EditorLayout.svelte
+│   ├── TopBar.svelte
+│   ├── ComponentPalette.svelte
+│   ├── PaletteItem.svelte
+│   ├── Canvas.svelte
+│   ├── BlockWrapper.svelte
+│   ├── PropertyPanel.svelte
+│   ├── LayerTree.svelte
+│   └── props/ (5 editors)
+├── stores/
+│   └── editor.svelte.ts
+├── storage/
+│   ├── types.ts
+│   ├── local.ts
+│   ├── github.ts
+│   └── draft-store.ts
+└── utils/
+    ├── id.ts
+    ├── tree.ts
+    ├── validation.ts
+    ├── shortcuts.ts
+    └── index.ts
+
+src/routes/builder/
+├── +layout.svelte
+├── +page.svelte
+├── [slug]/+page.svelte
+└── preview/+page.svelte
+
+src/routes/pages/[slug]/
+├── +page.server.ts
+└── +page.svelte
+
+src/routes/api/builder/
+├── pages/+server.ts
+├── pages/[slug]/+server.ts
+└── publish/+server.ts
+
+content/
+├── pages/*.json
+├── _drafts/
+└── _templates/
+```
+
+## Dependencies
+
+| Package | Size | Phase | Status |
+|---------|------|-------|--------|
+| `nanoid` | ~130B | 1 | ✅ Installed |
+| `@types/node` | dev | 1 | ✅ Installed |
+| `svelte-dnd-action` | ~8KB gz | 3 | Pending |
+| `arctic` | ~15KB | 5 | Pending |
+| `idb` | ~1.2KB | 5 | Pending (optional) |

--- a/content/pages/test.json
+++ b/content/pages/test.json
@@ -1,0 +1,321 @@
+{
+  "version": 1,
+  "meta": {
+    "title": "Test Page - Builder",
+    "slug": "test",
+    "description": "A test page to validate the builder renderer",
+    "status": "draft",
+    "createdAt": "2026-02-18T00:00:00Z",
+    "updatedAt": "2026-02-18T00:00:00Z"
+  },
+  "body": [
+    {
+      "id": "sec-hero",
+      "type": "_section",
+      "props": {
+        "padding": "py-24 px-4",
+        "maxWidth": "max-w-5xl",
+        "background": "bg-background"
+      },
+      "children": [
+        {
+          "id": "hero-title",
+          "type": "_text",
+          "props": {
+            "content": "Welcome to the Site Builder",
+            "tag": "h1",
+            "class": "text-5xl font-bold text-center mb-4"
+          }
+        },
+        {
+          "id": "hero-subtitle",
+          "type": "_text",
+          "props": {
+            "content": "This page is rendered from a JSON document using the BlockRenderer.",
+            "tag": "p",
+            "class": "text-xl text-muted-foreground text-center mb-8"
+          }
+        },
+        {
+          "id": "hero-sparkles",
+          "type": "sparkles-text",
+          "props": {
+            "text": "FancyUI Builder",
+            "sparklesCount": 12,
+            "class": "text-4xl font-bold text-center"
+          }
+        }
+      ]
+    },
+    {
+      "id": "spacer-1",
+      "type": "_spacer",
+      "props": {
+        "size": "h-8"
+      }
+    },
+    {
+      "id": "sec-features",
+      "type": "_section",
+      "props": {
+        "padding": "py-16 px-4",
+        "maxWidth": "max-w-6xl",
+        "background": ""
+      },
+      "children": [
+        {
+          "id": "features-title",
+          "type": "_text",
+          "props": {
+            "content": "Features",
+            "tag": "h2",
+            "class": "text-3xl font-bold text-center mb-12"
+          }
+        },
+        {
+          "id": "features-grid",
+          "type": "_grid",
+          "props": {
+            "columns": "3",
+            "gap": "gap-6"
+          },
+          "children": [
+            {
+              "id": "card-1",
+              "type": "card-spotlight",
+              "props": {
+                "class": "h-48"
+              },
+              "children": [
+                {
+                  "id": "card-1-text",
+                  "type": "_text",
+                  "props": {
+                    "content": "Recursive Rendering",
+                    "tag": "h3",
+                    "class": "text-lg font-semibold text-white"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "card-2",
+              "type": "card-spotlight",
+              "props": {
+                "class": "h-48"
+              },
+              "children": [
+                {
+                  "id": "card-2-text",
+                  "type": "_text",
+                  "props": {
+                    "content": "JSON-driven pages",
+                    "tag": "h3",
+                    "class": "text-lg font-semibold text-white"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "card-3",
+              "type": "card-spotlight",
+              "props": {
+                "class": "h-48"
+              },
+              "children": [
+                {
+                  "id": "card-3-text",
+                  "type": "_text",
+                  "props": {
+                    "content": "50+ Components",
+                    "tag": "h3",
+                    "class": "text-lg font-semibold text-white"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sec-effects",
+      "type": "_section",
+      "props": {
+        "padding": "py-16 px-4",
+        "maxWidth": "max-w-5xl"
+      },
+      "children": [
+        {
+          "id": "effects-title",
+          "type": "_text",
+          "props": {
+            "content": "Effects Showcase",
+            "tag": "h2",
+            "class": "text-3xl font-bold text-center mb-12"
+          }
+        },
+        {
+          "id": "effects-flex",
+          "type": "_flex",
+          "props": {
+            "direction": "row",
+            "justify": "center",
+            "align": "center",
+            "gap": "gap-8",
+            "wrap": true
+          },
+          "children": [
+            {
+              "id": "neon-demo",
+              "type": "neon-border",
+              "props": {
+                "color1": "#0496ff",
+                "color2": "#ff0a54",
+                "animationType": "full",
+                "class": "p-8 rounded-xl"
+              },
+              "children": [
+                {
+                  "id": "neon-text",
+                  "type": "_text",
+                  "props": {
+                    "content": "Neon Border",
+                    "tag": "p",
+                    "class": "text-lg font-semibold"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "glow-demo",
+              "type": "glow-border",
+              "props": {
+                "borderRadius": 12,
+                "class": "p-8"
+              },
+              "children": [
+                {
+                  "id": "glow-text",
+                  "type": "_text",
+                  "props": {
+                    "content": "Glow Border",
+                    "tag": "p",
+                    "class": "text-lg font-semibold"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sec-text",
+      "type": "_section",
+      "props": {
+        "padding": "py-16 px-4",
+        "maxWidth": "max-w-5xl"
+      },
+      "children": [
+        {
+          "id": "text-title",
+          "type": "_text",
+          "props": {
+            "content": "Text Components",
+            "tag": "h2",
+            "class": "text-3xl font-bold text-center mb-12"
+          }
+        },
+        {
+          "id": "text-flex",
+          "type": "_flex",
+          "props": {
+            "direction": "column",
+            "align": "center",
+            "gap": "gap-8"
+          },
+          "children": [
+            {
+              "id": "colourful-demo",
+              "type": "colourful-text",
+              "props": {
+                "text": "Colourful Animation"
+              }
+            },
+            {
+              "id": "number-demo",
+              "type": "number-ticker",
+              "props": {
+                "value": 2026,
+                "class": "text-5xl font-bold"
+              }
+            },
+            {
+              "id": "letter-demo",
+              "type": "letter-pullup",
+              "props": {
+                "words": "Letter Pullup Effect",
+                "class": "text-2xl font-bold"
+              }
+            },
+            {
+              "id": "flip-demo",
+              "type": "flip-words",
+              "props": {
+                "words": ["Beautiful", "Modern", "Fast", "Accessible"],
+                "duration": 2500,
+                "class": "text-3xl font-bold"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sec-buttons",
+      "type": "_section",
+      "props": {
+        "padding": "py-16 px-4",
+        "maxWidth": "max-w-5xl"
+      },
+      "children": [
+        {
+          "id": "buttons-title",
+          "type": "_text",
+          "props": {
+            "content": "Button Components",
+            "tag": "h2",
+            "class": "text-3xl font-bold text-center mb-12"
+          }
+        },
+        {
+          "id": "buttons-flex",
+          "type": "_flex",
+          "props": {
+            "direction": "row",
+            "justify": "center",
+            "gap": "gap-6",
+            "wrap": true
+          },
+          "children": [
+            {
+              "id": "shimmer-demo",
+              "type": "shimmer-button",
+              "props": {
+                "text": "Shimmer Button"
+              }
+            },
+            {
+              "id": "rainbow-demo",
+              "type": "rainbow-button",
+              "props": {
+                "text": "Rainbow Button"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/svelte": "^5.3.1",
 		"@types/canvas-confetti": "^1.9.0",
+		"@types/node": "^25.2.3",
 		"bits-ui": "^2.15.4",
 		"clsx": "^2.1.1",
 		"jsdom": "^28.0.0",
@@ -40,6 +41,7 @@
 	},
 	"dependencies": {
 		"canvas-confetti": "^1.9.4",
-		"gsap": "^3.14.2"
+		"gsap": "^3.14.2",
+		"nanoid": "^5.1.6"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       gsap:
         specifier: ^3.14.2
         version: 3.14.2
+      nanoid:
+        specifier: ^5.1.6
+        version: 5.1.6
     devDependencies:
       '@internationalized/date':
         specifier: ^3.10.1
@@ -23,13 +26,13 @@ importers:
         version: 0.562.0(svelte@5.46.1)
       '@sveltejs/adapter-auto':
         specifier: ^7.0.0
-        version: 7.0.0(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))
+        version: 7.0.0(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))
       '@sveltejs/kit':
         specifier: ^2.49.1
-        version: 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.1
-        version: 6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
       '@tailwindcss/forms':
         specifier: ^0.5.10
         version: 0.5.11(tailwindcss@4.1.18)
@@ -38,19 +41,22 @@ importers:
         version: 0.5.19(tailwindcss@4.1.18)
       '@tailwindcss/vite':
         specifier: ^4.1.17
-        version: 4.1.18(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.1.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.3.1
-        version: 5.3.1(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2))
+        version: 5.3.1(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2))
       '@types/canvas-confetti':
         specifier: ^1.9.0
         version: 1.9.0
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
       bits-ui:
         specifier: ^2.15.4
-        version: 2.15.4(@internationalized/date@3.10.1)(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
+        version: 2.15.4(@internationalized/date@3.10.1)(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -80,10 +86,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.2.6
-        version: 7.3.1(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
+        version: 4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
 
 packages:
 
@@ -663,6 +669,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
@@ -1011,6 +1020,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.6:
+    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -1195,6 +1209,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@7.20.0:
     resolution: {integrity: sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==}
@@ -1573,15 +1590,15 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-auto@7.0.0(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))':
+  '@sveltejs/adapter-auto@7.0.0(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))':
     dependencies:
-      '@sveltejs/kit': 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
+      '@sveltejs/kit': 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
 
-  '@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -1594,26 +1611,26 @@ snapshots:
       set-cookie-parser: 2.7.2
       sirv: 3.0.2
       svelte: 5.46.1
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
       obug: 2.1.1
       svelte: 5.46.1
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.46.1
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.30.2)
-      vitefu: 1.1.1(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+      vitefu: 1.1.1(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
 
   '@swc/helpers@0.5.18':
     dependencies:
@@ -1690,12 +1707,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -1721,14 +1738,14 @@ snapshots:
     dependencies:
       svelte: 5.46.1
 
-  '@testing-library/svelte@5.3.1(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2))':
+  '@testing-library/svelte@5.3.1(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.46.1)
       svelte: 5.46.1
     optionalDependencies:
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.30.2)
-      vitest: 4.0.18(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+      vitest: 4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
 
   '@types/aria-query@5.0.4': {}
 
@@ -1745,6 +1762,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
   '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1754,13 +1775,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -1806,15 +1827,15 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  bits-ui@2.15.4(@internationalized/date@3.10.1)(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1):
+  bits-ui@2.15.4(@internationalized/date@3.10.1)(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1):
     dependencies:
       '@floating-ui/core': 1.7.3
       '@floating-ui/dom': 1.7.4
       '@internationalized/date': 3.10.1
       esm-env: 1.2.2
-      runed: 0.35.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
+      runed: 0.35.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
       svelte: 5.46.1
-      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
+      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
       tabbable: 6.4.0
     transitivePeerDependencies:
       - '@sveltejs/kit'
@@ -2068,6 +2089,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.6: {}
+
   obug@2.1.1: {}
 
   parse5@8.0.0:
@@ -2141,14 +2164,14 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.55.1
       fsevents: 2.3.3
 
-  runed@0.35.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1):
+  runed@0.35.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1):
     dependencies:
       dequal: 2.0.3
       esm-env: 1.2.2
       lz-string: 1.5.0
       svelte: 5.46.1
     optionalDependencies:
-      '@sveltejs/kit': 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
+      '@sveltejs/kit': 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
 
   sade@1.8.1:
     dependencies:
@@ -2194,10 +2217,10 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
-  svelte-toolbelt@0.10.6(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1):
+  svelte-toolbelt@0.10.6(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1):
     dependencies:
       clsx: 2.1.1
-      runed: 0.35.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
+      runed: 0.35.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
       style-to-object: 1.0.14
       svelte: 5.46.1
     transitivePeerDependencies:
@@ -2270,11 +2293,13 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@7.16.0: {}
+
   undici@7.20.0: {}
 
   util-deprecate@1.0.2: {}
 
-  vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2):
+  vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2283,18 +2308,19 @@ snapshots:
       rollup: 4.55.1
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.2.3
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
 
-  vitefu@1.1.1(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2)):
+  vitefu@1.1.1(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)):
     optionalDependencies:
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
 
-  vitest@4.0.18(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2):
+  vitest@4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -2311,9 +2337,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 25.2.3
       jsdom: 28.0.0
     transitivePeerDependencies:
       - jiti

--- a/src/lib/builder/index.ts
+++ b/src/lib/builder/index.ts
@@ -1,0 +1,27 @@
+// Types
+export type {
+	PageDocument,
+	PageMeta,
+	PageStatus,
+	BlockNode,
+	PropType,
+	PropSchema,
+	BuilderComponentMeta,
+	PaletteCategory
+} from './types/index.js';
+
+// Registry
+export {
+	builderRegistry,
+	getBuilderComponent,
+	getAllBuilderComponents,
+	getBuilderComponentsByCategory,
+	isLayoutPrimitive,
+	getDefaultProps
+} from './registry/index.js';
+
+// Renderer
+export { BlockRenderer, PageRenderer, resolveComponent } from './renderer/index.js';
+
+// Utils
+export { createBlockId, findNode, removeNode, insertNode, moveNode } from './utils/index.js';

--- a/src/lib/builder/registry/builder-registry.ts
+++ b/src/lib/builder/registry/builder-registry.ts
@@ -1,0 +1,681 @@
+/**
+ * Builder Registry
+ *
+ * Defines which components are available in the site builder,
+ * along with their editable prop schemas and builder metadata.
+ * Separate from the fancy-ui registry (which tracks porting status).
+ */
+
+import type { BuilderComponentMeta } from '../types/registry.js';
+
+// =============================================================================
+// Layout Primitives
+// =============================================================================
+
+const layoutPrimitives: Record<string, BuilderComponentMeta> = {
+	_section: {
+		name: 'Section',
+		slug: '_section',
+		description: 'Page section with optional padding and background',
+		icon: 'LayoutTemplate',
+		paletteCategory: 'layout',
+		acceptsChildren: true,
+		propSchemas: {
+			class: { type: 'string', label: 'CSS Classes', default: '' },
+			padding: {
+				type: 'select',
+				label: 'Padding',
+				default: 'py-16 px-4',
+				options: [
+					{ label: 'None', value: '' },
+					{ label: 'Small', value: 'py-8 px-4' },
+					{ label: 'Medium', value: 'py-16 px-4' },
+					{ label: 'Large', value: 'py-24 px-4' }
+				]
+			},
+			maxWidth: {
+				type: 'select',
+				label: 'Max Width',
+				default: 'max-w-6xl',
+				options: [
+					{ label: 'Full', value: '' },
+					{ label: 'Small (3xl)', value: 'max-w-3xl' },
+					{ label: 'Medium (5xl)', value: 'max-w-5xl' },
+					{ label: 'Large (6xl)', value: 'max-w-6xl' },
+					{ label: 'XL (7xl)', value: 'max-w-7xl' }
+				]
+			},
+			background: {
+				type: 'string',
+				label: 'Background',
+				default: '',
+				description: 'Tailwind bg class (e.g. bg-muted, bg-primary/10)'
+			}
+		}
+	},
+
+	_container: {
+		name: 'Container',
+		slug: '_container',
+		description: 'Centered container with max width',
+		icon: 'Box',
+		paletteCategory: 'layout',
+		acceptsChildren: true,
+		propSchemas: {
+			class: { type: 'string', label: 'CSS Classes', default: '' },
+			maxWidth: {
+				type: 'select',
+				label: 'Max Width',
+				default: 'max-w-6xl',
+				options: [
+					{ label: 'Small (3xl)', value: 'max-w-3xl' },
+					{ label: 'Medium (5xl)', value: 'max-w-5xl' },
+					{ label: 'Large (6xl)', value: 'max-w-6xl' },
+					{ label: 'XL (7xl)', value: 'max-w-7xl' }
+				]
+			}
+		}
+	},
+
+	_grid: {
+		name: 'Grid',
+		slug: '_grid',
+		description: 'CSS Grid layout with configurable columns',
+		icon: 'LayoutGrid',
+		paletteCategory: 'layout',
+		acceptsChildren: true,
+		propSchemas: {
+			class: { type: 'string', label: 'CSS Classes', default: '' },
+			columns: {
+				type: 'select',
+				label: 'Columns',
+				default: '3',
+				options: [
+					{ label: '1 Column', value: '1' },
+					{ label: '2 Columns', value: '2' },
+					{ label: '3 Columns', value: '3' },
+					{ label: '4 Columns', value: '4' }
+				]
+			},
+			gap: {
+				type: 'select',
+				label: 'Gap',
+				default: 'gap-6',
+				options: [
+					{ label: 'None', value: '' },
+					{ label: 'Small', value: 'gap-2' },
+					{ label: 'Medium', value: 'gap-4' },
+					{ label: 'Large', value: 'gap-6' },
+					{ label: 'XL', value: 'gap-8' }
+				]
+			}
+		}
+	},
+
+	_flex: {
+		name: 'Flex',
+		slug: '_flex',
+		description: 'Flexbox layout container',
+		icon: 'AlignHorizontalSpaceAround',
+		paletteCategory: 'layout',
+		acceptsChildren: true,
+		propSchemas: {
+			class: { type: 'string', label: 'CSS Classes', default: '' },
+			direction: {
+				type: 'select',
+				label: 'Direction',
+				default: 'row',
+				options: [
+					{ label: 'Row', value: 'row' },
+					{ label: 'Column', value: 'column' },
+					{ label: 'Row Reverse', value: 'row-reverse' },
+					{ label: 'Column Reverse', value: 'column-reverse' }
+				]
+			},
+			align: {
+				type: 'select',
+				label: 'Align Items',
+				default: 'center',
+				options: [
+					{ label: 'Start', value: 'start' },
+					{ label: 'Center', value: 'center' },
+					{ label: 'End', value: 'end' },
+					{ label: 'Stretch', value: 'stretch' }
+				]
+			},
+			justify: {
+				type: 'select',
+				label: 'Justify Content',
+				default: 'start',
+				options: [
+					{ label: 'Start', value: 'start' },
+					{ label: 'Center', value: 'center' },
+					{ label: 'End', value: 'end' },
+					{ label: 'Between', value: 'between' },
+					{ label: 'Around', value: 'around' }
+				]
+			},
+			gap: {
+				type: 'select',
+				label: 'Gap',
+				default: 'gap-4',
+				options: [
+					{ label: 'None', value: '' },
+					{ label: 'Small', value: 'gap-2' },
+					{ label: 'Medium', value: 'gap-4' },
+					{ label: 'Large', value: 'gap-6' },
+					{ label: 'XL', value: 'gap-8' }
+				]
+			},
+			wrap: {
+				type: 'boolean',
+				label: 'Wrap',
+				default: false
+			}
+		}
+	},
+
+	_text: {
+		name: 'Text',
+		slug: '_text',
+		description: 'Text block with configurable style',
+		icon: 'Type',
+		paletteCategory: 'text',
+		acceptsChildren: false,
+		propSchemas: {
+			content: {
+				type: 'string',
+				label: 'Content',
+				default: 'Enter text here...',
+				multiline: true
+			},
+			tag: {
+				type: 'select',
+				label: 'HTML Tag',
+				default: 'p',
+				options: [
+					{ label: 'Paragraph', value: 'p' },
+					{ label: 'Heading 1', value: 'h1' },
+					{ label: 'Heading 2', value: 'h2' },
+					{ label: 'Heading 3', value: 'h3' },
+					{ label: 'Heading 4', value: 'h4' },
+					{ label: 'Span', value: 'span' }
+				]
+			},
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	_image: {
+		name: 'Image',
+		slug: '_image',
+		description: 'Image element with alt text',
+		icon: 'Image',
+		paletteCategory: 'media',
+		acceptsChildren: false,
+		propSchemas: {
+			src: { type: 'image', label: 'Image URL', default: '' },
+			alt: { type: 'string', label: 'Alt Text', default: '' },
+			class: { type: 'string', label: 'CSS Classes', default: '' },
+			objectFit: {
+				type: 'select',
+				label: 'Object Fit',
+				default: 'cover',
+				options: [
+					{ label: 'Cover', value: 'cover' },
+					{ label: 'Contain', value: 'contain' },
+					{ label: 'Fill', value: 'fill' },
+					{ label: 'None', value: 'none' }
+				]
+			}
+		}
+	},
+
+	_spacer: {
+		name: 'Spacer',
+		slug: '_spacer',
+		description: 'Vertical space between blocks',
+		icon: 'SeparatorHorizontal',
+		paletteCategory: 'layout',
+		acceptsChildren: false,
+		propSchemas: {
+			size: {
+				type: 'select',
+				label: 'Size',
+				default: 'h-8',
+				options: [
+					{ label: 'XS', value: 'h-2' },
+					{ label: 'Small', value: 'h-4' },
+					{ label: 'Medium', value: 'h-8' },
+					{ label: 'Large', value: 'h-16' },
+					{ label: 'XL', value: 'h-24' },
+					{ label: 'XXL', value: 'h-32' }
+				]
+			}
+		}
+	}
+};
+
+// =============================================================================
+// FancyUI Components
+// =============================================================================
+
+const fancyComponents: Record<string, BuilderComponentMeta> = {
+	'border-beam': {
+		name: 'BorderBeam',
+		slug: 'border-beam',
+		description: 'Animated beam traveling around borders',
+		icon: 'Sparkles',
+		paletteCategory: 'effects',
+		acceptsChildren: false,
+		propSchemas: {
+			size: { type: 'number', label: 'Beam Size', default: 200, min: 50, max: 500, step: 10 },
+			duration: { type: 'number', label: 'Duration (s)', default: 15, min: 1, max: 60, step: 1 },
+			borderWidth: {
+				type: 'number',
+				label: 'Border Width',
+				default: 1.5,
+				min: 0.5,
+				max: 5,
+				step: 0.5
+			},
+			anchor: { type: 'number', label: 'Anchor', default: 90, min: 0, max: 360, step: 1 },
+			colorFrom: { type: 'color', label: 'Color From', default: '#ffaa40' },
+			colorTo: { type: 'color', label: 'Color To', default: '#9c40ff' },
+			delay: { type: 'number', label: 'Delay (s)', default: 0, min: 0, max: 10, step: 0.5 }
+		}
+	},
+
+	'glow-border': {
+		name: 'GlowBorder',
+		slug: 'glow-border',
+		description: 'Animated glowing border with gradient',
+		icon: 'Sun',
+		paletteCategory: 'effects',
+		acceptsChildren: true,
+		propSchemas: {
+			borderRadius: {
+				type: 'number',
+				label: 'Border Radius',
+				default: 10,
+				min: 0,
+				max: 50,
+				step: 1
+			},
+			borderWidth: {
+				type: 'number',
+				label: 'Border Width',
+				default: 2,
+				min: 1,
+				max: 10,
+				step: 1
+			},
+			duration: { type: 'number', label: 'Duration (s)', default: 10, min: 1, max: 30, step: 1 },
+			color: { type: 'color', label: 'Color', default: '#FFFFFF' },
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	meteors: {
+		name: 'Meteors',
+		slug: 'meteors',
+		description: 'Animated meteor shower effect',
+		icon: 'Zap',
+		paletteCategory: 'effects',
+		acceptsChildren: false,
+		propSchemas: {
+			count: { type: 'number', label: 'Count', default: 20, min: 1, max: 50, step: 1 },
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	'shimmer-button': {
+		name: 'ShimmerButton',
+		slug: 'shimmer-button',
+		description: 'Button with shimmer border effect',
+		icon: 'MousePointerClick',
+		paletteCategory: 'buttons',
+		acceptsChildren: false,
+		propSchemas: {
+			text: {
+				type: 'string',
+				label: 'Button Text',
+				default: 'Click me',
+				description: 'Text displayed inside the button'
+			},
+			shimmerColor: { type: 'color', label: 'Shimmer Color', default: '#ffffff' },
+			shimmerSize: { type: 'string', label: 'Shimmer Size', default: '0.05em' },
+			borderRadius: { type: 'string', label: 'Border Radius', default: '100px' },
+			shimmerDuration: { type: 'string', label: 'Duration', default: '3s' },
+			background: { type: 'string', label: 'Background', default: 'rgba(0, 0, 0, 1)' },
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	'rainbow-button': {
+		name: 'RainbowButton',
+		slug: 'rainbow-button',
+		description: 'Button with rainbow gradient border',
+		icon: 'Rainbow',
+		paletteCategory: 'buttons',
+		acceptsChildren: false,
+		propSchemas: {
+			text: {
+				type: 'string',
+				label: 'Button Text',
+				default: 'Click me',
+				description: 'Text displayed inside the button'
+			},
+			speed: { type: 'number', label: 'Speed (s)', default: 2, min: 0.5, max: 10, step: 0.5 },
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	marquee: {
+		name: 'Marquee',
+		slug: 'marquee',
+		description: 'Infinite scrolling content',
+		icon: 'MoveHorizontal',
+		paletteCategory: 'layout',
+		acceptsChildren: true,
+		propSchemas: {
+			reverse: { type: 'boolean', label: 'Reverse', default: false },
+			pauseOnHover: { type: 'boolean', label: 'Pause on Hover', default: false },
+			vertical: { type: 'boolean', label: 'Vertical', default: false },
+			repeat: { type: 'number', label: 'Repeat', default: 4, min: 1, max: 10, step: 1 },
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	ripple: {
+		name: 'Ripple',
+		slug: 'ripple',
+		description: 'Concentric pulsing circles',
+		icon: 'Waves',
+		paletteCategory: 'effects',
+		acceptsChildren: false,
+		propSchemas: {
+			baseCircleSize: {
+				type: 'number',
+				label: 'Circle Size',
+				default: 210,
+				min: 50,
+				max: 500,
+				step: 10
+			},
+			numberOfCircles: {
+				type: 'number',
+				label: 'Circle Count',
+				default: 7,
+				min: 1,
+				max: 15,
+				step: 1
+			},
+			waveSpeed: {
+				type: 'number',
+				label: 'Wave Speed',
+				default: 80,
+				min: 10,
+				max: 200,
+				step: 10
+			},
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	'sparkles-text': {
+		name: 'SparklesText',
+		slug: 'sparkles-text',
+		description: 'Text with animated sparkle stars',
+		icon: 'Sparkle',
+		paletteCategory: 'text',
+		acceptsChildren: false,
+		propSchemas: {
+			text: { type: 'string', label: 'Text', default: 'Sparkles' },
+			sparklesCount: {
+				type: 'number',
+				label: 'Sparkle Count',
+				default: 10,
+				min: 1,
+				max: 30,
+				step: 1
+			},
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	'colourful-text': {
+		name: 'ColourfulText',
+		slug: 'colourful-text',
+		description: 'Per-character color animation',
+		icon: 'Palette',
+		paletteCategory: 'text',
+		acceptsChildren: false,
+		propSchemas: {
+			text: { type: 'string', label: 'Text', default: 'Colourful' },
+			duration: {
+				type: 'number',
+				label: 'Duration (s)',
+				default: 0.5,
+				min: 0.1,
+				max: 3,
+				step: 0.1
+			},
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	'number-ticker': {
+		name: 'NumberTicker',
+		slug: 'number-ticker',
+		description: 'Animated number counter',
+		icon: 'Hash',
+		paletteCategory: 'text',
+		acceptsChildren: false,
+		propSchemas: {
+			value: { type: 'number', label: 'Value', default: 100, min: 0, max: 999999, step: 1 },
+			direction: {
+				type: 'select',
+				label: 'Direction',
+				default: 'up',
+				options: [
+					{ label: 'Up', value: 'up' },
+					{ label: 'Down', value: 'down' }
+				]
+			},
+			duration: {
+				type: 'number',
+				label: 'Duration (ms)',
+				default: 1000,
+				min: 100,
+				max: 5000,
+				step: 100
+			},
+			delay: { type: 'number', label: 'Delay (ms)', default: 0, min: 0, max: 3000, step: 100 },
+			decimalPlaces: {
+				type: 'number',
+				label: 'Decimal Places',
+				default: 0,
+				min: 0,
+				max: 4,
+				step: 1
+			},
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	'flip-words': {
+		name: 'FlipWords',
+		slug: 'flip-words',
+		description: 'Cycling word animation',
+		icon: 'RotateCw',
+		paletteCategory: 'text',
+		acceptsChildren: false,
+		propSchemas: {
+			words: {
+				type: 'json',
+				label: 'Words',
+				default: ['Hello', 'World', 'Svelte'],
+				description: 'JSON array of words to cycle through'
+			},
+			duration: {
+				type: 'number',
+				label: 'Duration (ms)',
+				default: 3000,
+				min: 500,
+				max: 10000,
+				step: 100
+			},
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	'card-spotlight': {
+		name: 'CardSpotlight',
+		slug: 'card-spotlight',
+		description: 'Card with spotlight gradient on hover',
+		icon: 'Lightbulb',
+		paletteCategory: 'cards',
+		acceptsChildren: true,
+		propSchemas: {
+			gradientSize: {
+				type: 'number',
+				label: 'Gradient Size',
+				default: 200,
+				min: 50,
+				max: 500,
+				step: 10
+			},
+			gradientColor: { type: 'color', label: 'Gradient Color', default: '#262626' },
+			gradientOpacity: {
+				type: 'number',
+				label: 'Gradient Opacity',
+				default: 0.8,
+				min: 0,
+				max: 1,
+				step: 0.1
+			},
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	'neon-border': {
+		name: 'NeonBorder',
+		slug: 'neon-border',
+		description: 'Dual-color neon glow border',
+		icon: 'Lightbulb',
+		paletteCategory: 'effects',
+		acceptsChildren: true,
+		propSchemas: {
+			color1: { type: 'color', label: 'Color 1', default: '#0496ff' },
+			color2: { type: 'color', label: 'Color 2', default: '#ff0a54' },
+			animationType: {
+				type: 'select',
+				label: 'Animation',
+				default: 'half',
+				options: [
+					{ label: 'None', value: 'none' },
+					{ label: 'Half', value: 'half' },
+					{ label: 'Full', value: 'full' }
+				]
+			},
+			duration: { type: 'number', label: 'Duration (s)', default: 6, min: 1, max: 20, step: 1 },
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	'letter-pullup': {
+		name: 'LetterPullup',
+		slug: 'letter-pullup',
+		description: 'Staggered letter pull-up animation',
+		icon: 'ArrowUp',
+		paletteCategory: 'text',
+		acceptsChildren: false,
+		propSchemas: {
+			words: { type: 'string', label: 'Text', default: 'Letter Pullup' },
+			delay: {
+				type: 'number',
+				label: 'Delay per letter (s)',
+				default: 0.05,
+				min: 0.01,
+				max: 0.3,
+				step: 0.01
+			},
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	},
+
+	'box-reveal': {
+		name: 'BoxReveal',
+		slug: 'box-reveal',
+		description: 'Content reveal with sliding box',
+		icon: 'Square',
+		paletteCategory: 'text',
+		acceptsChildren: true,
+		propSchemas: {
+			color: { type: 'color', label: 'Box Color', default: '#5046e6' },
+			duration: {
+				type: 'number',
+				label: 'Duration (s)',
+				default: 0.5,
+				min: 0.1,
+				max: 2,
+				step: 0.1
+			},
+			delay: {
+				type: 'number',
+				label: 'Delay (s)',
+				default: 0.25,
+				min: 0,
+				max: 2,
+				step: 0.05
+			},
+			class: { type: 'string', label: 'CSS Classes', default: '' }
+		}
+	}
+};
+
+// =============================================================================
+// Combined Registry
+// =============================================================================
+
+export const builderRegistry: Record<string, BuilderComponentMeta> = {
+	...layoutPrimitives,
+	...fancyComponents
+};
+
+/** Get a builder component by slug */
+export function getBuilderComponent(slug: string): BuilderComponentMeta | undefined {
+	return builderRegistry[slug];
+}
+
+/** Get all builder components */
+export function getAllBuilderComponents(): BuilderComponentMeta[] {
+	return Object.values(builderRegistry);
+}
+
+/** Get builder components by palette category */
+export function getBuilderComponentsByCategory(
+	category: string
+): BuilderComponentMeta[] {
+	return Object.values(builderRegistry).filter((c) => c.paletteCategory === category);
+}
+
+/** Check if a slug is a layout primitive */
+export function isLayoutPrimitive(slug: string): boolean {
+	return slug.startsWith('_');
+}
+
+/** Get default props for a component from its schema */
+export function getDefaultProps(slug: string): Record<string, unknown> {
+	const meta = builderRegistry[slug];
+	if (!meta) return {};
+
+	const defaults: Record<string, unknown> = {};
+	for (const [key, schema] of Object.entries(meta.propSchemas)) {
+		if (schema.default !== undefined) {
+			defaults[key] = schema.default;
+		}
+	}
+	return defaults;
+}

--- a/src/lib/builder/registry/builder-registry.ts
+++ b/src/lib/builder/registry/builder-registry.ts
@@ -216,6 +216,8 @@ const layoutPrimitives: Record<string, BuilderComponentMeta> = {
 		propSchemas: {
 			src: { type: 'image', label: 'Image URL', default: '' },
 			alt: { type: 'string', label: 'Alt Text', default: '' },
+			width: { type: 'number', label: 'Width', min: 0, step: 1, description: 'Intrinsic width for CLS optimization' },
+			height: { type: 'number', label: 'Height', min: 0, step: 1, description: 'Intrinsic height for CLS optimization' },
 			class: { type: 'string', label: 'CSS Classes', default: '' },
 			objectFit: {
 				type: 'select',

--- a/src/lib/builder/registry/index.ts
+++ b/src/lib/builder/registry/index.ts
@@ -1,0 +1,8 @@
+export {
+	builderRegistry,
+	getBuilderComponent,
+	getAllBuilderComponents,
+	getBuilderComponentsByCategory,
+	isLayoutPrimitive,
+	getDefaultProps
+} from './builder-registry.js';

--- a/src/lib/builder/renderer/BlockRenderer.svelte
+++ b/src/lib/builder/renderer/BlockRenderer.svelte
@@ -4,10 +4,32 @@
   Resolves a BlockNode's type to a Svelte component via the component map,
   passes its props, and recursively renders children.
 -->
-<script lang="ts">
-	import type { BlockNode } from '../types/page.js';
+<script lang="ts" module>
 	import { resolveComponent } from './component-map.js';
 	import { getBuilderComponent } from '../registry/builder-registry.js';
+
+	const componentCache = new Map<
+		string,
+		{
+			component: ReturnType<typeof resolveComponent>;
+			meta: ReturnType<typeof getBuilderComponent>;
+		}
+	>();
+
+	function getComponentInfo(type: string) {
+		const cached = componentCache.get(type);
+		if (cached) return cached;
+
+		const component = resolveComponent(type);
+		const meta = getBuilderComponent(type);
+		const info = { component, meta };
+		componentCache.set(type, info);
+		return info;
+	}
+</script>
+
+<script lang="ts">
+	import type { BlockNode } from '../types/page.js';
 	import BlockRendererSelf from './BlockRenderer.svelte';
 
 	interface Props {
@@ -16,17 +38,29 @@
 
 	let { node }: Props = $props();
 
-	let Component = $derived(resolveComponent(node.type));
-	let meta = $derived(getBuilderComponent(node.type));
+	let info = $derived(getComponentInfo(node.type));
+	let Component = $derived(info.component);
+	let meta = $derived(info.meta);
 	let hasChildren = $derived(
 		meta?.acceptsChildren && node.children && node.children.length > 0
 	);
+
+	/** Only pass props that are declared in the component's propSchemas */
+	let safeProps = $derived.by(() => {
+		if (!meta) return node.props;
+		const allowed = new Set(Object.keys(meta.propSchemas));
+		const filtered: Record<string, unknown> = {};
+		for (const [key, val] of Object.entries(node.props)) {
+			if (allowed.has(key)) filtered[key] = val;
+		}
+		return filtered;
+	});
 </script>
 
 {#if Component}
 	{#if hasChildren}
 		{@const childNodes = node.children!}
-		<Component {...node.props}>
+		<Component {...safeProps}>
 			{#snippet children()}
 				{#each childNodes as child (child.id)}
 					<BlockRendererSelf node={child} />
@@ -34,7 +68,7 @@
 			{/snippet}
 		</Component>
 	{:else}
-		<Component {...node.props} />
+		<Component {...safeProps} />
 	{/if}
 {:else}
 	<div class="rounded border border-dashed border-destructive/50 p-4 text-sm text-destructive">

--- a/src/lib/builder/renderer/BlockRenderer.svelte
+++ b/src/lib/builder/renderer/BlockRenderer.svelte
@@ -1,0 +1,43 @@
+<!--
+  BlockRenderer - Recursive component renderer.
+
+  Resolves a BlockNode's type to a Svelte component via the component map,
+  passes its props, and recursively renders children.
+-->
+<script lang="ts">
+	import type { BlockNode } from '../types/page.js';
+	import { resolveComponent } from './component-map.js';
+	import { getBuilderComponent } from '../registry/builder-registry.js';
+	import BlockRendererSelf from './BlockRenderer.svelte';
+
+	interface Props {
+		node: BlockNode;
+	}
+
+	let { node }: Props = $props();
+
+	let Component = $derived(resolveComponent(node.type));
+	let meta = $derived(getBuilderComponent(node.type));
+	let hasChildren = $derived(
+		meta?.acceptsChildren && node.children && node.children.length > 0
+	);
+</script>
+
+{#if Component}
+	{#if hasChildren}
+		{@const childNodes = node.children!}
+		<Component {...node.props}>
+			{#snippet children()}
+				{#each childNodes as child (child.id)}
+					<BlockRendererSelf node={child} />
+				{/each}
+			{/snippet}
+		</Component>
+	{:else}
+		<Component {...node.props} />
+	{/if}
+{:else}
+	<div class="rounded border border-dashed border-destructive/50 p-4 text-sm text-destructive">
+		Unknown component: <code>{node.type}</code>
+	</div>
+{/if}

--- a/src/lib/builder/renderer/PageRenderer.svelte
+++ b/src/lib/builder/renderer/PageRenderer.svelte
@@ -1,0 +1,23 @@
+<!--
+  PageRenderer - Renders a full PageDocument.
+
+  Takes a PageDocument and renders all root-level blocks
+  using BlockRenderer recursively.
+-->
+<script lang="ts">
+	import type { PageDocument } from '../types/page.js';
+	import BlockRenderer from './BlockRenderer.svelte';
+
+	interface Props {
+		page: PageDocument;
+		class?: string;
+	}
+
+	let { page, class: className = '' }: Props = $props();
+</script>
+
+<div class={className}>
+	{#each page.body as node (node.id)}
+		<BlockRenderer {node} />
+	{/each}
+</div>

--- a/src/lib/builder/renderer/adapters/BentoGridItemAdapter.svelte
+++ b/src/lib/builder/renderer/adapters/BentoGridItemAdapter.svelte
@@ -1,0 +1,40 @@
+<!--
+  Adapter for BentoGridItem component.
+  BentoGridItem uses `header`, `icon`, `title`, `description` snippets.
+  In the builder, we use simple string props instead.
+-->
+<script lang="ts">
+	import { BentoGridItem } from '$lib/fancy-ui/bento-grid/index.js';
+
+	interface Props {
+		headerText?: string;
+		titleText?: string;
+		descriptionText?: string;
+		class?: string;
+	}
+
+	let {
+		headerText = '',
+		titleText = 'Title',
+		descriptionText = 'Description',
+		class: className = ''
+	}: Props = $props();
+</script>
+
+{#snippet header()}
+	{#if headerText}
+		<div class="flex h-full min-h-24 items-center justify-center rounded-xl bg-gradient-to-br from-neutral-200 to-neutral-100 dark:from-neutral-900 dark:to-neutral-800">
+			<span class="text-sm text-muted-foreground">{headerText}</span>
+		</div>
+	{/if}
+{/snippet}
+
+{#snippet title()}
+	{titleText}
+{/snippet}
+
+{#snippet description()}
+	{descriptionText}
+{/snippet}
+
+<BentoGridItem class={className} {header} {title} {description} />

--- a/src/lib/builder/renderer/adapters/ContainerScrollAdapter.svelte
+++ b/src/lib/builder/renderer/adapters/ContainerScrollAdapter.svelte
@@ -1,0 +1,45 @@
+<!--
+  Adapter for ContainerScroll component.
+  ContainerScroll uses `titleContent` and `cardContent` snippets.
+  In the builder, we use simple string props instead.
+-->
+<script lang="ts">
+	import { ContainerScroll } from '$lib/fancy-ui/container-scroll/index.js';
+
+	interface Props {
+		titleText?: string;
+		subtitleText?: string;
+		imageSrc?: string;
+		imageAlt?: string;
+		class?: string;
+	}
+
+	let {
+		titleText = 'Scroll Animation',
+		subtitleText = 'Powered by FancyUI',
+		imageSrc = '',
+		imageAlt = 'Preview',
+		class: className = ''
+	}: Props = $props();
+</script>
+
+{#snippet titleContent()}
+	<div>
+		<h2 class="text-4xl font-semibold text-foreground">{titleText}</h2>
+		{#if subtitleText}
+			<p class="mt-2 text-muted-foreground">{subtitleText}</p>
+		{/if}
+	</div>
+{/snippet}
+
+{#snippet cardContent()}
+	{#if imageSrc}
+		<img src={imageSrc} alt={imageAlt} class="mx-auto h-full w-full rounded-2xl object-cover" />
+	{:else}
+		<div class="flex h-full w-full items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-primary/5">
+			<p class="text-lg text-muted-foreground">Card Content</p>
+		</div>
+	{/if}
+{/snippet}
+
+<ContainerScroll class={className} {titleContent} {cardContent} />

--- a/src/lib/builder/renderer/adapters/FlipCardAdapter.svelte
+++ b/src/lib/builder/renderer/adapters/FlipCardAdapter.svelte
@@ -1,0 +1,38 @@
+<!--
+  Adapter for FlipCard component.
+  FlipCard uses `children` (front) and `back` snippets.
+  In the builder, we use `frontText` and `backText` string props instead.
+-->
+<script lang="ts">
+	import { FlipCard } from '$lib/fancy-ui/flip-card/index.js';
+
+	interface Props {
+		rotate?: 'x' | 'y';
+		frontText?: string;
+		backText?: string;
+		class?: string;
+	}
+
+	let {
+		rotate = 'y',
+		frontText = 'Front',
+		backText = 'Back',
+		class: className = ''
+	}: Props = $props();
+</script>
+
+{#snippet front()}
+	<div class="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/20 to-primary/5 p-4">
+		<p class="text-lg font-semibold">{frontText}</p>
+	</div>
+{/snippet}
+
+{#snippet back()}
+	<div class="flex h-full w-full items-center justify-center p-4">
+		<p class="text-sm">{backText}</p>
+	</div>
+{/snippet}
+
+<FlipCard {rotate} class={className} {back}>
+	{@render front()}
+</FlipCard>

--- a/src/lib/builder/renderer/adapters/RainbowButtonAdapter.svelte
+++ b/src/lib/builder/renderer/adapters/RainbowButtonAdapter.svelte
@@ -1,0 +1,20 @@
+<!--
+  Adapter for RainbowButton.
+  RainbowButton uses a `children` snippet for content.
+  The builder uses a `text` prop instead.
+-->
+<script lang="ts">
+	import { RainbowButton } from '$lib/fancy-ui/rainbow-button/index.js';
+
+	interface Props {
+		text?: string;
+		speed?: number;
+		class?: string;
+	}
+
+	let { text = 'Click me', speed, class: className }: Props = $props();
+</script>
+
+<RainbowButton {speed} class={className}>
+	<span>{text}</span>
+</RainbowButton>

--- a/src/lib/builder/renderer/adapters/RainbowButtonAdapter.svelte
+++ b/src/lib/builder/renderer/adapters/RainbowButtonAdapter.svelte
@@ -10,11 +10,12 @@
 		text?: string;
 		speed?: number;
 		class?: string;
+		[key: string]: unknown;
 	}
 
-	let { text = 'Click me', speed, class: className }: Props = $props();
+	let { text = 'Click me', speed, class: className, ...restProps }: Props = $props();
 </script>
 
-<RainbowButton {speed} class={className}>
+<RainbowButton {speed} class={className} {...restProps}>
 	<span>{text}</span>
 </RainbowButton>

--- a/src/lib/builder/renderer/adapters/ShimmerButtonAdapter.svelte
+++ b/src/lib/builder/renderer/adapters/ShimmerButtonAdapter.svelte
@@ -1,0 +1,34 @@
+<!--
+  Adapter for ShimmerButton.
+  ShimmerButton uses a `children` snippet for content.
+  The builder uses a `text` prop instead.
+-->
+<script lang="ts">
+	import { ShimmerButton } from '$lib/fancy-ui/shimmer-button/index.js';
+
+	interface Props {
+		text?: string;
+		shimmerColor?: string;
+		shimmerSize?: string;
+		borderRadius?: string;
+		shimmerDuration?: string;
+		background?: string;
+		class?: string;
+	}
+
+	let {
+		text = 'Click me',
+		shimmerColor,
+		shimmerSize,
+		borderRadius,
+		shimmerDuration,
+		background,
+		class: className
+	}: Props = $props();
+</script>
+
+<ShimmerButton {shimmerColor} {shimmerSize} {borderRadius} {shimmerDuration} {background} class={className}>
+	<span class="relative z-10 whitespace-pre-wrap text-center text-sm font-medium leading-none tracking-tight text-white lg:text-lg dark:from-white dark:to-slate-900/10">
+		{text}
+	</span>
+</ShimmerButton>

--- a/src/lib/builder/renderer/adapters/ShimmerButtonAdapter.svelte
+++ b/src/lib/builder/renderer/adapters/ShimmerButtonAdapter.svelte
@@ -14,6 +14,7 @@
 		shimmerDuration?: string;
 		background?: string;
 		class?: string;
+		[key: string]: unknown;
 	}
 
 	let {
@@ -23,11 +24,12 @@
 		borderRadius,
 		shimmerDuration,
 		background,
-		class: className
+		class: className,
+		...restProps
 	}: Props = $props();
 </script>
 
-<ShimmerButton {shimmerColor} {shimmerSize} {borderRadius} {shimmerDuration} {background} class={className}>
+<ShimmerButton {shimmerColor} {shimmerSize} {borderRadius} {shimmerDuration} {background} class={className} {...restProps}>
 	<span class="relative z-10 whitespace-pre-wrap text-center text-sm font-medium leading-none tracking-tight text-white lg:text-lg dark:from-white dark:to-slate-900/10">
 		{text}
 	</span>

--- a/src/lib/builder/renderer/component-map.ts
+++ b/src/lib/builder/renderer/component-map.ts
@@ -1,0 +1,84 @@
+/**
+ * Component Map
+ *
+ * Maps component slugs to their actual Svelte component constructors.
+ * Used by BlockRenderer to resolve which component to render for each BlockNode.
+ */
+
+import type { Component } from 'svelte';
+
+// Layout primitives
+import SectionPrimitive from './primitives/Section.svelte';
+import ContainerPrimitive from './primitives/Container.svelte';
+import GridPrimitive from './primitives/Grid.svelte';
+import FlexPrimitive from './primitives/Flex.svelte';
+import TextPrimitive from './primitives/Text.svelte';
+import ImagePrimitive from './primitives/Image.svelte';
+import SpacerPrimitive from './primitives/Spacer.svelte';
+
+// FancyUI components (direct — these accept props only, no snippet wiring needed)
+import { BorderBeam } from '$lib/fancy-ui/border-beam/index.js';
+import { GlowBorder } from '$lib/fancy-ui/glow-border/index.js';
+import { Meteors } from '$lib/fancy-ui/meteors/index.js';
+import { Marquee } from '$lib/fancy-ui/marquee/index.js';
+import { Ripple } from '$lib/fancy-ui/ripple/index.js';
+import { SparklesText } from '$lib/fancy-ui/sparkles-text/index.js';
+import { ColourfulText } from '$lib/fancy-ui/colourful-text/index.js';
+import { NumberTicker } from '$lib/fancy-ui/number-ticker/index.js';
+import { FlipWords } from '$lib/fancy-ui/flip-words/index.js';
+import { CardSpotlight } from '$lib/fancy-ui/card-spotlight/index.js';
+import { NeonBorder } from '$lib/fancy-ui/neon-border/index.js';
+import { LetterPullup } from '$lib/fancy-ui/letter-pullup/index.js';
+import { BoxReveal } from '$lib/fancy-ui/box-reveal/index.js';
+
+// Adapter wrappers (for components that use snippets instead of plain props)
+import ShimmerButtonAdapter from './adapters/ShimmerButtonAdapter.svelte';
+import RainbowButtonAdapter from './adapters/RainbowButtonAdapter.svelte';
+import FlipCardAdapter from './adapters/FlipCardAdapter.svelte';
+import BentoGridItemAdapter from './adapters/BentoGridItemAdapter.svelte';
+import ContainerScrollAdapter from './adapters/ContainerScrollAdapter.svelte';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyComponent = Component<any>;
+
+/**
+ * Static map from slug to Svelte component.
+ * Add new components here as they become builder-compatible.
+ */
+export const componentMap: Record<string, AnyComponent> = {
+	// Layout primitives
+	_section: SectionPrimitive,
+	_container: ContainerPrimitive,
+	_grid: GridPrimitive,
+	_flex: FlexPrimitive,
+	_text: TextPrimitive,
+	_image: ImagePrimitive,
+	_spacer: SpacerPrimitive,
+
+	// FancyUI components
+	'border-beam': BorderBeam as AnyComponent,
+	'glow-border': GlowBorder as AnyComponent,
+	meteors: Meteors as AnyComponent,
+	'shimmer-button': ShimmerButtonAdapter as AnyComponent,
+	'rainbow-button': RainbowButtonAdapter as AnyComponent,
+	marquee: Marquee as AnyComponent,
+	ripple: Ripple as AnyComponent,
+	'sparkles-text': SparklesText as AnyComponent,
+	'colourful-text': ColourfulText as AnyComponent,
+	'number-ticker': NumberTicker as AnyComponent,
+	'flip-words': FlipWords as AnyComponent,
+	'card-spotlight': CardSpotlight as AnyComponent,
+	'neon-border': NeonBorder as AnyComponent,
+	'letter-pullup': LetterPullup as AnyComponent,
+	'box-reveal': BoxReveal as AnyComponent,
+
+	// Adapters for multi-snippet components
+	'flip-card': FlipCardAdapter as AnyComponent,
+	'bento-grid-item': BentoGridItemAdapter as AnyComponent,
+	'container-scroll': ContainerScrollAdapter as AnyComponent
+};
+
+/** Resolve a component slug to its Svelte constructor */
+export function resolveComponent(slug: string): AnyComponent | undefined {
+	return componentMap[slug];
+}

--- a/src/lib/builder/renderer/index.ts
+++ b/src/lib/builder/renderer/index.ts
@@ -1,0 +1,3 @@
+export { default as BlockRenderer } from './BlockRenderer.svelte';
+export { default as PageRenderer } from './PageRenderer.svelte';
+export { componentMap, resolveComponent } from './component-map.js';

--- a/src/lib/builder/renderer/primitives/Container.svelte
+++ b/src/lib/builder/renderer/primitives/Container.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		maxWidth?: string;
+		class?: string;
+		children?: Snippet;
+	}
+
+	let { maxWidth = 'max-w-6xl', class: className = '', children }: Props = $props();
+</script>
+
+<div class={cn('mx-auto', maxWidth, className)}>
+	{#if children}
+		{@render children()}
+	{/if}
+</div>

--- a/src/lib/builder/renderer/primitives/Flex.svelte
+++ b/src/lib/builder/renderer/primitives/Flex.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		direction?: string;
+		align?: string;
+		justify?: string;
+		gap?: string;
+		wrap?: boolean;
+		class?: string;
+		children?: Snippet;
+	}
+
+	let {
+		direction = 'row',
+		align = 'center',
+		justify = 'start',
+		gap = 'gap-4',
+		wrap = false,
+		class: className = '',
+		children
+	}: Props = $props();
+
+	const directionMap: Record<string, string> = {
+		row: 'flex-row',
+		column: 'flex-col',
+		'row-reverse': 'flex-row-reverse',
+		'column-reverse': 'flex-col-reverse'
+	};
+
+	const alignMap: Record<string, string> = {
+		start: 'items-start',
+		center: 'items-center',
+		end: 'items-end',
+		stretch: 'items-stretch'
+	};
+
+	const justifyMap: Record<string, string> = {
+		start: 'justify-start',
+		center: 'justify-center',
+		end: 'justify-end',
+		between: 'justify-between',
+		around: 'justify-around'
+	};
+
+	let flexClasses = $derived(
+		cn(
+			'flex',
+			directionMap[direction] ?? 'flex-row',
+			alignMap[align] ?? 'items-center',
+			justifyMap[justify] ?? 'justify-start',
+			gap,
+			wrap && 'flex-wrap',
+			className
+		)
+	);
+</script>
+
+<div class={flexClasses}>
+	{#if children}
+		{@render children()}
+	{/if}
+</div>

--- a/src/lib/builder/renderer/primitives/Grid.svelte
+++ b/src/lib/builder/renderer/primitives/Grid.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		columns?: string;
+		gap?: string;
+		class?: string;
+		children?: Snippet;
+	}
+
+	let { columns = '3', gap = 'gap-6', class: className = '', children }: Props = $props();
+
+	const colsClass: Record<string, string> = {
+		'1': 'grid-cols-1',
+		'2': 'grid-cols-1 md:grid-cols-2',
+		'3': 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+		'4': 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4'
+	};
+
+	let gridCols = $derived(colsClass[columns] ?? colsClass['3']);
+</script>
+
+<div class={cn('grid', gridCols, gap, className)}>
+	{#if children}
+		{@render children()}
+	{/if}
+</div>

--- a/src/lib/builder/renderer/primitives/Image.svelte
+++ b/src/lib/builder/renderer/primitives/Image.svelte
@@ -4,11 +4,13 @@
 	interface Props {
 		src?: string;
 		alt?: string;
+		width?: number;
+		height?: number;
 		objectFit?: string;
 		class?: string;
 	}
 
-	let { src = '', alt = '', objectFit = 'cover', class: className = '' }: Props = $props();
+	let { src = '', alt = '', width, height, objectFit = 'cover', class: className = '' }: Props = $props();
 
 	const fitMap: Record<string, string> = {
 		cover: 'object-cover',
@@ -21,7 +23,7 @@
 </script>
 
 {#if src}
-	<img {src} {alt} class={cn(fitClass, className)} />
+	<img {src} {alt} {width} {height} class={cn(fitClass, className)} />
 {:else}
 	<div
 		class={cn(

--- a/src/lib/builder/renderer/primitives/Image.svelte
+++ b/src/lib/builder/renderer/primitives/Image.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+
+	interface Props {
+		src?: string;
+		alt?: string;
+		objectFit?: string;
+		class?: string;
+	}
+
+	let { src = '', alt = '', objectFit = 'cover', class: className = '' }: Props = $props();
+
+	const fitMap: Record<string, string> = {
+		cover: 'object-cover',
+		contain: 'object-contain',
+		fill: 'object-fill',
+		none: 'object-none'
+	};
+
+	let fitClass = $derived(fitMap[objectFit] ?? 'object-cover');
+</script>
+
+{#if src}
+	<img {src} {alt} class={cn(fitClass, className)} />
+{:else}
+	<div
+		class={cn(
+			'flex items-center justify-center bg-muted text-muted-foreground text-sm h-48',
+			className
+		)}
+	>
+		No image
+	</div>
+{/if}

--- a/src/lib/builder/renderer/primitives/Section.svelte
+++ b/src/lib/builder/renderer/primitives/Section.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		padding?: string;
+		maxWidth?: string;
+		background?: string;
+		class?: string;
+		children?: Snippet;
+	}
+
+	let {
+		padding = 'py-16 px-4',
+		maxWidth = 'max-w-6xl',
+		background = '',
+		class: className = '',
+		children
+	}: Props = $props();
+</script>
+
+<section class={cn(padding, background, className)}>
+	<div class={cn('mx-auto', maxWidth)}>
+		{#if children}
+			{@render children()}
+		{/if}
+	</div>
+</section>

--- a/src/lib/builder/renderer/primitives/Spacer.svelte
+++ b/src/lib/builder/renderer/primitives/Spacer.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+
+	interface Props {
+		size?: string;
+	}
+
+	let { size = 'h-8' }: Props = $props();
+</script>
+
+<div class={cn(size)} aria-hidden="true"></div>

--- a/src/lib/builder/renderer/primitives/Text.svelte
+++ b/src/lib/builder/renderer/primitives/Text.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+
+	interface Props {
+		content?: string;
+		tag?: string;
+		class?: string;
+	}
+
+	let { content = '', tag = 'p', class: className = '' }: Props = $props();
+</script>
+
+{#if tag === 'h1'}
+	<h1 class={cn(className)}>{content}</h1>
+{:else if tag === 'h2'}
+	<h2 class={cn(className)}>{content}</h2>
+{:else if tag === 'h3'}
+	<h3 class={cn(className)}>{content}</h3>
+{:else if tag === 'h4'}
+	<h4 class={cn(className)}>{content}</h4>
+{:else if tag === 'span'}
+	<span class={cn(className)}>{content}</span>
+{:else}
+	<p class={cn(className)}>{content}</p>
+{/if}

--- a/src/lib/builder/types/index.ts
+++ b/src/lib/builder/types/index.ts
@@ -1,0 +1,15 @@
+export type { PageDocument, PageMeta, PageStatus, BlockNode } from './page.js';
+export type {
+	PropType,
+	PropSchema,
+	PropSchemaBase,
+	StringPropSchema,
+	NumberPropSchema,
+	BooleanPropSchema,
+	ColorPropSchema,
+	SelectPropSchema,
+	JsonPropSchema,
+	ImagePropSchema,
+	PaletteCategory,
+	BuilderComponentMeta
+} from './registry.js';

--- a/src/lib/builder/types/page.ts
+++ b/src/lib/builder/types/page.ts
@@ -1,0 +1,37 @@
+/**
+ * Page document types for the site builder.
+ *
+ * Each page is stored as a JSON file in content/pages/.
+ * The document contains metadata and a tree of BlockNodes.
+ */
+
+export type PageStatus = 'draft' | 'published';
+
+export interface PageMeta {
+	title: string;
+	slug: string;
+	description?: string;
+	status: PageStatus;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface BlockNode {
+	/** Unique ID (nanoid) */
+	id: string;
+	/** Component type slug from builder registry, or layout primitive prefixed with _ */
+	type: string;
+	/** Props passed to the component */
+	props: Record<string, unknown>;
+	/** Nested children (for layout primitives and components that accept children) */
+	children?: BlockNode[];
+}
+
+export interface PageDocument {
+	/** Schema version for future migration */
+	version: 1;
+	/** Page metadata */
+	meta: PageMeta;
+	/** Root-level blocks */
+	body: BlockNode[];
+}

--- a/src/lib/builder/types/registry.ts
+++ b/src/lib/builder/types/registry.ts
@@ -1,0 +1,110 @@
+/**
+ * Builder registry types.
+ *
+ * PropSchema describes the editable properties of a component.
+ * BuilderComponentMeta extends the base registry with builder-specific metadata.
+ */
+
+export type PropType =
+	| 'string'
+	| 'number'
+	| 'boolean'
+	| 'color'
+	| 'select'
+	| 'json'
+	| 'image';
+
+export interface PropSchemaBase {
+	/** Display label in the property panel */
+	label: string;
+	/** Property type */
+	type: PropType;
+	/** Default value */
+	default?: unknown;
+	/** Optional description / tooltip */
+	description?: string;
+}
+
+export interface StringPropSchema extends PropSchemaBase {
+	type: 'string';
+	default?: string;
+	/** If true, renders a textarea instead of an input */
+	multiline?: boolean;
+	/** Placeholder text */
+	placeholder?: string;
+}
+
+export interface NumberPropSchema extends PropSchemaBase {
+	type: 'number';
+	default?: number;
+	min?: number;
+	max?: number;
+	step?: number;
+}
+
+export interface BooleanPropSchema extends PropSchemaBase {
+	type: 'boolean';
+	default?: boolean;
+}
+
+export interface ColorPropSchema extends PropSchemaBase {
+	type: 'color';
+	default?: string;
+}
+
+export interface SelectPropSchema extends PropSchemaBase {
+	type: 'select';
+	default?: string;
+	options: { label: string; value: string }[];
+}
+
+export interface JsonPropSchema extends PropSchemaBase {
+	type: 'json';
+	default?: unknown;
+}
+
+export interface ImagePropSchema extends PropSchemaBase {
+	type: 'image';
+	default?: string;
+}
+
+export type PropSchema =
+	| StringPropSchema
+	| NumberPropSchema
+	| BooleanPropSchema
+	| ColorPropSchema
+	| SelectPropSchema
+	| JsonPropSchema
+	| ImagePropSchema;
+
+/** Palette category for grouping in the editor sidebar */
+export type PaletteCategory =
+	| 'layout'
+	| 'text'
+	| 'cards'
+	| 'effects'
+	| 'backgrounds'
+	| 'buttons'
+	| 'media'
+	| 'navigation'
+	| 'feedback'
+	| 'data-display';
+
+export interface BuilderComponentMeta {
+	/** Display name */
+	name: string;
+	/** Slug matching the fancy-ui registry or a layout primitive (_section, etc.) */
+	slug: string;
+	/** Short description */
+	description: string;
+	/** Lucide icon name for the palette */
+	icon: string;
+	/** Palette category for grouping */
+	paletteCategory: PaletteCategory;
+	/** Whether this component can have child blocks */
+	acceptsChildren: boolean;
+	/** Which component types are allowed as children (empty = any, undefined = none) */
+	allowedChildTypes?: string[];
+	/** Editable prop schemas */
+	propSchemas: Record<string, PropSchema>;
+}

--- a/src/lib/builder/utils/id.ts
+++ b/src/lib/builder/utils/id.ts
@@ -1,0 +1,6 @@
+import { nanoid } from 'nanoid';
+
+/** Generate a unique block ID (12 chars) */
+export function createBlockId(): string {
+	return nanoid(12);
+}

--- a/src/lib/builder/utils/index.ts
+++ b/src/lib/builder/utils/index.ts
@@ -1,0 +1,11 @@
+export { createBlockId } from './id.js';
+export {
+	findNode,
+	findParent,
+	removeNode,
+	insertNode,
+	moveNode,
+	cloneNode,
+	countNodes,
+	flattenTree
+} from './tree.js';

--- a/src/lib/builder/utils/tree.test.ts
+++ b/src/lib/builder/utils/tree.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import type { BlockNode } from '../types/page.js';
+import {
+	findNode,
+	findParent,
+	removeNode,
+	insertNode,
+	moveNode,
+	cloneNode,
+	countNodes,
+	flattenTree
+} from './tree.js';
+
+function makeNode(id: string, children?: BlockNode[]): BlockNode {
+	return { id, type: '_text', props: { content: id }, children };
+}
+
+function makeTree(): BlockNode[] {
+	return [
+		makeNode('a', [makeNode('a1'), makeNode('a2', [makeNode('a2x')])]),
+		makeNode('b'),
+		makeNode('c', [makeNode('c1')])
+	];
+}
+
+describe('findNode', () => {
+	it('finds root-level node', () => {
+		expect(findNode(makeTree(), 'b')?.id).toBe('b');
+	});
+
+	it('finds deeply nested node', () => {
+		expect(findNode(makeTree(), 'a2x')?.id).toBe('a2x');
+	});
+
+	it('returns undefined for missing id', () => {
+		expect(findNode(makeTree(), 'zzz')).toBeUndefined();
+	});
+});
+
+describe('findParent', () => {
+	it('finds parent array and index for root node', () => {
+		const tree = makeTree();
+		const result = findParent(tree, 'b');
+		expect(result).toBeDefined();
+		expect(result!.index).toBe(1);
+		expect(result!.parent).toBe(tree);
+	});
+
+	it('finds parent array and index for nested node', () => {
+		const tree = makeTree();
+		const result = findParent(tree, 'a2x');
+		expect(result).toBeDefined();
+		expect(result!.index).toBe(0);
+		expect(result!.parent[0].id).toBe('a2x');
+	});
+
+	it('returns undefined for missing id', () => {
+		expect(findParent(makeTree(), 'zzz')).toBeUndefined();
+	});
+});
+
+describe('removeNode', () => {
+	it('removes a root node', () => {
+		const tree = makeTree();
+		const removed = removeNode(tree, 'b');
+		expect(removed?.id).toBe('b');
+		expect(tree.length).toBe(2);
+		expect(findNode(tree, 'b')).toBeUndefined();
+	});
+
+	it('removes a nested node', () => {
+		const tree = makeTree();
+		const removed = removeNode(tree, 'a2x');
+		expect(removed?.id).toBe('a2x');
+		expect(findNode(tree, 'a2')?.children).toHaveLength(0);
+	});
+
+	it('returns undefined for missing id', () => {
+		const tree = makeTree();
+		expect(removeNode(tree, 'zzz')).toBeUndefined();
+		expect(tree.length).toBe(3);
+	});
+});
+
+describe('insertNode', () => {
+	it('inserts at root level', () => {
+		const tree = makeTree();
+		const node = makeNode('new');
+		insertNode(tree, null, 1, node);
+		expect(tree[1].id).toBe('new');
+		expect(tree.length).toBe(4);
+	});
+
+	it('inserts as child of existing node', () => {
+		const tree = makeTree();
+		const node = makeNode('new');
+		insertNode(tree, 'b', 0, node);
+		expect(findNode(tree, 'b')?.children?.[0].id).toBe('new');
+	});
+
+	it('clamps negative index to 0', () => {
+		const tree = makeTree();
+		insertNode(tree, null, -5, makeNode('front'));
+		expect(tree[0].id).toBe('front');
+	});
+
+	it('clamps out-of-bounds index to end', () => {
+		const tree = makeTree();
+		insertNode(tree, null, 999, makeNode('end'));
+		expect(tree[tree.length - 1].id).toBe('end');
+	});
+
+	it('returns false for missing parent', () => {
+		expect(insertNode(makeTree(), 'zzz', 0, makeNode('x'))).toBe(false);
+	});
+});
+
+describe('moveNode', () => {
+	it('moves a node to a new position at root', () => {
+		const tree = makeTree();
+		moveNode(tree, 'c', null, 0);
+		expect(tree[0].id).toBe('c');
+	});
+
+	it('moves a node into a new parent', () => {
+		const tree = makeTree();
+		moveNode(tree, 'b', 'c', 0);
+		expect(findNode(tree, 'c')?.children?.[0].id).toBe('b');
+		expect(tree.length).toBe(2);
+	});
+
+	it('prevents moving a node into itself', () => {
+		const tree = makeTree();
+		const result = moveNode(tree, 'a', 'a', 0);
+		expect(result).toBe(false);
+		expect(tree.length).toBe(3);
+	});
+
+	it('prevents moving a node into its own descendant', () => {
+		const tree = makeTree();
+		const result = moveNode(tree, 'a', 'a2x', 0);
+		expect(result).toBe(false);
+		expect(tree.length).toBe(3);
+	});
+});
+
+describe('cloneNode', () => {
+	let counter = 0;
+	const idFn = () => `clone-${counter++}`;
+
+	it('creates a new id', () => {
+		counter = 0;
+		const original = makeNode('orig');
+		const clone = cloneNode(original, idFn);
+		expect(clone.id).not.toBe(original.id);
+	});
+
+	it('deep clones props (no shared references)', () => {
+		counter = 0;
+		const original: BlockNode = {
+			id: 'orig',
+			type: 'flip-words',
+			props: { words: ['a', 'b'] }
+		};
+		const clone = cloneNode(original, idFn);
+		(clone.props.words as string[]).push('c');
+		expect((original.props.words as string[]).length).toBe(2);
+	});
+
+	it('recursively clones children with new ids', () => {
+		counter = 0;
+		const original = makeNode('p', [makeNode('c1'), makeNode('c2')]);
+		const clone = cloneNode(original, idFn);
+		expect(clone.children).toHaveLength(2);
+		expect(clone.children![0].id).not.toBe('c1');
+		expect(clone.children![1].id).not.toBe('c2');
+	});
+});
+
+describe('countNodes', () => {
+	it('counts all nodes in a tree', () => {
+		expect(countNodes(makeTree())).toBe(7);
+	});
+
+	it('returns 0 for empty tree', () => {
+		expect(countNodes([])).toBe(0);
+	});
+});
+
+describe('flattenTree', () => {
+	it('flattens all nodes depth-first', () => {
+		const flat = flattenTree(makeTree());
+		expect(flat.map((n) => n.id)).toEqual(['a', 'a1', 'a2', 'a2x', 'b', 'c', 'c1']);
+	});
+
+	it('returns empty for empty tree', () => {
+		expect(flattenTree([])).toEqual([]);
+	});
+});

--- a/src/lib/builder/utils/tree.ts
+++ b/src/lib/builder/utils/tree.ts
@@ -40,7 +40,7 @@ export function removeNode(nodes: BlockNode[], id: string): BlockNode | undefine
 	return result.parent.splice(result.index, 1)[0];
 }
 
-/** Insert a node at a specific position in the tree */
+/** Insert a node at a specific position in the tree. Index is clamped to valid range. */
 export function insertNode(
 	nodes: BlockNode[],
 	parentId: string | null,
@@ -48,7 +48,8 @@ export function insertNode(
 	node: BlockNode
 ): boolean {
 	if (parentId === null) {
-		nodes.splice(index, 0, node);
+		const clamped = Math.max(0, Math.min(index, nodes.length));
+		nodes.splice(clamped, 0, node);
 		return true;
 	}
 
@@ -56,7 +57,8 @@ export function insertNode(
 	if (!parent) return false;
 
 	if (!parent.children) parent.children = [];
-	parent.children.splice(index, 0, node);
+	const clamped = Math.max(0, Math.min(index, parent.children.length));
+	parent.children.splice(clamped, 0, node);
 	return true;
 }
 

--- a/src/lib/builder/utils/tree.ts
+++ b/src/lib/builder/utils/tree.ts
@@ -1,0 +1,107 @@
+/**
+ * Tree manipulation utilities for BlockNode trees.
+ */
+
+import type { BlockNode } from '../types/page.js';
+
+/** Find a node by ID in a tree (depth-first) */
+export function findNode(nodes: BlockNode[], id: string): BlockNode | undefined {
+	for (const node of nodes) {
+		if (node.id === id) return node;
+		if (node.children) {
+			const found = findNode(node.children, id);
+			if (found) return found;
+		}
+	}
+	return undefined;
+}
+
+/** Find the parent of a node by the node's ID */
+export function findParent(
+	nodes: BlockNode[],
+	id: string
+): { parent: BlockNode[]; index: number } | undefined {
+	for (let i = 0; i < nodes.length; i++) {
+		if (nodes[i].id === id) {
+			return { parent: nodes, index: i };
+		}
+		if (nodes[i].children) {
+			const found = findParent(nodes[i].children!, id);
+			if (found) return found;
+		}
+	}
+	return undefined;
+}
+
+/** Remove a node by ID from the tree. Returns the removed node or undefined. */
+export function removeNode(nodes: BlockNode[], id: string): BlockNode | undefined {
+	const result = findParent(nodes, id);
+	if (!result) return undefined;
+	return result.parent.splice(result.index, 1)[0];
+}
+
+/** Insert a node at a specific position in the tree */
+export function insertNode(
+	nodes: BlockNode[],
+	parentId: string | null,
+	index: number,
+	node: BlockNode
+): boolean {
+	if (parentId === null) {
+		nodes.splice(index, 0, node);
+		return true;
+	}
+
+	const parent = findNode(nodes, parentId);
+	if (!parent) return false;
+
+	if (!parent.children) parent.children = [];
+	parent.children.splice(index, 0, node);
+	return true;
+}
+
+/** Move a node from one position to another */
+export function moveNode(
+	nodes: BlockNode[],
+	nodeId: string,
+	newParentId: string | null,
+	newIndex: number
+): boolean {
+	const removed = removeNode(nodes, nodeId);
+	if (!removed) return false;
+	return insertNode(nodes, newParentId, newIndex, removed);
+}
+
+/** Deep clone a node tree (for copy/paste) */
+export function cloneNode(node: BlockNode, newIdFn: () => string): BlockNode {
+	return {
+		...node,
+		id: newIdFn(),
+		props: { ...node.props },
+		children: node.children?.map((child) => cloneNode(child, newIdFn))
+	};
+}
+
+/** Count all nodes in a tree */
+export function countNodes(nodes: BlockNode[]): number {
+	let count = 0;
+	for (const node of nodes) {
+		count += 1;
+		if (node.children) {
+			count += countNodes(node.children);
+		}
+	}
+	return count;
+}
+
+/** Flatten a tree into a flat array */
+export function flattenTree(nodes: BlockNode[]): BlockNode[] {
+	const result: BlockNode[] = [];
+	for (const node of nodes) {
+		result.push(node);
+		if (node.children) {
+			result.push(...flattenTree(node.children));
+		}
+	}
+	return result;
+}

--- a/src/lib/builder/utils/tree.ts
+++ b/src/lib/builder/utils/tree.ts
@@ -60,13 +60,23 @@ export function insertNode(
 	return true;
 }
 
-/** Move a node from one position to another */
+/** Check if `ancestorId` is an ancestor of `nodeId` in the tree */
+function isDescendant(nodes: BlockNode[], ancestorId: string, nodeId: string): boolean {
+	const ancestor = findNode(nodes, ancestorId);
+	if (!ancestor?.children) return false;
+	return !!findNode(ancestor.children, nodeId);
+}
+
+/** Move a node from one position to another. Prevents circular references. */
 export function moveNode(
 	nodes: BlockNode[],
 	nodeId: string,
 	newParentId: string | null,
 	newIndex: number
 ): boolean {
+	if (newParentId !== null && (newParentId === nodeId || isDescendant(nodes, nodeId, newParentId))) {
+		return false;
+	}
 	const removed = removeNode(nodes, nodeId);
 	if (!removed) return false;
 	return insertNode(nodes, newParentId, newIndex, removed);
@@ -77,7 +87,7 @@ export function cloneNode(node: BlockNode, newIdFn: () => string): BlockNode {
 	return {
 		...node,
 		id: newIdFn(),
-		props: { ...node.props },
+		props: structuredClone(node.props),
 		children: node.children?.map((child) => cloneNode(child, newIdFn))
 	};
 }

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -11,6 +11,8 @@ export * from './blur-reveal/index.js';
 export * from './bg-falling-stars/index.js';
 export * from './bg-stars/index.js';
 export * from './border-beam/index.js';
+export * from './glow-border/index.js';
+export * from './marquee/index.js';
 export * from './compare/index.js';
 export * from './image-trail-cursor/index.js';
 export * from './interactive-grid-pattern/index.js';

--- a/src/routes/pages/[slug]/+page.server.ts
+++ b/src/routes/pages/[slug]/+page.server.ts
@@ -1,0 +1,26 @@
+import { error } from '@sveltejs/kit';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import type { PageDocument } from '$lib/builder/types/page.js';
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async ({ params }) => {
+	const slug = params.slug;
+	const filePath = join(process.cwd(), 'content', 'pages', `${slug}.json`);
+
+	try {
+		const raw = await readFile(filePath, 'utf-8');
+		const page: PageDocument = JSON.parse(raw);
+
+		if (page.version !== 1) {
+			error(500, `Unsupported page version: ${page.version}`);
+		}
+
+		return { page };
+	} catch (err: unknown) {
+		if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+			error(404, `Page not found: ${slug}`);
+		}
+		throw err;
+	}
+};

--- a/src/routes/pages/[slug]/+page.server.ts
+++ b/src/routes/pages/[slug]/+page.server.ts
@@ -1,16 +1,30 @@
 import { error } from '@sveltejs/kit';
 import { readFile } from 'fs/promises';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import type { PageDocument } from '$lib/builder/types/page.js';
 import type { PageServerLoad } from './$types.js';
 
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
 export const load: PageServerLoad = async ({ params }) => {
 	const slug = params.slug;
-	const filePath = join(process.cwd(), 'content', 'pages', `${slug}.json`);
+
+	if (!SLUG_RE.test(slug)) {
+		error(400, 'Invalid page slug');
+	}
+
+	const pagesDir = resolve(process.cwd(), 'content', 'pages');
+	const filePath = join(pagesDir, `${slug}.json`);
 
 	try {
 		const raw = await readFile(filePath, 'utf-8');
-		const page: PageDocument = JSON.parse(raw);
+
+		let page: PageDocument;
+		try {
+			page = JSON.parse(raw);
+		} catch {
+			error(500, 'Invalid page format');
+		}
 
 		if (page.version !== 1) {
 			error(500, `Unsupported page version: ${page.version}`);

--- a/src/routes/pages/[slug]/+page.server.ts
+++ b/src/routes/pages/[slug]/+page.server.ts
@@ -30,6 +30,10 @@ export const load: PageServerLoad = async ({ params }) => {
 			error(500, `Unsupported page version: ${page.version}`);
 		}
 
+		if (!page.meta || !page.meta.title || !page.meta.slug || !Array.isArray(page.body)) {
+			error(500, 'Malformed page document: missing required fields');
+		}
+
 		return { page };
 	} catch (err: unknown) {
 		if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {

--- a/src/routes/pages/[slug]/+page.svelte
+++ b/src/routes/pages/[slug]/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { PageRenderer } from '$lib/builder/renderer/index.js';
+
+	let { data } = $props();
+</script>
+
+<svelte:head>
+	<title>{data.page.meta.title}</title>
+	{#if data.page.meta.description}
+		<meta name="description" content={data.page.meta.description} />
+	{/if}
+</svelte:head>
+
+<PageRenderer page={data.page} />


### PR DESCRIPTION
## Summary

- **Builder core infrastructure**: TypeScript types (`PageDocument`, `BlockNode`, `PropSchema`), builder registry with prop schemas for 15 FancyUI components + 7 layout primitives
- **Recursive renderer**: `BlockRenderer.svelte` resolves component slugs to Svelte 5 components, renders children recursively. `PageRenderer.svelte` handles full pages from JSON.
- **Adapter wrappers** for multi-snippet components (FlipCard, BentoGridItem, ContainerScroll, ShimmerButton, RainbowButton)
- **Layout primitives**: Section, Container, Grid, Flex, Text, Image, Spacer
- **`/pages/[slug]` route**: loads JSON from `content/pages/` filesystem and renders with PageRenderer
- **Tree utilities**: findNode, insertNode, removeNode, moveNode, cloneNode
- **`BUILDER.md`**: full plan covering all 7 phases

### How to test

1. `pnpm dev`
2. Navigate to `/pages/test` — renders a multi-section page from `content/pages/test.json`
3. Verify: hero with SparklesText, features grid with CardSpotlight, effects (NeonBorder, GlowBorder), text animations (ColourfulText, NumberTicker, LetterPullup, FlipWords), buttons (ShimmerButton, RainbowButton)

## Test plan

- [x] `pnpm check` passes (0 new errors)
- [x] `/pages/test` returns 200 with all sections rendered
- [x] `/pages/nonexistent` returns 404
- [ ] Visual review of `/pages/test` in browser