### PR TITLE
feat: site builder Phase 2 — editor UI

### DIFF
--- a/src/lib/builder/editor/BlockWrapper.svelte
+++ b/src/lib/builder/editor/BlockWrapper.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { getEditorState } from '../stores/editor.svelte.js';
+	import { ArrowUp, ArrowDown, X } from '@lucide/svelte';
+
+	interface Props {
+		blockId: string;
+		children: Snippet;
+	}
+
+	let { blockId, children }: Props = $props();
+
+	const editor = getEditorState();
+	let isSelected = $derived(editor.selectedBlockId === blockId);
+	let isHovered = $state(false);
+
+	function handleClick(e: MouseEvent) {
+		e.stopPropagation();
+		editor.selectBlock(blockId);
+	}
+
+	function handleMoveUp(e: MouseEvent) {
+		e.stopPropagation();
+		editor.moveBlockUp(blockId);
+	}
+
+	function handleMoveDown(e: MouseEvent) {
+		e.stopPropagation();
+		editor.moveBlockDown(blockId);
+	}
+
+	function handleDelete(e: MouseEvent) {
+		e.stopPropagation();
+		editor.removeBlock(blockId);
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="relative transition-all {isSelected
+		? 'ring-2 ring-primary rounded-sm'
+		: isHovered
+			? 'ring-1 ring-dashed ring-muted-foreground/30 rounded-sm'
+			: ''}"
+	data-block-id={blockId}
+	onclick={handleClick}
+	onmouseenter={() => (isHovered = true)}
+	onmouseleave={() => (isHovered = false)}
+>
+	{#if isSelected}
+		<div class="absolute -top-7 right-0 z-50 flex gap-0.5 rounded-t-md bg-primary px-1 py-0.5">
+			<button
+				type="button"
+				class="rounded p-0.5 text-primary-foreground hover:bg-primary-foreground/20"
+				title="Move up"
+				onclick={handleMoveUp}
+			>
+				<ArrowUp class="h-3.5 w-3.5" />
+			</button>
+			<button
+				type="button"
+				class="rounded p-0.5 text-primary-foreground hover:bg-primary-foreground/20"
+				title="Move down"
+				onclick={handleMoveDown}
+			>
+				<ArrowDown class="h-3.5 w-3.5" />
+			</button>
+			<button
+				type="button"
+				class="rounded p-0.5 text-primary-foreground hover:bg-destructive"
+				title="Delete"
+				onclick={handleDelete}
+			>
+				<X class="h-3.5 w-3.5" />
+			</button>
+		</div>
+	{/if}
+
+	{@render children()}
+</div>

--- a/src/lib/builder/editor/Canvas.svelte
+++ b/src/lib/builder/editor/Canvas.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { getEditorState } from '../stores/editor.svelte.js';
+	import CanvasBlockRenderer from './CanvasBlockRenderer.svelte';
+
+	const editor = getEditorState();
+
+	let viewportClass = $derived.by(() => {
+		switch (editor.viewport) {
+			case 'tablet':
+				return 'max-w-[768px] mx-auto';
+			case 'mobile':
+				return 'max-w-[375px] mx-auto';
+			default:
+				return 'max-w-full';
+		}
+	});
+
+	function handleCanvasClick() {
+		editor.deselectBlock();
+	}
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="flex-1 overflow-y-auto bg-muted/30 p-4"
+	onclick={handleCanvasClick}
+>
+	<div class="{viewportClass} min-h-full bg-background shadow-sm transition-all duration-200" style="contain: layout style">
+		{#if editor.page.body.length > 0}
+			{#each editor.page.body as node (node.id)}
+				<CanvasBlockRenderer {node} />
+			{/each}
+		{:else}
+			<div class="flex min-h-[400px] items-center justify-center">
+				<p class="text-muted-foreground">Click a component in the palette to add it here</p>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/builder/editor/CanvasBlockRenderer.svelte
+++ b/src/lib/builder/editor/CanvasBlockRenderer.svelte
@@ -1,0 +1,46 @@
+<!--
+  CanvasBlockRenderer - Like BlockRenderer but wraps every block in BlockWrapper.
+  Used in the editor canvas for selection/interaction.
+-->
+<script lang="ts">
+	import type { BlockNode } from '../types/page.js';
+	import { resolveComponent } from '../renderer/component-map.js';
+	import { getBuilderComponent } from '../registry/builder-registry.js';
+	import BlockWrapper from './BlockWrapper.svelte';
+	import CanvasBlockRendererSelf from './CanvasBlockRenderer.svelte';
+
+	interface Props {
+		node: BlockNode;
+	}
+
+	let { node }: Props = $props();
+
+	let Component = $derived(resolveComponent(node.type));
+	let meta = $derived(getBuilderComponent(node.type));
+	let hasChildren = $derived(
+		meta?.acceptsChildren && node.children && node.children.length > 0
+	);
+</script>
+
+<BlockWrapper blockId={node.id}>
+	{#if Component}
+		{#if hasChildren}
+			{@const childNodes = node.children!}
+			<Component {...node.props}>
+				{#snippet children()}
+					{#each childNodes as child (child.id)}
+						<CanvasBlockRendererSelf node={child} />
+					{/each}
+				{/snippet}
+			</Component>
+		{:else}
+			<Component {...node.props} />
+		{/if}
+	{:else}
+		<div
+			class="rounded border border-dashed border-destructive/50 p-4 text-sm text-destructive"
+		>
+			Unknown component: <code>{node.type}</code>
+		</div>
+	{/if}
+</BlockWrapper>

--- a/src/lib/builder/editor/ComponentPalette.svelte
+++ b/src/lib/builder/editor/ComponentPalette.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import { getAllBuilderComponents } from '../registry/index.js';
+	import type { PaletteCategory } from '../types/registry.js';
+	import PaletteItem from './PaletteItem.svelte';
+
+	let search = $state('');
+
+	const allComponents = getAllBuilderComponents();
+
+	let filtered = $derived(
+		search.trim()
+			? allComponents.filter(
+					(c) =>
+						c.name.toLowerCase().includes(search.toLowerCase()) ||
+						c.description.toLowerCase().includes(search.toLowerCase())
+				)
+			: allComponents
+	);
+
+	const categoryLabels: Record<PaletteCategory, string> = {
+		layout: 'Layout',
+		text: 'Text',
+		cards: 'Cards',
+		effects: 'Effects',
+		backgrounds: 'Backgrounds',
+		buttons: 'Buttons',
+		media: 'Media',
+		navigation: 'Navigation',
+		feedback: 'Feedback',
+		'data-display': 'Data Display'
+	};
+
+	const categoryOrder: PaletteCategory[] = [
+		'layout',
+		'text',
+		'cards',
+		'effects',
+		'buttons',
+		'media',
+		'backgrounds',
+		'navigation',
+		'feedback',
+		'data-display'
+	];
+
+	let grouped = $derived.by(() => {
+		const groups = new Map<PaletteCategory, typeof filtered>();
+		for (const cat of categoryOrder) {
+			const items = filtered.filter((c) => c.paletteCategory === cat);
+			if (items.length > 0) {
+				groups.set(cat, items);
+			}
+		}
+		return groups;
+	});
+</script>
+
+<div class="flex flex-col gap-1">
+	<div class="px-2 pb-1">
+		<input
+			type="text"
+			placeholder="Search components..."
+			class="h-8 w-full rounded-md border border-border bg-input px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:outline-none"
+			bind:value={search}
+		/>
+	</div>
+
+	<div class="space-y-0.5">
+		{#each grouped as [category, items]}
+			<details class="group" open>
+				<summary
+					class="flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground select-none hover:text-foreground"
+				>
+					<svg
+						class="h-3 w-3 shrink-0 transition-transform group-open:rotate-90"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+					>
+						<path d="M9 18l6-6-6-6" />
+					</svg>
+					{categoryLabels[category]}
+				</summary>
+				<div class="pb-1 pl-1">
+					{#each items as meta (meta.slug)}
+						<PaletteItem {meta} />
+					{/each}
+				</div>
+			</details>
+		{/each}
+
+		{#if grouped.size === 0}
+			<p class="px-2 py-4 text-center text-xs text-muted-foreground">No components found</p>
+		{/if}
+	</div>
+</div>

--- a/src/lib/builder/editor/EditorLayout.svelte
+++ b/src/lib/builder/editor/EditorLayout.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import ComponentPalette from './ComponentPalette.svelte';
+	import LayerTree from './LayerTree.svelte';
+	import Canvas from './Canvas.svelte';
+	import TopBar from './TopBar.svelte';
+	import PropertyPanel from './PropertyPanel.svelte';
+</script>
+
+<div class="grid h-screen grid-cols-[240px_1fr_320px]">
+	<!-- Left panel: Palette + Layer Tree -->
+	<div class="flex flex-col border-r border-border bg-background">
+		<div class="shrink-0 border-b border-border px-2 py-2">
+			<h2 class="px-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+				Components
+			</h2>
+		</div>
+		<div class="flex-1 overflow-y-auto px-1 py-1">
+			<ComponentPalette />
+		</div>
+
+		<div class="h-px bg-border"></div>
+
+		<div class="shrink-0 border-t border-border px-2 py-2">
+			<h2 class="px-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+				Layers
+			</h2>
+		</div>
+		<div class="flex-1 overflow-y-auto">
+			<LayerTree />
+		</div>
+	</div>
+
+	<!-- Center: TopBar + Canvas -->
+	<div class="flex flex-col overflow-hidden">
+		<TopBar />
+		<Canvas />
+	</div>
+
+	<!-- Right panel: Properties -->
+	<div class="overflow-y-auto border-l border-border bg-background">
+		<div class="shrink-0 border-b border-border px-4 py-2">
+			<h2 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+				Properties
+			</h2>
+		</div>
+		<PropertyPanel />
+	</div>
+</div>

--- a/src/lib/builder/editor/IconMap.ts
+++ b/src/lib/builder/editor/IconMap.ts
@@ -1,0 +1,61 @@
+/**
+ * Static map from icon name strings (used in builder registry)
+ * to Lucide Svelte component constructors.
+ * Avoids dynamic imports.
+ */
+
+import type { Component } from 'svelte';
+import {
+	LayoutTemplate,
+	Box,
+	LayoutGrid,
+	AlignHorizontalSpaceAround,
+	Type,
+	Image,
+	SeparatorHorizontal,
+	Sparkles,
+	Sun,
+	Zap,
+	MousePointerClick,
+	Rainbow,
+	MoveHorizontal,
+	Waves,
+	Sparkle,
+	Palette,
+	Hash,
+	RotateCw,
+	Lightbulb,
+	ArrowUp,
+	Square,
+	HelpCircle
+} from '@lucide/svelte';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const iconMap: Record<string, Component<any>> = {
+	LayoutTemplate,
+	Box,
+	LayoutGrid,
+	AlignHorizontalSpaceAround,
+	Type,
+	Image,
+	SeparatorHorizontal,
+	Sparkles,
+	Sun,
+	Zap,
+	MousePointerClick,
+	Rainbow,
+	MoveHorizontal,
+	Waves,
+	Sparkle,
+	Palette,
+	Hash,
+	RotateCw,
+	Lightbulb,
+	ArrowUp,
+	Square
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getIcon(name: string): Component<any> {
+	return iconMap[name] ?? HelpCircle;
+}

--- a/src/lib/builder/editor/LayerTree.svelte
+++ b/src/lib/builder/editor/LayerTree.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { getEditorState } from '../stores/editor.svelte.js';
+	import LayerTreeNode from './LayerTreeNode.svelte';
+
+	const editor = getEditorState();
+</script>
+
+<div class="flex flex-col gap-0.5 px-1 py-1">
+	{#if editor.page.body.length > 0}
+		{#each editor.page.body as node (node.id)}
+			<LayerTreeNode {node} />
+		{/each}
+	{:else}
+		<p class="px-2 py-4 text-center text-xs text-muted-foreground">
+			No blocks yet. Add one from the palette above.
+		</p>
+	{/if}
+</div>

--- a/src/lib/builder/editor/LayerTreeNode.svelte
+++ b/src/lib/builder/editor/LayerTreeNode.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import type { BlockNode } from '../types/page.js';
+	import { getBuilderComponent } from '../registry/index.js';
+	import { getEditorState } from '../stores/editor.svelte.js';
+	import { getIcon } from './IconMap.js';
+	import LayerTreeNodeSelf from './LayerTreeNode.svelte';
+
+	interface Props {
+		node: BlockNode;
+		depth?: number;
+	}
+
+	let { node, depth = 0 }: Props = $props();
+
+	const editor = getEditorState();
+	let meta = $derived(getBuilderComponent(node.type));
+	let Icon = $derived(meta ? getIcon(meta.icon) : null);
+	let hasChildren = $derived(node.children && node.children.length > 0);
+	let isSelected = $derived(editor.selectedBlockId === node.id);
+	let expanded = $state(true);
+
+	let label = $derived.by(() => {
+		if (node.type === '_text') {
+			const content = (node.props.content as string) ?? '';
+			return content.length > 30 ? content.slice(0, 30) + '...' : content || 'Empty text';
+		}
+		return meta?.name ?? node.type;
+	});
+
+	function handleClick() {
+		editor.selectBlock(node.id);
+	}
+
+	function toggleExpand(e: MouseEvent) {
+		e.stopPropagation();
+		expanded = !expanded;
+	}
+</script>
+
+<div>
+	<div
+		role="treeitem"
+		tabindex="0"
+		aria-expanded={hasChildren ? expanded : undefined}
+		aria-selected={isSelected}
+		class="flex w-full cursor-pointer items-center gap-1 rounded-sm px-1 py-0.5 text-left text-sm transition-colors select-none {isSelected
+			? 'bg-accent text-accent-foreground'
+			: 'hover:bg-accent/50'}"
+		style="padding-left: {depth * 16 + 4}px"
+		onclick={handleClick}
+		onkeydown={(e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				handleClick();
+			}
+		}}
+	>
+		{#if hasChildren}
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<span
+				class="flex h-4 w-4 shrink-0 items-center justify-center"
+				onclick={toggleExpand}
+				onkeydown={(e) => {
+					if (e.key === 'Enter' || e.key === ' ') {
+						e.preventDefault();
+						e.stopPropagation();
+						expanded = !expanded;
+					}
+				}}
+			>
+				<svg
+					class="h-3 w-3 transition-transform {expanded ? 'rotate-90' : ''}"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+				>
+					<path d="M9 18l6-6-6-6" />
+				</svg>
+			</span>
+		{:else}
+			<span class="h-4 w-4 shrink-0"></span>
+		{/if}
+
+		{#if Icon}
+			<Icon class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+		{/if}
+
+		<span class="truncate">{label}</span>
+	</div>
+
+	{#if hasChildren && expanded}
+		{#each node.children! as child (child.id)}
+			<LayerTreeNodeSelf node={child} depth={depth + 1} />
+		{/each}
+	{/if}
+</div>

--- a/src/lib/builder/editor/PaletteItem.svelte
+++ b/src/lib/builder/editor/PaletteItem.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import type { BuilderComponentMeta } from '../types/registry.js';
+	import { getIcon } from './IconMap.js';
+	import { getEditorState } from '../stores/editor.svelte.js';
+
+	interface Props {
+		meta: BuilderComponentMeta;
+	}
+
+	let { meta }: Props = $props();
+
+	const editor = getEditorState();
+	let Icon = $derived(getIcon(meta.icon));
+
+	function handleClick() {
+		// If a container is selected, add as child; otherwise add to root
+		const parentId =
+			editor.selectedBlock && editor.selectedMeta?.acceptsChildren
+				? editor.selectedBlockId
+				: null;
+		editor.addBlock(meta.slug, parentId);
+	}
+</script>
+
+<button
+	type="button"
+	class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground transition-colors"
+	onclick={handleClick}
+	title={meta.description}
+>
+	<Icon class="h-4 w-4 shrink-0 text-muted-foreground" />
+	<span class="truncate">{meta.name}</span>
+</button>

--- a/src/lib/builder/editor/PropertyPanel.svelte
+++ b/src/lib/builder/editor/PropertyPanel.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+	import { getEditorState } from '../stores/editor.svelte.js';
+	import StringEditor from './props/StringEditor.svelte';
+	import NumberEditor from './props/NumberEditor.svelte';
+	import BooleanEditor from './props/BooleanEditor.svelte';
+	import ColorEditor from './props/ColorEditor.svelte';
+	import SelectEditor from './props/SelectEditor.svelte';
+
+	const editor = getEditorState();
+
+	function handlePropChange(key: string, value: unknown) {
+		if (!editor.selectedBlockId) return;
+		editor.updateBlockProp(editor.selectedBlockId, key, value);
+	}
+</script>
+
+<div class="flex h-full flex-col">
+	{#if editor.selectedBlock && editor.selectedMeta}
+		{@const block = editor.selectedBlock}
+		{@const meta = editor.selectedMeta}
+
+		<div class="border-b border-border px-4 py-3">
+			<h3 class="text-sm font-semibold">{meta.name}</h3>
+			<p class="text-xs text-muted-foreground">{meta.slug}</p>
+		</div>
+
+		<div class="flex-1 space-y-4 overflow-y-auto p-4">
+			{#each Object.entries(meta.propSchemas) as [key, schema]}
+				<div>
+					<!-- svelte-ignore a11y_label_has_associated_control -->
+					<label class="mb-1.5 block text-xs font-medium text-muted-foreground">
+						{schema.label}
+						{#if schema.description}
+							<span class="ml-1 text-muted-foreground/60" title={schema.description}>?</span>
+						{/if}
+					</label>
+					{#if schema.type === 'string' || schema.type === 'image'}
+						<StringEditor
+							value={String(block.props[key] ?? schema.default ?? '')}
+							{schema}
+							onchange={(v) => handlePropChange(key, v)}
+						/>
+					{:else if schema.type === 'number'}
+						<NumberEditor
+							value={Number(block.props[key] ?? schema.default ?? 0)}
+							{schema}
+							onchange={(v) => handlePropChange(key, v)}
+						/>
+					{:else if schema.type === 'boolean'}
+						<BooleanEditor
+							value={Boolean(block.props[key] ?? schema.default ?? false)}
+							{schema}
+							onchange={(v) => handlePropChange(key, v)}
+						/>
+					{:else if schema.type === 'color'}
+						<ColorEditor
+							value={String(block.props[key] ?? schema.default ?? '#000000')}
+							{schema}
+							onchange={(v) => handlePropChange(key, v)}
+						/>
+					{:else if schema.type === 'select'}
+						<SelectEditor
+							value={String(block.props[key] ?? schema.default ?? '')}
+							{schema}
+							onchange={(v) => handlePropChange(key, v)}
+						/>
+					{:else if schema.type === 'json'}
+						<textarea
+							class="h-20 w-full resize-y rounded-md border border-border bg-input px-3 py-2 font-mono text-xs text-foreground focus:ring-2 focus:ring-ring focus:outline-none"
+							value={JSON.stringify(block.props[key] ?? schema.default, null, 2)}
+							oninput={(e) => {
+								try {
+									const parsed = JSON.parse(e.currentTarget.value);
+									handlePropChange(key, parsed);
+								} catch {
+									// Invalid JSON, ignore
+								}
+							}}
+						></textarea>
+					{/if}
+				</div>
+			{/each}
+		</div>
+
+		<div class="border-t border-border p-4">
+			<button
+				type="button"
+				class="w-full rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
+				onclick={() => editor.removeBlock(block.id)}
+			>
+				Delete Block
+			</button>
+		</div>
+	{:else}
+		<div class="flex flex-1 items-center justify-center p-6 text-center">
+			<p class="text-sm text-muted-foreground">Select a block to edit its properties</p>
+		</div>
+	{/if}
+</div>

--- a/src/lib/builder/editor/TopBar.svelte
+++ b/src/lib/builder/editor/TopBar.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { getEditorState, type Viewport } from '../stores/editor.svelte.js';
+	import { Monitor, Tablet, Smartphone, ArrowLeft, Save } from '@lucide/svelte';
+
+	const editor = getEditorState();
+
+	const viewportOptions: { icon: typeof Monitor; value: Viewport; label: string }[] = [
+		{ icon: Monitor, value: 'desktop', label: 'Desktop' },
+		{ icon: Tablet, value: 'tablet', label: 'Tablet' },
+		{ icon: Smartphone, value: 'mobile', label: 'Mobile' }
+	];
+
+	function handleSave() {
+		console.log('Save page:', JSON.stringify(editor.page, null, 2));
+	}
+</script>
+
+<div
+	class="flex h-12 shrink-0 items-center gap-4 border-b border-border bg-background px-4"
+>
+	<!-- Left: Back link -->
+	<a href="/builder" class="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+		<ArrowLeft class="h-4 w-4" />
+		Builder
+	</a>
+
+	<!-- Center: Editable title -->
+	<div class="flex flex-1 justify-center">
+		<input
+			type="text"
+			class="h-8 max-w-xs rounded-md border border-transparent bg-transparent px-2 text-center text-sm font-medium hover:border-border focus:border-border focus:ring-2 focus:ring-ring focus:outline-none"
+			value={editor.page.meta.title}
+			oninput={(e) => editor.updatePageMeta('title', e.currentTarget.value)}
+		/>
+	</div>
+
+	<!-- Right: Viewport toggles + Save -->
+	<div class="flex items-center gap-1">
+		{#each viewportOptions as { icon: Icon, value, label }}
+			<button
+				type="button"
+				class="rounded-md p-1.5 transition-colors {editor.viewport === value
+					? 'bg-accent text-accent-foreground'
+					: 'text-muted-foreground hover:text-foreground'}"
+				title={label}
+				onclick={() => (editor.viewport = value)}
+			>
+				<Icon class="h-4 w-4" />
+			</button>
+		{/each}
+
+		<div class="mx-2 h-5 w-px bg-border"></div>
+
+		<button
+			type="button"
+			class="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+			onclick={handleSave}
+		>
+			<Save class="h-3.5 w-3.5" />
+			Save
+		</button>
+	</div>
+</div>

--- a/src/lib/builder/editor/props/BooleanEditor.svelte
+++ b/src/lib/builder/editor/props/BooleanEditor.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import type { BooleanPropSchema } from '../../types/registry.js';
+
+	interface Props {
+		value: boolean;
+		schema: BooleanPropSchema;
+		onchange: (value: boolean) => void;
+	}
+
+	let { value, schema, onchange }: Props = $props();
+</script>
+
+<button
+	type="button"
+	role="switch"
+	aria-checked={value}
+	aria-label={schema.label}
+	class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-none {value
+		? 'bg-primary'
+		: 'bg-muted'}"
+	onclick={() => onchange(!value)}
+>
+	<span
+		class="pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform {value
+			? 'translate-x-5'
+			: 'translate-x-0'}"
+	></span>
+</button>

--- a/src/lib/builder/editor/props/ColorEditor.svelte
+++ b/src/lib/builder/editor/props/ColorEditor.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import type { ColorPropSchema } from '../../types/registry.js';
+
+	interface Props {
+		value: string;
+		schema: ColorPropSchema;
+		onchange: (value: string) => void;
+	}
+
+	let { value, schema: _schema, onchange }: Props = $props();
+</script>
+
+<div class="flex items-center gap-2">
+	<input
+		type="color"
+		class="h-9 w-9 shrink-0 cursor-pointer rounded-md border border-border bg-input p-0.5"
+		{value}
+		oninput={(e) => onchange(e.currentTarget.value)}
+	/>
+	<input
+		type="text"
+		class="h-9 w-full rounded-md border border-border bg-input px-3 text-sm text-foreground focus:ring-2 focus:ring-ring focus:outline-none"
+		{value}
+		oninput={(e) => onchange(e.currentTarget.value)}
+	/>
+</div>

--- a/src/lib/builder/editor/props/NumberEditor.svelte
+++ b/src/lib/builder/editor/props/NumberEditor.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { NumberPropSchema } from '../../types/registry.js';
+
+	interface Props {
+		value: number;
+		schema: NumberPropSchema;
+		onchange: (value: number) => void;
+	}
+
+	let { value, schema, onchange }: Props = $props();
+</script>
+
+<input
+	type="number"
+	class="h-9 w-full rounded-md border border-border bg-input px-3 text-sm text-foreground focus:ring-2 focus:ring-ring focus:outline-none"
+	{value}
+	min={schema.min}
+	max={schema.max}
+	step={schema.step}
+	oninput={(e) => {
+		const num = parseFloat(e.currentTarget.value);
+		if (!Number.isNaN(num)) onchange(num);
+	}}
+/>

--- a/src/lib/builder/editor/props/SelectEditor.svelte
+++ b/src/lib/builder/editor/props/SelectEditor.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { SelectPropSchema } from '../../types/registry.js';
+
+	interface Props {
+		value: string;
+		schema: SelectPropSchema;
+		onchange: (value: string) => void;
+	}
+
+	let { value, schema, onchange }: Props = $props();
+</script>
+
+<select
+	class="h-9 w-full rounded-md border border-border bg-input px-3 text-sm text-foreground focus:ring-2 focus:ring-ring focus:outline-none"
+	{value}
+	onchange={(e) => onchange(e.currentTarget.value)}
+>
+	{#each schema.options as opt}
+		<option value={opt.value} selected={opt.value === value}>{opt.label}</option>
+	{/each}
+</select>

--- a/src/lib/builder/editor/props/StringEditor.svelte
+++ b/src/lib/builder/editor/props/StringEditor.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { StringPropSchema, ImagePropSchema } from '../../types/registry.js';
+
+	interface Props {
+		value: string;
+		schema: StringPropSchema | ImagePropSchema;
+		onchange: (value: string) => void;
+	}
+
+	let { value, schema, onchange }: Props = $props();
+
+	let multiline = $derived(schema.type === 'string' && schema.multiline);
+	let placeholder = $derived(schema.type === 'string' ? (schema.placeholder ?? '') : '');
+</script>
+
+{#if multiline}
+	<textarea
+		class="h-20 w-full resize-y rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:outline-none"
+		{value}
+		placeholder={placeholder}
+		oninput={(e) => onchange(e.currentTarget.value)}
+	></textarea>
+{:else}
+	<input
+		type="text"
+		class="h-9 w-full rounded-md border border-border bg-input px-3 text-sm text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:outline-none"
+		{value}
+		placeholder={placeholder}
+		oninput={(e) => onchange(e.currentTarget.value)}
+	/>
+{/if}

--- a/src/lib/builder/stores/editor.svelte.ts
+++ b/src/lib/builder/stores/editor.svelte.ts
@@ -1,0 +1,113 @@
+/**
+ * Editor State Store
+ *
+ * Class-based Svelte 5 runes store for the site builder editor.
+ * Shared via setContext/getContext.
+ */
+
+import { setContext, getContext } from 'svelte';
+import type { PageDocument, BlockNode, BuilderComponentMeta } from '../types/index.js';
+import { getBuilderComponent, getDefaultProps } from '../registry/index.js';
+import { findNode, findParent, removeNode, createBlockId } from '../utils/index.js';
+
+export type Viewport = 'desktop' | 'tablet' | 'mobile';
+
+const EDITOR_CTX_KEY = Symbol('editor-state');
+
+export class EditorState {
+	page: PageDocument = $state() as PageDocument;
+	selectedBlockId: string | null = $state(null);
+	viewport: Viewport = $state('desktop');
+
+	selectedBlock: BlockNode | undefined = $derived.by(() => {
+		if (!this.selectedBlockId) return undefined;
+		return findNode(this.page.body, this.selectedBlockId);
+	});
+
+	selectedMeta: BuilderComponentMeta | undefined = $derived.by(() => {
+		if (!this.selectedBlock) return undefined;
+		return getBuilderComponent(this.selectedBlock.type);
+	});
+
+	constructor(page: PageDocument) {
+		this.page = page;
+	}
+
+	selectBlock(id: string) {
+		this.selectedBlockId = id;
+	}
+
+	deselectBlock() {
+		this.selectedBlockId = null;
+	}
+
+	updateBlockProp(blockId: string, key: string, value: unknown) {
+		const node = findNode(this.page.body, blockId);
+		if (!node) return;
+		node.props[key] = value;
+	}
+
+	addBlock(type: string, parentId?: string | null, index?: number) {
+		const meta = getBuilderComponent(type);
+		if (!meta) return;
+
+		const newNode: BlockNode = {
+			id: createBlockId(),
+			type,
+			props: getDefaultProps(type)
+		};
+
+		if (meta.acceptsChildren) {
+			newNode.children = [];
+		}
+
+		if (parentId) {
+			const parent = findNode(this.page.body, parentId);
+			if (!parent) return;
+			if (!parent.children) parent.children = [];
+			const idx = index ?? parent.children.length;
+			parent.children.splice(idx, 0, newNode);
+		} else {
+			const idx = index ?? this.page.body.length;
+			this.page.body.splice(idx, 0, newNode);
+		}
+
+		this.selectedBlockId = newNode.id;
+	}
+
+	removeBlock(id: string) {
+		if (this.selectedBlockId === id) {
+			this.selectedBlockId = null;
+		}
+		removeNode(this.page.body, id);
+	}
+
+	moveBlockUp(id: string) {
+		const result = findParent(this.page.body, id);
+		if (!result || result.index === 0) return;
+		const [node] = result.parent.splice(result.index, 1);
+		result.parent.splice(result.index - 1, 0, node);
+	}
+
+	moveBlockDown(id: string) {
+		const result = findParent(this.page.body, id);
+		if (!result || result.index >= result.parent.length - 1) return;
+		const [node] = result.parent.splice(result.index, 1);
+		result.parent.splice(result.index + 1, 0, node);
+	}
+
+	updatePageMeta(key: string, value: unknown) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(this.page.meta as any)[key] = value;
+	}
+}
+
+export function createEditorState(page: PageDocument): EditorState {
+	const state = new EditorState(page);
+	setContext(EDITOR_CTX_KEY, state);
+	return state;
+}
+
+export function getEditorState(): EditorState {
+	return getContext<EditorState>(EDITOR_CTX_KEY);
+}

--- a/src/routes/builder/+layout.svelte
+++ b/src/routes/builder/+layout.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
+</script>
+
+{@render children()}

--- a/src/routes/builder/+page.server.ts
+++ b/src/routes/builder/+page.server.ts
@@ -1,0 +1,45 @@
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+import type { PageDocument } from '$lib/builder/types/page.js';
+import type { PageServerLoad } from './$types.js';
+
+export interface PageListItem {
+	slug: string;
+	title: string;
+	status: string;
+	updatedAt: string;
+}
+
+export const load: PageServerLoad = async () => {
+	const dir = join(process.cwd(), 'content', 'pages');
+
+	let files: string[];
+	try {
+		files = await readdir(dir);
+	} catch {
+		return { pages: [] as PageListItem[] };
+	}
+
+	const pages: PageListItem[] = [];
+
+	for (const file of files) {
+		if (!file.endsWith('.json')) continue;
+
+		try {
+			const raw = await readFile(join(dir, file), 'utf-8');
+			const doc: PageDocument = JSON.parse(raw);
+			pages.push({
+				slug: doc.meta.slug,
+				title: doc.meta.title,
+				status: doc.meta.status,
+				updatedAt: doc.meta.updatedAt
+			});
+		} catch {
+			// Skip invalid files
+		}
+	}
+
+	pages.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+
+	return { pages };
+};

--- a/src/routes/builder/+page.svelte
+++ b/src/routes/builder/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import { FilePen, Plus } from '@lucide/svelte';
+
+	let { data } = $props();
+</script>
+
+<svelte:head>
+	<title>Site Builder</title>
+</svelte:head>
+
+<div class="min-h-screen bg-background">
+	<div class="mx-auto max-w-4xl px-4 py-12">
+		<div class="mb-8 flex items-center justify-between">
+			<div>
+				<h1 class="text-3xl font-bold">Site Builder</h1>
+				<p class="mt-1 text-muted-foreground">Manage and edit your pages</p>
+			</div>
+			<a
+				href="/builder/new"
+				class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+			>
+				<Plus class="h-4 w-4" />
+				New Page
+			</a>
+		</div>
+
+		{#if data.pages.length > 0}
+			<div class="grid gap-4">
+				{#each data.pages as page}
+					<a
+						href="/builder/{page.slug}"
+						class="group flex items-center gap-4 rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent"
+					>
+						<div
+							class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted"
+						>
+							<FilePen class="h-5 w-5 text-muted-foreground" />
+						</div>
+						<div class="flex-1">
+							<h2 class="font-medium group-hover:text-accent-foreground">{page.title}</h2>
+							<p class="text-sm text-muted-foreground">/{page.slug}</p>
+						</div>
+						<div class="flex items-center gap-2">
+							<span
+								class="rounded-full px-2 py-0.5 text-xs font-medium {page.status === 'published'
+									? 'bg-green-500/10 text-green-500'
+									: 'bg-yellow-500/10 text-yellow-500'}"
+							>
+								{page.status}
+							</span>
+						</div>
+					</a>
+				{/each}
+			</div>
+		{:else}
+			<div class="rounded-lg border border-dashed border-border py-12 text-center">
+				<p class="text-muted-foreground">No pages yet. Create your first page to get started.</p>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/routes/builder/[slug]/+page.server.ts
+++ b/src/routes/builder/[slug]/+page.server.ts
@@ -1,0 +1,44 @@
+import { error } from '@sveltejs/kit';
+import { readFile } from 'fs/promises';
+import { join, resolve } from 'path';
+import type { PageDocument } from '$lib/builder/types/page.js';
+import type { PageServerLoad } from './$types.js';
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const load: PageServerLoad = async ({ params }) => {
+	const slug = params.slug;
+
+	if (!SLUG_RE.test(slug)) {
+		error(400, 'Invalid page slug');
+	}
+
+	const pagesDir = resolve(process.cwd(), 'content', 'pages');
+	const filePath = join(pagesDir, `${slug}.json`);
+
+	try {
+		const raw = await readFile(filePath, 'utf-8');
+
+		let page: PageDocument;
+		try {
+			page = JSON.parse(raw);
+		} catch {
+			error(500, 'Invalid page format');
+		}
+
+		if (page.version !== 1) {
+			error(500, `Unsupported page version: ${page.version}`);
+		}
+
+		if (!page.meta || !page.meta.title || !page.meta.slug || !Array.isArray(page.body)) {
+			error(500, 'Malformed page document: missing required fields');
+		}
+
+		return { page };
+	} catch (err: unknown) {
+		if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+			error(404, `Page not found: ${slug}`);
+		}
+		throw err;
+	}
+};

--- a/src/routes/builder/[slug]/+page.svelte
+++ b/src/routes/builder/[slug]/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { createEditorState } from '$lib/builder/stores/editor.svelte.js';
+	import EditorLayout from '$lib/builder/editor/EditorLayout.svelte';
+
+	let { data } = $props();
+
+	const editor = createEditorState(data.page);
+</script>
+
+<svelte:head>
+	<title>Edit: {editor.page.meta.title}</title>
+</svelte:head>
+
+<EditorLayout />


### PR DESCRIPTION
## Summary
- **Editor state store** — Svelte 5 runes class (`$state`/`$derived`) shared via context, with methods for block selection, prop editing, add/remove/reorder
- **3-panel editor layout** — left (component palette + layer tree), center (top bar + canvas), right (property panel)
- **Component palette** — search input, grouped by category (layout, text, cards, effects, buttons, media), click-to-add
- **Canvas** — renders page blocks wrapped in selectable/hoverable BlockWrappers, viewport simulation (desktop/tablet/mobile)
- **Property panel** — typed editors (string, number, boolean, color, select, JSON) bound to selected block's prop schemas
- **Layer tree** — recursive tree view of page hierarchy, click to select, expand/collapse
- **Builder routes** — `/builder` dashboard listing pages, `/builder/[slug]` editor loading JSON from filesystem

## Test plan
- [ ] `/builder` shows dashboard with "test" page card
- [ ] `/builder/test` opens 3-panel editor with full page rendered
- [ ] Click palette item → block added to canvas + selected
- [ ] Click block in canvas → blue ring, props appear in right panel
- [ ] Edit a prop → canvas updates live
- [ ] Delete button removes block from canvas and tree
- [ ] Layer tree shows hierarchy, click selects block
- [ ] Viewport toggles (desktop/tablet/mobile) change canvas width
- [ ] `pnpm check` passes with no new errors