### PR TITLE
feat: site builder Phase 4 — live preview

### DIFF
--- a/BUILDER.md
+++ b/BUILDER.md
@@ -227,18 +227,27 @@ Modified:
 
 ---
 
-### Phase 4: Live Preview
+### Phase 4: Live Preview ✅
 
-**Status: TODO**
+**Status: DONE**
 
 Wire reactive updates between editor state and the canvas.
 
 #### Deliverables
 
-- **Reactive canvas**: modifying props in the property panel instantly updates the preview
+- **Reactive canvas**: modifying props in the property panel instantly updates the preview (already worked via Svelte 5 runes since Phase 2)
 - **Edit/Interact toggle**: `pointer-events: none` on components in edit mode, `pointer-events: auto` in interact mode
-- **Responsive preview**: CSS zoom for mobile/tablet/desktop breakpoints
-- **Inline text editing**: double-click a `_text` block to edit content directly
+- **Responsive preview**: CSS `zoom` for mobile/tablet/desktop breakpoints with `ResizeObserver` + viewport dimension label
+- **Inline text editing**: double-click a `_text` block to edit content directly via `contenteditable`
+
+#### Files Modified
+
+- `src/lib/builder/stores/editor.svelte.ts` — added `mode`, `inlineEditBlockId`, `toggleMode()`, `startInlineEdit()`, `stopInlineEdit()`
+- `src/lib/builder/editor/TopBar.svelte` — added Edit/Interact toggle button (MousePointer/Hand icons)
+- `src/lib/builder/editor/BlockWrapper.svelte` — pointer-events-none in edit mode, hide selection UI in interact mode, dblclick for inline editing
+- `src/lib/builder/editor/Canvas.svelte` — ResizeObserver + CSS zoom for responsive preview, viewport label, disabled deselect in interact mode
+- `src/lib/builder/editor/CanvasBlockRenderer.svelte` — conditional InlineTextEditor rendering for `_text` blocks
+- `src/lib/builder/editor/InlineTextEditor.svelte` — **new**, contenteditable component matching `_text` block styling
 
 ---
 

--- a/src/lib/builder/editor/BlockWrapper.svelte
+++ b/src/lib/builder/editor/BlockWrapper.svelte
@@ -14,6 +14,8 @@
 	const editor = getEditorState();
 	let isSelected = $derived(editor.selectedBlockId === blockId);
 	let isHovered = $state(false);
+	let isEditMode = $derived(editor.mode === 'edit');
+	let isInlineEditing = $derived(editor.inlineEditBlockId === blockId);
 
 	// Drag state
 	let startX = 0;
@@ -32,9 +34,15 @@
 	});
 
 	function handleClick(e: MouseEvent) {
-		if (dragging) return;
+		if (dragging || !isEditMode) return;
 		e.stopPropagation();
 		editor.selectBlock(blockId);
+	}
+
+	function handleDblClick(e: MouseEvent) {
+		if (!isEditMode) return;
+		e.stopPropagation();
+		editor.startInlineEdit(blockId);
 	}
 
 	function handleMoveUp(e: MouseEvent) {
@@ -89,18 +97,19 @@
 	}
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
-	class="relative transition-all duration-75 {isSelected
+	class="relative transition-all duration-75 {isEditMode && isSelected
 		? 'ring-2 ring-primary rounded-sm'
-		: isHovered
+		: isEditMode && isHovered
 			? 'ring-1 ring-dashed ring-muted-foreground/30 rounded-sm'
 			: ''} {isBeingDragged ? 'opacity-40' : ''} {dropPosition === 'inside'
 		? 'ring-2 ring-primary/50 ring-inset bg-primary/5 rounded-sm'
 		: ''}"
 	data-drop-id={blockId}
 	onclick={handleClick}
+	ondblclick={handleDblClick}
 	onmouseenter={() => (isHovered = true)}
 	onmouseleave={() => (isHovered = false)}
 >
@@ -108,7 +117,7 @@
 		<div class="pointer-events-none absolute -top-px left-0 right-0 z-40 h-0.5 bg-primary"></div>
 	{/if}
 
-	{#if isSelected}
+	{#if isEditMode && isSelected && !isInlineEditing}
 		<div class="absolute -top-7 right-0 z-50 flex gap-0.5 rounded-t-md bg-primary px-1 py-0.5">
 			<button
 				type="button"
@@ -146,7 +155,13 @@
 		</div>
 	{/if}
 
-	{@render children()}
+	{#if isEditMode && !isInlineEditing}
+		<div class="pointer-events-none">
+			{@render children()}
+		</div>
+	{:else}
+		{@render children()}
+	{/if}
 
 	{#if dropPosition === 'after'}
 		<div class="pointer-events-none absolute -bottom-px left-0 right-0 z-40 h-0.5 bg-primary"></div>

--- a/src/lib/builder/editor/Canvas.svelte
+++ b/src/lib/builder/editor/Canvas.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { getEditorState } from '../stores/editor.svelte.js';
 	import { getBuilderComponent } from '../registry/index.js';
 	import { calculateDropPosition, isValidDrop } from '../utils/drag.js';
@@ -8,20 +9,51 @@
 
 	const editor = getEditorState();
 
-	let canvasEl: HTMLDivElement;
+	const DEVICE_WIDTHS: Record<string, number> = {
+		tablet: 768,
+		mobile: 375
+	};
 
-	let viewportClass = $derived.by(() => {
-		switch (editor.viewport) {
-			case 'tablet':
-				return 'max-w-[768px] mx-auto';
-			case 'mobile':
-				return 'max-w-[375px] mx-auto';
-			default:
-				return 'max-w-full';
+	const DEVICE_LABELS: Record<string, string> = {
+		tablet: '768 × 1024',
+		mobile: '375 × 812'
+	};
+
+	let canvasEl: HTMLDivElement;
+	let containerWidth = $state(0);
+
+	let viewportWidth = $derived.by(() => {
+		return DEVICE_WIDTHS[editor.viewport] ?? 0;
+	});
+
+	let zoomLevel = $derived.by(() => {
+		if (!viewportWidth || containerWidth <= 0) return 1;
+		const padding = 32; // p-4 on each side
+		const available = Math.max(containerWidth - padding, 0);
+		return Math.min(available / viewportWidth, 1);
+	});
+
+	let viewportStyle = $derived.by(() => {
+		if (!viewportWidth) {
+			return 'contain: layout style';
 		}
+		return `width: ${viewportWidth}px; zoom: ${zoomLevel}; contain: layout style`;
+	});
+
+	let viewportLabel = $derived(DEVICE_LABELS[editor.viewport] ?? null);
+
+	onMount(() => {
+		const observer = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				containerWidth = entry.contentBoxSize?.[0]?.inlineSize ?? entry.contentRect.width;
+			}
+		});
+		observer.observe(canvasEl);
+		return () => observer.disconnect();
 	});
 
 	function handleCanvasClick() {
+		if (editor.mode === 'interact') return;
 		editor.deselectBlock();
 	}
 
@@ -112,7 +144,13 @@
 	bind:this={canvasEl}
 	onclick={handleCanvasClick}
 >
-	<div class="{viewportClass} min-h-full bg-background shadow-sm transition-all duration-200" style="contain: layout style">
+	{#if viewportLabel}
+		<div class="mb-2 text-center text-xs text-muted-foreground">{viewportLabel}</div>
+	{/if}
+	<div
+		class="min-h-full bg-background shadow-sm transition-all duration-200 {viewportWidth ? 'mx-auto' : ''}"
+		style={viewportStyle}
+	>
 		{#if editor.page.body.length > 0}
 			{#each editor.page.body as node (node.id)}
 				<CanvasBlockRenderer {node} />

--- a/src/lib/builder/editor/CanvasBlockRenderer.svelte
+++ b/src/lib/builder/editor/CanvasBlockRenderer.svelte
@@ -6,7 +6,9 @@
 	import type { BlockNode } from '../types/page.js';
 	import { resolveComponent } from '../renderer/component-map.js';
 	import { getBuilderComponent } from '../registry/builder-registry.js';
+	import { getEditorState } from '../stores/editor.svelte.js';
 	import BlockWrapper from './BlockWrapper.svelte';
+	import InlineTextEditor from './InlineTextEditor.svelte';
 	import CanvasBlockRendererSelf from './CanvasBlockRenderer.svelte';
 
 	interface Props {
@@ -15,15 +17,27 @@
 
 	let { node }: Props = $props();
 
+	const editor = getEditorState();
+
 	let Component = $derived(resolveComponent(node.type));
 	let meta = $derived(getBuilderComponent(node.type));
 	let hasChildren = $derived(
 		meta?.acceptsChildren && node.children && node.children.length > 0
 	);
+	let isInlineEditing = $derived(
+		node.type === '_text' && editor.inlineEditBlockId === node.id
+	);
 </script>
 
 <BlockWrapper blockId={node.id}>
-	{#if Component}
+	{#if isInlineEditing}
+		<InlineTextEditor
+			blockId={node.id}
+			content={node.props.content as string}
+			tag={node.props.tag as string}
+			class={node.props.class as string}
+		/>
+	{:else if Component}
 		{#if hasChildren}
 			{@const childNodes = node.children!}
 			<Component {...node.props}>

--- a/src/lib/builder/editor/InlineTextEditor.svelte
+++ b/src/lib/builder/editor/InlineTextEditor.svelte
@@ -1,0 +1,114 @@
+<!--
+  InlineTextEditor — contenteditable overlay for _text blocks.
+  Renders the same tag/class as the Text primitive but with contenteditable.
+  On blur or Escape → commits text. On Enter for heading tags → commits.
+-->
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { cn } from '$lib/utils';
+	import { getEditorState } from '../stores/editor.svelte.js';
+
+	interface Props {
+		blockId: string;
+		content?: string;
+		tag?: string;
+		class?: string;
+	}
+
+	let { blockId, content = '', tag = 'p', class: className = '' }: Props = $props();
+
+	const editor = getEditorState();
+	let el = $state<HTMLElement | null>(null);
+
+	const isHeading = $derived(tag.startsWith('h'));
+	const editableClass = $derived(
+		cn(className, 'outline-none ring-2 ring-primary/50 rounded-sm cursor-text')
+	);
+
+	onMount(() => {
+		if (el) {
+			el.textContent = content;
+			el.focus();
+			// Place cursor at end
+			const range = document.createRange();
+			range.selectNodeContents(el);
+			range.collapse(false);
+			const sel = window.getSelection();
+			sel?.removeAllRanges();
+			sel?.addRange(range);
+		}
+	});
+
+	function commit() {
+		if (!el) return;
+		const text = el.textContent ?? '';
+		editor.updateBlockProp(blockId, 'content', text);
+		editor.stopInlineEdit();
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			commit();
+		} else if (e.key === 'Enter' && isHeading) {
+			e.preventDefault();
+			commit();
+		}
+	}
+
+	function handleBlur() {
+		commit();
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_missing_content -->
+{#if tag === 'h1'}
+	<h1
+		bind:this={el}
+		class={editableClass}
+		contenteditable="true"
+		onkeydown={handleKeydown}
+		onblur={handleBlur}
+	></h1>
+{:else if tag === 'h2'}
+	<h2
+		bind:this={el}
+		class={editableClass}
+		contenteditable="true"
+		onkeydown={handleKeydown}
+		onblur={handleBlur}
+	></h2>
+{:else if tag === 'h3'}
+	<h3
+		bind:this={el}
+		class={editableClass}
+		contenteditable="true"
+		onkeydown={handleKeydown}
+		onblur={handleBlur}
+	></h3>
+{:else if tag === 'h4'}
+	<h4
+		bind:this={el}
+		class={editableClass}
+		contenteditable="true"
+		onkeydown={handleKeydown}
+		onblur={handleBlur}
+	></h4>
+{:else if tag === 'span'}
+	<span
+		bind:this={el}
+		class={editableClass}
+		contenteditable="true"
+		onkeydown={handleKeydown}
+		onblur={handleBlur}
+	></span>
+{:else}
+	<p
+		bind:this={el}
+		class={editableClass}
+		contenteditable="true"
+		onkeydown={handleKeydown}
+		onblur={handleBlur}
+	></p>
+{/if}

--- a/src/lib/builder/editor/InlineTextEditor.svelte
+++ b/src/lib/builder/editor/InlineTextEditor.svelte
@@ -17,6 +17,9 @@
 
 	let { blockId, content = '', tag = 'p', class: className = '' }: Props = $props();
 
+	const ALLOWED_TAGS = ['h1', 'h2', 'h3', 'h4', 'p', 'span'];
+	const safeTag = $derived(ALLOWED_TAGS.includes(tag) ? tag : 'p');
+
 	const editor = getEditorState();
 	let el = $state<HTMLElement | null>(null);
 
@@ -59,56 +62,22 @@
 	function handleBlur() {
 		commit();
 	}
+
+	function handlePaste(e: ClipboardEvent) {
+		e.preventDefault();
+		const text = e.clipboardData?.getData('text/plain') ?? '';
+		document.execCommand('insertText', false, text);
+	}
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <!-- svelte-ignore a11y_missing_content -->
-{#if tag === 'h1'}
-	<h1
-		bind:this={el}
-		class={editableClass}
-		contenteditable="true"
-		onkeydown={handleKeydown}
-		onblur={handleBlur}
-	></h1>
-{:else if tag === 'h2'}
-	<h2
-		bind:this={el}
-		class={editableClass}
-		contenteditable="true"
-		onkeydown={handleKeydown}
-		onblur={handleBlur}
-	></h2>
-{:else if tag === 'h3'}
-	<h3
-		bind:this={el}
-		class={editableClass}
-		contenteditable="true"
-		onkeydown={handleKeydown}
-		onblur={handleBlur}
-	></h3>
-{:else if tag === 'h4'}
-	<h4
-		bind:this={el}
-		class={editableClass}
-		contenteditable="true"
-		onkeydown={handleKeydown}
-		onblur={handleBlur}
-	></h4>
-{:else if tag === 'span'}
-	<span
-		bind:this={el}
-		class={editableClass}
-		contenteditable="true"
-		onkeydown={handleKeydown}
-		onblur={handleBlur}
-	></span>
-{:else}
-	<p
-		bind:this={el}
-		class={editableClass}
-		contenteditable="true"
-		onkeydown={handleKeydown}
-		onblur={handleBlur}
-	></p>
-{/if}
+<svelte:element
+	this={safeTag}
+	bind:this={el}
+	class={editableClass}
+	contenteditable="plaintext-only"
+	onkeydown={handleKeydown}
+	onblur={handleBlur}
+	onpaste={handlePaste}
+/>

--- a/src/lib/builder/editor/InlineTextEditor.svelte
+++ b/src/lib/builder/editor/InlineTextEditor.svelte
@@ -23,7 +23,7 @@
 	const editor = getEditorState();
 	let el = $state<HTMLElement | null>(null);
 
-	const isHeading = $derived(tag.startsWith('h'));
+	const isHeading = $derived(safeTag.startsWith('h'));
 	const editableClass = $derived(
 		cn(className, 'outline-none ring-2 ring-primary/50 rounded-sm cursor-text')
 	);
@@ -66,17 +66,40 @@
 	function handlePaste(e: ClipboardEvent) {
 		e.preventDefault();
 		const text = e.clipboardData?.getData('text/plain') ?? '';
-		document.execCommand('insertText', false, text);
+		if (!el || !text) return;
+
+		const selection = window.getSelection();
+		if (!selection) return;
+
+		let range: Range;
+		if (selection.rangeCount > 0 && el.contains(selection.getRangeAt(0).commonAncestorContainer)) {
+			range = selection.getRangeAt(0);
+		} else {
+			range = document.createRange();
+			range.selectNodeContents(el);
+			range.collapse(false);
+		}
+
+		range.deleteContents();
+		const textNode = document.createTextNode(text);
+		range.insertNode(textNode);
+		range.setStartAfter(textNode);
+		range.collapse(true);
+		selection.removeAllRanges();
+		selection.addRange(range);
 	}
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
 <!-- svelte-ignore a11y_missing_content -->
 <svelte:element
 	this={safeTag}
 	bind:this={el}
 	class={editableClass}
 	contenteditable="plaintext-only"
+	role="textbox"
+	tabindex="0"
+	aria-label="Inline text editor"
+	aria-multiline={isHeading ? 'false' : 'true'}
 	onkeydown={handleKeydown}
 	onblur={handleBlur}
 	onpaste={handlePaste}

--- a/src/lib/builder/editor/TopBar.svelte
+++ b/src/lib/builder/editor/TopBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getEditorState, type Viewport } from '../stores/editor.svelte.js';
-	import { Monitor, Tablet, Smartphone, ArrowLeft, Save } from '@lucide/svelte';
+	import { Monitor, Tablet, Smartphone, ArrowLeft, Save, MousePointer, Hand } from '@lucide/svelte';
 
 	const editor = getEditorState();
 
@@ -48,6 +48,25 @@
 				<Icon class="h-4 w-4" />
 			</button>
 		{/each}
+
+		<div class="mx-2 h-5 w-px bg-border"></div>
+
+		<!-- Edit/Interact mode toggle -->
+		<button
+			type="button"
+			class="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm font-medium transition-colors {editor.mode === 'interact'
+				? 'bg-accent text-accent-foreground'
+				: 'text-muted-foreground hover:text-foreground'}"
+			title={editor.mode === 'edit' ? 'Switch to Interact mode' : 'Switch to Edit mode'}
+			onclick={() => editor.toggleMode()}
+		>
+			{#if editor.mode === 'edit'}
+				<MousePointer class="h-4 w-4" />
+			{:else}
+				<Hand class="h-4 w-4" />
+			{/if}
+			<span class="text-xs">{editor.mode === 'edit' ? 'Edit' : 'Interact'}</span>
+		</button>
 
 		<div class="mx-2 h-5 w-px bg-border"></div>
 

--- a/src/lib/builder/stores/editor.svelte.ts
+++ b/src/lib/builder/stores/editor.svelte.ts
@@ -67,6 +67,7 @@ export class EditorState {
 		if (this.mode === 'interact') {
 			this.selectedBlockId = null;
 			this.stopInlineEdit();
+			this.endDrag();
 		}
 	}
 

--- a/src/lib/builder/stores/editor.svelte.ts
+++ b/src/lib/builder/stores/editor.svelte.ts
@@ -11,6 +11,7 @@ import { getBuilderComponent, getDefaultProps } from '../registry/index.js';
 import { findNode, findParentId, findParent, removeNode, moveNode, createBlockId } from '../utils/index.js';
 
 export type Viewport = 'desktop' | 'tablet' | 'mobile';
+export type EditorMode = 'edit' | 'interact';
 
 export type DragSource =
 	| { type: 'block'; blockId: string }
@@ -27,6 +28,8 @@ export class EditorState {
 	page: PageDocument = $state() as PageDocument;
 	selectedBlockId: string | null = $state(null);
 	viewport: Viewport = $state('desktop');
+	mode: EditorMode = $state('edit');
+	inlineEditBlockId: string | null = $state(null);
 
 	// Drag-and-drop state
 	dragSource: DragSource | null = $state(null);
@@ -56,6 +59,27 @@ export class EditorState {
 
 	deselectBlock() {
 		this.selectedBlockId = null;
+		this.stopInlineEdit();
+	}
+
+	toggleMode() {
+		this.mode = this.mode === 'edit' ? 'interact' : 'edit';
+		if (this.mode === 'interact') {
+			this.selectedBlockId = null;
+			this.stopInlineEdit();
+		}
+	}
+
+	startInlineEdit(id: string) {
+		if (this.mode !== 'edit') return;
+		const node = findNode(this.page.body, id);
+		if (!node || node.type !== '_text') return;
+		this.selectedBlockId = id;
+		this.inlineEditBlockId = id;
+	}
+
+	stopInlineEdit() {
+		this.inlineEditBlockId = null;
 	}
 
 	updateBlockProp(blockId: string, key: string, value: unknown) {


### PR DESCRIPTION
## Summary

- **Edit/Interact mode toggle** — TopBar button switches between Edit mode (`pointer-events: none` on components, clicks select blocks) and Interact mode (components respond to hover/click normally)
- **Responsive preview with CSS zoom** — `ResizeObserver` measures canvas container; tablet (768px) and mobile (375px) viewports use CSS `zoom` to fit within available space; viewport dimension label shown above canvas
- **Inline text editing** — double-click a `_text` block to edit its content via `contenteditable`; commits on blur, Escape, or Enter (for headings); updated text reflects in the property panel

## Files changed

| File | Change |
|------|--------|
| `src/lib/builder/stores/editor.svelte.ts` | Added `mode`, `inlineEditBlockId`, `toggleMode()`, `startInlineEdit()`, `stopInlineEdit()` |
| `src/lib/builder/editor/TopBar.svelte` | Edit/Interact toggle button (MousePointer/Hand icons) |
| `src/lib/builder/editor/BlockWrapper.svelte` | Pointer-events-none in edit mode, hide selection UI in interact mode, dblclick for inline editing |
| `src/lib/builder/editor/Canvas.svelte` | ResizeObserver + CSS zoom for responsive preview, viewport label, disabled deselect in interact mode |
| `src/lib/builder/editor/CanvasBlockRenderer.svelte` | Conditional InlineTextEditor rendering for `_text` blocks |
| `src/lib/builder/editor/InlineTextEditor.svelte` | **New** — contenteditable component matching `_text` block styling |
| `BUILDER.md` | Phase 4 marked as done |

## Test plan

- [ ] Click a ShimmerButton in edit mode → selects the block (no component interaction)
- [ ] Switch to Interact mode → hover/click effects work on components; selection/drag disabled
- [ ] Switch to mobile viewport → canvas shows 375px viewport zoomed to fit, "375 × 812" label visible
- [ ] Switch to tablet → 768px zoomed; desktop → full width, no zoom
- [ ] Double-click a `_text` block → text becomes editable with cursor; type new text; click away → text persists and appears in property panel's Content field
- [ ] `pnpm check` — no new errors