### PR TITLE
fix: eliminate parent scroll and pin Delete button in builder

### DIFF
--- a/src/lib/builder/editor/EditorLayout.svelte
+++ b/src/lib/builder/editor/EditorLayout.svelte
@@ -48,7 +48,7 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="grid h-screen grid-cols-[240px_1fr_320px]">
+<div class="grid flex-1 min-h-0 grid-cols-[240px_1fr_320px]">
 	<!-- Left panel: Palette + Layer Tree -->
 	<div class="flex flex-col border-r border-border bg-background">
 		<div class="shrink-0 border-b border-border px-2 py-2">
@@ -82,7 +82,7 @@
 	<AutoSave />
 
 	<!-- Right panel: Properties -->
-	<div class="overflow-y-auto border-l border-border bg-background">
+	<div class="flex flex-col overflow-hidden border-l border-border bg-background">
 		<div class="shrink-0 border-b border-border px-4 py-2">
 			<h2 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
 				Properties

--- a/src/lib/builder/editor/EditorLayout.svelte
+++ b/src/lib/builder/editor/EditorLayout.svelte
@@ -48,9 +48,9 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="grid flex-1 min-h-0 grid-cols-[240px_1fr_320px]">
+<div class="grid flex-1 min-h-0 grid-cols-[240px_1fr_320px] grid-rows-[1fr]">
 	<!-- Left panel: Palette + Layer Tree -->
-	<div class="flex flex-col border-r border-border bg-background">
+	<div class="flex flex-col overflow-hidden border-r border-border bg-background">
 		<div class="shrink-0 border-b border-border px-2 py-2">
 			<h2 class="px-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
 				Components

--- a/src/lib/builder/editor/PropertyPanel.svelte
+++ b/src/lib/builder/editor/PropertyPanel.svelte
@@ -14,7 +14,7 @@
 	}
 </script>
 
-<div class="flex h-full flex-col">
+<div class="flex min-h-0 flex-1 flex-col">
 	{#if editor.selectedBlock && editor.selectedMeta}
 		{@const block = editor.selectedBlock}
 		{@const meta = editor.selectedMeta}

--- a/src/lib/builder/editor/PropertyPanel.svelte
+++ b/src/lib/builder/editor/PropertyPanel.svelte
@@ -19,12 +19,12 @@
 		{@const block = editor.selectedBlock}
 		{@const meta = editor.selectedMeta}
 
-		<div class="border-b border-border px-4 py-3">
+		<div class="shrink-0 border-b border-border px-4 py-3">
 			<h3 class="text-sm font-semibold">{meta.name}</h3>
 			<p class="text-xs text-muted-foreground">{meta.slug}</p>
 		</div>
 
-		<div class="flex-1 space-y-4 overflow-y-auto p-4">
+		<div class="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
 			{#each Object.entries(meta.propSchemas) as [key, schema]}
 				<div>
 					<!-- svelte-ignore a11y_label_has_associated_control -->
@@ -82,7 +82,7 @@
 			{/each}
 		</div>
 
-		<div class="border-t border-border p-4">
+		<div class="shrink-0 border-t border-border p-4">
 			<button
 				type="button"
 				class="w-full rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"

--- a/src/routes/builder/+layout.svelte
+++ b/src/routes/builder/+layout.svelte
@@ -10,19 +10,21 @@
 	let { children, data }: Props = $props();
 </script>
 
-{#if data.user}
-	<div class="flex h-8 items-center justify-end gap-3 border-b border-border bg-muted/50 px-4 text-xs text-muted-foreground">
-		<span>{data.user.username}</span>
-		<form method="POST" action="/auth/logout">
-			<button
-				type="submit"
-				class="inline-flex items-center gap-1 hover:text-foreground"
-			>
-				<LogOut class="h-3 w-3" />
-				Logout
-			</button>
-		</form>
-	</div>
-{/if}
+<div class="flex h-screen flex-col overflow-hidden">
+	{#if data.user}
+		<div class="flex h-8 shrink-0 items-center justify-end gap-3 border-b border-border bg-muted/50 px-4 text-xs text-muted-foreground">
+			<span>{data.user.username}</span>
+			<form method="POST" action="/auth/logout">
+				<button
+					type="submit"
+					class="inline-flex items-center gap-1 hover:text-foreground"
+				>
+					<LogOut class="h-3 w-3" />
+					Logout
+				</button>
+			</form>
+		</div>
+	{/if}
 
-{@render children()}
+	{@render children()}
+</div>

--- a/src/routes/builder/+page.svelte
+++ b/src/routes/builder/+page.svelte
@@ -68,7 +68,7 @@
 	<title>Site Builder</title>
 </svelte:head>
 
-<div class="min-h-screen bg-background">
+<div class="min-h-0 flex-1 overflow-y-auto bg-background">
 	<div class="mx-auto max-w-4xl px-4 py-12">
 		<div class="mb-8 flex items-center justify-between">
 			<div>

--- a/src/routes/builder/new/+page.svelte
+++ b/src/routes/builder/new/+page.svelte
@@ -59,7 +59,7 @@
 	<title>New Page - Site Builder</title>
 </svelte:head>
 
-<div class="min-h-screen bg-background">
+<div class="min-h-0 flex-1 overflow-y-auto bg-background">
 	<div class="mx-auto max-w-lg px-4 py-12">
 		<a
 			href="/builder"


### PR DESCRIPTION
## Summary

- **Parent scroll removed**: Builder layout now wraps in `flex h-screen flex-col overflow-hidden` — the auth header + editor fill exactly the viewport, no body overflow
- **Delete button pinned**: Properties panel right column switched from `overflow-y-auto` to `flex flex-col overflow-hidden`, so PropertyPanel can pin the Delete button at the bottom while prop editors scroll independently
- **Dashboard/new-page scroll**: Changed from `min-h-screen` to `flex-1 overflow-y-auto` for internal scroll within the layout container

## Files changed

| File | Change |
|------|--------|
| `+layout.svelte` | Wrap in `flex h-screen flex-col overflow-hidden` |
| `EditorLayout.svelte` | `h-screen` → `flex-1 min-h-0`; right panel `overflow-y-auto` → `flex flex-col overflow-hidden` |
| `PropertyPanel.svelte` | `h-full` → `flex-1 min-h-0` |
| `+page.svelte` (dashboard) | `min-h-screen` → `flex-1 overflow-y-auto min-h-0` |
| `new/+page.svelte` | `min-h-screen` → `flex-1 overflow-y-auto min-h-0` |

## Test plan

- [ ] Editor: no scroll on the page body — only canvas, left panel sections, and right panel props scroll independently
- [ ] Select a block with many props — Delete button stays visible at the bottom without scrolling
- [ ] Dashboard (`/builder`) scrolls internally when many pages exist
- [ ] New page form (`/builder/new`) scrolls if viewport is small
- [ ] Auth header (when visible) doesn't push content below viewport