### PR TITLE
feat: keyboard shortcuts + copy/paste (Phase 6B)

### DIFF
--- a/src/lib/builder/editor/EditorLayout.svelte
+++ b/src/lib/builder/editor/EditorLayout.svelte
@@ -22,14 +22,70 @@
 		}
 
 		const mod = e.metaKey || e.ctrlKey;
-		if (!mod) return;
 
-		if (e.key === 'z' && !e.shiftKey) {
-			e.preventDefault();
-			editor.undo();
-		} else if ((e.key === 'z' && e.shiftKey) || (e.key === 'y' && !e.shiftKey)) {
-			e.preventDefault();
-			editor.redo();
+		if (mod) {
+			switch (e.key.toLowerCase()) {
+				case 'z':
+					e.preventDefault();
+					if (e.shiftKey) {
+						editor.redo();
+					} else {
+						editor.undo();
+					}
+					return;
+				case 'y':
+					if (!e.shiftKey) {
+						e.preventDefault();
+						editor.redo();
+					}
+					return;
+				case 's':
+					e.preventDefault();
+					editor.requestSave();
+					return;
+				case 'c':
+					e.preventDefault();
+					editor.copyBlock();
+					return;
+				case 'x':
+					e.preventDefault();
+					editor.cutBlock();
+					return;
+				case 'v':
+					e.preventDefault();
+					editor.pasteBlock();
+					return;
+				case 'd':
+					e.preventDefault();
+					editor.duplicateBlock();
+					return;
+			}
+			return;
+		}
+
+		// Non-modifier shortcuts (edit mode only)
+		if (editor.mode !== 'edit') return;
+
+		switch (e.key) {
+			case 'Delete':
+			case 'Backspace':
+				if (editor.selectedBlockId) {
+					e.preventDefault();
+					editor.removeBlock(editor.selectedBlockId);
+				}
+				return;
+			case 'ArrowUp':
+				e.preventDefault();
+				editor.selectPrev();
+				return;
+			case 'ArrowDown':
+				e.preventDefault();
+				editor.selectNext();
+				return;
+			case 'Escape':
+				e.preventDefault();
+				editor.deselectBlock();
+				return;
 		}
 	}
 

--- a/src/lib/builder/editor/EditorLayout.svelte
+++ b/src/lib/builder/editor/EditorLayout.svelte
@@ -69,8 +69,8 @@
 		switch (e.key) {
 			case 'Delete':
 			case 'Backspace':
+				e.preventDefault();
 				if (editor.selectedBlockId) {
-					e.preventDefault();
 					editor.removeBlock(editor.selectedBlockId);
 				}
 				return;

--- a/src/lib/builder/editor/TopBar.svelte
+++ b/src/lib/builder/editor/TopBar.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { getEditorState, type Viewport } from '../stores/editor.svelte.js';
 	import { deleteDraft } from '../storage/indexeddb.js';
 	import { Monitor, Tablet, Smartphone, ArrowLeft, Save, MousePointer, Hand, Loader2, Check, Undo2, Redo2 } from '@lucide/svelte';
 
 	const editor = getEditorState();
+
+	// Wire Cmd+S → handleSave
+	onMount(() => {
+		editor.onSave = handleSave;
+		return () => {
+			editor.onSave = null;
+		};
+	});
 
 	const viewportOptions: { icon: typeof Monitor; value: Viewport; label: string }[] = [
 		{ icon: Monitor, value: 'desktop', label: 'Desktop' },

--- a/src/lib/builder/stores/editor-undo.test.ts
+++ b/src/lib/builder/stores/editor-undo.test.ts
@@ -299,4 +299,280 @@ describe('EditorState undo/redo integration', () => {
 			expect(bodyIds(editor)).toEqual(['a', 'b']);
 		});
 	});
+
+	describe('copy and paste', () => {
+		it('copies selected block and pastes after it with fresh ID', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a'), makeBlock('b')] })
+			);
+
+			editor.selectBlock('a');
+			editor.copyBlock();
+			expect(editor.clipboard).not.toBeNull();
+			expect(editor.clipboard!.id).not.toBe('a');
+
+			editor.pasteBlock();
+			expect(editor.page.body).toHaveLength(3);
+			// Pasted block should be after 'a', before 'b'
+			expect(editor.page.body[0].id).toBe('a');
+			expect(editor.page.body[2].id).toBe('b');
+			// Pasted block has new ID, same content
+			const pasted = editor.page.body[1];
+			expect(pasted.id).not.toBe('a');
+			expect(pasted.props.content).toBe('a');
+			// Selection moves to pasted
+			expect(editor.selectedBlockId).toBe(pasted.id);
+		});
+
+		it('paste twice generates different IDs each time', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a')] })
+			);
+
+			editor.selectBlock('a');
+			editor.copyBlock();
+
+			editor.pasteBlock();
+			const firstPastedId = editor.selectedBlockId;
+
+			editor.pasteBlock();
+			const secondPastedId = editor.selectedBlockId;
+
+			expect(firstPastedId).not.toBe(secondPastedId);
+			expect(editor.page.body).toHaveLength(3);
+		});
+
+		it('paste with no selection appends to root', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a')] })
+			);
+
+			editor.selectBlock('a');
+			editor.copyBlock();
+			editor.deselectBlock();
+
+			editor.pasteBlock();
+			expect(editor.page.body).toHaveLength(2);
+			expect(editor.page.body[1].props.content).toBe('a');
+		});
+
+		it('paste is undoable', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a')] })
+			);
+
+			editor.selectBlock('a');
+			editor.copyBlock();
+			editor.pasteBlock();
+			expect(editor.page.body).toHaveLength(2);
+
+			editor.undo();
+			expect(editor.page.body).toHaveLength(1);
+			expect(editor.page.body[0].id).toBe('a');
+		});
+
+		it('does nothing if clipboard is empty', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a')] })
+			);
+
+			editor.pasteBlock();
+			expect(editor.page.body).toHaveLength(1);
+		});
+
+		it('does nothing if no block selected on copy', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a')] })
+			);
+
+			editor.copyBlock();
+			expect(editor.clipboard).toBeNull();
+		});
+	});
+
+	describe('cut', () => {
+		it('removes block and populates clipboard', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a'), makeBlock('b')] })
+			);
+
+			editor.selectBlock('a');
+			editor.cutBlock();
+
+			expect(bodyIds(editor)).toEqual(['b']);
+			expect(editor.clipboard).not.toBeNull();
+			expect(editor.clipboard!.props.content).toBe('a');
+		});
+
+		it('cut then paste restores block elsewhere', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a'), makeBlock('b'), makeBlock('c')] })
+			);
+
+			editor.selectBlock('a');
+			editor.cutBlock();
+			expect(bodyIds(editor)).toEqual(['b', 'c']);
+
+			editor.selectBlock('c');
+			editor.pasteBlock();
+
+			expect(editor.page.body).toHaveLength(3);
+			// Pasted after 'c'
+			const pasted = editor.page.body[2];
+			expect(pasted.props.content).toBe('a');
+		});
+
+		it('undo after cut restores the removed block', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a'), makeBlock('b')] })
+			);
+
+			editor.selectBlock('a');
+			editor.cutBlock();
+			expect(bodyIds(editor)).toEqual(['b']);
+
+			editor.undo();
+			expect(bodyIds(editor)).toEqual(['a', 'b']);
+			// Clipboard stays populated after undo
+			expect(editor.clipboard).not.toBeNull();
+		});
+	});
+
+	describe('duplicate', () => {
+		it('creates a copy after the selected block', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a'), makeBlock('b')] })
+			);
+
+			editor.selectBlock('a');
+			editor.duplicateBlock();
+
+			expect(editor.page.body).toHaveLength(3);
+			expect(editor.page.body[0].id).toBe('a');
+			expect(editor.page.body[2].id).toBe('b');
+			// Duplicate has same content but different ID
+			const dup = editor.page.body[1];
+			expect(dup.id).not.toBe('a');
+			expect(dup.props.content).toBe('a');
+			// Selection moves to duplicate
+			expect(editor.selectedBlockId).toBe(dup.id);
+		});
+
+		it('duplicate is undoable in one step', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a')] })
+			);
+
+			editor.selectBlock('a');
+			editor.duplicateBlock();
+			expect(editor.page.body).toHaveLength(2);
+
+			editor.undo();
+			expect(editor.page.body).toHaveLength(1);
+			expect(editor.page.body[0].id).toBe('a');
+			expect(editor.selectedBlockId).toBe('a');
+		});
+
+		it('does nothing with no selection', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a')] })
+			);
+
+			editor.duplicateBlock();
+			expect(editor.page.body).toHaveLength(1);
+		});
+	});
+
+	describe('arrow navigation', () => {
+		it('selectNext cycles through blocks in tree order', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a'), makeBlock('b'), makeBlock('c')] })
+			);
+
+			// No selection → selects first
+			editor.selectNext();
+			expect(editor.selectedBlockId).toBe('a');
+
+			editor.selectNext();
+			expect(editor.selectedBlockId).toBe('b');
+
+			editor.selectNext();
+			expect(editor.selectedBlockId).toBe('c');
+
+			// Wraps around
+			editor.selectNext();
+			expect(editor.selectedBlockId).toBe('a');
+		});
+
+		it('selectPrev cycles in reverse', () => {
+			const editor = new EditorState(
+				makePage({ body: [makeBlock('a'), makeBlock('b'), makeBlock('c')] })
+			);
+
+			// No selection → selects last
+			editor.selectPrev();
+			expect(editor.selectedBlockId).toBe('c');
+
+			editor.selectPrev();
+			expect(editor.selectedBlockId).toBe('b');
+
+			editor.selectPrev();
+			expect(editor.selectedBlockId).toBe('a');
+
+			// Wraps around
+			editor.selectPrev();
+			expect(editor.selectedBlockId).toBe('c');
+		});
+
+		it('handles nested children in tree order', () => {
+			const parentBlock: BlockNode = {
+				id: 'parent',
+				type: '_container',
+				props: {},
+				children: [makeBlock('child1'), makeBlock('child2')]
+			};
+			const editor = new EditorState(
+				makePage({ body: [parentBlock, makeBlock('sibling')] })
+			);
+
+			editor.selectNext();
+			expect(editor.selectedBlockId).toBe('parent');
+
+			editor.selectNext();
+			expect(editor.selectedBlockId).toBe('child1');
+
+			editor.selectNext();
+			expect(editor.selectedBlockId).toBe('child2');
+
+			editor.selectNext();
+			expect(editor.selectedBlockId).toBe('sibling');
+		});
+
+		it('does nothing with empty body', () => {
+			const editor = new EditorState(makePage());
+
+			editor.selectNext();
+			expect(editor.selectedBlockId).toBeNull();
+
+			editor.selectPrev();
+			expect(editor.selectedBlockId).toBeNull();
+		});
+	});
+
+	describe('requestSave', () => {
+		it('calls onSave callback when set', () => {
+			const editor = new EditorState(makePage());
+			const saveFn = vi.fn();
+			editor.onSave = saveFn;
+
+			editor.requestSave();
+			expect(saveFn).toHaveBeenCalledOnce();
+		});
+
+		it('does nothing when onSave is not set', () => {
+			const editor = new EditorState(makePage());
+			// Should not throw
+			editor.requestSave();
+		});
+	});
 });

--- a/src/lib/builder/stores/editor.svelte.ts
+++ b/src/lib/builder/stores/editor.svelte.ts
@@ -8,7 +8,7 @@
 import { setContext, getContext } from 'svelte';
 import type { PageDocument, BlockNode, BuilderComponentMeta } from '../types/index.js';
 import { getBuilderComponent, getDefaultProps } from '../registry/index.js';
-import { findNode, findParentId, findParent, removeNode, moveNode, createBlockId } from '../utils/index.js';
+import { findNode, findParentId, findParent, removeNode, moveNode, insertNode, cloneNode, flattenTree, createBlockId } from '../utils/index.js';
 import { HistoryManager } from './history.svelte.js';
 
 export type Viewport = 'desktop' | 'tablet' | 'mobile';
@@ -42,6 +42,12 @@ export class EditorState {
 	private history = new HistoryManager();
 	canUndo: boolean = $derived(this.history.canUndo);
 	canRedo: boolean = $derived(this.history.canRedo);
+
+	// Clipboard (in-memory, session-scoped)
+	clipboard: BlockNode | null = $state(null);
+
+	// Save callback — wired by TopBar
+	onSave: (() => void) | null = null;
 
 	isDragging = $derived(this.dragSource !== null);
 
@@ -249,6 +255,87 @@ export class EditorState {
 		if (!snapshot) return;
 		this.page = snapshot.page;
 		this.selectedBlockId = snapshot.selectedBlockId;
+	}
+
+	// --- Save ---
+
+	requestSave() {
+		this.onSave?.();
+	}
+
+	// --- Navigation ---
+
+	selectNext() {
+		const flat = flattenTree(this.page.body);
+		if (flat.length === 0) return;
+		if (!this.selectedBlockId) {
+			this.selectedBlockId = flat[0].id;
+			return;
+		}
+		const idx = flat.findIndex((n) => n.id === this.selectedBlockId);
+		const next = (idx + 1) % flat.length;
+		this.selectedBlockId = flat[next].id;
+	}
+
+	selectPrev() {
+		const flat = flattenTree(this.page.body);
+		if (flat.length === 0) return;
+		if (!this.selectedBlockId) {
+			this.selectedBlockId = flat[flat.length - 1].id;
+			return;
+		}
+		const idx = flat.findIndex((n) => n.id === this.selectedBlockId);
+		const prev = (idx - 1 + flat.length) % flat.length;
+		this.selectedBlockId = flat[prev].id;
+	}
+
+	// --- Clipboard ---
+
+	copyBlock() {
+		if (!this.selectedBlock) return;
+		const snapshot = $state.snapshot(this.selectedBlock);
+		this.clipboard = cloneNode(snapshot, createBlockId);
+	}
+
+	cutBlock() {
+		if (!this.selectedBlockId) return;
+		this.copyBlock();
+		this.removeBlock(this.selectedBlockId!);
+	}
+
+	pasteBlock() {
+		if (!this.clipboard) return;
+		const clone = cloneNode($state.snapshot(this.clipboard), createBlockId);
+
+		this.history.push(this.page, this.selectedBlockId, { type: 'structure' });
+
+		if (this.selectedBlockId) {
+			const parentId = findParentId(this.page.body, this.selectedBlockId);
+			const result = findParent(this.page.body, this.selectedBlockId);
+			if (result) {
+				insertNode(this.page.body, parentId, result.index + 1, clone);
+			}
+		} else {
+			this.page.body.push(clone);
+		}
+
+		this.selectedBlockId = clone.id;
+	}
+
+	duplicateBlock() {
+		if (!this.selectedBlockId || !this.selectedBlock) return;
+		const snapshot = $state.snapshot(this.selectedBlock);
+		const clone = cloneNode(snapshot, createBlockId);
+
+		this.history.push(this.page, this.selectedBlockId, { type: 'structure' });
+
+		const parentId = findParentId(this.page.body, this.selectedBlockId);
+		const result = findParent(this.page.body, this.selectedBlockId);
+		if (result) {
+			insertNode(this.page.body, parentId, result.index + 1, clone);
+		}
+
+		this.selectedBlockId = clone.id;
 	}
 }
 

--- a/src/lib/builder/stores/editor.svelte.ts
+++ b/src/lib/builder/stores/editor.svelte.ts
@@ -299,23 +299,23 @@ export class EditorState {
 
 	cutBlock() {
 		if (!this.selectedBlockId) return;
+		const blockId = this.selectedBlockId;
 		this.copyBlock();
-		this.removeBlock(this.selectedBlockId!);
+		this.removeBlock(blockId);
 	}
 
 	pasteBlock() {
 		if (!this.clipboard) return;
 		const clone = cloneNode($state.snapshot(this.clipboard), createBlockId);
 
-		this.history.push(this.page, this.selectedBlockId, { type: 'structure' });
-
 		if (this.selectedBlockId) {
 			const parentId = findParentId(this.page.body, this.selectedBlockId);
 			const result = findParent(this.page.body, this.selectedBlockId);
-			if (result) {
-				insertNode(this.page.body, parentId, result.index + 1, clone);
-			}
+			if (!result) return;
+			this.history.push(this.page, this.selectedBlockId, { type: 'structure' });
+			insertNode(this.page.body, parentId, result.index + 1, clone);
 		} else {
+			this.history.push(this.page, this.selectedBlockId, { type: 'structure' });
 			this.page.body.push(clone);
 		}
 
@@ -327,13 +327,12 @@ export class EditorState {
 		const snapshot = $state.snapshot(this.selectedBlock);
 		const clone = cloneNode(snapshot, createBlockId);
 
-		this.history.push(this.page, this.selectedBlockId, { type: 'structure' });
-
 		const parentId = findParentId(this.page.body, this.selectedBlockId);
 		const result = findParent(this.page.body, this.selectedBlockId);
-		if (result) {
-			insertNode(this.page.body, parentId, result.index + 1, clone);
-		}
+		if (!result) return;
+
+		this.history.push(this.page, this.selectedBlockId, { type: 'structure' });
+		insertNode(this.page.body, parentId, result.index + 1, clone);
 
 		this.selectedBlockId = clone.id;
 	}


### PR DESCRIPTION
## Summary

- **Clipboard operations**: Cmd/Ctrl+C (copy), Cmd/Ctrl+X (cut), Cmd/Ctrl+V (paste), Cmd/Ctrl+D (duplicate) — in-memory clipboard with fresh IDs on each paste via `cloneNode()`
- **Navigation**: ArrowUp/ArrowDown to cycle through blocks in tree order (edit mode only), Escape to deselect
- **Delete**: Delete/Backspace removes selected block (edit mode only)
- **Save**: Cmd/Ctrl+S triggers save (wired via `editor.onSave` callback set by TopBar)
- All shortcuts skip when focus is in INPUT/TEXTAREA/contenteditable

## Files changed

| File | Changes |
|------|---------|
| `editor.svelte.ts` | `clipboard`, `onSave` fields + 7 new methods (`requestSave`, `selectNext/Prev`, `copyBlock`, `cutBlock`, `pasteBlock`, `duplicateBlock`) |
| `EditorLayout.svelte` | Expanded `handleKeydown` with full switch/case for all shortcuts |
| `TopBar.svelte` | Wire `editor.onSave = handleSave` via `onMount` |
| `editor-undo.test.ts` | 14 new tests (30 total) covering clipboard, navigation, save |

## Test plan

- [ ] Cmd+S triggers save (same as clicking Save button)
- [ ] Select block → Delete → block removed
- [ ] ArrowDown/ArrowUp cycles through blocks in tree order
- [ ] Cmd+C on block → Cmd+V → duplicate appears after selected, with fresh IDs
- [ ] Cmd+V twice → two copies with different IDs
- [ ] Cmd+X → block removed + clipboard populated → Cmd+V → restored elsewhere
- [ ] Cmd+D → instant duplicate after selected block
- [ ] Cmd+Z after paste/cut/duplicate → reverts correctly
- [ ] Escape → deselects block
- [ ] All shortcuts ignored when typing in inputs/textareas