### PR TITLE
test: add E2E Playwright tests for builder

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+# E2E test env — override OAuth credentials to empty so auth is bypassed in dev mode
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+AUTH_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ vendor/
 .claude/
 .playwright-mcp/
 
+# Playwright
+test-results/
+playwright-report/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test": "vitest run",
-		"test:watch": "vitest"
+		"test:watch": "vitest",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui"
 	},
 	"devDependencies": {
 		"@internationalized/date": "^3.10.1",
 		"@lucide/svelte": "^0.562.0",
+		"@playwright/test": "^1.58.2",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/kit": "^2.49.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+	testDir: './tests/e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		baseURL: 'http://localhost:5174',
+		trace: 'on-first-retry'
+	},
+	projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+	webServer: {
+		command: 'pnpm dev --port 5174 --mode test',
+		port: 5174,
+		reuseExistingServer: !process.env.CI
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@lucide/svelte':
         specifier: ^0.562.0
         version: 0.562.0(svelte@5.46.1)
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@sveltejs/adapter-auto':
         specifier: ^7.0.0
         version: 7.0.0(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))
@@ -369,6 +372,11 @@ packages:
 
   '@oslojs/jwt@0.2.0':
     resolution: {integrity: sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -877,6 +885,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1064,6 +1077,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -1550,6 +1573,10 @@ snapshots:
     dependencies:
       '@oslojs/encoding': 0.4.1
 
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
   '@polka/url@1.0.0-next.29': {}
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
@@ -1996,6 +2023,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2151,6 +2181,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-selector-parser@6.0.10:
     dependencies:

--- a/src/lib/builder/editor/Canvas.svelte
+++ b/src/lib/builder/editor/Canvas.svelte
@@ -141,6 +141,7 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
 	class="relative flex-1 overflow-y-auto bg-muted/30 p-4"
+	data-testid="canvas"
 	bind:this={canvasEl}
 	onclick={handleCanvasClick}
 >

--- a/src/lib/builder/editor/PaletteItem.svelte
+++ b/src/lib/builder/editor/PaletteItem.svelte
@@ -65,6 +65,7 @@
 	type="button"
 	class="flex w-full cursor-grab items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors select-none hover:bg-accent hover:text-accent-foreground"
 	style="touch-action: none;"
+	data-testid="palette-item-{meta.slug}"
 	onclick={handleClick}
 	onpointerdown={onPointerDown}
 	title={meta.description}

--- a/tests/e2e/builder-dnd.spec.ts
+++ b/tests/e2e/builder-dnd.spec.ts
@@ -1,22 +1,22 @@
 import { test, expect } from '@playwright/test';
 
 const BUILDER_URL = '/builder/test';
+// process.platform matches the test runner OS — fine for local + CI where
+// runner and browser always share the same platform (no remote browsers).
 const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
 
 test.describe('Builder — Drag-and-drop (palette → canvas)', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto(BUILDER_URL);
 		await page.locator('[role="treeitem"]').first().waitFor({ timeout: 15000 });
+		// networkidle ensures Svelte hydration is complete before interacting
 		await page.waitForLoadState('networkidle');
 	});
 
 	test('Clicking a palette component adds it to the canvas and layer tree', async ({ page }) => {
 		const initialCount = await page.locator('[role="treeitem"]').count();
 
-		// Click "Spacer" from the palette — it's a button in the palette panel (left sidebar)
-		// Use a more specific selector to target palette buttons (not tree items)
-		const paletteButton = page.locator('button', { hasText: 'Spacer' }).first();
-		await paletteButton.click();
+		await page.locator('[data-testid="palette-item-_spacer"]').click();
 
 		// A new block should appear in the layer tree
 		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount + 1);
@@ -26,8 +26,7 @@ test.describe('Builder — Drag-and-drop (palette → canvas)', () => {
 		const initialCount = await page.locator('[role="treeitem"]').count();
 
 		// Add a component via click
-		const paletteButton = page.locator('button', { hasText: 'Spacer' }).first();
-		await paletteButton.click();
+		await page.locator('[data-testid="palette-item-_spacer"]').click();
 		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount + 1);
 
 		// Undo
@@ -39,9 +38,8 @@ test.describe('Builder — Drag-and-drop (palette → canvas)', () => {
 	test('Dragging a palette component to the canvas adds it', async ({ page }) => {
 		const initialCount = await page.locator('[role="treeitem"]').count();
 
-		// Locate a palette button and the canvas drop zone
-		const paletteBtn = page.locator('button', { hasText: 'Spacer' }).first();
-		const canvas = page.locator('.overflow-y-auto.bg-muted\\/30');
+		const paletteBtn = page.locator('[data-testid="palette-item-_spacer"]');
+		const canvas = page.locator('[data-testid="canvas"]');
 
 		// Get bounding boxes
 		const paletteBB = await paletteBtn.boundingBox();
@@ -49,7 +47,9 @@ test.describe('Builder — Drag-and-drop (palette → canvas)', () => {
 		expect(paletteBB).toBeTruthy();
 		expect(canvasBB).toBeTruthy();
 
-		// Simulate a pointer-event based drag (start → move past threshold → release on canvas)
+		// Simulate a pointer-event based drag (start → move past threshold → release on canvas).
+		// The component uses pointer events with a 5px drag threshold, so we move 10px first
+		// to initiate the drag, then glide to the canvas center before dropping.
 		const startX = paletteBB!.x + paletteBB!.width / 2;
 		const startY = paletteBB!.y + paletteBB!.height / 2;
 		const endX = canvasBB!.x + canvasBB!.width / 2;

--- a/tests/e2e/builder-dnd.spec.ts
+++ b/tests/e2e/builder-dnd.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+
+const BUILDER_URL = '/builder/test';
+const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+test.describe('Builder — Drag-and-drop (palette → canvas)', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(BUILDER_URL);
+		await page.locator('[role="treeitem"]').first().waitFor({ timeout: 15000 });
+		await page.waitForLoadState('networkidle');
+	});
+
+	test('Clicking a palette component adds it to the canvas and layer tree', async ({ page }) => {
+		const initialCount = await page.locator('[role="treeitem"]').count();
+
+		// Click "Spacer" from the palette — it's a button in the palette panel (left sidebar)
+		// Use a more specific selector to target palette buttons (not tree items)
+		const paletteButton = page.locator('button', { hasText: 'Spacer' }).first();
+		await paletteButton.click();
+
+		// A new block should appear in the layer tree
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount + 1);
+	});
+
+	test('Undo removes the added block', async ({ page }) => {
+		const initialCount = await page.locator('[role="treeitem"]').count();
+
+		// Add a component via click
+		const paletteButton = page.locator('button', { hasText: 'Spacer' }).first();
+		await paletteButton.click();
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount + 1);
+
+		// Undo
+		await page.keyboard.press(`${modifier}+z`);
+
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount);
+	});
+
+	test('Dragging a palette component to the canvas adds it', async ({ page }) => {
+		const initialCount = await page.locator('[role="treeitem"]').count();
+
+		// Locate a palette button and the canvas drop zone
+		const paletteBtn = page.locator('button', { hasText: 'Spacer' }).first();
+		const canvas = page.locator('.overflow-y-auto.bg-muted\\/30');
+
+		// Get bounding boxes
+		const paletteBB = await paletteBtn.boundingBox();
+		const canvasBB = await canvas.boundingBox();
+		expect(paletteBB).toBeTruthy();
+		expect(canvasBB).toBeTruthy();
+
+		// Simulate a pointer-event based drag (start → move past threshold → release on canvas)
+		const startX = paletteBB!.x + paletteBB!.width / 2;
+		const startY = paletteBB!.y + paletteBB!.height / 2;
+		const endX = canvasBB!.x + canvasBB!.width / 2;
+		const endY = canvasBB!.y + canvasBB!.height / 2;
+
+		await page.mouse.move(startX, startY);
+		await page.mouse.down();
+
+		// Move past the 5px drag threshold
+		await page.mouse.move(startX + 10, startY + 10, { steps: 3 });
+
+		// Move to canvas center
+		await page.mouse.move(endX, endY, { steps: 5 });
+
+		// Drop
+		await page.mouse.up();
+
+		// A new block should appear
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount + 1);
+	});
+});

--- a/tests/e2e/builder-save.spec.ts
+++ b/tests/e2e/builder-save.spec.ts
@@ -1,12 +1,15 @@
 import { test, expect } from '@playwright/test';
 
 const BUILDER_URL = '/builder/test';
+// process.platform matches the test runner OS — fine for local + CI where
+// runner and browser always share the same platform (no remote browsers).
 const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
 
 test.describe('Builder — Save', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto(BUILDER_URL);
 		await page.locator('[role="treeitem"]').first().waitFor({ timeout: 15000 });
+		// networkidle ensures Svelte hydration is complete before interacting
 		await page.waitForLoadState('networkidle');
 	});
 
@@ -31,7 +34,10 @@ test.describe('Builder — Save', () => {
 		// Should transition to "Saved" (green button)
 		await expect(page.getByRole('button', { name: 'Saved' })).toBeVisible({ timeout: 5000 });
 
-		// After ~2s should go back to "Save"
+		// After ~2s the button resets to "Save".
+		// Using toBeVisible with a timeout rather than a fixed waitForTimeout —
+		// Playwright auto-retries until the condition is met, which is more
+		// reliable than guessing a sleep duration.
 		await expect(page.getByRole('button', { name: 'Save' })).toBeVisible({ timeout: 5000 });
 	});
 

--- a/tests/e2e/builder-save.spec.ts
+++ b/tests/e2e/builder-save.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+const BUILDER_URL = '/builder/test';
+const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+test.describe('Builder — Save', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(BUILDER_URL);
+		await page.locator('[role="treeitem"]').first().waitFor({ timeout: 15000 });
+		await page.waitForLoadState('networkidle');
+	});
+
+	test('Cmd+S triggers save and the button cycles through Saving → Saved → Save', async ({
+		page
+	}) => {
+		// The button starts at "Save"
+		const saveBtn = page.getByRole('button', { name: 'Save' });
+		await expect(saveBtn).toBeVisible();
+
+		// Listen for the PUT request
+		const savePromise = page.waitForResponse(
+			(res) => res.url().includes('/api/builder/pages/test') && res.request().method() === 'PUT'
+		);
+
+		await page.keyboard.press(`${modifier}+s`);
+
+		// Wait for the API response
+		const response = await savePromise;
+		expect(response.ok()).toBe(true);
+
+		// Should transition to "Saved" (green button)
+		await expect(page.getByRole('button', { name: 'Saved' })).toBeVisible({ timeout: 5000 });
+
+		// After ~2s should go back to "Save"
+		await expect(page.getByRole('button', { name: 'Save' })).toBeVisible({ timeout: 5000 });
+	});
+
+	test('Clicking the Save button triggers save', async ({ page }) => {
+		const savePromise = page.waitForResponse(
+			(res) => res.url().includes('/api/builder/pages/test') && res.request().method() === 'PUT'
+		);
+
+		await page.getByRole('button', { name: 'Save' }).click();
+
+		const response = await savePromise;
+		expect(response.ok()).toBe(true);
+
+		await expect(page.getByRole('button', { name: 'Saved' })).toBeVisible({ timeout: 5000 });
+	});
+});

--- a/tests/e2e/builder-shortcuts.spec.ts
+++ b/tests/e2e/builder-shortcuts.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from '@playwright/test';
+
+const BUILDER_URL = '/builder/test';
+const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+/** Wait for the editor to be fully loaded and hydrated */
+async function waitForEditor(page: import('@playwright/test').Page) {
+	await page.locator('[role="treeitem"]').first().waitFor({ timeout: 15000 });
+	await page.waitForLoadState('networkidle');
+}
+
+/** Return the currently selected tree item (aria-selected="true") */
+function selectedItem(page: import('@playwright/test').Page) {
+	return page.locator('[role="treeitem"][aria-selected="true"]');
+}
+
+test.describe('Builder — Keyboard shortcuts', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(BUILDER_URL);
+		await waitForEditor(page);
+	});
+
+	test('ArrowDown selects the first block when nothing is selected', async ({ page }) => {
+		// Nothing selected initially
+		await expect(selectedItem(page)).toHaveCount(0);
+
+		await page.keyboard.press('ArrowDown');
+
+		await expect(selectedItem(page)).toHaveCount(1);
+	});
+
+	test('ArrowDown / ArrowUp navigates through the layer tree', async ({ page }) => {
+		// Select the first node
+		await page.keyboard.press('ArrowDown');
+		await expect(selectedItem(page)).toHaveCount(1);
+		const first = await selectedItem(page).getAttribute('data-drop-id');
+
+		// Move down
+		await page.keyboard.press('ArrowDown');
+		const second = await selectedItem(page).getAttribute('data-drop-id');
+		expect(second).not.toBe(first);
+
+		// Move back up
+		await page.keyboard.press('ArrowUp');
+		const backToFirst = await selectedItem(page).getAttribute('data-drop-id');
+		expect(backToFirst).toBe(first);
+	});
+
+	test('Escape deselects the current block', async ({ page }) => {
+		// Select a block
+		await page.locator('[role="treeitem"]').first().click();
+		await expect(selectedItem(page)).toHaveCount(1);
+
+		await page.keyboard.press('Escape');
+
+		await expect(selectedItem(page)).toHaveCount(0);
+	});
+
+	test('Cmd+D duplicates the selected block', async ({ page }) => {
+		const initialCount = await page.locator('[role="treeitem"]').count();
+
+		// Select the first root block (the spacer)
+		await page.locator('[role="treeitem"]').first().click();
+		await expect(selectedItem(page)).toHaveCount(1);
+
+		await page.keyboard.press(`${modifier}+d`);
+
+		// A duplicate should appear
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount + 1);
+	});
+
+	test('Cmd+Z undoes the duplication', async ({ page }) => {
+		const initialCount = await page.locator('[role="treeitem"]').count();
+
+		// Select and duplicate
+		await page.locator('[role="treeitem"]').first().click();
+		await page.keyboard.press(`${modifier}+d`);
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount + 1);
+
+		// Undo
+		await page.keyboard.press(`${modifier}+z`);
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount);
+	});
+
+	test('Backspace deletes the selected block', async ({ page }) => {
+		const initialCount = await page.locator('[role="treeitem"]').count();
+
+		// Select the first root block
+		await page.locator('[role="treeitem"]').first().click();
+
+		await page.keyboard.press('Backspace');
+
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount - 1);
+
+		// Undo to restore
+		await page.keyboard.press(`${modifier}+z`);
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount);
+	});
+
+	test('Cmd+C / Cmd+V copies and pastes a block', async ({ page }) => {
+		const initialCount = await page.locator('[role="treeitem"]').count();
+
+		// Select the first block
+		await page.locator('[role="treeitem"]').first().click();
+
+		// Copy
+		await page.keyboard.press(`${modifier}+c`);
+
+		// Paste
+		await page.keyboard.press(`${modifier}+v`);
+
+		// One new block added
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount + 1);
+
+		// Undo
+		await page.keyboard.press(`${modifier}+z`);
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount);
+	});
+
+	test('Cmd+X cuts (removes) the selected block', async ({ page }) => {
+		const initialCount = await page.locator('[role="treeitem"]').count();
+
+		// Select the first block
+		await page.locator('[role="treeitem"]').first().click();
+		await expect(selectedItem(page)).toHaveCount(1);
+		const cutId = await selectedItem(page).getAttribute('data-drop-id');
+
+		// Cut
+		await page.keyboard.press(`${modifier}+x`);
+
+		// Block removed
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount - 1);
+
+		// The cut block is no longer in the tree
+		await expect(page.locator(`[data-drop-id="${cutId}"]`)).toHaveCount(0);
+
+		// Undo restores it
+		await page.keyboard.press(`${modifier}+z`);
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount);
+	});
+
+	test('Shortcuts are ignored when focus is in an input', async ({ page }) => {
+		const initialCount = await page.locator('[role="treeitem"]').count();
+
+		// Select a block first
+		await page.locator('[role="treeitem"]').first().click();
+		await expect(selectedItem(page)).toHaveCount(1);
+
+		// Focus the title input in the top bar
+		const titleInput = page.locator('input[type="text"]').first();
+		await titleInput.click();
+
+		// Try to duplicate — should be ignored because we're in an input
+		await page.keyboard.press(`${modifier}+d`);
+
+		// Count should remain the same
+		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount);
+	});
+});

--- a/tests/e2e/builder-shortcuts.spec.ts
+++ b/tests/e2e/builder-shortcuts.spec.ts
@@ -1,9 +1,14 @@
 import { test, expect } from '@playwright/test';
 
 const BUILDER_URL = '/builder/test';
+// process.platform matches the test runner OS — fine for local + CI where
+// runner and browser always share the same platform (no remote browsers).
 const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
 
-/** Wait for the editor to be fully loaded and hydrated */
+/** Wait for the editor to be fully loaded and hydrated.
+ *  15s timeout covers slow CI cold-starts; locally the tree appears in <2s.
+ *  networkidle is required because Svelte 5 SSR renders the DOM before
+ *  hydration wires up event handlers — without it, the first click is a no-op. */
 async function waitForEditor(page: import('@playwright/test').Page) {
 	await page.locator('[role="treeitem"]').first().waitFor({ timeout: 15000 });
 	await page.waitForLoadState('networkidle');

--- a/tests/e2e/builder-shortcuts.spec.ts
+++ b/tests/e2e/builder-shortcuts.spec.ts
@@ -64,8 +64,8 @@ test.describe('Builder — Keyboard shortcuts', () => {
 	test('Cmd+D duplicates the selected block', async ({ page }) => {
 		const initialCount = await page.locator('[role="treeitem"]').count();
 
-		// Select the first root block (the spacer)
-		await page.locator('[role="treeitem"]').first().click();
+		// Select a leaf block (spacer) so the count changes by exactly 1
+		await page.locator('[role="treeitem"][data-drop-id="spacer-1"]').click();
 		await expect(selectedItem(page)).toHaveCount(1);
 
 		await page.keyboard.press(`${modifier}+d`);
@@ -77,8 +77,8 @@ test.describe('Builder — Keyboard shortcuts', () => {
 	test('Cmd+Z undoes the duplication', async ({ page }) => {
 		const initialCount = await page.locator('[role="treeitem"]').count();
 
-		// Select and duplicate
-		await page.locator('[role="treeitem"]').first().click();
+		// Select a leaf block and duplicate
+		await page.locator('[role="treeitem"][data-drop-id="spacer-1"]').click();
 		await page.keyboard.press(`${modifier}+d`);
 		await expect(page.locator('[role="treeitem"]')).toHaveCount(initialCount + 1);
 
@@ -90,8 +90,8 @@ test.describe('Builder — Keyboard shortcuts', () => {
 	test('Backspace deletes the selected block', async ({ page }) => {
 		const initialCount = await page.locator('[role="treeitem"]').count();
 
-		// Select the first root block
-		await page.locator('[role="treeitem"]').first().click();
+		// Select a leaf block (spacer)
+		await page.locator('[role="treeitem"][data-drop-id="spacer-1"]').click();
 
 		await page.keyboard.press('Backspace');
 
@@ -105,8 +105,8 @@ test.describe('Builder — Keyboard shortcuts', () => {
 	test('Cmd+C / Cmd+V copies and pastes a block', async ({ page }) => {
 		const initialCount = await page.locator('[role="treeitem"]').count();
 
-		// Select the first block
-		await page.locator('[role="treeitem"]').first().click();
+		// Select a leaf block (spacer)
+		await page.locator('[role="treeitem"][data-drop-id="spacer-1"]').click();
 
 		// Copy
 		await page.keyboard.press(`${modifier}+c`);
@@ -125,8 +125,8 @@ test.describe('Builder — Keyboard shortcuts', () => {
 	test('Cmd+X cuts (removes) the selected block', async ({ page }) => {
 		const initialCount = await page.locator('[role="treeitem"]').count();
 
-		// Select the first block
-		await page.locator('[role="treeitem"]').first().click();
+		// Select a leaf block (spacer)
+		await page.locator('[role="treeitem"][data-drop-id="spacer-1"]').click();
 		await expect(selectedItem(page)).toHaveCount(1);
 		const cutId = await selectedItem(page).getAttribute('data-drop-id');
 


### PR DESCRIPTION
## Summary
- Add Playwright E2E infrastructure (config, `.env.test` for auth bypass, scripts)
- **14 tests** across 3 specs covering builder integrations that unit tests cannot cover:
  - `builder-shortcuts.spec.ts` (9 tests) — arrow navigation, escape, Cmd+D/Z/C/V/X, Backspace, input focus bypass
  - `builder-save.spec.ts` (2 tests) — Cmd+S and click Save trigger PUT API, button state cycle (Saving → Saved → Save)
  - `builder-dnd.spec.ts` (3 tests) — palette click adds block, undo removes it, pointer drag from palette to canvas

## Test plan
- [x] `pnpm test:e2e` — all 14 tests pass (~10s)
- [ ] Verify existing unit tests still pass (`pnpm test`)
- [ ] Review that `.env.test` auth bypass is safe for CI