### PR TITLE
feat: GitHubStorage — git-based CMS for production builder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,16 @@ GITHUB_ALLOWED_USERS=your_username
 
 # Secret for signing session cookies (generate with: openssl rand -hex 32)
 AUTH_SECRET=your_secret_here
+
+# GitHub repo where pages are stored (required for production)
+GITHUB_REPO_OWNER=your_github_username
+GITHUB_REPO_NAME=your_repo_name
+
+# Optional: Personal Access Token (if set, used instead of OAuth token)
+# GITHUB_TOKEN=ghp_xxx
+
+# Optional: branch to commit to (default: main)
+# GITHUB_BRANCH=main
+
+# Optional: path within the repo for page JSON files (default: content/pages)
+# GITHUB_CONTENT_PATH=content/pages

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -5,6 +5,7 @@ declare global {
 		// interface Error {}
 		interface Locals {
 			user?: { username: string };
+			githubToken?: string;
 		}
 		// interface PageData {}
 		// interface PageState {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,7 +1,7 @@
 import { redirect, error } from '@sveltejs/kit';
 import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
-import { verifySessionCookie } from '$lib/server/auth/index.js';
+import { verifySessionCookie, getTokenFromCookie } from '$lib/server/auth/index.js';
 import type { Handle } from '@sveltejs/kit';
 
 export const handle: Handle = async ({ event, resolve }) => {
@@ -15,6 +15,13 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 		if (!authConfigured && dev) {
 			event.locals.user = { username: 'dev' };
+			// In dev without OAuth, githubToken stays undefined → factory falls back to FilesystemStorage
+		} else if (!authConfigured && !dev) {
+			// Production without OAuth configured — block access
+			if (isBuilderApi) {
+				error(403, 'Builder is not configured — set GitHub OAuth env vars');
+			}
+			error(403, 'Builder is not configured — set GitHub OAuth env vars');
 		} else {
 			const session = verifySessionCookie(event.cookies);
 
@@ -26,6 +33,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 			}
 
 			event.locals.user = session;
+			event.locals.githubToken = getTokenFromCookie(event.cookies) ?? undefined;
 		}
 	}
 

--- a/src/lib/builder/storage/errors.ts
+++ b/src/lib/builder/storage/errors.ts
@@ -1,0 +1,32 @@
+export type StorageErrorCode = 'NOT_FOUND' | 'CONFLICT' | 'AUTH' | 'UNKNOWN';
+
+export class StorageError extends Error {
+	readonly code: StorageErrorCode;
+	readonly statusCode: number;
+
+	constructor(code: StorageErrorCode, message: string) {
+		super(message);
+		this.name = 'StorageError';
+		this.code = code;
+		this.statusCode = STATUS_MAP[code];
+	}
+
+	static notFound(slug: string): StorageError {
+		return new StorageError('NOT_FOUND', `Page not found: ${slug}`);
+	}
+
+	static conflict(slug: string): StorageError {
+		return new StorageError('CONFLICT', `Page already exists: ${slug}`);
+	}
+
+	static auth(message = 'Authentication required'): StorageError {
+		return new StorageError('AUTH', message);
+	}
+}
+
+const STATUS_MAP: Record<StorageErrorCode, number> = {
+	NOT_FOUND: 404,
+	CONFLICT: 409,
+	AUTH: 401,
+	UNKNOWN: 500
+};

--- a/src/lib/builder/storage/factory.server.ts
+++ b/src/lib/builder/storage/factory.server.ts
@@ -1,0 +1,44 @@
+import { dev } from '$app/environment';
+import { env } from '$env/dynamic/private';
+import type { PageStorage } from './types.js';
+import { GitHubStorage } from './github.server.js';
+import { FilesystemStorage } from './filesystem.server.js';
+
+/**
+ * Returns the appropriate PageStorage for builder routes.
+ *
+ * Priority:
+ * 1. GITHUB_TOKEN env var (PAT)       → GitHubStorage
+ * 2. token param (OAuth user token)    → GitHubStorage
+ * 3. dev mode                          → FilesystemStorage
+ * 4. otherwise                         → throws
+ */
+export function getBuilderStorage(token?: string): PageStorage {
+	const pat = env.GITHUB_TOKEN;
+	const ghToken = pat || token;
+
+	if (ghToken) {
+		const owner = env.GITHUB_REPO_OWNER;
+		const repo = env.GITHUB_REPO_NAME;
+
+		if (!owner || !repo) {
+			throw new Error('GITHUB_REPO_OWNER and GITHUB_REPO_NAME must be set');
+		}
+
+		return new GitHubStorage({
+			token: ghToken,
+			owner,
+			repo,
+			branch: env.GITHUB_BRANCH || undefined,
+			contentPath: env.GITHUB_CONTENT_PATH || undefined
+		});
+	}
+
+	if (dev) {
+		return new FilesystemStorage();
+	}
+
+	throw new Error(
+		'No storage backend available. Set GITHUB_TOKEN or configure GitHub OAuth.'
+	);
+}

--- a/src/lib/builder/storage/filesystem.server.ts
+++ b/src/lib/builder/storage/filesystem.server.ts
@@ -2,6 +2,7 @@ import { readdir, readFile, writeFile, unlink, mkdir } from 'fs/promises';
 import { join, resolve } from 'path';
 import type { PageDocument } from '../types/page.js';
 import type { PageStorage, PageListItem } from './types.js';
+import { StorageError } from './errors.js';
 
 const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
@@ -61,7 +62,15 @@ export class FilesystemStorage implements PageStorage {
 	async get(slug: string): Promise<PageDocument> {
 		validateSlug(slug);
 
-		const raw = await readFile(this.filePath(slug), 'utf-8');
+		let raw: string;
+		try {
+			raw = await readFile(this.filePath(slug), 'utf-8');
+		} catch (err: unknown) {
+			if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+				throw StorageError.notFound(slug);
+			}
+			throw err;
+		}
 		const page: PageDocument = JSON.parse(raw);
 
 		if (page.version !== 1) {
@@ -85,7 +94,14 @@ export class FilesystemStorage implements PageStorage {
 
 	async delete(slug: string): Promise<void> {
 		validateSlug(slug);
-		await unlink(this.filePath(slug));
+		try {
+			await unlink(this.filePath(slug));
+		} catch (err: unknown) {
+			if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+				throw StorageError.notFound(slug);
+			}
+			throw err;
+		}
 	}
 
 	async publish(slug: string): Promise<void> {

--- a/src/lib/builder/storage/github.server.ts
+++ b/src/lib/builder/storage/github.server.ts
@@ -45,7 +45,7 @@ export class GitHubStorage implements PageStorage {
 		this.owner = config.owner;
 		this.repo = config.repo;
 		this.branch = config.branch ?? 'main';
-		this.contentPath = config.contentPath ?? 'content/pages';
+		this.contentPath = (config.contentPath ?? 'content/pages').replace(/^\/+|\/+$/g, '');
 	}
 
 	private get baseUrl(): string {
@@ -194,24 +194,28 @@ export class GitHubStorage implements PageStorage {
 			throw err;
 		}
 
+		const fileEntries = entries.filter(
+			(entry) => entry.type === 'file' && entry.name.endsWith('.json')
+		);
+
 		const pages: PageListItem[] = [];
 
-		for (const entry of entries) {
-			if (entry.type !== 'file' || !entry.name.endsWith('.json')) continue;
-
-			try {
-				const file = await this.request<GitHubFileResponse>(entry.path);
-				const doc: PageDocument = JSON.parse(this.decodeContent(file.content));
-				pages.push({
-					slug: doc.meta.slug,
-					title: doc.meta.title,
-					status: doc.meta.status,
-					updatedAt: doc.meta.updatedAt
-				});
-			} catch {
-				// Skip invalid files
-			}
-		}
+		await Promise.all(
+			fileEntries.map(async (entry) => {
+				try {
+					const file = await this.request<GitHubFileResponse>(entry.path);
+					const doc: PageDocument = JSON.parse(this.decodeContent(file.content));
+					pages.push({
+						slug: doc.meta.slug,
+						title: doc.meta.title,
+						status: doc.meta.status,
+						updatedAt: doc.meta.updatedAt
+					});
+				} catch {
+					// Skip invalid files
+				}
+			})
+		);
 
 		pages.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 		return pages;
@@ -268,13 +272,24 @@ export class GitHubStorage implements PageStorage {
 	}
 
 	async publish(slug: string): Promise<void> {
-		const page = await this.get(slug);
+		validateSlug(slug);
+
+		// Fetch once to get both content and SHA, avoiding race conditions
+		const { content, sha } = await this.getFile(slug);
+		const page: PageDocument = JSON.parse(content);
+
+		if (page.version !== 1) {
+			throw new Error(`Unsupported page version: ${page.version}`);
+		}
+		if (!page.meta || !page.meta.title || !page.meta.slug || !Array.isArray(page.body)) {
+			throw new Error('Malformed page document: missing required fields');
+		}
+
 		page.meta.status = 'published';
 		page.meta.updatedAt = new Date().toISOString();
 		const json = JSON.stringify(page, null, 2);
 		const path = this.filePath(slug);
 
-		const { sha } = await this.getFile(slug);
 		await this.putFile(path, json, `Publish page: ${slug}`, sha);
 	}
 }

--- a/src/lib/builder/storage/github.server.ts
+++ b/src/lib/builder/storage/github.server.ts
@@ -1,0 +1,280 @@
+import type { PageDocument } from '../types/page.js';
+import type { PageStorage, PageListItem } from './types.js';
+import { StorageError } from './errors.js';
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function validateSlug(slug: string): void {
+	if (!SLUG_RE.test(slug)) {
+		throw new Error(`Invalid page slug: ${slug}`);
+	}
+}
+
+interface GitHubFileResponse {
+	content: string;
+	sha: string;
+	name: string;
+	path: string;
+	encoding: string;
+}
+
+interface GitHubDirEntry {
+	name: string;
+	path: string;
+	sha: string;
+	type: 'file' | 'dir';
+}
+
+export interface GitHubStorageConfig {
+	token: string;
+	owner: string;
+	repo: string;
+	branch?: string;
+	contentPath?: string;
+}
+
+export class GitHubStorage implements PageStorage {
+	private token: string;
+	private owner: string;
+	private repo: string;
+	private branch: string;
+	private contentPath: string;
+
+	constructor(config: GitHubStorageConfig) {
+		this.token = config.token;
+		this.owner = config.owner;
+		this.repo = config.repo;
+		this.branch = config.branch ?? 'main';
+		this.contentPath = config.contentPath ?? 'content/pages';
+	}
+
+	private get baseUrl(): string {
+		return `https://api.github.com/repos/${this.owner}/${this.repo}/contents`;
+	}
+
+	private filePath(slug: string): string {
+		return `${this.contentPath}/${slug}.json`;
+	}
+
+	private async request<T>(
+		path: string,
+		options: RequestInit = {}
+	): Promise<T> {
+		const url = `${this.baseUrl}/${path}${path.includes('?') ? '&' : '?'}ref=${this.branch}`;
+
+		const res = await fetch(url, {
+			...options,
+			headers: {
+				Authorization: `Bearer ${this.token}`,
+				Accept: 'application/vnd.github.v3+json',
+				'Content-Type': 'application/json',
+				'X-GitHub-Api-Version': '2022-11-28',
+				...options.headers
+			}
+		});
+
+		if (!res.ok) {
+			if (res.status === 404) {
+				throw StorageError.notFound(path);
+			}
+			if (res.status === 401 || res.status === 403) {
+				throw StorageError.auth('GitHub API authentication failed');
+			}
+			if (res.status === 409) {
+				throw new StorageError('CONFLICT', 'SHA conflict — file was modified concurrently');
+			}
+			const body = await res.text().catch(() => '');
+			throw new StorageError('UNKNOWN', `GitHub API error ${res.status}: ${body}`);
+		}
+
+		return res.json() as Promise<T>;
+	}
+
+	/** PUT (create or update) a file — does NOT append ?ref= (uses `branch` in body) */
+	private async putFile(
+		path: string,
+		content: string,
+		message: string,
+		sha?: string
+	): Promise<void> {
+		const url = `${this.baseUrl}/${path}`;
+
+		const body: Record<string, string> = {
+			message,
+			content: Buffer.from(content, 'utf-8').toString('base64'),
+			branch: this.branch
+		};
+		if (sha) {
+			body.sha = sha;
+		}
+
+		const res = await fetch(url, {
+			method: 'PUT',
+			headers: {
+				Authorization: `Bearer ${this.token}`,
+				Accept: 'application/vnd.github.v3+json',
+				'Content-Type': 'application/json',
+				'X-GitHub-Api-Version': '2022-11-28'
+			},
+			body: JSON.stringify(body)
+		});
+
+		if (!res.ok) {
+			if (res.status === 401 || res.status === 403) {
+				throw StorageError.auth('GitHub API authentication failed');
+			}
+			if (res.status === 409) {
+				throw new StorageError('CONFLICT', 'SHA conflict — file was modified concurrently');
+			}
+			if (res.status === 422) {
+				// 422 can mean the file already exists when creating without sha
+				const text = await res.text().catch(() => '');
+				throw new StorageError('CONFLICT', `GitHub API 422: ${text}`);
+			}
+			const text = await res.text().catch(() => '');
+			throw new StorageError('UNKNOWN', `GitHub API error ${res.status}: ${text}`);
+		}
+	}
+
+	/** DELETE a file */
+	private async deleteFile(path: string, sha: string, message: string): Promise<void> {
+		const url = `${this.baseUrl}/${path}`;
+
+		const res = await fetch(url, {
+			method: 'DELETE',
+			headers: {
+				Authorization: `Bearer ${this.token}`,
+				Accept: 'application/vnd.github.v3+json',
+				'Content-Type': 'application/json',
+				'X-GitHub-Api-Version': '2022-11-28'
+			},
+			body: JSON.stringify({
+				message,
+				sha,
+				branch: this.branch
+			})
+		});
+
+		if (!res.ok) {
+			if (res.status === 404) {
+				throw StorageError.notFound(path);
+			}
+			if (res.status === 401 || res.status === 403) {
+				throw StorageError.auth('GitHub API authentication failed');
+			}
+			const text = await res.text().catch(() => '');
+			throw new StorageError('UNKNOWN', `GitHub API error ${res.status}: ${text}`);
+		}
+	}
+
+	private decodeContent(b64: string): string {
+		// GitHub returns base64 with newlines — strip them
+		const clean = b64.replace(/\n/g, '');
+		return Buffer.from(clean, 'base64').toString('utf-8');
+	}
+
+	/** Get file content and SHA */
+	private async getFile(slug: string): Promise<{ content: string; sha: string }> {
+		const path = this.filePath(slug);
+		const file = await this.request<GitHubFileResponse>(path);
+		return {
+			content: this.decodeContent(file.content),
+			sha: file.sha
+		};
+	}
+
+	async list(): Promise<PageListItem[]> {
+		let entries: GitHubDirEntry[];
+		try {
+			entries = await this.request<GitHubDirEntry[]>(this.contentPath);
+		} catch (err) {
+			if (err instanceof StorageError && err.code === 'NOT_FOUND') {
+				return []; // Directory doesn't exist yet
+			}
+			throw err;
+		}
+
+		const pages: PageListItem[] = [];
+
+		for (const entry of entries) {
+			if (entry.type !== 'file' || !entry.name.endsWith('.json')) continue;
+
+			try {
+				const file = await this.request<GitHubFileResponse>(entry.path);
+				const doc: PageDocument = JSON.parse(this.decodeContent(file.content));
+				pages.push({
+					slug: doc.meta.slug,
+					title: doc.meta.title,
+					status: doc.meta.status,
+					updatedAt: doc.meta.updatedAt
+				});
+			} catch {
+				// Skip invalid files
+			}
+		}
+
+		pages.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+		return pages;
+	}
+
+	async get(slug: string): Promise<PageDocument> {
+		validateSlug(slug);
+
+		const { content } = await this.getFile(slug);
+		const page: PageDocument = JSON.parse(content);
+
+		if (page.version !== 1) {
+			throw new Error(`Unsupported page version: ${page.version}`);
+		}
+		if (!page.meta || !page.meta.title || !page.meta.slug || !Array.isArray(page.body)) {
+			throw new Error('Malformed page document: missing required fields');
+		}
+
+		return page;
+	}
+
+	async save(page: PageDocument): Promise<void> {
+		validateSlug(page.meta.slug);
+		page.meta.updatedAt = new Date().toISOString();
+		const json = JSON.stringify(page, null, 2);
+		const path = this.filePath(page.meta.slug);
+
+		// Try to get existing file for SHA (update case)
+		let sha: string | undefined;
+		let isCreate = false;
+		try {
+			const existing = await this.getFile(page.meta.slug);
+			sha = existing.sha;
+		} catch (err) {
+			if (err instanceof StorageError && err.code === 'NOT_FOUND') {
+				isCreate = true;
+			} else {
+				throw err;
+			}
+		}
+
+		const message = isCreate
+			? `Create page: ${page.meta.slug}`
+			: `Update page: ${page.meta.slug}`;
+
+		await this.putFile(path, json, message, sha);
+	}
+
+	async delete(slug: string): Promise<void> {
+		validateSlug(slug);
+
+		const { sha } = await this.getFile(slug);
+		await this.deleteFile(this.filePath(slug), sha, `Delete page: ${slug}`);
+	}
+
+	async publish(slug: string): Promise<void> {
+		const page = await this.get(slug);
+		page.meta.status = 'published';
+		page.meta.updatedAt = new Date().toISOString();
+		const json = JSON.stringify(page, null, 2);
+		const path = this.filePath(slug);
+
+		const { sha } = await this.getFile(slug);
+		await this.putFile(path, json, `Publish page: ${slug}`, sha);
+	}
+}

--- a/src/lib/builder/storage/index.ts
+++ b/src/lib/builder/storage/index.ts
@@ -1,3 +1,6 @@
 export type { PageStorage, PageListItem } from './types.js';
 export { isValidSlug, isValidPageDocument } from './types.js';
 export { FilesystemStorage, getStorage } from './filesystem.server.js';
+export { GitHubStorage } from './github.server.js';
+export { getBuilderStorage } from './factory.server.js';
+export { StorageError } from './errors.js';

--- a/src/lib/server/auth/index.ts
+++ b/src/lib/server/auth/index.ts
@@ -1,2 +1,9 @@
 export { getGitHub, getAllowedUsers } from './github.js';
-export { createSessionCookie, verifySessionCookie, clearSessionCookie } from './session.js';
+export {
+	createSessionCookie,
+	verifySessionCookie,
+	clearSessionCookie,
+	createTokenCookie,
+	getTokenFromCookie,
+	clearTokenCookie
+} from './session.js';

--- a/src/lib/server/auth/session.ts
+++ b/src/lib/server/auth/session.ts
@@ -78,3 +78,28 @@ export function verifySessionCookie(cookies: Cookies): { username: string } | nu
 export function clearSessionCookie(cookies: Cookies): void {
 	cookies.delete(COOKIE_NAME, { path: '/' });
 }
+
+// --- GitHub token cookie (stores the OAuth access token for GitHub API calls) ---
+
+const TOKEN_COOKIE_NAME = 'builder_github_token';
+
+export function createTokenCookie(cookies: Cookies, token: string): void {
+	const value = sign(token);
+	cookies.set(TOKEN_COOKIE_NAME, value, {
+		path: '/',
+		httpOnly: true,
+		secure: !dev,
+		sameSite: 'lax',
+		maxAge: MAX_AGE
+	});
+}
+
+export function getTokenFromCookie(cookies: Cookies): string | null {
+	const cookie = cookies.get(TOKEN_COOKIE_NAME);
+	if (!cookie) return null;
+	return verify(cookie);
+}
+
+export function clearTokenCookie(cookies: Cookies): void {
+	cookies.delete(TOKEN_COOKIE_NAME, { path: '/' });
+}

--- a/src/routes/api/builder/pages/+server.ts
+++ b/src/routes/api/builder/pages/+server.ts
@@ -1,9 +1,9 @@
 import { json, error } from '@sveltejs/kit';
-import { getStorage, isValidSlug } from '$lib/builder/storage/index.js';
+import { getBuilderStorage, isValidSlug, StorageError } from '$lib/builder/storage/index.js';
 import type { PageDocument } from '$lib/builder/types/page.js';
 import type { RequestHandler } from './$types.js';
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, locals }) => {
 	let body: Record<string, unknown>;
 	try {
 		body = await request.json();
@@ -20,14 +20,14 @@ export const POST: RequestHandler = async ({ request }) => {
 		error(400, 'Valid slug is required (lowercase alphanumeric with hyphens)');
 	}
 
-	const storage = getStorage();
+	const storage = getBuilderStorage(locals.githubToken);
 
 	// Check if page already exists
 	try {
 		await storage.get(slug);
 		error(409, `Page "${slug}" already exists`);
 	} catch (err: unknown) {
-		if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+		if (err instanceof StorageError && err.code === 'NOT_FOUND') {
 			// Expected — page does not exist yet
 		} else if (err && typeof err === 'object' && 'status' in err && err.status === 409) {
 			throw err;

--- a/src/routes/api/builder/pages/[slug]/+server.ts
+++ b/src/routes/api/builder/pages/[slug]/+server.ts
@@ -1,5 +1,10 @@
 import { json, error } from '@sveltejs/kit';
-import { getStorage, isValidSlug, isValidPageDocument } from '$lib/builder/storage/index.js';
+import {
+	getBuilderStorage,
+	isValidSlug,
+	isValidPageDocument,
+	StorageError
+} from '$lib/builder/storage/index.js';
 import type { RequestHandler } from './$types.js';
 
 function validateSlug(slug: string) {
@@ -8,24 +13,24 @@ function validateSlug(slug: string) {
 	}
 }
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, locals }) => {
 	validateSlug(params.slug);
-	const storage = getStorage();
+	const storage = getBuilderStorage(locals.githubToken);
 
 	try {
 		const page = await storage.get(params.slug);
 		return json(page);
 	} catch (err: unknown) {
-		if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
-			error(404, `Page not found: ${params.slug}`);
+		if (err instanceof StorageError) {
+			error(err.statusCode, err.message);
 		}
 		throw err;
 	}
 };
 
-export const PUT: RequestHandler = async ({ params, request }) => {
+export const PUT: RequestHandler = async ({ params, request, locals }) => {
 	validateSlug(params.slug);
-	const storage = getStorage();
+	const storage = getBuilderStorage(locals.githubToken);
 
 	let page: unknown;
 	try {
@@ -47,6 +52,9 @@ export const PUT: RequestHandler = async ({ params, request }) => {
 		await storage.save(page);
 		return json({ ok: true, updatedAt: page.meta.updatedAt });
 	} catch (err: unknown) {
+		if (err instanceof StorageError) {
+			error(err.statusCode, err.message);
+		}
 		if (err instanceof Error) {
 			error(400, err.message);
 		}
@@ -54,16 +62,16 @@ export const PUT: RequestHandler = async ({ params, request }) => {
 	}
 };
 
-export const DELETE: RequestHandler = async ({ params }) => {
+export const DELETE: RequestHandler = async ({ params, locals }) => {
 	validateSlug(params.slug);
-	const storage = getStorage();
+	const storage = getBuilderStorage(locals.githubToken);
 
 	try {
 		await storage.delete(params.slug);
 		return json({ ok: true });
 	} catch (err: unknown) {
-		if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
-			error(404, `Page not found: ${params.slug}`);
+		if (err instanceof StorageError) {
+			error(err.statusCode, err.message);
 		}
 		throw err;
 	}

--- a/src/routes/api/builder/publish/+server.ts
+++ b/src/routes/api/builder/publish/+server.ts
@@ -1,8 +1,8 @@
 import { json, error } from '@sveltejs/kit';
-import { getStorage, isValidSlug } from '$lib/builder/storage/index.js';
+import { getBuilderStorage, isValidSlug, StorageError } from '$lib/builder/storage/index.js';
 import type { RequestHandler } from './$types.js';
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, locals }) => {
 	let body: Record<string, unknown>;
 	try {
 		body = await request.json();
@@ -16,14 +16,14 @@ export const POST: RequestHandler = async ({ request }) => {
 		error(400, 'Valid slug is required');
 	}
 
-	const storage = getStorage();
+	const storage = getBuilderStorage(locals.githubToken);
 
 	try {
 		await storage.publish(slug);
 		return json({ ok: true });
 	} catch (err: unknown) {
-		if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
-			error(404, `Page not found: ${slug}`);
+		if (err instanceof StorageError) {
+			error(err.statusCode, err.message);
 		}
 		throw err;
 	}

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -1,5 +1,10 @@
 import { error, redirect } from '@sveltejs/kit';
-import { getGitHub, getAllowedUsers, createSessionCookie } from '$lib/server/auth/index.js';
+import {
+	getGitHub,
+	getAllowedUsers,
+	createSessionCookie,
+	createTokenCookie
+} from '$lib/server/auth/index.js';
 import type { RequestHandler } from './$types.js';
 
 export const GET: RequestHandler = async ({ url, cookies }) => {
@@ -37,5 +42,6 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 	}
 
 	createSessionCookie(cookies, username);
+	createTokenCookie(cookies, accessToken);
 	redirect(302, '/builder');
 };

--- a/src/routes/auth/login/+server.ts
+++ b/src/routes/auth/login/+server.ts
@@ -1,13 +1,18 @@
-import { redirect } from '@sveltejs/kit';
+import { redirect, error } from '@sveltejs/kit';
 import { generateState } from 'arctic';
 import { getGitHub } from '$lib/server/auth/index.js';
 import type { RequestHandler } from './$types.js';
 
 export const GET: RequestHandler = async ({ cookies, url }) => {
-	const github = getGitHub();
-	const state = generateState();
+	let github;
+	try {
+		github = getGitHub();
+	} catch {
+		error(500, 'GitHub OAuth is not configured');
+	}
 
-	const authorizationUrl = github.createAuthorizationURL(state, ['read:user']);
+	const state = generateState();
+	const authorizationUrl = github.createAuthorizationURL(state, ['read:user', 'public_repo']);
 
 	cookies.set('github_oauth_state', state, {
 		path: '/',

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -1,8 +1,9 @@
 import { redirect } from '@sveltejs/kit';
-import { clearSessionCookie } from '$lib/server/auth/index.js';
+import { clearSessionCookie, clearTokenCookie } from '$lib/server/auth/index.js';
 import type { RequestHandler } from './$types.js';
 
 export const POST: RequestHandler = async ({ cookies }) => {
 	clearSessionCookie(cookies);
+	clearTokenCookie(cookies);
 	redirect(302, '/');
 };

--- a/src/routes/builder/+page.server.ts
+++ b/src/routes/builder/+page.server.ts
@@ -1,8 +1,8 @@
-import { getStorage } from '$lib/builder/storage/index.js';
+import { getBuilderStorage } from '$lib/builder/storage/index.js';
 import type { PageServerLoad } from './$types.js';
 
-export const load: PageServerLoad = async () => {
-	const storage = getStorage();
+export const load: PageServerLoad = async ({ locals }) => {
+	const storage = getBuilderStorage(locals.githubToken);
 	const pages = await storage.list();
 	return { pages };
 };

--- a/src/routes/builder/[slug]/+page.server.ts
+++ b/src/routes/builder/[slug]/+page.server.ts
@@ -1,20 +1,20 @@
 import { error } from '@sveltejs/kit';
-import { getStorage, isValidSlug } from '$lib/builder/storage/index.js';
+import { getBuilderStorage, isValidSlug, StorageError } from '$lib/builder/storage/index.js';
 import type { PageServerLoad } from './$types.js';
 
-export const load: PageServerLoad = async ({ params }) => {
+export const load: PageServerLoad = async ({ params, locals }) => {
 	if (!isValidSlug(params.slug)) {
 		error(400, 'Invalid page slug');
 	}
 
-	const storage = getStorage();
+	const storage = getBuilderStorage(locals.githubToken);
 
 	try {
 		const page = await storage.get(params.slug);
 		return { page };
 	} catch (err: unknown) {
-		if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
-			error(404, `Page not found: ${params.slug}`);
+		if (err instanceof StorageError) {
+			error(err.statusCode, err.message);
 		}
 		if (err instanceof Error) {
 			error(500, err.message);

--- a/src/routes/pages/[slug]/+page.server.ts
+++ b/src/routes/pages/[slug]/+page.server.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { getStorage, isValidSlug } from '$lib/builder/storage/index.js';
+import { getStorage, isValidSlug, StorageError } from '$lib/builder/storage/index.js';
 import type { PageServerLoad } from './$types.js';
 
 export const load: PageServerLoad = async ({ params }) => {
@@ -13,8 +13,8 @@ export const load: PageServerLoad = async ({ params }) => {
 		const page = await storage.get(params.slug);
 		return { page };
 	} catch (err: unknown) {
-		if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
-			error(404, `Page not found: ${params.slug}`);
+		if (err instanceof StorageError) {
+			error(err.statusCode, err.message);
 		}
 		if (err instanceof Error) {
 			error(500, err.message);


### PR DESCRIPTION
## Summary

- **GitHubStorage** backend that reads/writes page JSON via the GitHub Contents API — each save creates a commit, which triggers Vercel auto-redeploy
- **StorageError** class for uniform error handling across storage backends (replaces raw `ENOENT` checks)
- **`getBuilderStorage(token?)`** factory that selects the right backend: PAT env var → OAuth token → FilesystemStorage (dev only)
- OAuth token stored in a signed `httpOnly` cookie alongside the session cookie
- OAuth scope expanded to `public_repo` for write access
- Production guard: returns 403 if GitHub OAuth is not configured

## Architecture

| Route | Storage | Why |
|-------|---------|-----|
| `/pages/[slug]` (public) | FilesystemStorage | Fast, no token needed, reads deployed files |
| `/builder/*`, `/api/builder/*` | GitHubStorage | Fresh data, commits on save |

## Env vars required on Vercel

```
GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, AUTH_SECRET
GITHUB_REPO_OWNER, GITHUB_REPO_NAME
# Optional: GITHUB_TOKEN (PAT), GITHUB_BRANCH, GITHUB_CONTENT_PATH
```

## Test plan

- [ ] `pnpm check` passes (only pre-existing warnings)
- [ ] `pnpm test` — 404/404 tests pass
- [ ] `pnpm build` succeeds
- [ ] Dev mode: builder still works with FilesystemStorage (no env vars needed)
- [ ] Production: set env vars on Vercel, login via OAuth, save a page → verify commit on GitHub