### PR TITLE
feat: add TextGenerateEffect component

### DIFF
--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -48,6 +48,7 @@ export * from "./sparkles/index.js";
 export * from "./glowing-effect/index.js";
 export * from "./confetti/index.js";
 export * from "./ripple/index.js";
+export * from "./text-generate-effect/index.js";
 export * from "./tracing-beam/index.js";
 
 // =============================================================================

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -452,6 +452,14 @@ export const registry: Record<string, ComponentMeta> = {
 		status: "done",
 	},
 
+	"text-generate-effect": {
+		name: "TextGenerateEffect",
+		slug: "text-generate-effect",
+		description: "Typewriter-style text reveal that fades in words one by one with optional blur",
+		category: "text",
+		status: "done",
+	},
+
 	"tracing-beam": {
 		name: "TracingBeam",
 		slug: "tracing-beam",

--- a/src/lib/fancy-ui/text-generate-effect/README.md
+++ b/src/lib/fancy-ui/text-generate-effect/README.md
@@ -1,0 +1,14 @@
+# TextGenerateEffect
+
+Typewriter-style text reveal that fades in words one by one with an optional blur effect.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `words` | `string` | required | Text to animate (split on spaces) |
+| `filter` | `boolean` | `true` | Enable blur-to-sharp transition |
+| `duration` | `number` | `0.7` | Transition duration per word (seconds) |
+| `delay` | `number` | `0` | Initial delay before animation starts (ms) |
+| `stagger` | `number` | `200` | Delay between each word appearing (ms) |
+| `class` | `string` | — | Additional CSS classes |

--- a/src/lib/fancy-ui/text-generate-effect/TextGenerateEffect.svelte
+++ b/src/lib/fancy-ui/text-generate-effect/TextGenerateEffect.svelte
@@ -1,0 +1,68 @@
+<script lang="ts" module>
+	export interface TextGenerateEffectProps {
+		words: string;
+		filter?: boolean;
+		duration?: number;
+		delay?: number;
+		stagger?: number;
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { onMount } from 'svelte';
+
+	let {
+		words,
+		filter = true,
+		duration = 0.7,
+		delay = 0,
+		stagger = 200,
+		class: className
+	}: TextGenerateEffectProps = $props();
+
+	let wordsArray = $derived(words.split(' '));
+	let scopeRef: HTMLDivElement;
+
+	onMount(() => {
+		const spans = scopeRef.querySelectorAll<HTMLSpanElement>('span');
+
+		const timeout = setTimeout(() => {
+			spans.forEach((span, index) => {
+				const wordTimeout = setTimeout(() => {
+					span.style.opacity = '1';
+					span.style.filter = filter ? 'blur(0px)' : 'none';
+				}, index * stagger);
+
+				// Store timeout ID for cleanup
+				(span as HTMLSpanElement & { _tid?: ReturnType<typeof setTimeout> })._tid =
+					wordTimeout;
+			});
+		}, delay);
+
+		return () => {
+			clearTimeout(timeout);
+			spans.forEach((span) => {
+				const tid = (span as HTMLSpanElement & { _tid?: ReturnType<typeof setTimeout> })
+					._tid;
+				if (tid) clearTimeout(tid);
+			});
+		};
+	});
+</script>
+
+<div class={cn('leading-snug tracking-wide', className)}>
+	<div bind:this={scopeRef}>
+		{#each wordsArray as word, idx (word + idx)}
+			<span
+				class="inline-block"
+				style="opacity: 0; filter: {filter
+					? 'blur(10px)'
+					: 'none'}; transition: opacity {duration}s, filter {duration}s;"
+			>
+				{word}&nbsp;
+			</span>
+		{/each}
+	</div>
+</div>

--- a/src/lib/fancy-ui/text-generate-effect/TextGenerateEffect.test.ts
+++ b/src/lib/fancy-ui/text-generate-effect/TextGenerateEffect.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import TextGenerateEffect from './TextGenerateEffect.svelte';
+
+describe('TextGenerateEffect', () => {
+	it('renders all words as spans', () => {
+		const { container } = render(TextGenerateEffect, {
+			props: { words: 'hello world test' }
+		});
+		const spans = container.querySelectorAll('span');
+		expect(spans.length).toBe(3);
+	});
+
+	it('words start hidden with blur', () => {
+		const { container } = render(TextGenerateEffect, {
+			props: { words: 'fade in' }
+		});
+		const spans = container.querySelectorAll('span');
+		expect(spans[0].style.opacity).toBe('0');
+		expect(spans[0].style.filter).toContain('blur(10px)');
+	});
+
+	it('words start hidden without blur when filter is false', () => {
+		const { container } = render(TextGenerateEffect, {
+			props: { words: 'no blur', filter: false }
+		});
+		const spans = container.querySelectorAll('span');
+		expect(spans[0].style.opacity).toBe('0');
+		expect(spans[0].style.filter).toBe('none');
+	});
+
+	it('reveals words after stagger delay', async () => {
+		vi.useFakeTimers();
+		const { container } = render(TextGenerateEffect, {
+			props: { words: 'one two three', stagger: 100 }
+		});
+		const spans = container.querySelectorAll('span');
+
+		// Flush the outer setTimeout(fn, 0) + first word setTimeout(fn, 0)
+		await vi.advanceTimersByTimeAsync(1);
+		expect(spans[0].style.opacity).toBe('1');
+		expect(spans[1].style.opacity).toBe('0');
+
+		// After 100ms — second word
+		await vi.advanceTimersByTimeAsync(100);
+		expect(spans[1].style.opacity).toBe('1');
+		expect(spans[2].style.opacity).toBe('0');
+
+		// After 200ms — third word
+		await vi.advanceTimersByTimeAsync(100);
+		expect(spans[2].style.opacity).toBe('1');
+
+		vi.useRealTimers();
+	});
+
+	it('respects initial delay', async () => {
+		vi.useFakeTimers();
+		const { container } = render(TextGenerateEffect, {
+			props: { words: 'delayed text', delay: 500 }
+		});
+		const spans = container.querySelectorAll('span');
+
+		await vi.advanceTimersByTimeAsync(499);
+		expect(spans[0].style.opacity).toBe('0');
+
+		await vi.advanceTimersByTimeAsync(2);
+		expect(spans[0].style.opacity).toBe('1');
+
+		vi.useRealTimers();
+	});
+
+	it('applies custom class', () => {
+		const { container } = render(TextGenerateEffect, {
+			props: { words: 'styled', class: 'my-class' }
+		});
+		const wrapper = container.firstElementChild as HTMLElement;
+		expect(wrapper.className).toContain('my-class');
+	});
+
+	it('sets custom duration in transition style', () => {
+		const { container } = render(TextGenerateEffect, {
+			props: { words: 'fast', duration: 0.3 }
+		});
+		const span = container.querySelector('span') as HTMLElement;
+		expect(span.style.transition).toContain('0.3s');
+	});
+});

--- a/src/lib/fancy-ui/text-generate-effect/index.ts
+++ b/src/lib/fancy-ui/text-generate-effect/index.ts
@@ -1,0 +1,2 @@
+export { default as TextGenerateEffect } from './TextGenerateEffect.svelte';
+export type { TextGenerateEffectProps } from './TextGenerateEffect.svelte';

--- a/src/routes/demo/text-generate-effect/+page.svelte
+++ b/src/routes/demo/text-generate-effect/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { TextGenerateEffect } from '$lib/fancy-ui/text-generate-effect';
+</script>
+
+<svelte:head>
+	<title>TextGenerateEffect - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">TextGenerateEffect</h1>
+	<p class="text-muted-foreground mb-8">
+		Typewriter-style text reveal that fades in words one by one with an optional blur effect.
+	</p>
+
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="border rounded-lg p-8 bg-card">
+			<TextGenerateEffect
+				words="Svelte is a radical new approach to building user interfaces. It shifts work from the browser to a compile step that happens when you build your app."
+			/>
+		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Without Blur</h2>
+		<div class="border rounded-lg p-8 bg-card">
+			<TextGenerateEffect
+				words="This text fades in without the blur effect, using a simple opacity transition."
+				filter={false}
+			/>
+		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Fast Reveal</h2>
+		<div class="border rounded-lg p-8 bg-card">
+			<TextGenerateEffect
+				words="Quick reveal with a short duration and tight stagger between words."
+				duration={0.3}
+				stagger={80}
+			/>
+		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Slow & Dramatic</h2>
+		<div class="border rounded-lg p-8 bg-card">
+			<TextGenerateEffect
+				words="Each word appears slowly with a long pause between them for dramatic effect."
+				duration={1.5}
+				stagger={500}
+				class="text-2xl font-semibold"
+			/>
+		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Delayed Start</h2>
+		<div class="border rounded-lg p-8 bg-card">
+			<TextGenerateEffect
+				words="This text waits one second before starting to reveal."
+				delay={1000}
+			/>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary

- Typewriter-style text reveal — fades in words one by one with optional blur-to-sharp transition
- Added `stagger` prop (not in original) for configurable delay between words

## Files

- `src/lib/fancy-ui/text-generate-effect/TextGenerateEffect.svelte` — component
- `src/lib/fancy-ui/text-generate-effect/TextGenerateEffect.test.ts` — 7 tests
- `src/lib/fancy-ui/text-generate-effect/index.ts` — re-exports
- `src/lib/fancy-ui/text-generate-effect/README.md` — docs
- `src/routes/demo/text-generate-effect/+page.svelte` — demo with 5 variants
- `src/lib/fancy-ui/index.ts` — added export
- `src/lib/fancy-ui/registry.ts` — added entry (category: text)

## Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `words` | `string` | required | Text to animate |
| `filter` | `boolean` | `true` | Enable blur effect |
| `duration` | `number` | `0.7` | Transition duration (s) |
| `delay` | `number` | `0` | Initial delay (ms) |
| `stagger` | `number` | `200` | Delay between words (ms) |
| `class` | `string` | — | Additional CSS classes |

## Test plan
- [x] 7 unit tests passing
- [ ] Visual check on `/demo/text-generate-effect`