### PR TITLE
feat: add LineShadowText component

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -354,12 +354,13 @@
 - [ ] **radiant-text** - Glowing radiant text
 - [ ] **spinning-text** - Circular spinning text
 - [ ] **text-3d** - 3D extruded text
-- [ ] **text-generate-effect** - Typewriter text generation
+- [x] **text-generate-effect** - Typewriter text generation
 - [ ] **text-glitch** - Glitchy text effect
 - [ ] **text-highlight** - Animated text highlight
 - [ ] **text-hover-effect** - Text with hover animations
 - [ ] **text-reveal** - Text reveal on scroll
 - [ ] **text-scroll-reveal** - Scroll-triggered text reveal
+- [x] **line-shadow-text** - Text with line shadow
 - [ ] **video-text** - Video masked text
 
 ### 8.4 Backgrounds — 4/19 (21%)

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -49,6 +49,7 @@ export * from "./glowing-effect/index.js";
 export * from "./confetti/index.js";
 export * from "./ripple/index.js";
 export * from "./text-generate-effect/index.js";
+export * from "./line-shadow-text/index.js";
 export * from "./tracing-beam/index.js";
 
 // =============================================================================

--- a/src/lib/fancy-ui/line-shadow-text/LineShadowText.svelte
+++ b/src/lib/fancy-ui/line-shadow-text/LineShadowText.svelte
@@ -1,0 +1,50 @@
+<script lang="ts" module>
+	export interface LineShadowTextProps {
+		text: string;
+		shadowColor?: string;
+		as?: 'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'div';
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let { text, shadowColor = 'black', as = 'span', class: className }: LineShadowTextProps =
+		$props();
+
+	let style = $derived(`--shadow-color: ${shadowColor}`);
+</script>
+
+<svelte:element
+	this={as}
+	class={cn(
+		'line-shadow-text relative z-0 inline-flex',
+		'after:absolute after:left-[0.04em] after:top-[0.04em] after:-z-10',
+		'after:bg-[linear-gradient(45deg,transparent_45%,var(--shadow-color)_45%,var(--shadow-color)_55%,transparent_0)]',
+		'after:bg-[length:0.06em_0.06em] after:bg-clip-text after:text-transparent',
+		"after:content-[attr(data-text)]",
+		className
+	)}
+	{style}
+	data-text={text}
+>
+	{text}
+</svelte:element>
+
+<style>
+	:global {
+		@keyframes line-shadow {
+			0% {
+				background-position: 0 0;
+			}
+			100% {
+				background-position: 100% -100%;
+			}
+		}
+	}
+
+	.line-shadow-text::after {
+		animation: line-shadow 15s linear infinite;
+	}
+</style>

--- a/src/lib/fancy-ui/line-shadow-text/LineShadowText.test.ts
+++ b/src/lib/fancy-ui/line-shadow-text/LineShadowText.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import LineShadowText from './LineShadowText.svelte';
+
+describe('LineShadowText', () => {
+	it('renders text content', () => {
+		const { container } = render(LineShadowText, {
+			props: { text: 'Hello' }
+		});
+		expect(container.textContent).toContain('Hello');
+	});
+
+	it('sets data-text attribute for ::after content', () => {
+		const { container } = render(LineShadowText, {
+			props: { text: 'Shadow' }
+		});
+		const el = container.firstElementChild as HTMLElement;
+		expect(el.dataset.text).toBe('Shadow');
+	});
+
+	it('renders as span by default', () => {
+		const { container } = render(LineShadowText, {
+			props: { text: 'Default' }
+		});
+		expect(container.querySelector('span')).toBeTruthy();
+	});
+
+	it('renders as custom element', () => {
+		const { container } = render(LineShadowText, {
+			props: { text: 'Heading', as: 'h1' }
+		});
+		expect(container.querySelector('h1')).toBeTruthy();
+	});
+
+	it('sets shadow color CSS variable', () => {
+		const { container } = render(LineShadowText, {
+			props: { text: 'Colored', shadowColor: 'red' }
+		});
+		const el = container.firstElementChild as HTMLElement;
+		expect(el.style.getPropertyValue('--shadow-color')).toBe('red');
+	});
+
+	it('defaults shadow color to black', () => {
+		const { container } = render(LineShadowText, {
+			props: { text: 'Default color' }
+		});
+		const el = container.firstElementChild as HTMLElement;
+		expect(el.style.getPropertyValue('--shadow-color')).toBe('black');
+	});
+
+	it('applies custom class', () => {
+		const { container } = render(LineShadowText, {
+			props: { text: 'Styled', class: 'text-4xl font-bold' }
+		});
+		const el = container.firstElementChild as HTMLElement;
+		expect(el.className).toContain('text-4xl');
+		expect(el.className).toContain('font-bold');
+	});
+
+	it('has line-shadow-text class for animation', () => {
+		const { container } = render(LineShadowText, {
+			props: { text: 'Animated' }
+		});
+		const el = container.firstElementChild as HTMLElement;
+		expect(el.className).toContain('line-shadow-text');
+	});
+});

--- a/src/lib/fancy-ui/line-shadow-text/README.md
+++ b/src/lib/fancy-ui/line-shadow-text/README.md
@@ -1,0 +1,12 @@
+# LineShadowText
+
+Text with an animated diagonal line shadow pattern that scrolls continuously behind the text.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `text` | `string` | required | Text content to display |
+| `shadowColor` | `string` | `'black'` | Color of the line shadow |
+| `as` | `string` | `'span'` | HTML element to render as |
+| `class` | `string` | — | Additional CSS classes |

--- a/src/lib/fancy-ui/line-shadow-text/index.ts
+++ b/src/lib/fancy-ui/line-shadow-text/index.ts
@@ -1,0 +1,2 @@
+export { default as LineShadowText } from './LineShadowText.svelte';
+export type { LineShadowTextProps } from './LineShadowText.svelte';

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -460,6 +460,14 @@ export const registry: Record<string, ComponentMeta> = {
 		status: "done",
 	},
 
+	"line-shadow-text": {
+		name: "LineShadowText",
+		slug: "line-shadow-text",
+		description: "Text with animated diagonal line shadow pattern that scrolls continuously",
+		category: "text",
+		status: "done",
+	},
+
 	"tracing-beam": {
 		name: "TracingBeam",
 		slug: "tracing-beam",

--- a/src/routes/demo/line-shadow-text/+page.svelte
+++ b/src/routes/demo/line-shadow-text/+page.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { LineShadowText } from '$lib/fancy-ui/line-shadow-text';
+</script>
+
+<svelte:head>
+	<title>LineShadowText - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto py-12 px-4">
+	<h1 class="text-3xl font-bold mb-2">LineShadowText</h1>
+	<p class="text-muted-foreground mb-8">
+		Text with an animated diagonal line shadow pattern.
+	</p>
+
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
+		<div class="border rounded-lg p-8 bg-card flex items-center justify-center">
+			<LineShadowText text="Shadow Text" class="text-6xl font-bold" />
+		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Custom Shadow Color</h2>
+		<div class="border rounded-lg p-8 bg-card flex flex-col items-center gap-6">
+			<LineShadowText text="Red Shadow" shadowColor="red" class="text-5xl font-bold" />
+			<LineShadowText text="Blue Shadow" shadowColor="royalblue" class="text-5xl font-bold" />
+			<LineShadowText
+				text="Emerald Shadow"
+				shadowColor="oklch(0.765 0.177 163.22)"
+				class="text-5xl font-bold"
+			/>
+		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">As Heading</h2>
+		<div class="border rounded-lg p-8 bg-card">
+			<LineShadowText text="Page Title" as="h1" class="text-5xl font-extrabold tracking-tight" />
+		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="text-xl font-semibold mb-4">Dark Background</h2>
+		<div class="border rounded-lg p-8 bg-black flex items-center justify-center">
+			<LineShadowText
+				text="Light on Dark"
+				shadowColor="white"
+				class="text-6xl font-bold text-white"
+			/>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary

- Add `LineShadowText` — animated diagonal line shadow pattern behind text
- Pure CSS animation using `::after` pseudo-element with `background-clip: text`
- Mark `text-generate-effect` and `line-shadow-text` as done in TODO.md

## Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `text` | `string` | required | Text to display |
| `shadowColor` | `string` | `'black'` | Color of the line shadow |
| `as` | `string` | `'span'` | HTML element to render as |
| `class` | `string` | — | Additional CSS classes |

## Test plan
- [x] 8 unit tests passing
- [ ] Visual check on `/demo/line-shadow-text`