### PR TITLE
fix: let browser handle Cmd+Shift shortcuts in editor

### DIFF
--- a/src/lib/builder/editor/EditorLayout.svelte
+++ b/src/lib/builder/editor/EditorLayout.svelte
@@ -48,18 +48,22 @@
 					editor.requestSave();
 					return;
 				case "c":
+					if (e.shiftKey) return; // let browser handle Cmd+Shift+C (inspector)
 					e.preventDefault();
 					editor.copyBlock();
 					return;
 				case "x":
+					if (e.shiftKey) return;
 					e.preventDefault();
 					editor.cutBlock();
 					return;
 				case "v":
+					if (e.shiftKey) return;
 					e.preventDefault();
 					editor.pasteBlock();
 					return;
 				case "d":
+					if (e.shiftKey) return;
 					e.preventDefault();
 					editor.duplicateBlock();
 					return;


### PR DESCRIPTION
## Summary
- Editor keydown handler was capturing all Cmd+C/X/V/D including with Shift modifier
- Added `if (e.shiftKey) return` guards so Cmd+Shift+C (DevTools inspector) and similar browser shortcuts work as expected

## Test plan
- [ ] Open builder editor, press Cmd+Shift+C — DevTools inspector should open
- [ ] Cmd+C still copies selected block
- [ ] Cmd+V still pastes block