### PR TITLE
feat: add configurable STORAGE_BACKEND env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,10 @@ GITHUB_REPO_NAME=your_repo_name
 
 # Optional: path within the repo for page JSON files (default: content/pages)
 # GITHUB_CONTENT_PATH=content/pages
+
+# Storage backend: "filesystem" | "github" (default: auto-detect)
+# When not set, auto-detects: GITHUB_TOKEN → github, dev mode → filesystem
+# STORAGE_BACKEND=filesystem
+
+# Optional: custom directory for filesystem storage (default: ./content/pages)
+# FILESYSTEM_STORAGE_DIR=./content/pages

--- a/src/lib/builder/storage/factory.server.ts
+++ b/src/lib/builder/storage/factory.server.ts
@@ -5,42 +5,74 @@ import type { PageStorage } from "./types.js";
 import { GitHubStorage } from "./github.server.js";
 import { FilesystemStorage } from "./filesystem.server.js";
 
+type StorageBackend = "filesystem" | "github";
+
+const VALID_BACKENDS: StorageBackend[] = ["filesystem", "github"];
+
+function createGitHubStorage(token?: string): GitHubStorage {
+	const ghToken = env.GITHUB_TOKEN || token;
+
+	if (!ghToken) {
+		error(500, "GitHub storage requires GITHUB_TOKEN env var or an OAuth token.");
+	}
+
+	const owner = env.GITHUB_REPO_OWNER;
+	const repo = env.GITHUB_REPO_NAME;
+
+	if (!owner || !repo) {
+		error(500, "GITHUB_REPO_OWNER and GITHUB_REPO_NAME must be set for GitHub storage.");
+	}
+
+	return new GitHubStorage({
+		token: ghToken,
+		owner,
+		repo,
+		branch: env.GITHUB_BRANCH || undefined,
+		contentPath: env.GITHUB_CONTENT_PATH || undefined,
+	});
+}
+
 /**
  * Returns the appropriate PageStorage for builder routes.
  *
- * Priority:
- * 1. GITHUB_TOKEN env var (PAT)       → GitHubStorage
- * 2. token param (OAuth user token)    → GitHubStorage
- * 3. dev mode                          → FilesystemStorage
- * 4. otherwise                         → throws
+ * Selection:
+ * 1. STORAGE_BACKEND env var (explicit) → use that backend
+ * 2. Auto-detect fallback (backwards compatible):
+ *    a. GITHUB_TOKEN or token param → GitHubStorage
+ *    b. dev mode                    → FilesystemStorage
+ *    c. otherwise                   → throws
  */
 export function getBuilderStorage(token?: string): PageStorage {
-	const pat = env.GITHUB_TOKEN;
-	const ghToken = pat || token;
+	const backend = env.STORAGE_BACKEND as StorageBackend | undefined;
 
-	if (ghToken) {
-		const owner = env.GITHUB_REPO_OWNER;
-		const repo = env.GITHUB_REPO_NAME;
-
-		if (!owner || !repo) {
+	if (backend) {
+		if (!VALID_BACKENDS.includes(backend)) {
 			error(
 				500,
-				"Builder storage misconfigured: GITHUB_REPO_OWNER and GITHUB_REPO_NAME must be set"
+				`Unknown STORAGE_BACKEND: "${backend}". Valid values: ${VALID_BACKENDS.join(", ")}`
 			);
 		}
 
-		return new GitHubStorage({
-			token: ghToken,
-			owner,
-			repo,
-			branch: env.GITHUB_BRANCH || undefined,
-			contentPath: env.GITHUB_CONTENT_PATH || undefined,
-		});
+		switch (backend) {
+			case "filesystem":
+				return new FilesystemStorage(env.FILESYSTEM_STORAGE_DIR || undefined);
+			case "github":
+				return createGitHubStorage(token);
+		}
+	}
+
+	// Auto-detect fallback (original behavior)
+	const ghToken = env.GITHUB_TOKEN || token;
+	if (ghToken) {
+		return createGitHubStorage(token);
 	}
 
 	if (dev) {
 		return new FilesystemStorage();
 	}
 
-	error(500, "No storage backend available. Set GITHUB_TOKEN or configure GitHub OAuth.");
+	error(
+		500,
+		"No storage backend available. Set STORAGE_BACKEND, GITHUB_TOKEN, or configure OAuth."
+	);
 }

--- a/src/lib/builder/storage/filesystem.server.ts
+++ b/src/lib/builder/storage/filesystem.server.ts
@@ -137,12 +137,3 @@ export class FilesystemStorage implements PageStorage {
 		await writeFile(this.siteConfigPath, json, "utf-8");
 	}
 }
-
-let _instance: FilesystemStorage | undefined;
-
-export function getStorage(): PageStorage {
-	if (!_instance) {
-		_instance = new FilesystemStorage();
-	}
-	return _instance;
-}

--- a/src/lib/builder/storage/index.ts
+++ b/src/lib/builder/storage/index.ts
@@ -1,6 +1,6 @@
 export type { PageStorage, PageListItem } from "./types.js";
 export { isValidSlug, isValidPageDocument } from "./types.js";
-export { FilesystemStorage, getStorage } from "./filesystem.server.js";
+export { FilesystemStorage } from "./filesystem.server.js";
 export { GitHubStorage } from "./github.server.js";
 export { getBuilderStorage } from "./factory.server.js";
 export { StorageError } from "./errors.js";

--- a/src/routes/pages/[slug]/+page.server.ts
+++ b/src/routes/pages/[slug]/+page.server.ts
@@ -1,13 +1,13 @@
 import { error } from "@sveltejs/kit";
-import { getStorage, isValidSlug, StorageError } from "$lib/builder/storage/index.js";
+import { getBuilderStorage, isValidSlug, StorageError } from "$lib/builder/storage/index.js";
 import type { PageServerLoad } from "./$types.js";
 
-export const load: PageServerLoad = async ({ params }) => {
+export const load: PageServerLoad = async ({ params, locals }) => {
 	if (!isValidSlug(params.slug)) {
 		error(400, "Invalid page slug");
 	}
 
-	const storage = getStorage();
+	const storage = getBuilderStorage(locals.githubToken);
 
 	try {
 		const page = await storage.get(params.slug);


### PR DESCRIPTION
## Summary
- Add `STORAGE_BACKEND` env var (`filesystem` | `github`) for explicit backend selection instead of implicit auto-detection
- Extract `createGitHubStorage()` helper to reduce duplication in factory
- Remove `getStorage()` singleton — all routes now go through `getBuilderStorage()` for consistent backend selection
- Backwards compatible: without `STORAGE_BACKEND`, auto-detect works exactly as before

## Test plan
- [ ] `pnpm check` passes (no new errors)
- [ ] `STORAGE_BACKEND=filesystem pnpm dev` → uses filesystem storage
- [ ] Without env var → auto-detects as before
- [ ] `STORAGE_BACKEND=invalid` → clear error message
- [ ] `/pages/[slug]` route works with configured backend