### PR TITLE
chore: rename project to fancy-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# inspira-svelte
+# fancy-ui
 
 Beautiful animation and UI components for **Svelte 5**.
 
 ![Svelte 5](https://img.shields.io/badge/Svelte-5-FF3E00?logo=svelte&logoColor=white)
 ![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-06B6D4?logo=tailwindcss&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)
-![Components](https://img.shields.io/badge/Components-31-8B5CF6)
+![Components](https://img.shields.io/badge/Components-52-8B5CF6)
 ![MIT License](https://img.shields.io/badge/License-MIT-green)
 
 <p align="center">
   <a href="https://svelte-ui-omega.vercel.app">
-    <img src=".github/demo-gallery.png" alt="inspira-svelte demo gallery" width="800" />
+    <img src=".github/demo-gallery.png" alt="fancy-ui demo gallery" width="800" />
   </a>
 </p>
 
@@ -114,8 +114,8 @@ Beautiful animation and UI components for **Svelte 5**.
 
 ```bash
 # Clone the repository
-git clone https://github.com/RamaHerbin/svelteUI.git
-cd svelteUI
+git clone https://github.com/RamaHerbin/fancy-ui.git
+cd fancy-ui
 
 # Install dependencies
 pnpm install

--- a/src/lib/fancy-ui/line-shadow-text/LineShadowText.svelte
+++ b/src/lib/fancy-ui/line-shadow-text/LineShadowText.svelte
@@ -2,16 +2,20 @@
 	export interface LineShadowTextProps {
 		text: string;
 		shadowColor?: string;
-		as?: 'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'div';
+		as?: "span" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "div";
 		class?: string;
 	}
 </script>
 
 <script lang="ts">
-	import { cn } from '$lib/utils.js';
+	import { cn } from "$lib/utils.js";
 
-	let { text, shadowColor = 'black', as = 'span', class: className }: LineShadowTextProps =
-		$props();
+	let {
+		text,
+		shadowColor = "black",
+		as = "span",
+		class: className,
+	}: LineShadowTextProps = $props();
 
 	let style = $derived(`--shadow-color: ${shadowColor}`);
 </script>
@@ -19,10 +23,10 @@
 <svelte:element
 	this={as}
 	class={cn(
-		'line-shadow-text relative z-0 inline-flex',
-		'after:absolute after:left-[0.04em] after:top-[0.04em] after:-z-10',
-		'after:bg-[linear-gradient(45deg,transparent_45%,var(--shadow-color)_45%,var(--shadow-color)_55%,transparent_0)]',
-		'after:bg-[length:0.06em_0.06em] after:bg-clip-text after:text-transparent',
+		"line-shadow-text relative z-0 inline-flex",
+		"after:absolute after:top-[0.04em] after:left-[0.04em] after:-z-10",
+		"after:bg-[linear-gradient(45deg,transparent_45%,var(--shadow-color)_45%,var(--shadow-color)_55%,transparent_0)]",
+		"after:bg-[length:0.06em_0.06em] after:bg-clip-text after:text-transparent",
 		"after:content-[attr(data-text)]",
 		className
 	)}

--- a/src/lib/fancy-ui/line-shadow-text/LineShadowText.test.ts
+++ b/src/lib/fancy-ui/line-shadow-text/LineShadowText.test.ts
@@ -1,67 +1,67 @@
-import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/svelte';
-import LineShadowText from './LineShadowText.svelte';
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+import LineShadowText from "./LineShadowText.svelte";
 
-describe('LineShadowText', () => {
-	it('renders text content', () => {
+describe("LineShadowText", () => {
+	it("renders text content", () => {
 		const { container } = render(LineShadowText, {
-			props: { text: 'Hello' }
+			props: { text: "Hello" },
 		});
-		expect(container.textContent).toContain('Hello');
+		expect(container.textContent).toContain("Hello");
 	});
 
-	it('sets data-text attribute for ::after content', () => {
+	it("sets data-text attribute for ::after content", () => {
 		const { container } = render(LineShadowText, {
-			props: { text: 'Shadow' }
+			props: { text: "Shadow" },
 		});
 		const el = container.firstElementChild as HTMLElement;
-		expect(el.dataset.text).toBe('Shadow');
+		expect(el.dataset.text).toBe("Shadow");
 	});
 
-	it('renders as span by default', () => {
+	it("renders as span by default", () => {
 		const { container } = render(LineShadowText, {
-			props: { text: 'Default' }
+			props: { text: "Default" },
 		});
-		expect(container.querySelector('span')).toBeTruthy();
+		expect(container.querySelector("span")).toBeTruthy();
 	});
 
-	it('renders as custom element', () => {
+	it("renders as custom element", () => {
 		const { container } = render(LineShadowText, {
-			props: { text: 'Heading', as: 'h1' }
+			props: { text: "Heading", as: "h1" },
 		});
-		expect(container.querySelector('h1')).toBeTruthy();
+		expect(container.querySelector("h1")).toBeTruthy();
 	});
 
-	it('sets shadow color CSS variable', () => {
+	it("sets shadow color CSS variable", () => {
 		const { container } = render(LineShadowText, {
-			props: { text: 'Colored', shadowColor: 'red' }
-		});
-		const el = container.firstElementChild as HTMLElement;
-		expect(el.style.getPropertyValue('--shadow-color')).toBe('red');
-	});
-
-	it('defaults shadow color to black', () => {
-		const { container } = render(LineShadowText, {
-			props: { text: 'Default color' }
+			props: { text: "Colored", shadowColor: "red" },
 		});
 		const el = container.firstElementChild as HTMLElement;
-		expect(el.style.getPropertyValue('--shadow-color')).toBe('black');
+		expect(el.style.getPropertyValue("--shadow-color")).toBe("red");
 	});
 
-	it('applies custom class', () => {
+	it("defaults shadow color to black", () => {
 		const { container } = render(LineShadowText, {
-			props: { text: 'Styled', class: 'text-4xl font-bold' }
+			props: { text: "Default color" },
 		});
 		const el = container.firstElementChild as HTMLElement;
-		expect(el.className).toContain('text-4xl');
-		expect(el.className).toContain('font-bold');
+		expect(el.style.getPropertyValue("--shadow-color")).toBe("black");
 	});
 
-	it('has line-shadow-text class for animation', () => {
+	it("applies custom class", () => {
 		const { container } = render(LineShadowText, {
-			props: { text: 'Animated' }
+			props: { text: "Styled", class: "text-4xl font-bold" },
 		});
 		const el = container.firstElementChild as HTMLElement;
-		expect(el.className).toContain('line-shadow-text');
+		expect(el.className).toContain("text-4xl");
+		expect(el.className).toContain("font-bold");
+	});
+
+	it("has line-shadow-text class for animation", () => {
+		const { container } = render(LineShadowText, {
+			props: { text: "Animated" },
+		});
+		const el = container.firstElementChild as HTMLElement;
+		expect(el.className).toContain("line-shadow-text");
 	});
 });

--- a/src/lib/fancy-ui/line-shadow-text/index.ts
+++ b/src/lib/fancy-ui/line-shadow-text/index.ts
@@ -1,2 +1,2 @@
-export { default as LineShadowText } from './LineShadowText.svelte';
-export type { LineShadowTextProps } from './LineShadowText.svelte';
+export { default as LineShadowText } from "./LineShadowText.svelte";
+export type { LineShadowTextProps } from "./LineShadowText.svelte";

--- a/src/lib/fancy-ui/text-generate-effect/TextGenerateEffect.svelte
+++ b/src/lib/fancy-ui/text-generate-effect/TextGenerateEffect.svelte
@@ -10,8 +10,8 @@
 </script>
 
 <script lang="ts">
-	import { cn } from '$lib/utils.js';
-	import { onMount } from 'svelte';
+	import { cn } from "$lib/utils.js";
+	import { onMount } from "svelte";
 
 	let {
 		words,
@@ -19,40 +19,38 @@
 		duration = 0.7,
 		delay = 0,
 		stagger = 200,
-		class: className
+		class: className,
 	}: TextGenerateEffectProps = $props();
 
-	let wordsArray = $derived(words.split(' '));
+	let wordsArray = $derived(words.split(" "));
 	let scopeRef: HTMLDivElement;
 
 	onMount(() => {
-		const spans = scopeRef.querySelectorAll<HTMLSpanElement>('span');
+		const spans = scopeRef.querySelectorAll<HTMLSpanElement>("span");
 
 		const timeout = setTimeout(() => {
 			spans.forEach((span, index) => {
 				const wordTimeout = setTimeout(() => {
-					span.style.opacity = '1';
-					span.style.filter = filter ? 'blur(0px)' : 'none';
+					span.style.opacity = "1";
+					span.style.filter = filter ? "blur(0px)" : "none";
 				}, index * stagger);
 
 				// Store timeout ID for cleanup
-				(span as HTMLSpanElement & { _tid?: ReturnType<typeof setTimeout> })._tid =
-					wordTimeout;
+				(span as HTMLSpanElement & { _tid?: ReturnType<typeof setTimeout> })._tid = wordTimeout;
 			});
 		}, delay);
 
 		return () => {
 			clearTimeout(timeout);
 			spans.forEach((span) => {
-				const tid = (span as HTMLSpanElement & { _tid?: ReturnType<typeof setTimeout> })
-					._tid;
+				const tid = (span as HTMLSpanElement & { _tid?: ReturnType<typeof setTimeout> })._tid;
 				if (tid) clearTimeout(tid);
 			});
 		};
 	});
 </script>
 
-<div class={cn('leading-snug tracking-wide', className)}>
+<div class={cn("leading-snug tracking-wide", className)}>
 	<div bind:this={scopeRef}>
 		{#each wordsArray as word, idx (word + idx)}
 			<span

--- a/src/lib/fancy-ui/text-generate-effect/TextGenerateEffect.test.ts
+++ b/src/lib/fancy-ui/text-generate-effect/TextGenerateEffect.test.ts
@@ -1,87 +1,87 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/svelte';
-import TextGenerateEffect from './TextGenerateEffect.svelte';
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/svelte";
+import TextGenerateEffect from "./TextGenerateEffect.svelte";
 
-describe('TextGenerateEffect', () => {
-	it('renders all words as spans', () => {
+describe("TextGenerateEffect", () => {
+	it("renders all words as spans", () => {
 		const { container } = render(TextGenerateEffect, {
-			props: { words: 'hello world test' }
+			props: { words: "hello world test" },
 		});
-		const spans = container.querySelectorAll('span');
+		const spans = container.querySelectorAll("span");
 		expect(spans.length).toBe(3);
 	});
 
-	it('words start hidden with blur', () => {
+	it("words start hidden with blur", () => {
 		const { container } = render(TextGenerateEffect, {
-			props: { words: 'fade in' }
+			props: { words: "fade in" },
 		});
-		const spans = container.querySelectorAll('span');
-		expect(spans[0].style.opacity).toBe('0');
-		expect(spans[0].style.filter).toContain('blur(10px)');
+		const spans = container.querySelectorAll("span");
+		expect(spans[0].style.opacity).toBe("0");
+		expect(spans[0].style.filter).toContain("blur(10px)");
 	});
 
-	it('words start hidden without blur when filter is false', () => {
+	it("words start hidden without blur when filter is false", () => {
 		const { container } = render(TextGenerateEffect, {
-			props: { words: 'no blur', filter: false }
+			props: { words: "no blur", filter: false },
 		});
-		const spans = container.querySelectorAll('span');
-		expect(spans[0].style.opacity).toBe('0');
-		expect(spans[0].style.filter).toBe('none');
+		const spans = container.querySelectorAll("span");
+		expect(spans[0].style.opacity).toBe("0");
+		expect(spans[0].style.filter).toBe("none");
 	});
 
-	it('reveals words after stagger delay', async () => {
+	it("reveals words after stagger delay", async () => {
 		vi.useFakeTimers();
 		const { container } = render(TextGenerateEffect, {
-			props: { words: 'one two three', stagger: 100 }
+			props: { words: "one two three", stagger: 100 },
 		});
-		const spans = container.querySelectorAll('span');
+		const spans = container.querySelectorAll("span");
 
 		// Flush the outer setTimeout(fn, 0) + first word setTimeout(fn, 0)
 		await vi.advanceTimersByTimeAsync(1);
-		expect(spans[0].style.opacity).toBe('1');
-		expect(spans[1].style.opacity).toBe('0');
+		expect(spans[0].style.opacity).toBe("1");
+		expect(spans[1].style.opacity).toBe("0");
 
 		// After 100ms — second word
 		await vi.advanceTimersByTimeAsync(100);
-		expect(spans[1].style.opacity).toBe('1');
-		expect(spans[2].style.opacity).toBe('0');
+		expect(spans[1].style.opacity).toBe("1");
+		expect(spans[2].style.opacity).toBe("0");
 
 		// After 200ms — third word
 		await vi.advanceTimersByTimeAsync(100);
-		expect(spans[2].style.opacity).toBe('1');
+		expect(spans[2].style.opacity).toBe("1");
 
 		vi.useRealTimers();
 	});
 
-	it('respects initial delay', async () => {
+	it("respects initial delay", async () => {
 		vi.useFakeTimers();
 		const { container } = render(TextGenerateEffect, {
-			props: { words: 'delayed text', delay: 500 }
+			props: { words: "delayed text", delay: 500 },
 		});
-		const spans = container.querySelectorAll('span');
+		const spans = container.querySelectorAll("span");
 
 		await vi.advanceTimersByTimeAsync(499);
-		expect(spans[0].style.opacity).toBe('0');
+		expect(spans[0].style.opacity).toBe("0");
 
 		await vi.advanceTimersByTimeAsync(2);
-		expect(spans[0].style.opacity).toBe('1');
+		expect(spans[0].style.opacity).toBe("1");
 
 		vi.useRealTimers();
 	});
 
-	it('applies custom class', () => {
+	it("applies custom class", () => {
 		const { container } = render(TextGenerateEffect, {
-			props: { words: 'styled', class: 'my-class' }
+			props: { words: "styled", class: "my-class" },
 		});
 		const wrapper = container.firstElementChild as HTMLElement;
-		expect(wrapper.className).toContain('my-class');
+		expect(wrapper.className).toContain("my-class");
 	});
 
-	it('sets custom duration in transition style', () => {
+	it("sets custom duration in transition style", () => {
 		const { container } = render(TextGenerateEffect, {
-			props: { words: 'fast', duration: 0.3 }
+			props: { words: "fast", duration: 0.3 },
 		});
-		const span = container.querySelector('span') as HTMLElement;
-		expect(span.style.transition).toContain('0.3s');
+		const span = container.querySelector("span") as HTMLElement;
+		expect(span.style.transition).toContain("0.3s");
 	});
 });

--- a/src/lib/fancy-ui/text-generate-effect/index.ts
+++ b/src/lib/fancy-ui/text-generate-effect/index.ts
@@ -1,2 +1,2 @@
-export { default as TextGenerateEffect } from './TextGenerateEffect.svelte';
-export type { TextGenerateEffectProps } from './TextGenerateEffect.svelte';
+export { default as TextGenerateEffect } from "./TextGenerateEffect.svelte";
+export type { TextGenerateEffectProps } from "./TextGenerateEffect.svelte";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,7 @@
 	import type { TimelineItem } from "$lib/fancy-ui";
 	import ThemeToggle from "$lib/components/ThemeToggle.svelte";
 
-	const GITHUB_URL = "https://github.com/ramaherbin/inspira-svelte";
+	const GITHUB_URL = "https://github.com/ramaherbin/fancy-ui";
 	const DEMO_URL = "/demo";
 
 	const taglineWords = ["animated", "beautiful", "interactive", "composable", "performant"];
@@ -27,7 +27,10 @@
 		{ id: "v10", label: "v1.0" },
 	];
 
-	const roadmapContent: Record<string, { status: string; statusColor: string; items: { done?: boolean; text: string }[] }> = {
+	const roadmapContent: Record<
+		string,
+		{ status: string; statusColor: string; items: { done?: boolean; text: string }[] }
+	> = {
 		now: {
 			status: "Released",
 			statusColor: "bg-emerald-500/10 text-emerald-400 border-emerald-500/20",
@@ -100,7 +103,9 @@
 </div>
 
 <!-- ─── HERO ─────────────────────────────────────────────────────────────── -->
-<section class="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-[#030712]">
+<section
+	class="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-[#030712]"
+>
 	<!-- Particle background -->
 	<div class="absolute inset-0">
 		<Sparkles
@@ -115,7 +120,9 @@
 
 	<!-- Content -->
 	<div class="relative z-10 flex flex-col items-center gap-6 px-4 text-center">
-		<div class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm text-white/60">
+		<div
+			class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm text-white/60"
+		>
 			<span class="size-1.5 rounded-full bg-emerald-400"></span>
 			Open source · MIT License
 		</div>
@@ -130,11 +137,8 @@
 		</h1>
 
 		<p class="max-w-xl text-xl text-white/60">
-			50+ <FlipWords
-				words={taglineWords}
-				duration={2500}
-				class="font-semibold text-white"
-			/> UI components for Svelte 5
+			50+ <FlipWords words={taglineWords} duration={2500} class="font-semibold text-white" /> UI components
+			for Svelte 5
 		</p>
 
 		<p class="max-w-md text-sm text-white/40">
@@ -150,7 +154,9 @@
 				class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-5 py-2.5 text-sm font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
 			>
 				<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-					<path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
+					<path
+						d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"
+					/>
 				</svg>
 				GitHub
 			</a>
@@ -159,25 +165,30 @@
 
 	<!-- Scroll indicator -->
 	<div class="absolute bottom-8 left-1/2 -translate-x-1/2 animate-bounce text-white/30">
-		<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
-			<path d="M12 5v14M5 12l7 7 7-7"/>
+		<svg
+			width="20"
+			height="20"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<path d="M12 5v14M5 12l7 7 7-7" />
 		</svg>
 	</div>
 </section>
 
 <!-- ─── STATS ──────────────────────────────────────────────────────────────── -->
-<section class="border-border border-y bg-background">
-	<div class="mx-auto grid max-w-3xl grid-cols-3 divide-x divide-border">
-		{#each [
-			{ value: 50, suffix: "+", label: "Components" },
-			{ value: 5, suffix: "", label: "Svelte 5 runes" },
-			{ value: 100, suffix: "%", label: "TypeScript" },
-		] as stat}
+<section class="border-border bg-background border-y">
+	<div class="divide-border mx-auto grid max-w-3xl grid-cols-3 divide-x">
+		{#each [{ value: 50, suffix: "+", label: "Components" }, { value: 5, suffix: "", label: "Svelte 5 runes" }, { value: 100, suffix: "%", label: "TypeScript" }] as stat}
 			<div class="flex flex-col items-center gap-1 py-10">
-				<div class="text-4xl font-bold tabular-nums text-foreground sm:text-5xl">
+				<div class="text-foreground text-4xl font-bold tabular-nums sm:text-5xl">
 					<NumberTicker value={stat.value} duration={1500} />{stat.suffix}
 				</div>
-				<p class="text-sm text-muted-foreground">{stat.label}</p>
+				<p class="text-muted-foreground text-sm">{stat.label}</p>
 			</div>
 		{/each}
 	</div>
@@ -186,20 +197,22 @@
 <!-- ─── COMPONENT SHOWCASE ────────────────────────────────────────────────── -->
 <section class="mx-auto max-w-6xl px-4 py-20">
 	<BoxReveal color="var(--primary)" duration={0.4}>
-		<h2 class="mb-2 text-center text-3xl font-bold text-foreground sm:text-4xl">
+		<h2 class="text-foreground mb-2 text-center text-3xl font-bold sm:text-4xl">
 			Everything you need
 		</h2>
 	</BoxReveal>
 	<BoxReveal color="var(--primary)" duration={0.4} delay={0.4}>
-		<p class="mb-12 text-center text-muted-foreground">
+		<p class="text-muted-foreground mb-12 text-center">
 			Live interactive previews — no screenshots
 		</p>
 	</BoxReveal>
 
 	<div class="grid grid-cols-2 gap-4 md:grid-cols-4">
-
 		<!-- Sparkles card -->
-		<a href="/demo/sparkles" class="group relative col-span-2 row-span-2 min-h-48 overflow-hidden rounded-xl border border-border bg-[#030712]">
+		<a
+			href="/demo/sparkles"
+			class="group border-border relative col-span-2 row-span-2 min-h-48 overflow-hidden rounded-xl border bg-[#030712]"
+		>
 			<Sparkles background="transparent" particleColor="#ffffff" particleDensity={60} />
 			<div class="absolute inset-0 flex items-end p-4">
 				<div>
@@ -210,31 +223,40 @@
 		</a>
 
 		<!-- BorderBeam card -->
-		<a href="/demo/border-beam" class="group relative min-h-36 overflow-hidden rounded-xl border border-border bg-card p-4">
+		<a
+			href="/demo/border-beam"
+			class="group border-border bg-card relative min-h-36 overflow-hidden rounded-xl border p-4"
+		>
 			<BorderBeam duration={6} size={80} colorFrom="#9E7AFF" colorTo="#FE8BBB" />
 			<div class="flex h-full flex-col items-center justify-center gap-1">
-				<div class="h-2 w-16 rounded-full bg-muted"></div>
-				<div class="h-2 w-10 rounded-full bg-muted/60"></div>
+				<div class="bg-muted h-2 w-16 rounded-full"></div>
+				<div class="bg-muted/60 h-2 w-10 rounded-full"></div>
 			</div>
 			<div class="absolute bottom-3 left-4">
-				<p class="text-xs text-muted-foreground">Effects</p>
-				<p class="text-sm font-semibold text-foreground">BorderBeam</p>
+				<p class="text-muted-foreground text-xs">Effects</p>
+				<p class="text-foreground text-sm font-semibold">BorderBeam</p>
 			</div>
 		</a>
 
 		<!-- NumberTicker card -->
-		<a href="/demo/number-ticker" class="group relative min-h-36 overflow-hidden rounded-xl border border-border bg-card p-4">
+		<a
+			href="/demo/number-ticker"
+			class="group border-border bg-card relative min-h-36 overflow-hidden rounded-xl border p-4"
+		>
 			<div class="flex h-full flex-col items-center justify-center">
 				<NumberTicker value={9842} duration={2000} class="text-4xl font-bold" />
 			</div>
 			<div class="absolute bottom-3 left-4">
-				<p class="text-xs text-muted-foreground">Text</p>
-				<p class="text-sm font-semibold text-foreground">NumberTicker</p>
+				<p class="text-muted-foreground text-xs">Text</p>
+				<p class="text-foreground text-sm font-semibold">NumberTicker</p>
 			</div>
 		</a>
 
 		<!-- Meteors card -->
-		<a href="/demo/meteors" class="group relative min-h-36 overflow-hidden rounded-xl border border-border bg-[#030712]">
+		<a
+			href="/demo/meteors"
+			class="group border-border relative min-h-36 overflow-hidden rounded-xl border bg-[#030712]"
+		>
 			<Meteors count={12} />
 			<div class="absolute inset-0 flex items-end p-4">
 				<div>
@@ -245,75 +267,88 @@
 		</a>
 
 		<!-- LineShadowText card -->
-		<a href="/demo/line-shadow-text" class="group relative min-h-36 overflow-hidden rounded-xl border border-border bg-card p-4">
+		<a
+			href="/demo/line-shadow-text"
+			class="group border-border bg-card relative min-h-36 overflow-hidden rounded-xl border p-4"
+		>
 			<div class="flex h-full flex-col items-center justify-center">
 				<LineShadowText
 					text="Fancy"
 					shadowColor="oklch(0.554 0.046 257.417)"
-					class="text-4xl font-bold text-foreground"
+					class="text-foreground text-4xl font-bold"
 				/>
 			</div>
 			<div class="absolute bottom-3 left-4">
-				<p class="text-xs text-muted-foreground">Text</p>
-				<p class="text-sm font-semibold text-foreground">LineShadowText</p>
+				<p class="text-muted-foreground text-xs">Text</p>
+				<p class="text-foreground text-sm font-semibold">LineShadowText</p>
 			</div>
 		</a>
 
 		<!-- Marquee card — full width -->
-		<a href="/demo/marquee" class="group relative col-span-2 min-h-36 overflow-hidden rounded-xl border border-border bg-card">
+		<a
+			href="/demo/marquee"
+			class="group border-border bg-card relative col-span-2 min-h-36 overflow-hidden rounded-xl border"
+		>
 			<div class="flex h-full flex-col justify-center py-4">
 				<Marquee pauseOnHover repeat={3} class="[--duration:20s]">
 					{#each techBadges as badge}
-						<span class="mx-2 rounded-full border border-border bg-muted px-3 py-1 text-xs font-medium text-muted-foreground">
+						<span
+							class="border-border bg-muted text-muted-foreground mx-2 rounded-full border px-3 py-1 text-xs font-medium"
+						>
 							{badge}
 						</span>
 					{/each}
 				</Marquee>
 			</div>
 			<div class="absolute bottom-3 left-4">
-				<p class="text-xs text-muted-foreground">Effects</p>
-				<p class="text-sm font-semibold text-foreground">Marquee</p>
+				<p class="text-muted-foreground text-xs">Effects</p>
+				<p class="text-foreground text-sm font-semibold">Marquee</p>
 			</div>
 		</a>
 
 		<!-- SparklesText card -->
-		<a href="/demo/sparkles-text" class="group relative min-h-36 overflow-hidden rounded-xl border border-border bg-card p-4">
+		<a
+			href="/demo/sparkles-text"
+			class="group border-border bg-card relative min-h-36 overflow-hidden rounded-xl border p-4"
+		>
 			<div class="flex h-full flex-col items-center justify-center">
 				<SparklesText
 					text="Magic"
 					sparklesCount={6}
 					colors={{ first: "#9E7AFF", second: "#FE8BBB" }}
-					class="text-3xl font-bold text-foreground"
+					class="text-foreground text-3xl font-bold"
 				/>
 			</div>
 			<div class="absolute bottom-3 left-4">
-				<p class="text-xs text-muted-foreground">Text</p>
-				<p class="text-sm font-semibold text-foreground">SparklesText</p>
+				<p class="text-muted-foreground text-xs">Text</p>
+				<p class="text-foreground text-sm font-semibold">SparklesText</p>
 			</div>
 		</a>
 
 		<!-- FlipWords card -->
-		<a href="/demo/flip-words" class="group relative min-h-36 overflow-hidden rounded-xl border border-border bg-card p-4">
+		<a
+			href="/demo/flip-words"
+			class="group border-border bg-card relative min-h-36 overflow-hidden rounded-xl border p-4"
+		>
 			<div class="flex h-full flex-col items-center justify-center text-center">
-				<p class="text-sm text-muted-foreground">Build</p>
+				<p class="text-muted-foreground text-sm">Build</p>
 				<FlipWords
 					words={["faster", "smarter", "better", "beautifully"]}
 					duration={2000}
-					class="text-2xl font-bold text-foreground"
+					class="text-foreground text-2xl font-bold"
 				/>
 			</div>
 			<div class="absolute bottom-3 left-4">
-				<p class="text-xs text-muted-foreground">Text</p>
-				<p class="text-sm font-semibold text-foreground">FlipWords</p>
+				<p class="text-muted-foreground text-xs">Text</p>
+				<p class="text-foreground text-sm font-semibold">FlipWords</p>
 			</div>
 		</a>
-
 	</div>
 
 	<div class="mt-8 text-center">
 		<a
 			href={DEMO_URL}
-			class="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+			class="text-muted-foreground hover:text-foreground text-sm underline-offset-4 hover:underline"
 		>
 			See all 50+ components →
 		</a>
@@ -324,10 +359,10 @@
 <section class="bg-muted/40 px-4 py-20">
 	<div class="mx-auto max-w-2xl">
 		<BoxReveal color="var(--primary)" duration={0.4}>
-			<h2 class="mb-8 text-center text-3xl font-bold text-foreground sm:text-4xl">Quick start</h2>
+			<h2 class="text-foreground mb-8 text-center text-3xl font-bold sm:text-4xl">Quick start</h2>
 		</BoxReveal>
 
-		<div class="relative overflow-hidden rounded-xl border border-border bg-[#0d1117]">
+		<div class="border-border relative overflow-hidden rounded-xl border bg-[#0d1117]">
 			<BorderBeam duration={12} size={120} colorFrom="#9E7AFF" colorTo="#FE8BBB" borderWidth={1} />
 			<div class="p-6 font-mono text-sm">
 				<div class="mb-1 text-white/40"># 1. Clone and install</div>
@@ -339,7 +374,7 @@
 					<span class="text-purple-400">from</span>
 					<span class="text-amber-300"> '$lib/fancy-ui'</span>
 				</div>
-				<div class="mb-4 text-white/30 text-xs">&nbsp;</div>
+				<div class="mb-4 text-xs text-white/30">&nbsp;</div>
 				<div class="mb-1 text-white/40"># 3. Use it</div>
 				<div>
 					<span class="text-blue-400">&lt;BorderBeam</span>
@@ -367,7 +402,7 @@
 			{@const step = roadmapContent[item.id]}
 			{#if step}
 				<div class="mb-4 flex items-center gap-2">
-					<h3 class="text-lg font-bold text-foreground md:hidden">{item.label}</h3>
+					<h3 class="text-foreground text-lg font-bold md:hidden">{item.label}</h3>
 					<span class="rounded-full border px-2.5 py-0.5 text-xs font-medium {step.statusColor}">
 						{step.status}
 					</span>
@@ -377,15 +412,31 @@
 						<li class="flex items-start gap-2.5 text-sm">
 							{#if entry.done}
 								<span class="mt-0.5 shrink-0 text-emerald-500">
-									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
-										<path d="M20 6 9 17l-5-5"/>
+									<svg
+										width="14"
+										height="14"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2.5"
+										aria-hidden="true"
+									>
+										<path d="M20 6 9 17l-5-5" />
 									</svg>
 								</span>
 								<span class="text-foreground">{entry.text}</span>
 							{:else}
-								<span class="mt-0.5 shrink-0 text-muted-foreground/40">
-									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-										<circle cx="12" cy="12" r="9"/>
+								<span class="text-muted-foreground/40 mt-0.5 shrink-0">
+									<svg
+										width="14"
+										height="14"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2"
+										aria-hidden="true"
+									>
+										<circle cx="12" cy="12" r="9" />
 									</svg>
 								</span>
 								<span class="text-muted-foreground">{entry.text}</span>

--- a/src/routes/demo/line-shadow-text/+page.svelte
+++ b/src/routes/demo/line-shadow-text/+page.svelte
@@ -1,27 +1,25 @@
 <script lang="ts">
-	import { LineShadowText } from '$lib/fancy-ui/line-shadow-text';
+	import { LineShadowText } from "$lib/fancy-ui/line-shadow-text";
 </script>
 
 <svelte:head>
 	<title>LineShadowText - FancyUI</title>
 </svelte:head>
 
-<div class="container mx-auto py-12 px-4">
-	<h1 class="text-3xl font-bold mb-2">LineShadowText</h1>
-	<p class="text-muted-foreground mb-8">
-		Text with an animated diagonal line shadow pattern.
-	</p>
+<div class="container mx-auto px-4 py-12">
+	<h1 class="mb-2 text-3xl font-bold">LineShadowText</h1>
+	<p class="text-muted-foreground mb-8">Text with an animated diagonal line shadow pattern.</p>
 
 	<section class="mb-12">
-		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
-		<div class="border rounded-lg p-8 bg-card flex items-center justify-center">
+		<h2 class="mb-4 text-xl font-semibold">Basic Usage</h2>
+		<div class="bg-card flex items-center justify-center rounded-lg border p-8">
 			<LineShadowText text="Shadow Text" class="text-6xl font-bold" />
 		</div>
 	</section>
 
 	<section class="mb-12">
-		<h2 class="text-xl font-semibold mb-4">Custom Shadow Color</h2>
-		<div class="border rounded-lg p-8 bg-card flex flex-col items-center gap-6">
+		<h2 class="mb-4 text-xl font-semibold">Custom Shadow Color</h2>
+		<div class="bg-card flex flex-col items-center gap-6 rounded-lg border p-8">
 			<LineShadowText text="Red Shadow" shadowColor="red" class="text-5xl font-bold" />
 			<LineShadowText text="Blue Shadow" shadowColor="royalblue" class="text-5xl font-bold" />
 			<LineShadowText
@@ -33,15 +31,15 @@
 	</section>
 
 	<section class="mb-12">
-		<h2 class="text-xl font-semibold mb-4">As Heading</h2>
-		<div class="border rounded-lg p-8 bg-card">
+		<h2 class="mb-4 text-xl font-semibold">As Heading</h2>
+		<div class="bg-card rounded-lg border p-8">
 			<LineShadowText text="Page Title" as="h1" class="text-5xl font-extrabold tracking-tight" />
 		</div>
 	</section>
 
 	<section class="mb-12">
-		<h2 class="text-xl font-semibold mb-4">Dark Background</h2>
-		<div class="border rounded-lg p-8 bg-black flex items-center justify-center">
+		<h2 class="mb-4 text-xl font-semibold">Dark Background</h2>
+		<div class="flex items-center justify-center rounded-lg border bg-black p-8">
 			<LineShadowText
 				text="Light on Dark"
 				shadowColor="white"

--- a/src/routes/demo/text-generate-effect/+page.svelte
+++ b/src/routes/demo/text-generate-effect/+page.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-	import { TextGenerateEffect } from '$lib/fancy-ui/text-generate-effect';
+	import { TextGenerateEffect } from "$lib/fancy-ui/text-generate-effect";
 </script>
 
 <svelte:head>
 	<title>TextGenerateEffect - FancyUI</title>
 </svelte:head>
 
-<div class="container mx-auto py-12 px-4">
-	<h1 class="text-3xl font-bold mb-2">TextGenerateEffect</h1>
+<div class="container mx-auto px-4 py-12">
+	<h1 class="mb-2 text-3xl font-bold">TextGenerateEffect</h1>
 	<p class="text-muted-foreground mb-8">
 		Typewriter-style text reveal that fades in words one by one with an optional blur effect.
 	</p>
 
 	<section class="mb-12">
-		<h2 class="text-xl font-semibold mb-4">Basic Usage</h2>
-		<div class="border rounded-lg p-8 bg-card">
+		<h2 class="mb-4 text-xl font-semibold">Basic Usage</h2>
+		<div class="bg-card rounded-lg border p-8">
 			<TextGenerateEffect
 				words="Svelte is a radical new approach to building user interfaces. It shifts work from the browser to a compile step that happens when you build your app."
 			/>
@@ -22,8 +22,8 @@
 	</section>
 
 	<section class="mb-12">
-		<h2 class="text-xl font-semibold mb-4">Without Blur</h2>
-		<div class="border rounded-lg p-8 bg-card">
+		<h2 class="mb-4 text-xl font-semibold">Without Blur</h2>
+		<div class="bg-card rounded-lg border p-8">
 			<TextGenerateEffect
 				words="This text fades in without the blur effect, using a simple opacity transition."
 				filter={false}
@@ -32,8 +32,8 @@
 	</section>
 
 	<section class="mb-12">
-		<h2 class="text-xl font-semibold mb-4">Fast Reveal</h2>
-		<div class="border rounded-lg p-8 bg-card">
+		<h2 class="mb-4 text-xl font-semibold">Fast Reveal</h2>
+		<div class="bg-card rounded-lg border p-8">
 			<TextGenerateEffect
 				words="Quick reveal with a short duration and tight stagger between words."
 				duration={0.3}
@@ -43,8 +43,8 @@
 	</section>
 
 	<section class="mb-12">
-		<h2 class="text-xl font-semibold mb-4">Slow & Dramatic</h2>
-		<div class="border rounded-lg p-8 bg-card">
+		<h2 class="mb-4 text-xl font-semibold">Slow & Dramatic</h2>
+		<div class="bg-card rounded-lg border p-8">
 			<TextGenerateEffect
 				words="Each word appears slowly with a long pause between them for dramatic effect."
 				duration={1.5}
@@ -55,8 +55,8 @@
 	</section>
 
 	<section class="mb-12">
-		<h2 class="text-xl font-semibold mb-4">Delayed Start</h2>
-		<div class="border rounded-lg p-8 bg-card">
+		<h2 class="mb-4 text-xl font-semibold">Delayed Start</h2>
+		<div class="bg-card rounded-lg border p-8">
 			<TextGenerateEffect
 				words="This text waits one second before starting to reveal."
 				delay={1000}


### PR DESCRIPTION
## Summary
- Rename README title from `inspira-svelte` to `fancy-ui`
- Update clone URL (`svelteUI` → `fancy-ui`) and image alt text
- Fix component count badge (31 → 52)
- Fix landing page GitHub URL (`inspira-svelte` → `fancy-ui`)

## Test plan
- [x] README displays correct title and clone URL on GitHub
- [x] Landing page GitHub link points to `github.com/RamaHerbin/fancy-ui`
- [x] Component count badge shows 52