### PR TITLE
feat: add AnimatedTestimonials component

### DIFF
--- a/src/lib/fancy-ui/animated-testimonials/AnimatedTestimonials.svelte
+++ b/src/lib/fancy-ui/animated-testimonials/AnimatedTestimonials.svelte
@@ -1,0 +1,187 @@
+<script lang="ts" module>
+	/**
+	 * AnimatedTestimonials - Animated testimonial carousel
+	 *
+	 * Cycles through testimonials with smooth slide animations.
+	 * Supports manual navigation and optional autoplay.
+	 */
+	export interface Testimonial {
+		/** The testimonial quote */
+		quote: string;
+		/** Author's full name */
+		name: string;
+		/** Author's title or role */
+		designation: string;
+		/** URL to author's avatar image */
+		src: string;
+	}
+
+	export interface AnimatedTestimonialsProps {
+		/** Array of testimonials to display */
+		testimonials: Testimonial[];
+		/** Auto-advance testimonials */
+		autoplay?: boolean;
+		/** Interval between auto-advances (ms) */
+		interval?: number;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { onMount } from "svelte";
+
+	let {
+		testimonials,
+		autoplay = false,
+		interval = 5000,
+		class: className,
+	}: AnimatedTestimonialsProps = $props();
+
+	let activeIndex = $state(0);
+	let direction = $state<"next" | "prev">("next");
+	let isAnimating = $state(false);
+	let autoplayTimer: ReturnType<typeof setInterval> | null = null;
+
+	function navigate(dir: "next" | "prev") {
+		if (isAnimating) return;
+		direction = dir;
+		isAnimating = true;
+		setTimeout(() => {
+			activeIndex =
+				dir === "next"
+					? (activeIndex + 1) % testimonials.length
+					: (activeIndex - 1 + testimonials.length) % testimonials.length;
+			isAnimating = false;
+		}, 300);
+	}
+
+	function startAutoplay() {
+		if (!autoplay) return;
+		autoplayTimer = setInterval(() => navigate("next"), interval);
+	}
+
+	function stopAutoplay() {
+		if (autoplayTimer) {
+			clearInterval(autoplayTimer);
+			autoplayTimer = null;
+		}
+	}
+
+	onMount(() => {
+		startAutoplay();
+		return () => stopAutoplay();
+	});
+
+	let activeTestimonial = $derived(testimonials[activeIndex]);
+</script>
+
+<div
+	class={cn("relative mx-auto max-w-sm md:max-w-4xl antialiased font-sans px-4 md:px-8 lg:px-12 py-20", className)}
+	onmouseenter={stopAutoplay}
+	onmouseleave={startAutoplay}
+	role="region"
+	aria-label="Testimonials"
+>
+	<div class="relative grid grid-cols-1 gap-20 md:grid-cols-2">
+		<!-- Image column -->
+		<div class="relative h-80 w-full">
+			{#each testimonials as testimonial, index}
+				<div
+					class={cn(
+						"absolute inset-0 h-full w-full origin-bottom rounded-3xl transition-all duration-500 ease-in-out",
+						index === activeIndex
+							? "z-20 opacity-100 scale-100 translate-y-0 rotate-0"
+							: "z-10 opacity-0 scale-95 translate-y-4",
+						index !== activeIndex && direction === "next"
+							? "-translate-y-4"
+							: index !== activeIndex
+								? "translate-y-4"
+								: ""
+					)}
+				>
+					<img
+						src={testimonial.src}
+						alt={testimonial.name}
+						class="h-full w-full rounded-3xl object-cover object-center"
+						draggable="false"
+					/>
+				</div>
+			{/each}
+		</div>
+
+		<!-- Content column -->
+		<div class="flex flex-col justify-between py-4">
+			<div
+				class={cn(
+					"transition-all duration-300 ease-in-out",
+					isAnimating
+						? direction === "next"
+							? "opacity-0 translate-y-4"
+							: "opacity-0 -translate-y-4"
+						: "opacity-100 translate-y-0"
+				)}
+			>
+				<p
+					class="text-lg text-gray-500 dark:text-neutral-300"
+					aria-live="polite"
+				>
+					{activeTestimonial.quote}
+				</p>
+				<div class="mt-8">
+					<p class="text-base font-bold text-gray-900 dark:text-white">
+						{activeTestimonial.name}
+					</p>
+					<p class="text-sm text-gray-500 dark:text-neutral-400">
+						{activeTestimonial.designation}
+					</p>
+				</div>
+			</div>
+
+			<!-- Navigation -->
+			<div class="mt-8 flex gap-4">
+				<button
+					onclick={() => navigate("prev")}
+					class="group/button flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 transition-colors hover:bg-gray-200 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+					aria-label="Previous testimonial"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="20"
+						height="20"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						class="text-gray-800 transition-transform group-hover/button:-translate-x-0.5 dark:text-neutral-200"
+					>
+						<path d="m15 18-6-6 6-6" />
+					</svg>
+				</button>
+				<button
+					onclick={() => navigate("next")}
+					class="group/button flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 transition-colors hover:bg-gray-200 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+					aria-label="Next testimonial"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="20"
+						height="20"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						class="text-gray-800 transition-transform group-hover/button:translate-x-0.5 dark:text-neutral-200"
+					>
+						<path d="m9 18 6-6-6-6" />
+					</svg>
+				</button>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/lib/fancy-ui/animated-testimonials/AnimatedTestimonials.svelte
+++ b/src/lib/fancy-ui/animated-testimonials/AnimatedTestimonials.svelte
@@ -26,11 +26,13 @@
 		/** Additional CSS classes */
 		class?: string;
 	}
+
+	/** Duration must match the CSS transition duration below */
+	const TRANSITION_DURATION = 300;
 </script>
 
 <script lang="ts">
 	import { cn } from "$lib/utils.js";
-	import { onMount } from "svelte";
 
 	let {
 		testimonials,
@@ -42,146 +44,152 @@
 	let activeIndex = $state(0);
 	let direction = $state<"next" | "prev">("next");
 	let isAnimating = $state(false);
-	let autoplayTimer: ReturnType<typeof setInterval> | null = null;
+	let isHovered = $state(false);
+
+	let navigateTimer: ReturnType<typeof setTimeout> | null = null;
 
 	function navigate(dir: "next" | "prev") {
-		if (isAnimating) return;
+		if (isAnimating || testimonials.length === 0) return;
 		direction = dir;
 		isAnimating = true;
-		setTimeout(() => {
+		navigateTimer = setTimeout(() => {
 			activeIndex =
 				dir === "next"
 					? (activeIndex + 1) % testimonials.length
 					: (activeIndex - 1 + testimonials.length) % testimonials.length;
 			isAnimating = false;
-		}, 300);
+			navigateTimer = null;
+		}, TRANSITION_DURATION);
 	}
 
-	function startAutoplay() {
-		if (!autoplay) return;
-		autoplayTimer = setInterval(() => navigate("next"), interval);
-	}
+	// Reactive autoplay: restarts whenever autoplay, interval, or hover state changes
+	$effect(() => {
+		if (!autoplay || isHovered || testimonials.length === 0) return;
 
-	function stopAutoplay() {
-		if (autoplayTimer) {
-			clearInterval(autoplayTimer);
-			autoplayTimer = null;
-		}
-	}
-
-	onMount(() => {
-		startAutoplay();
-		return () => stopAutoplay();
+		const timer = setInterval(() => navigate("next"), interval);
+		return () => clearInterval(timer);
 	});
 
-	let activeTestimonial = $derived(testimonials[activeIndex]);
+	// Cleanup navigate timeout on destroy
+	$effect(() => {
+		return () => {
+			if (navigateTimer) clearTimeout(navigateTimer);
+		};
+	});
+
+	let activeTestimonial = $derived(
+		testimonials.length > 0 ? testimonials[activeIndex] : null
+	);
 </script>
 
 <div
 	class={cn("relative mx-auto max-w-sm md:max-w-4xl antialiased font-sans px-4 md:px-8 lg:px-12 py-20", className)}
-	onmouseenter={stopAutoplay}
-	onmouseleave={startAutoplay}
+	onmouseenter={() => (isHovered = true)}
+	onmouseleave={() => (isHovered = false)}
 	role="region"
 	aria-label="Testimonials"
 >
-	<div class="relative grid grid-cols-1 gap-20 md:grid-cols-2">
-		<!-- Image column -->
-		<div class="relative h-80 w-full">
-			{#each testimonials as testimonial, index}
+	{#if testimonials.length === 0}
+		<p class="text-center text-muted-foreground">No testimonials available.</p>
+	{:else}
+		<div class="relative grid grid-cols-1 gap-20 md:grid-cols-2">
+			<!-- Image column -->
+			<div class="relative h-80 w-full">
+				{#each testimonials as testimonial, index}
+					<div
+						class={cn(
+							"absolute inset-0 h-full w-full origin-bottom rounded-3xl transition-all ease-in-out",
+							index === activeIndex
+								? "z-20 opacity-100 scale-100 translate-y-0 rotate-0"
+								: "z-10 opacity-0 scale-95 translate-y-4",
+							index !== activeIndex && direction === "next"
+								? "-translate-y-4"
+								: index !== activeIndex
+									? "translate-y-4"
+									: ""
+						)}
+						style="transition-duration: {TRANSITION_DURATION}ms"
+					>
+						<img
+							src={testimonial.src}
+							alt={testimonial.name}
+							class="h-full w-full rounded-3xl object-cover object-center"
+							draggable="false"
+						/>
+					</div>
+				{/each}
+			</div>
+
+			<!-- Content column -->
+			<div class="flex flex-col justify-between py-4">
 				<div
 					class={cn(
-						"absolute inset-0 h-full w-full origin-bottom rounded-3xl transition-all duration-500 ease-in-out",
-						index === activeIndex
-							? "z-20 opacity-100 scale-100 translate-y-0 rotate-0"
-							: "z-10 opacity-0 scale-95 translate-y-4",
-						index !== activeIndex && direction === "next"
-							? "-translate-y-4"
-							: index !== activeIndex
-								? "translate-y-4"
-								: ""
+						"ease-in-out",
+						isAnimating
+							? direction === "next"
+								? "opacity-0 translate-y-4"
+								: "opacity-0 -translate-y-4"
+							: "opacity-100 translate-y-0"
 					)}
+					style="transition: opacity {TRANSITION_DURATION}ms, transform {TRANSITION_DURATION}ms"
 				>
-					<img
-						src={testimonial.src}
-						alt={testimonial.name}
-						class="h-full w-full rounded-3xl object-cover object-center"
-						draggable="false"
-					/>
+					<p class="text-lg text-gray-500 dark:text-neutral-300" aria-live="polite">
+						{activeTestimonial?.quote}
+					</p>
+					<div class="mt-8">
+						<p class="text-base font-bold text-gray-900 dark:text-white">
+							{activeTestimonial?.name}
+						</p>
+						<p class="text-sm text-gray-500 dark:text-neutral-400">
+							{activeTestimonial?.designation}
+						</p>
+					</div>
 				</div>
-			{/each}
-		</div>
 
-		<!-- Content column -->
-		<div class="flex flex-col justify-between py-4">
-			<div
-				class={cn(
-					"transition-all duration-300 ease-in-out",
-					isAnimating
-						? direction === "next"
-							? "opacity-0 translate-y-4"
-							: "opacity-0 -translate-y-4"
-						: "opacity-100 translate-y-0"
-				)}
-			>
-				<p
-					class="text-lg text-gray-500 dark:text-neutral-300"
-					aria-live="polite"
-				>
-					{activeTestimonial.quote}
-				</p>
-				<div class="mt-8">
-					<p class="text-base font-bold text-gray-900 dark:text-white">
-						{activeTestimonial.name}
-					</p>
-					<p class="text-sm text-gray-500 dark:text-neutral-400">
-						{activeTestimonial.designation}
-					</p>
+				<!-- Navigation -->
+				<div class="mt-8 flex gap-4">
+					<button
+						onclick={() => navigate("prev")}
+						class="group/button flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 transition-colors hover:bg-gray-200 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+						aria-label="Previous testimonial"
+					>
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="20"
+							height="20"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							class="text-gray-800 transition-transform group-hover/button:-translate-x-0.5 dark:text-neutral-200"
+						>
+							<path d="m15 18-6-6 6-6" />
+						</svg>
+					</button>
+					<button
+						onclick={() => navigate("next")}
+						class="group/button flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 transition-colors hover:bg-gray-200 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+						aria-label="Next testimonial"
+					>
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="20"
+							height="20"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							class="text-gray-800 transition-transform group-hover/button:translate-x-0.5 dark:text-neutral-200"
+						>
+							<path d="m9 18 6-6-6-6" />
+						</svg>
+					</button>
 				</div>
 			</div>
-
-			<!-- Navigation -->
-			<div class="mt-8 flex gap-4">
-				<button
-					onclick={() => navigate("prev")}
-					class="group/button flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 transition-colors hover:bg-gray-200 dark:bg-neutral-800 dark:hover:bg-neutral-700"
-					aria-label="Previous testimonial"
-				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						width="20"
-						height="20"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						class="text-gray-800 transition-transform group-hover/button:-translate-x-0.5 dark:text-neutral-200"
-					>
-						<path d="m15 18-6-6 6-6" />
-					</svg>
-				</button>
-				<button
-					onclick={() => navigate("next")}
-					class="group/button flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 transition-colors hover:bg-gray-200 dark:bg-neutral-800 dark:hover:bg-neutral-700"
-					aria-label="Next testimonial"
-				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						width="20"
-						height="20"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						class="text-gray-800 transition-transform group-hover/button:translate-x-0.5 dark:text-neutral-200"
-					>
-						<path d="m9 18 6-6-6-6" />
-					</svg>
-				</button>
-			</div>
 		</div>
-	</div>
+	{/if}
 </div>

--- a/src/lib/fancy-ui/animated-testimonials/AnimatedTestimonials.test.ts
+++ b/src/lib/fancy-ui/animated-testimonials/AnimatedTestimonials.test.ts
@@ -1,0 +1,105 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { flushSync } from "svelte";
+import AnimatedTestimonials from "./AnimatedTestimonials.svelte";
+import type { Testimonial } from "./AnimatedTestimonials.svelte";
+
+const testimonials: Testimonial[] = [
+	{ quote: "First quote", name: "Alice", designation: "CEO", src: "alice.jpg" },
+	{ quote: "Second quote", name: "Bob", designation: "CTO", src: "bob.jpg" },
+	{ quote: "Third quote", name: "Carol", designation: "CFO", src: "carol.jpg" },
+];
+
+describe("AnimatedTestimonials", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		cleanup();
+	});
+
+	it("renders the first testimonial initially", () => {
+		const { getByText } = render(AnimatedTestimonials, { props: { testimonials } });
+		expect(getByText("First quote")).toBeTruthy();
+		expect(getByText("Alice")).toBeTruthy();
+		expect(getByText("CEO")).toBeTruthy();
+	});
+
+	it("shows empty state when testimonials array is empty", () => {
+		const { getByText } = render(AnimatedTestimonials, { props: { testimonials: [] } });
+		expect(getByText("No testimonials available.")).toBeTruthy();
+	});
+
+	it("advances to next testimonial on next button click", () => {
+		const { getByLabelText, getByText } = render(AnimatedTestimonials, {
+			props: { testimonials },
+		});
+		fireEvent.click(getByLabelText("Next testimonial"));
+		flushSync(() => vi.advanceTimersByTime(300));
+		expect(getByText("Second quote")).toBeTruthy();
+		expect(getByText("Bob")).toBeTruthy();
+	});
+
+	it("goes to previous testimonial on prev button click", () => {
+		const { getByLabelText, getByText } = render(AnimatedTestimonials, {
+			props: { testimonials },
+		});
+		// Go to second first
+		fireEvent.click(getByLabelText("Next testimonial"));
+		flushSync(() => vi.advanceTimersByTime(300));
+		// Then go back
+		fireEvent.click(getByLabelText("Previous testimonial"));
+		flushSync(() => vi.advanceTimersByTime(300));
+		expect(getByText("First quote")).toBeTruthy();
+	});
+
+	it("wraps around to last testimonial when going prev from first", () => {
+		const { getByLabelText, getByText } = render(AnimatedTestimonials, {
+			props: { testimonials },
+		});
+		fireEvent.click(getByLabelText("Previous testimonial"));
+		flushSync(() => vi.advanceTimersByTime(300));
+		expect(getByText("Third quote")).toBeTruthy();
+	});
+
+	it("wraps around to first testimonial when going next from last", () => {
+		const { getByLabelText, getByText } = render(AnimatedTestimonials, {
+			props: { testimonials },
+		});
+		fireEvent.click(getByLabelText("Next testimonial"));
+		flushSync(() => vi.advanceTimersByTime(300));
+		fireEvent.click(getByLabelText("Next testimonial"));
+		flushSync(() => vi.advanceTimersByTime(300));
+		fireEvent.click(getByLabelText("Next testimonial"));
+		flushSync(() => vi.advanceTimersByTime(300));
+		expect(getByText("First quote")).toBeTruthy();
+	});
+
+	it("auto-advances testimonials when autoplay is enabled", () => {
+		const { getByText } = render(AnimatedTestimonials, {
+			props: { testimonials, autoplay: true, interval: 3000 },
+		});
+		expect(getByText("First quote")).toBeTruthy();
+		flushSync(() => {
+			vi.advanceTimersByTime(3000);
+			vi.advanceTimersByTime(300);
+		});
+		expect(getByText("Second quote")).toBeTruthy();
+	});
+
+	it("does not auto-advance when autoplay is false", () => {
+		const { getByText } = render(AnimatedTestimonials, {
+			props: { testimonials, autoplay: false, interval: 1000 },
+		});
+		vi.advanceTimersByTime(5000);
+		expect(getByText("First quote")).toBeTruthy();
+	});
+
+	it("renders navigation buttons", () => {
+		const { getByLabelText } = render(AnimatedTestimonials, { props: { testimonials } });
+		expect(getByLabelText("Previous testimonial")).toBeTruthy();
+		expect(getByLabelText("Next testimonial")).toBeTruthy();
+	});
+});

--- a/src/lib/fancy-ui/animated-testimonials/index.ts
+++ b/src/lib/fancy-ui/animated-testimonials/index.ts
@@ -1,0 +1,2 @@
+export { default as AnimatedTestimonials } from "./AnimatedTestimonials.svelte";
+export type { AnimatedTestimonialsProps, Testimonial } from "./AnimatedTestimonials.svelte";

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -6,6 +6,7 @@
 // =============================================================================
 
 export * from "./animated-beam/index.js";
+export * from "./animated-testimonials/index.js";
 export * from "./fluid-cursor/index.js";
 export * from "./animated-tooltip/index.js";
 export * from "./blur-reveal/index.js";

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -82,6 +82,14 @@ export const registry: Record<string, ComponentMeta> = {
 		status: "done",
 	},
 
+	"animated-testimonials": {
+		name: "AnimatedTestimonials",
+		slug: "animated-testimonials",
+		description: "Testimonial carousel with smooth slide animations and optional autoplay",
+		category: "data-display",
+		status: "done",
+	},
+
 	"bg-falling-stars": {
 		name: "FallingStarsBg",
 		slug: "bg-falling-stars",

--- a/src/routes/demo/animated-testimonials/+page.svelte
+++ b/src/routes/demo/animated-testimonials/+page.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+	import { AnimatedTestimonials } from "$lib/fancy-ui/animated-testimonials";
+	import type { Testimonial } from "$lib/fancy-ui/animated-testimonials";
+
+	const testimonials: Testimonial[] = [
+		{
+			quote:
+				"The attention to detail and innovative features have completely transformed our workflow. This is exactly what we've been looking for.",
+			name: "Sarah Chen",
+			designation: "Product Manager at TechFlow",
+			src: "https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?w=500&auto=format&fit=crop&q=60",
+		},
+		{
+			quote:
+				"Implementation was seamless and the results exceeded our expectations. The platform's flexibility is truly impressive.",
+			name: "Michael Rivera",
+			designation: "CTO at InnovateSphere",
+			src: "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=500&auto=format&fit=crop&q=60",
+		},
+		{
+			quote:
+				"This solution has significantly improved our team's productivity. The intuitive interface makes complex tasks simple.",
+			name: "Emily Watson",
+			designation: "Operations Director at CloudScale",
+			src: "https://images.unsplash.com/photo-1623582854588-d60de57fa33f?w=500&auto=format&fit=crop&q=60",
+		},
+		{
+			quote:
+				"Outstanding support and robust features. It's rare to find a product that delivers on all its promises.",
+			name: "James Kim",
+			designation: "Engineering Lead at DataPro",
+			src: "https://images.unsplash.com/photo-1636041293178-808a6762ab39?w=500&auto=format&fit=crop&q=60",
+		},
+		{
+			quote:
+				"The scalability and performance have been game-changing for our organization. Highly recommend to any growing business.",
+			name: "Lisa Thompson",
+			designation: "VP of Technology at FutureNet",
+			src: "https://images.unsplash.com/photo-1624561172888-ac93c696e10c?w=500&auto=format&fit=crop&q=60",
+		},
+	];
+
+	const autoplayTestimonials: Testimonial[] = testimonials.slice(0, 3);
+</script>
+
+<svelte:head>
+	<title>AnimatedTestimonials - FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto px-4 py-12">
+	<div class="mb-10">
+		<h1 class="text-3xl font-bold tracking-tight">Animated Testimonials</h1>
+		<p class="mt-2 text-muted-foreground">
+			Testimonial carousel with smooth slide animations, navigation arrows, and optional autoplay.
+		</p>
+	</div>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Basic Usage</h2>
+		<div class="rounded-lg border bg-card flex items-center justify-center min-h-[400px]">
+			<AnimatedTestimonials {testimonials} />
+		</div>
+	</section>
+
+	<!-- With Autoplay -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">With Autoplay</h2>
+		<p class="mb-4 text-sm text-muted-foreground">
+			Auto-advances every 3 seconds. Pauses on hover.
+		</p>
+		<div class="rounded-lg border bg-card flex items-center justify-center min-h-[400px]">
+			<AnimatedTestimonials testimonials={autoplayTestimonials} autoplay interval={3000} />
+		</div>
+	</section>
+
+	<!-- Props -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Props</h2>
+		<div class="overflow-x-auto rounded-lg border">
+			<table class="w-full text-sm">
+				<thead class="bg-muted/50">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Prop</th>
+						<th class="px-4 py-3 text-left font-medium">Type</th>
+						<th class="px-4 py-3 text-left font-medium">Default</th>
+						<th class="px-4 py-3 text-left font-medium">Description</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y">
+					<tr>
+						<td class="px-4 py-3 font-mono text-primary">testimonials</td>
+						<td class="px-4 py-3 font-mono text-muted-foreground">Testimonial[]</td>
+						<td class="px-4 py-3 text-muted-foreground">required</td>
+						<td class="px-4 py-3 text-muted-foreground">Array of testimonial objects</td>
+					</tr>
+					<tr>
+						<td class="px-4 py-3 font-mono text-primary">autoplay</td>
+						<td class="px-4 py-3 font-mono text-muted-foreground">boolean</td>
+						<td class="px-4 py-3 font-mono text-muted-foreground">false</td>
+						<td class="px-4 py-3 text-muted-foreground">Auto-advance testimonials</td>
+					</tr>
+					<tr>
+						<td class="px-4 py-3 font-mono text-primary">interval</td>
+						<td class="px-4 py-3 font-mono text-muted-foreground">number</td>
+						<td class="px-4 py-3 font-mono text-muted-foreground">5000</td>
+						<td class="px-4 py-3 text-muted-foreground">Autoplay interval in milliseconds</td>
+					</tr>
+					<tr>
+						<td class="px-4 py-3 font-mono text-primary">class</td>
+						<td class="px-4 py-3 font-mono text-muted-foreground">string</td>
+						<td class="px-4 py-3 font-mono text-muted-foreground">undefined</td>
+						<td class="px-4 py-3 text-muted-foreground">Additional CSS classes</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+
+	<!-- Testimonial type -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Testimonial Type</h2>
+		<div class="overflow-x-auto rounded-lg border">
+			<table class="w-full text-sm">
+				<thead class="bg-muted/50">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Field</th>
+						<th class="px-4 py-3 text-left font-medium">Type</th>
+						<th class="px-4 py-3 text-left font-medium">Description</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y">
+					<tr>
+						<td class="px-4 py-3 font-mono text-primary">quote</td>
+						<td class="px-4 py-3 font-mono text-muted-foreground">string</td>
+						<td class="px-4 py-3 text-muted-foreground">The testimonial text</td>
+					</tr>
+					<tr>
+						<td class="px-4 py-3 font-mono text-primary">name</td>
+						<td class="px-4 py-3 font-mono text-muted-foreground">string</td>
+						<td class="px-4 py-3 text-muted-foreground">Author's full name</td>
+					</tr>
+					<tr>
+						<td class="px-4 py-3 font-mono text-primary">designation</td>
+						<td class="px-4 py-3 font-mono text-muted-foreground">string</td>
+						<td class="px-4 py-3 text-muted-foreground">Author's title or role</td>
+					</tr>
+					<tr>
+						<td class="px-4 py-3 font-mono text-primary">src</td>
+						<td class="px-4 py-3 font-mono text-muted-foreground">string</td>
+						<td class="px-4 py-3 text-muted-foreground">URL to the author's avatar image</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary

- Add `AnimatedTestimonials` component with stacked image cards and smooth slide transitions
- Navigation arrows (prev/next) with direction-aware animations
- Optional `autoplay` prop with configurable `interval`, pauses on hover
- Demo page at `/demo/animated-testimonials` with basic and autoplay examples
- Registered in registry under `data-display` category

## Test plan

- [ ] Navigate forward/backward between testimonials
- [ ] Verify slide animations are direction-aware
- [ ] Test autoplay starts and pauses on hover
- [ ] Check dark mode rendering
- [ ] Verify responsive layout on mobile and desktop