### PR TITLE
feat(demo): add credits section to all component demo pages

### DIFF
--- a/src/lib/components/DemoCredits.svelte
+++ b/src/lib/components/DemoCredits.svelte
@@ -18,7 +18,7 @@
 							href={credit.url}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-foreground font-medium underline underline-offset-4 hover:opacity-70 transition-opacity"
+							class="text-foreground font-medium underline underline-offset-4 transition-opacity hover:opacity-70"
 						>
 							{credit.source}
 						</a>

--- a/src/lib/components/DemoCredits.svelte
+++ b/src/lib/components/DemoCredits.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import type { ComponentMeta } from "$lib/types.js";
+
+	let { component }: { component: ComponentMeta } = $props();
+</script>
+
+{#if component.credits && component.credits.length > 0}
+	<div class="border-border mt-12 border-t pt-8">
+		<h2 class="text-muted-foreground mb-3 text-xs font-semibold tracking-wider uppercase">
+			Credits
+		</h2>
+		<ul class="flex flex-col gap-1.5">
+			{#each component.credits as credit}
+				<li class="text-sm">
+					<span class="text-muted-foreground">Inspired by </span>
+					{#if credit.url}
+						<a
+							href={credit.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="text-foreground font-medium underline underline-offset-4 hover:opacity-70 transition-opacity"
+						>
+							{credit.source}
+						</a>
+					{:else}
+						<span class="text-foreground font-medium">{credit.source}</span>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	</div>
+{/if}

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -80,6 +80,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Animated SVG beams connecting elements with smooth gradients",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/animated-beam" }],
 	},
 
 	"bg-falling-stars": {
@@ -96,6 +97,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Avatar row with animated tooltips that follow mouse movement",
 		category: "feedback",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/animated-tooltip" }],
 	},
 
 	"blur-reveal": {
@@ -104,6 +106,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Scroll-triggered blur-to-clear reveal animation with staggered children",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/blur-fade" }],
 	},
 
 	"border-beam": {
@@ -112,6 +115,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Animated beam effect that travels around borders",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/border-beam" }],
 	},
 
 	compare: {
@@ -120,6 +124,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Before/after image comparison slider with hover and drag modes",
 		category: "media",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/compare" }],
 	},
 
 	"image-trail-cursor": {
@@ -136,6 +141,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "SVG grid of squares that highlight on hover with smooth fade transitions",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/interactive-grid-pattern" }],
 	},
 
 	"logo-cloud": {
@@ -144,6 +150,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Logo display with animated marquee, static grid, and icon variants",
 		category: "data-display",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/marquee" }],
 	},
 
 	"direction-aware-hover": {
@@ -152,6 +159,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Image card with overlay that slides in from the mouse entry direction",
 		category: "cards",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/direction-aware-hover" }],
 	},
 
 	"rainbow-button": {
@@ -160,6 +168,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Animated button with a rainbow gradient border effect",
 		category: "buttons",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/rainbow-button" }],
 	},
 
 	"ripple-button": {
@@ -168,6 +177,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Button with ripple click effect",
 		category: "buttons",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/ripple-button" }],
 	},
 
 	"shimmer-button": {
@@ -176,6 +186,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Button with a rotating conic-gradient shimmer border effect",
 		category: "buttons",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/shimmer-button" }],
 	},
 
 	timeline: {
@@ -184,6 +195,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Vertical timeline with scroll-driven progress line and sticky labels",
 		category: "navigation",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/timeline" }],
 	},
 
 	"bg-stars": {
@@ -192,6 +204,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Animated starfield background with parallax mouse tracking",
 		category: "backgrounds",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/stars-background" }],
 	},
 
 	dock: {
@@ -200,6 +213,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "macOS-style dock with icon magnification on hover",
 		category: "navigation",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/dock" }],
 	},
 
 	"fluid-cursor": {
@@ -208,6 +222,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "WebGL fluid simulation that follows cursor movement",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Inspira UI", url: "https://inspira-ui.com/components/cursor/fluid-cursor" }],
 	},
 
 	"glow-border": {
@@ -216,6 +231,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Animated glowing border effect with gradient support",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/background-gradient" }],
 	},
 
 	"gradient-button": {
@@ -224,6 +240,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Button with a rotating conic-gradient rainbow border effect",
 		category: "buttons",
 		status: "done",
+		credits: [{ source: "Inspira UI", url: "https://inspira-ui.com/components/buttons/gradient-button" }],
 	},
 
 	"interactive-hover-button": {
@@ -232,6 +249,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Button with interactive hover effect revealing alternate content",
 		category: "buttons",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/interactive-hover-button" }],
 	},
 
 	marquee: {
@@ -240,6 +258,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Infinite scrolling component for text, images, or cards",
 		category: "layout",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/marquee" }],
 	},
 
 	meteors: {
@@ -248,6 +267,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Animated meteor shower effect with randomized positions and delays",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/meteors" }],
 	},
 
 	"flickering-grid": {
@@ -256,6 +276,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Canvas-based grid of squares with flickering opacity",
 		category: "backgrounds",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/flickering-grid" }],
 	},
 
 	"neon-border": {
@@ -264,6 +285,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Dual-color neon glow border effect with optional rotation animation",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/neon-gradient-card" }],
 	},
 
 	"colourful-text": {
@@ -272,6 +294,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Per-character color animation with shuffling colors",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/colourful-text" }],
 	},
 
 	"flip-words": {
@@ -280,6 +303,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Cycling word animation with per-letter fade-in and blur effects",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/flip-words" }],
 	},
 
 	"hyper-text": {
@@ -288,6 +312,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Character scramble effect that activates on hover",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/hyper-text" }],
 	},
 
 	"letter-pullup": {
@@ -296,6 +321,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Staggered letter pull-up animation with wave entrance effect",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/letter-pullup" }],
 	},
 
 	"number-ticker": {
@@ -304,6 +330,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Animated number counter with easing, triggered on viewport entry",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/number-ticker" }],
 	},
 
 	"sparkles-text": {
@@ -312,6 +339,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Text with animated SVG sparkle stars overlay",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/sparkles" }],
 	},
 
 	"box-reveal": {
@@ -320,6 +348,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Content reveal with sliding colored box animation",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/box-reveal" }],
 	},
 
 	"card-3d": {
@@ -328,6 +357,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Interactive 3D perspective card with depth effects on child elements",
 		category: "cards",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/3d-card-effect" }],
 	},
 
 	"card-spotlight": {
@@ -336,6 +366,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Card with mouse-following radial gradient spotlight overlay",
 		category: "cards",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/card-spotlight" }],
 	},
 
 	"bento-grid": {
@@ -344,6 +375,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Bento-style grid layout with slot-based and props-based card variants",
 		category: "cards",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/bento-grid" }],
 	},
 
 	"flip-card": {
@@ -360,6 +392,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "3D book component with cover, spine, and back face that opens on hover",
 		category: "cards",
 		status: "done",
+		credits: [{ source: "Inspira UI", url: "https://inspira-ui.com/components/cards/book" }],
 	},
 
 	"glare-card": {
@@ -368,6 +401,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Holographic trading card effect with mouse-tracking glare and rainbow foil",
 		category: "cards",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/glare-card" }],
 	},
 
 	"text-reveal-card": {
@@ -376,6 +410,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Card that reveals text on horizontal mouse drag with animated star particles",
 		category: "cards",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/text-reveal-card" }],
 	},
 
 	"container-scroll": {
@@ -384,6 +419,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Scroll-driven animation that rotates and scales a card from tilted to flat",
 		category: "layout",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/container-scroll-animation" }],
 	},
 
 	"container-text-flip": {
@@ -392,6 +428,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Text container that cycles through words with per-character blur animation",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Inspira UI", url: "https://inspira-ui.com/components/text/text-flip" }],
 	},
 
 	focus: {
@@ -400,6 +437,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Text component that cycles focus through words with blur and corner frame",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/focus-cards" }],
 	},
 
 	"liquid-glass": {
@@ -408,6 +446,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Glass-like visual effect using SVG filters for chromatic displacement",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Inspira UI", url: "https://inspira-ui.com/components/special-effects/liquid-glass" }],
 	},
 
 	"smooth-cursor": {
@@ -416,6 +455,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Physics-based smooth cursor with spring animations and rotation effects",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Inspira UI", url: "https://inspira-ui.com/components/cursor/smooth-cursor" }],
 	},
 
 	"glowing-effect": {
@@ -424,6 +464,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Mouse-proximity based glowing border effect with animated conic gradient",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/glowing-effect" }],
 	},
 
 	sparkles: {
@@ -433,6 +474,7 @@ export const registry: Record<string, ComponentMeta> = {
 			"Canvas-based floating particle sparkle effect with configurable density and colors",
 		category: "backgrounds",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/sparkles" }],
 	},
 
 	confetti: {
@@ -442,6 +484,7 @@ export const registry: Record<string, ComponentMeta> = {
 			"Confetti celebration effect powered by canvas-confetti with button trigger support",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/confetti" }],
 	},
 
 	ripple: {
@@ -450,6 +493,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Concentric pulsing circles with ripple wave animation",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/ripple" }],
 	},
 
 	"text-generate-effect": {
@@ -458,6 +502,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Typewriter-style text reveal that fades in words one by one with optional blur",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/text-generate-effect" }],
 	},
 
 	"line-shadow-text": {
@@ -466,6 +511,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Text with animated diagonal line shadow pattern that scrolls continuously",
 		category: "text",
 		status: "done",
+		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/line-shadow-text" }],
 	},
 
 	"tracing-beam": {
@@ -474,6 +520,7 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Vertical SVG beam that highlights scroll progress alongside content",
 		category: "effects",
 		status: "done",
+		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/tracing-beam" }],
 	},
 };
 

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -97,7 +97,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Avatar row with animated tooltips that follow mouse movement",
 		category: "feedback",
 		status: "done",
-		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/animated-tooltip" }],
+		credits: [
+			{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/animated-tooltip" },
+		],
 	},
 
 	"blur-reveal": {
@@ -141,7 +143,12 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "SVG grid of squares that highlight on hover with smooth fade transitions",
 		category: "effects",
 		status: "done",
-		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/interactive-grid-pattern" }],
+		credits: [
+			{
+				source: "Magic UI",
+				url: "https://magicui.design/docs/components/interactive-grid-pattern",
+			},
+		],
 	},
 
 	"logo-cloud": {
@@ -159,7 +166,12 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Image card with overlay that slides in from the mouse entry direction",
 		category: "cards",
 		status: "done",
-		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/direction-aware-hover" }],
+		credits: [
+			{
+				source: "Aceternity UI",
+				url: "https://ui.aceternity.com/components/direction-aware-hover",
+			},
+		],
 	},
 
 	"rainbow-button": {
@@ -204,7 +216,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Animated starfield background with parallax mouse tracking",
 		category: "backgrounds",
 		status: "done",
-		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/stars-background" }],
+		credits: [
+			{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/stars-background" },
+		],
 	},
 
 	dock: {
@@ -222,7 +236,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "WebGL fluid simulation that follows cursor movement",
 		category: "effects",
 		status: "done",
-		credits: [{ source: "Inspira UI", url: "https://inspira-ui.com/components/cursor/fluid-cursor" }],
+		credits: [
+			{ source: "Inspira UI", url: "https://inspira-ui.com/components/cursor/fluid-cursor" },
+		],
 	},
 
 	"glow-border": {
@@ -231,7 +247,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Animated glowing border effect with gradient support",
 		category: "effects",
 		status: "done",
-		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/background-gradient" }],
+		credits: [
+			{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/background-gradient" },
+		],
 	},
 
 	"gradient-button": {
@@ -240,7 +258,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Button with a rotating conic-gradient rainbow border effect",
 		category: "buttons",
 		status: "done",
-		credits: [{ source: "Inspira UI", url: "https://inspira-ui.com/components/buttons/gradient-button" }],
+		credits: [
+			{ source: "Inspira UI", url: "https://inspira-ui.com/components/buttons/gradient-button" },
+		],
 	},
 
 	"interactive-hover-button": {
@@ -249,7 +269,12 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Button with interactive hover effect revealing alternate content",
 		category: "buttons",
 		status: "done",
-		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/interactive-hover-button" }],
+		credits: [
+			{
+				source: "Magic UI",
+				url: "https://magicui.design/docs/components/interactive-hover-button",
+			},
+		],
 	},
 
 	marquee: {
@@ -276,7 +301,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Canvas-based grid of squares with flickering opacity",
 		category: "backgrounds",
 		status: "done",
-		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/flickering-grid" }],
+		credits: [
+			{ source: "Magic UI", url: "https://magicui.design/docs/components/flickering-grid" },
+		],
 	},
 
 	"neon-border": {
@@ -285,7 +312,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Dual-color neon glow border effect with optional rotation animation",
 		category: "effects",
 		status: "done",
-		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/neon-gradient-card" }],
+		credits: [
+			{ source: "Magic UI", url: "https://magicui.design/docs/components/neon-gradient-card" },
+		],
 	},
 
 	"colourful-text": {
@@ -294,7 +323,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Per-character color animation with shuffling colors",
 		category: "text",
 		status: "done",
-		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/colourful-text" }],
+		credits: [
+			{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/colourful-text" },
+		],
 	},
 
 	"flip-words": {
@@ -357,7 +388,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Interactive 3D perspective card with depth effects on child elements",
 		category: "cards",
 		status: "done",
-		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/3d-card-effect" }],
+		credits: [
+			{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/3d-card-effect" },
+		],
 	},
 
 	"card-spotlight": {
@@ -366,7 +399,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Card with mouse-following radial gradient spotlight overlay",
 		category: "cards",
 		status: "done",
-		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/card-spotlight" }],
+		credits: [
+			{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/card-spotlight" },
+		],
 	},
 
 	"bento-grid": {
@@ -410,7 +445,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Card that reveals text on horizontal mouse drag with animated star particles",
 		category: "cards",
 		status: "done",
-		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/text-reveal-card" }],
+		credits: [
+			{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/text-reveal-card" },
+		],
 	},
 
 	"container-scroll": {
@@ -419,7 +456,12 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Scroll-driven animation that rotates and scales a card from tilted to flat",
 		category: "layout",
 		status: "done",
-		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/container-scroll-animation" }],
+		credits: [
+			{
+				source: "Aceternity UI",
+				url: "https://ui.aceternity.com/components/container-scroll-animation",
+			},
+		],
 	},
 
 	"container-text-flip": {
@@ -446,7 +488,12 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Glass-like visual effect using SVG filters for chromatic displacement",
 		category: "effects",
 		status: "done",
-		credits: [{ source: "Inspira UI", url: "https://inspira-ui.com/components/special-effects/liquid-glass" }],
+		credits: [
+			{
+				source: "Inspira UI",
+				url: "https://inspira-ui.com/components/special-effects/liquid-glass",
+			},
+		],
 	},
 
 	"smooth-cursor": {
@@ -455,7 +502,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Physics-based smooth cursor with spring animations and rotation effects",
 		category: "effects",
 		status: "done",
-		credits: [{ source: "Inspira UI", url: "https://inspira-ui.com/components/cursor/smooth-cursor" }],
+		credits: [
+			{ source: "Inspira UI", url: "https://inspira-ui.com/components/cursor/smooth-cursor" },
+		],
 	},
 
 	"glowing-effect": {
@@ -502,7 +551,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Typewriter-style text reveal that fades in words one by one with optional blur",
 		category: "text",
 		status: "done",
-		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/text-generate-effect" }],
+		credits: [
+			{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/text-generate-effect" },
+		],
 	},
 
 	"line-shadow-text": {
@@ -511,7 +562,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Text with animated diagonal line shadow pattern that scrolls continuously",
 		category: "text",
 		status: "done",
-		credits: [{ source: "Magic UI", url: "https://magicui.design/docs/components/line-shadow-text" }],
+		credits: [
+			{ source: "Magic UI", url: "https://magicui.design/docs/components/line-shadow-text" },
+		],
 	},
 
 	"tracing-beam": {
@@ -520,7 +573,9 @@ export const registry: Record<string, ComponentMeta> = {
 		description: "Vertical SVG beam that highlights scroll progress alongside content",
 		category: "effects",
 		status: "done",
-		credits: [{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/tracing-beam" }],
+		credits: [
+			{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/tracing-beam" },
+		],
 	},
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -99,4 +99,9 @@ export interface ComponentMeta {
 	status: ComponentStatus;
 	/** Dependencies on other fancy-ui components */
 	dependencies?: string[];
+	/** Credits for the original design/implementation */
+	credits?: Array<{
+		source: string;
+		url?: string;
+	}>;
 }

--- a/src/routes/demo/+layout.svelte
+++ b/src/routes/demo/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from "$app/stores";
 	import ThemeToggle from "$lib/components/ThemeToggle.svelte";
+	import DemoCredits from "$lib/components/DemoCredits.svelte";
 	import {
 		categories,
 		categoryLabels,
@@ -227,5 +228,10 @@
 	<!-- Page content -->
 	<main>
 		{@render children()}
+		{#if currentComponent}
+			<div class="container mx-auto max-w-4xl px-4 pb-12">
+				<DemoCredits component={currentComponent} />
+			</div>
+		{/if}
 	</main>
 </div>


### PR DESCRIPTION
## Summary
- Add a `credits` field to `ComponentMeta` type to store attribution data
- Populate credits for ~48 components in the registry, linking to original sources (Aceternity UI, Magic UI, Inspira UI)
- Create `DemoCredits.svelte` component and integrate it in the demo layout — credits appear automatically on every page, no per-page edits needed

## Test plan
- [ ] Visit any demo page (e.g. `/demo/meteors`) and verify a "Credits" section appears at the bottom with a link to the original source
- [ ] Verify components without credits (e.g. `/demo/bg-falling-stars`) show no credits section
- [ ] Check that links open the correct external page