### PR TITLE
feat: add AppleCardCarousel component

### DIFF
--- a/.changeset/apple-card-carousel.md
+++ b/.changeset/apple-card-carousel.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": minor
+---
+
+feat: add AppleCardCarousel component — horizontal card carousel with spring-animated full-screen expansion, inspired by Apple's App Store UI

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
@@ -13,45 +13,54 @@
 		/** Rich content shown in the expanded view (takes precedence over description) */
 		content?: Snippet;
 	}
+
+	/** Shared transition duration — must stay in sync with the CSS transition below */
+	export const TRANSITION_MS = 400;
 </script>
 
 <script lang="ts">
-	import { onMount } from "svelte";
+	import { tick } from "svelte";
 	import { cn } from "$lib/utils.js";
 
 	interface Props {
 		card: AppleCardData;
 		index: number;
 		expandedIndex: number;
+		reducedMotion: boolean;
 		onExpand: (index: number) => void;
 		onCollapse: () => void;
 		class?: string;
 	}
 
-	let { card, index, expandedIndex, onExpand, onCollapse, class: className = "" }: Props = $props();
+	let {
+		card,
+		index,
+		expandedIndex,
+		reducedMotion,
+		onExpand,
+		onCollapse,
+		class: className = "",
+	}: Props = $props();
 
 	let cardEl: HTMLDivElement;
+	let dialogEl: HTMLDivElement;
+	let closeBtn: HTMLButtonElement;
 	let rect = $state<{ top: number; left: number; width: number; height: number } | null>(null);
 	let overlayVisible = $state(false);
 	let fullyExpanded = $state(false);
-	let reducedMotion = $state(false);
+	let previousFocus: HTMLElement | null = null;
 
-	onMount(() => {
-		const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-		reducedMotion = mq.matches;
-		const handler = (e: MediaQueryListEvent) => {
-			reducedMotion = e.matches;
-		};
-		mq.addEventListener("change", handler);
-		return () => mq.removeEventListener("change", handler);
-	});
-
-	function handleExpand() {
+	async function handleExpand() {
 		if (expandedIndex !== -1) return;
+		previousFocus = document.activeElement as HTMLElement;
 		const r = cardEl.getBoundingClientRect();
 		rect = { top: r.top, left: r.left, width: r.width, height: r.height };
 		overlayVisible = true;
 		onExpand(index);
+
+		// Wait for the overlay to be in the DOM before focusing
+		await tick();
+		closeBtn?.focus();
 
 		if (reducedMotion) {
 			fullyExpanded = true;
@@ -66,11 +75,13 @@
 
 	function handleCollapse() {
 		fullyExpanded = false;
-		const delay = reducedMotion ? 0 : 400;
+		const delay = reducedMotion ? 0 : TRANSITION_MS;
 		setTimeout(() => {
 			overlayVisible = false;
 			onCollapse();
 			rect = null;
+			previousFocus?.focus();
+			previousFocus = null;
 		}, delay);
 	}
 
@@ -82,7 +93,28 @@
 	}
 
 	function handleOverlayKeydown(e: KeyboardEvent) {
-		if (e.key === "Escape") handleCollapse();
+		if (e.key === "Escape") {
+			handleCollapse();
+			return;
+		}
+		// Simple focus trap: cycle focus within the dialog on Tab
+		if (e.key === "Tab" && dialogEl) {
+			const focusable = Array.from(
+				dialogEl.querySelectorAll<HTMLElement>(
+					'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+				)
+			);
+			if (focusable.length === 0) return;
+			const first = focusable[0];
+			const last = focusable[focusable.length - 1];
+			if (e.shiftKey && document.activeElement === first) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && document.activeElement === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
 	}
 </script>
 
@@ -120,11 +152,12 @@
 	<div
 		class="fixed inset-0 z-40 bg-black/80"
 		aria-hidden="true"
-		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion ? 0 : 400}ms ease;"
+		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion ? 0 : TRANSITION_MS}ms ease;"
 		onclick={handleCollapse}
 	></div>
 
 	<div
+		bind:this={dialogEl}
 		role="dialog"
 		aria-modal="true"
 		aria-label={card.title}
@@ -138,12 +171,13 @@
 			border-radius: {fullyExpanded ? '0px' : '1.5rem'};
 			transition: {reducedMotion
 			? 'none'
-			: 'top 0.4s cubic-bezier(0.32,0.72,0,1), left 0.4s cubic-bezier(0.32,0.72,0,1), width 0.4s cubic-bezier(0.32,0.72,0,1), height 0.4s cubic-bezier(0.32,0.72,0,1), border-radius 0.4s cubic-bezier(0.32,0.72,0,1)'};
+			: `top ${TRANSITION_MS}ms cubic-bezier(0.32,0.72,0,1), left ${TRANSITION_MS}ms cubic-bezier(0.32,0.72,0,1), width ${TRANSITION_MS}ms cubic-bezier(0.32,0.72,0,1), height ${TRANSITION_MS}ms cubic-bezier(0.32,0.72,0,1), border-radius ${TRANSITION_MS}ms cubic-bezier(0.32,0.72,0,1)`};
 		"
 		onkeydown={handleOverlayKeydown}
 	>
 		<!-- Close button -->
 		<button
+			bind:this={closeBtn}
 			class="absolute top-4 right-4 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-black/20 backdrop-blur-sm transition-colors hover:bg-black/30"
 			aria-label="Close"
 			onclick={handleCollapse}

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
@@ -1,0 +1,190 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	export interface AppleCardData {
+		/** Category label shown above the title */
+		category: string;
+		/** Main card title */
+		title: string;
+		/** URL of the card background image */
+		src: string;
+		/** Short description shown in the expanded view */
+		description?: string;
+		/** Rich content shown in the expanded view (takes precedence over description) */
+		content?: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { cn } from "$lib/utils.js";
+
+	interface Props {
+		card: AppleCardData;
+		index: number;
+		expandedIndex: number;
+		onExpand: (index: number) => void;
+		onCollapse: () => void;
+		class?: string;
+	}
+
+	let { card, index, expandedIndex, onExpand, onCollapse, class: className = "" }: Props = $props();
+
+	let cardEl: HTMLDivElement;
+	let rect = $state<{ top: number; left: number; width: number; height: number } | null>(null);
+	let overlayVisible = $state(false);
+	let fullyExpanded = $state(false);
+	let reducedMotion = $state(false);
+
+	onMount(() => {
+		const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+		reducedMotion = mq.matches;
+		const handler = (e: MediaQueryListEvent) => {
+			reducedMotion = e.matches;
+		};
+		mq.addEventListener("change", handler);
+		return () => mq.removeEventListener("change", handler);
+	});
+
+	function handleExpand() {
+		if (expandedIndex !== -1) return;
+		const r = cardEl.getBoundingClientRect();
+		rect = { top: r.top, left: r.left, width: r.width, height: r.height };
+		overlayVisible = true;
+		onExpand(index);
+
+		if (reducedMotion) {
+			fullyExpanded = true;
+		} else {
+			requestAnimationFrame(() => {
+				requestAnimationFrame(() => {
+					fullyExpanded = true;
+				});
+			});
+		}
+	}
+
+	function handleCollapse() {
+		fullyExpanded = false;
+		const delay = reducedMotion ? 0 : 400;
+		setTimeout(() => {
+			overlayVisible = false;
+			onCollapse();
+			rect = null;
+		}, delay);
+	}
+
+	function handleCardKeydown(e: KeyboardEvent) {
+		if (e.key === "Enter" || e.key === " ") {
+			e.preventDefault();
+			handleExpand();
+		}
+	}
+
+	function handleOverlayKeydown(e: KeyboardEvent) {
+		if (e.key === "Escape") handleCollapse();
+	}
+</script>
+
+<!-- Collapsed card in the carousel -->
+<div
+	bind:this={cardEl}
+	class={cn(
+		"relative h-80 w-56 shrink-0 cursor-pointer snap-start overflow-hidden rounded-3xl md:h-96 md:w-72",
+		className
+	)}
+	role="button"
+	tabindex="0"
+	aria-label="Open {card.title}"
+	onclick={handleExpand}
+	onkeydown={handleCardKeydown}
+>
+	<img
+		src={card.src}
+		alt={card.title}
+		class="absolute inset-0 h-full w-full object-cover transition-transform duration-500 hover:scale-105"
+		draggable="false"
+	/>
+	<div class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent"></div>
+	<div class="absolute bottom-0 left-0 p-5">
+		<p class="mb-1 text-xs font-semibold tracking-widest text-white/70 uppercase">
+			{card.category}
+		</p>
+		<h3 class="text-base font-semibold text-white md:text-lg">{card.title}</h3>
+	</div>
+</div>
+
+<!-- Expanded overlay -->
+{#if overlayVisible && rect !== null}
+	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+	<div
+		class="fixed inset-0 z-40 bg-black/80"
+		aria-hidden="true"
+		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion ? 0 : 400}ms ease;"
+		onclick={handleCollapse}
+	></div>
+
+	<div
+		role="dialog"
+		aria-modal="true"
+		aria-label={card.title}
+		tabindex="-1"
+		class="fixed z-50 overflow-y-auto bg-white dark:bg-neutral-900"
+		style="
+			top: {fullyExpanded ? '0px' : rect.top + 'px'};
+			left: {fullyExpanded ? '0px' : rect.left + 'px'};
+			width: {fullyExpanded ? '100vw' : rect.width + 'px'};
+			height: {fullyExpanded ? '100vh' : rect.height + 'px'};
+			border-radius: {fullyExpanded ? '0px' : '1.5rem'};
+			transition: {reducedMotion
+			? 'none'
+			: 'top 0.4s cubic-bezier(0.32,0.72,0,1), left 0.4s cubic-bezier(0.32,0.72,0,1), width 0.4s cubic-bezier(0.32,0.72,0,1), height 0.4s cubic-bezier(0.32,0.72,0,1), border-radius 0.4s cubic-bezier(0.32,0.72,0,1)'};
+		"
+		onkeydown={handleOverlayKeydown}
+	>
+		<!-- Close button -->
+		<button
+			class="absolute top-4 right-4 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-black/20 backdrop-blur-sm transition-colors hover:bg-black/30"
+			aria-label="Close"
+			onclick={handleCollapse}
+		>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="18"
+				height="18"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="white"
+				stroke-width="2.5"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="M18 6 6 18" />
+				<path d="m6 6 12 12" />
+			</svg>
+		</button>
+
+		<!-- Hero image -->
+		<div class="relative h-72 w-full shrink-0 md:h-96">
+			<img src={card.src} alt={card.title} class="h-full w-full object-cover" draggable="false" />
+			<div
+				class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent"
+			></div>
+			<div class="absolute bottom-0 left-0 p-6 md:p-8">
+				<p class="mb-2 text-xs font-semibold tracking-widest text-white/70 uppercase">
+					{card.category}
+				</p>
+				<h2 class="text-2xl font-bold text-white md:text-3xl">{card.title}</h2>
+			</div>
+		</div>
+
+		<!-- Content area -->
+		<div class="p-6 md:p-8">
+			{#if card.content}
+				{@render card.content()}
+			{:else if card.description}
+				<p class="leading-relaxed text-gray-600 dark:text-neutral-400">{card.description}</p>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.svelte
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.svelte
@@ -11,12 +11,24 @@
 </script>
 
 <script lang="ts">
+	import { onMount } from "svelte";
 	import { cn } from "$lib/utils.js";
 	import AppleCard from "./AppleCard.svelte";
 
 	let { cards, class: className = "" }: AppleCardCarouselProps = $props();
 
 	let expandedIndex = $state(-1);
+	let reducedMotion = $state(false);
+
+	onMount(() => {
+		const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+		reducedMotion = mq.matches;
+		const handler = (e: MediaQueryListEvent) => {
+			reducedMotion = e.matches;
+		};
+		mq.addEventListener("change", handler);
+		return () => mq.removeEventListener("change", handler);
+	});
 </script>
 
 <div class={cn("relative w-full", className)}>
@@ -28,6 +40,7 @@
 				{card}
 				index={i}
 				{expandedIndex}
+				{reducedMotion}
 				onExpand={(idx) => (expandedIndex = idx)}
 				onCollapse={() => (expandedIndex = -1)}
 			/>

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.svelte
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.svelte
@@ -1,0 +1,36 @@
+<script lang="ts" module>
+	import type { AppleCardData } from "./AppleCard.svelte";
+	export type { AppleCardData };
+
+	export interface AppleCardCarouselProps {
+		/** Cards to display in the carousel */
+		cards: AppleCardData[];
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import AppleCard from "./AppleCard.svelte";
+
+	let { cards, class: className = "" }: AppleCardCarouselProps = $props();
+
+	let expandedIndex = $state(-1);
+</script>
+
+<div class={cn("relative w-full", className)}>
+	<div
+		class="flex snap-x snap-mandatory gap-4 overflow-x-auto px-4 pb-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+	>
+		{#each cards as card, i}
+			<AppleCard
+				{card}
+				index={i}
+				{expandedIndex}
+				onExpand={(idx) => (expandedIndex = idx)}
+				onCollapse={() => (expandedIndex = -1)}
+			/>
+		{/each}
+	</div>
+</div>

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.test.ts
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.test.ts
@@ -78,6 +78,17 @@ describe("AppleCardCarousel", () => {
 		expect(getAllByRole("dialog")).toHaveLength(1);
 	});
 
+	it("clicking the backdrop collapses the card", () => {
+		const { getByLabelText, queryByRole } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		// The backdrop has aria-hidden="true"; target it via its class
+		const backdrop = document.querySelector(".fixed.z-40") as HTMLElement;
+		fireEvent.click(backdrop);
+		flushSync(() => vi.advanceTimersByTime(400));
+		expect(queryByRole("dialog")).toBeNull();
+	});
+
 	it("shows description text in the expanded view", () => {
 		const { getByLabelText, getByText } = render(AppleCardCarousel, { props: { cards } });
 		fireEvent.click(getByLabelText("Open Mountains"));

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.test.ts
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.test.ts
@@ -1,0 +1,87 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { flushSync } from "svelte";
+import AppleCardCarousel from "./AppleCardCarousel.svelte";
+import type { AppleCardData } from "./AppleCard.svelte";
+
+const cards: AppleCardData[] = [
+	{ category: "Nature", title: "Mountains", src: "mountains.jpg", description: "High peaks." },
+	{ category: "City", title: "Skyline", src: "skyline.jpg", description: "Urban lights." },
+	{ category: "Ocean", title: "Waves", src: "waves.jpg", description: "Deep blue." },
+];
+
+describe("AppleCardCarousel", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		cleanup();
+	});
+
+	it("renders all cards", () => {
+		const { getByText } = render(AppleCardCarousel, { props: { cards } });
+		expect(getByText("Mountains")).toBeTruthy();
+		expect(getByText("Skyline")).toBeTruthy();
+		expect(getByText("Waves")).toBeTruthy();
+	});
+
+	it("renders gracefully with no cards", () => {
+		const { container } = render(AppleCardCarousel, { props: { cards: [] } });
+		expect(container.querySelector("[role='button']")).toBeNull();
+	});
+
+	it("clicking a card shows the expanded dialog", () => {
+		const { getByLabelText } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		expect(getByLabelText("Mountains")).toBeTruthy();
+	});
+
+	it("expanded dialog has correct ARIA attributes", () => {
+		const { getByLabelText, getByRole } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		const dialog = getByRole("dialog");
+		expect(dialog).toBeTruthy();
+		expect(dialog.getAttribute("aria-modal")).toBe("true");
+	});
+
+	it("clicking the close button collapses the card", () => {
+		const { getByLabelText, queryByRole } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		fireEvent.click(getByLabelText("Close"));
+		flushSync(() => vi.advanceTimersByTime(400));
+		expect(queryByRole("dialog")).toBeNull();
+	});
+
+	it("pressing Escape collapses the card", () => {
+		const { getByLabelText, queryByRole } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		const dialog = getByLabelText("Mountains");
+		fireEvent.keyDown(dialog, { key: "Escape" });
+		flushSync(() => vi.advanceTimersByTime(400));
+		expect(queryByRole("dialog")).toBeNull();
+	});
+
+	it("only one card can be expanded at a time", () => {
+		const { getByLabelText, getAllByRole } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		expect(getAllByRole("dialog")).toHaveLength(1);
+		// Clicking another card while one is open should be a no-op
+		fireEvent.click(getByLabelText("Open Skyline"));
+		flushSync();
+		expect(getAllByRole("dialog")).toHaveLength(1);
+	});
+
+	it("shows description text in the expanded view", () => {
+		const { getByLabelText, getByText } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		expect(getByText("High peaks.")).toBeTruthy();
+	});
+});

--- a/src/lib/fancy-ui/apple-card-carousel/index.ts
+++ b/src/lib/fancy-ui/apple-card-carousel/index.ts
@@ -1,0 +1,3 @@
+export { default as AppleCardCarousel } from "./AppleCardCarousel.svelte";
+export { default as AppleCard } from "./AppleCard.svelte";
+export type { AppleCardCarouselProps, AppleCardData } from "./AppleCardCarousel.svelte";

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -5,6 +5,7 @@
 // Components
 // =============================================================================
 
+export * from "./apple-card-carousel/index.js";
 export * from "./animated-beam/index.js";
 export * from "./animated-testimonials/index.js";
 export * from "./fluid-cursor/index.js";

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -74,6 +74,21 @@ export const registry: Record<string, ComponentMeta> = {
 	// Done - Fully implemented and tested
 	// =========================================================================
 
+	"apple-card-carousel": {
+		name: "AppleCardCarousel",
+		slug: "apple-card-carousel",
+		description:
+			"Horizontal card carousel with spring-animated full-screen expansion, inspired by Apple's App Store UI",
+		category: "cards",
+		status: "done",
+		credits: [
+			{
+				source: "Aceternity UI",
+				url: "https://ui.aceternity.com/components/apple-cards-carousel",
+			},
+		],
+	},
+
 	"animated-beam": {
 		name: "AnimatedBeam",
 		slug: "animated-beam",

--- a/src/routes/demo/apple-card-carousel/+page.svelte
+++ b/src/routes/demo/apple-card-carousel/+page.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+	import { AppleCardCarousel } from "$lib/fancy-ui/apple-card-carousel";
+	import type { AppleCardData } from "$lib/fancy-ui/apple-card-carousel";
+
+	const cards: AppleCardData[] = [
+		{
+			category: "Nature",
+			title: "Misty Mountains",
+			src: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop&q=60",
+			description:
+				"A breathtaking view of misty mountains at dawn, where layers of fog weave between ancient peaks. The gentle interplay of light and shadow creates a landscape that feels both timeless and dreamlike.",
+		},
+		{
+			category: "Architecture",
+			title: "Brutalist Forms",
+			src: "https://images.unsplash.com/photo-1486325212027-8081e485255e?w=800&auto=format&fit=crop&q=60",
+			description:
+				"Raw concrete and bold geometry define this brutalist landmark. Every angle is deliberate, every surface a statement — architecture stripped of ornament and reduced to pure, honest form.",
+		},
+		{
+			category: "Ocean",
+			title: "Deep Blue",
+			src: "https://images.unsplash.com/photo-1505118380757-91f5f5632de0?w=800&auto=format&fit=crop&q=60",
+			description:
+				"Beneath the surface, an entire world exists in silence. The ocean holds ancient secrets in its depths — creatures of light, corridors of coral, and the steady hum of currents that have shaped continents.",
+		},
+		{
+			category: "Urban",
+			title: "City Lights",
+			src: "https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?w=800&auto=format&fit=crop&q=60",
+			description:
+				"The city never sleeps. From dusk to dawn, millions of lives intersect across glowing grids of steel and glass. Each light in a window is a story — ambition, rest, love, or loss.",
+		},
+		{
+			category: "Desert",
+			title: "Sand & Silence",
+			src: "https://images.unsplash.com/photo-1509316785289-025f5b846b35?w=800&auto=format&fit=crop&q=60",
+			description:
+				"The desert teaches patience. Endless dunes shift imperceptibly under a relentless sun, sculpted by winds that have carved canyons over millennia. Here, time moves at a different scale.",
+		},
+	];
+</script>
+
+<svelte:head>
+	<title>AppleCardCarousel — FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto px-4 py-12">
+	<div class="mb-10">
+		<h1 class="text-3xl font-bold tracking-tight">Apple Card Carousel</h1>
+		<p class="text-muted-foreground mt-2">
+			Horizontal card carousel with spring-animated full-screen expansion, inspired by Apple's App
+			Store UI.
+		</p>
+	</div>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Basic Usage</h2>
+		<p class="text-muted-foreground mb-4 text-sm">
+			Click any card to expand it. Press <kbd
+				class="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">Esc</kbd
+			> or click the backdrop to dismiss.
+		</p>
+		<div class="bg-card overflow-hidden rounded-lg border py-8">
+			<AppleCardCarousel {cards} />
+		</div>
+	</section>
+
+	<!-- Props -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Props</h2>
+		<div class="overflow-x-auto rounded-lg border">
+			<table class="w-full text-sm">
+				<thead class="bg-muted/50">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Prop</th>
+						<th class="px-4 py-3 text-left font-medium">Type</th>
+						<th class="px-4 py-3 text-left font-medium">Default</th>
+						<th class="px-4 py-3 text-left font-medium">Description</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y">
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">cards</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">AppleCardData[]</td>
+						<td class="text-muted-foreground px-4 py-3">required</td>
+						<td class="text-muted-foreground px-4 py-3">Array of card data objects</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">class</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Additional CSS classes</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+
+	<!-- AppleCardData type -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">AppleCardData Type</h2>
+		<div class="overflow-x-auto rounded-lg border">
+			<table class="w-full text-sm">
+				<thead class="bg-muted/50">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Field</th>
+						<th class="px-4 py-3 text-left font-medium">Type</th>
+						<th class="px-4 py-3 text-left font-medium">Description</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y">
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">category</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">Label shown above the title</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">title</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">Main card title</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">src</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">URL of the card background image</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">description</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">Optional text shown in the expanded view</td
+						>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">content</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">Snippet</td>
+						<td class="text-muted-foreground px-4 py-3"
+							>Optional rich content snippet for the expanded view (takes precedence over
+							description)</td
+						>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Adds `AppleCardCarousel` component: horizontal scrollable card carousel with CSS spring-animated full-screen expansion, inspired by Apple's App Store UI
- Each card expands from its position to full screen using a `cubic-bezier(0.32, 0.72, 0, 1)` transition (the same easing Apple uses)
- Supports `description` string and rich `Snippet` content in expanded view, `prefers-reduced-motion`, keyboard navigation (Escape to dismiss)

## Test plan
- [ ] Visit `/demo/apple-card-carousel` and click a card — it should expand smoothly from its position
- [ ] Press Escape or click the backdrop to dismiss
- [ ] Verify only one card can be open at a time
- [ ] Test on mobile (touch scroll + snap behavior)
- [ ] Verify with `prefers-reduced-motion: reduce` — expansion should be instant
- [ ] Run `pnpm test --run` — 8 new tests should pass