### PR TITLE
feat: add LineHoverLink component

### DIFF
--- a/.changeset/line-hover-link.md
+++ b/.changeset/line-hover-link.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": minor
+---
+
+feat: add LineHoverLink component — link with 11 animated underline hover effects, pure CSS

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -6,6 +6,7 @@
 // =============================================================================
 
 export * from "./apple-card-carousel/index.js";
+export * from "./line-hover-link/index.js";
 export * from "./animated-beam/index.js";
 export * from "./animated-testimonials/index.js";
 export * from "./fluid-cursor/index.js";

--- a/src/lib/fancy-ui/line-hover-link/LineHoverLink.svelte
+++ b/src/lib/fancy-ui/line-hover-link/LineHoverLink.svelte
@@ -59,14 +59,15 @@
 		children,
 	}: LineHoverLinkProps = $props();
 
-	const needsSpan = ["strike", "bounce", "arc", "scribble"].includes(variant);
+	const needsSpan = $derived(["strike", "bounce", "arc", "scribble"].includes(variant));
+	const relValue = $derived(target === "_blank" ? (rel ?? "noopener noreferrer") : rel);
 </script>
 
 <a
 	{href}
 	{target}
-	{rel}
 	aria-label={ariaLabel}
+	rel={relValue}
 	class={cn("link-hover", `link-hover--${variant}`, className)}
 >
 	{#if needsSpan}
@@ -134,7 +135,7 @@
 		transition: transform 0.3s;
 	}
 
-	.link-hover--slide:hover::before {
+	.link-hover--slide:is(:hover, :focus-visible)::before {
 		transform-origin: 0% 50%;
 		transform: scale3d(1, 1, 1);
 	}
@@ -146,7 +147,7 @@
 		transition: transform 0.3s cubic-bezier(0.7, 0, 0.2, 1);
 	}
 
-	.link-hover--double:hover::before {
+	.link-hover--double:is(:hover, :focus-visible)::before {
 		transform-origin: 0% 50%;
 		transform: scale3d(1, 1, 1);
 		transition-timing-function: cubic-bezier(0.4, 1, 0.8, 1);
@@ -160,7 +161,7 @@
 		transition: transform 0.3s cubic-bezier(0.7, 0, 0.2, 1);
 	}
 
-	.link-hover--double:hover::after {
+	.link-hover--double:is(:hover, :focus-visible)::after {
 		transform-origin: 100% 50%;
 		transform: scale3d(1, 1, 1);
 		transition-timing-function: cubic-bezier(0.4, 1, 0.8, 1);
@@ -173,7 +174,7 @@
 		transition: transform 0.3s cubic-bezier(0.2, 1, 0.8, 1);
 	}
 
-	.link-hover--grow:hover::before {
+	.link-hover--grow:is(:hover, :focus-visible)::before {
 		transform-origin: 0% 50%;
 		transform: scale3d(1, 2, 1);
 		transition-timing-function: cubic-bezier(0.7, 0, 0.2, 1);
@@ -187,7 +188,7 @@
 		transition: transform 0.4s 0.1s cubic-bezier(0.2, 1, 0.8, 1);
 	}
 
-	.link-hover--grow:hover::after {
+	.link-hover--grow:is(:hover, :focus-visible)::after {
 		transform-origin: 0% 50%;
 		transform: scale3d(1, 1, 1);
 		transition-timing-function: cubic-bezier(0.7, 0, 0.2, 1);
@@ -206,7 +207,7 @@
 		transition: transform 0.3s cubic-bezier(0.4, 1, 0.8, 1);
 	}
 
-	.link-hover--strike:hover::before {
+	.link-hover--strike:is(:hover, :focus-visible)::before {
 		transform-origin: 0% 50%;
 		transform: scale3d(1, 1, 1);
 	}
@@ -216,7 +217,7 @@
 		transition: transform 0.3s cubic-bezier(0.4, 1, 0.8, 1);
 	}
 
-	.link-hover--strike:hover span {
+	.link-hover--strike:is(:hover, :focus-visible) span {
 		transform: scale3d(1.1, 1.1, 1.1);
 	}
 
@@ -231,8 +232,8 @@
 		transition-timing-function: cubic-bezier(0.2, 1, 0.8, 1);
 	}
 
-	.link-hover--fade:hover::before,
-	.link-hover--fade:hover::after {
+	.link-hover--fade:is(:hover, :focus-visible)::before,
+	.link-hover--fade:is(:hover, :focus-visible)::after {
 		opacity: 1;
 		transform: translate3d(0, 0, 0);
 		transition-timing-function: cubic-bezier(0.2, 0, 0.3, 1);
@@ -246,11 +247,11 @@
 	}
 
 	.link-hover--fade::before,
-	.link-hover--fade:hover::after {
+	.link-hover--fade:is(:hover, :focus-visible)::after {
 		transition-delay: 0.1s;
 	}
 
-	.link-hover--fade:hover::before {
+	.link-hover--fade:is(:hover, :focus-visible)::before {
 		transition-delay: 0s;
 	}
 
@@ -261,7 +262,7 @@
 		opacity: 0;
 	}
 
-	.link-hover--pulse:hover::before {
+	.link-hover--pulse:is(:hover, :focus-visible)::before {
 		opacity: 1;
 		animation: lineUp 0.3s ease forwards;
 	}
@@ -292,7 +293,7 @@
 		transition-delay: 0s;
 	}
 
-	.link-hover--pulse:hover::after {
+	.link-hover--pulse:is(:hover, :focus-visible)::after {
 		opacity: 1;
 		transition-delay: 0.3s;
 	}
@@ -304,7 +305,7 @@
 		transition: transform 0.3s;
 	}
 
-	.link-hover--swap:hover::before {
+	.link-hover--swap:is(:hover, :focus-visible)::before {
 		transform: scale3d(1, 1, 1);
 	}
 
@@ -315,7 +316,7 @@
 		transform-origin: 100% 50%;
 	}
 
-	.link-hover--swap:hover::after {
+	.link-hover--swap:is(:hover, :focus-visible)::after {
 		transform: scale3d(0, 1, 1);
 	}
 
@@ -326,7 +327,7 @@
 		opacity: 0;
 	}
 
-	.link-hover--sweep:hover::before {
+	.link-hover--sweep:is(:hover, :focus-visible)::before {
 		opacity: 1;
 		animation: coverUp 0.3s ease forwards;
 	}
@@ -355,7 +356,7 @@
 		transition: opacity 0.3s;
 	}
 
-	.link-hover--sweep:hover::after {
+	.link-hover--sweep:is(:hover, :focus-visible)::after {
 		opacity: 0;
 	}
 
@@ -370,7 +371,7 @@
 		transition-timing-function: cubic-bezier(0.2, 0.57, 0.67, 1.53);
 	}
 
-	.link-hover--bounce:hover::before {
+	.link-hover--bounce:is(:hover, :focus-visible)::before {
 		transition-timing-function: cubic-bezier(0.8, 0, 0.1, 1);
 		transition-duration: 0.4s;
 		opacity: 1;
@@ -383,7 +384,7 @@
 		transition: transform 0.2s 0.05s cubic-bezier(0.2, 0.57, 0.67, 1.53);
 	}
 
-	.link-hover--bounce:hover span {
+	.link-hover--bounce:is(:hover, :focus-visible) span {
 		transform: translate3d(0, 0, 0);
 		transition-timing-function: cubic-bezier(0.8, 0, 0.1, 1);
 		transition-duration: 0.4s;
@@ -406,7 +407,7 @@
 		stroke-dashoffset: 1;
 	}
 
-	.link-hover:hover .link-hover__graphic--stroke :global(path) {
+	.link-hover:is(:hover, :focus-visible) .link-hover__graphic--stroke :global(path) {
 		stroke-dashoffset: 0;
 	}
 
@@ -424,7 +425,7 @@
 		transition: stroke-dashoffset 0.4s cubic-bezier(0.7, 0, 0.3, 1);
 	}
 
-	.link-hover:hover .link-hover__graphic--arc :global(path) {
+	.link-hover:is(:hover, :focus-visible) .link-hover__graphic--arc :global(path) {
 		transition-timing-function: cubic-bezier(0.8, 1, 0.7, 1);
 		transition-duration: 0.3s;
 	}
@@ -442,7 +443,7 @@
 		transition: stroke-dashoffset 0.6s cubic-bezier(0.7, 0, 0.3, 1);
 	}
 
-	.link-hover:hover .link-hover__graphic--scribble :global(path) {
+	.link-hover:is(:hover, :focus-visible) .link-hover__graphic--scribble :global(path) {
 		transition-timing-function: cubic-bezier(0.8, 1, 0.7, 1);
 		transition-duration: 0.3s;
 	}

--- a/src/lib/fancy-ui/line-hover-link/LineHoverLink.svelte
+++ b/src/lib/fancy-ui/line-hover-link/LineHoverLink.svelte
@@ -1,0 +1,449 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	/**
+	 * Line Hover Link Variants
+	 *
+	 * slide    - Line slides in from right to left
+	 * double   - Two lines animate with different timings
+	 * grow     - Line grows thicker on hover
+	 * strike   - Strikethrough effect with text scale
+	 * fade     - Lines fade up with stagger delay
+	 * pulse    - Line pulses up and down
+	 * swap     - Two lines go opposite directions
+	 * sweep    - Full background cover sweep
+	 * bounce   - Bouncy squish animation
+	 * arc      - SVG arc stroke draws in
+	 * scribble - SVG scribble stroke draws in
+	 */
+	export type LineHoverVariant =
+		| "slide"
+		| "double"
+		| "grow"
+		| "strike"
+		| "fade"
+		| "pulse"
+		| "swap"
+		| "sweep"
+		| "bounce"
+		| "arc"
+		| "scribble";
+
+	export interface LineHoverLinkProps {
+		/** The animation variant */
+		variant?: LineHoverVariant;
+		/** Link href */
+		href?: string;
+		/** Link target */
+		target?: string;
+		/** Link rel */
+		rel?: string;
+		/** Accessible label */
+		"aria-label"?: string;
+		/** Additional CSS classes */
+		class?: string;
+		children?: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let {
+		variant = "slide",
+		href = "#",
+		target,
+		rel,
+		"aria-label": ariaLabel,
+		class: className = "",
+		children,
+	}: LineHoverLinkProps = $props();
+
+	const needsSpan = ["strike", "bounce", "arc", "scribble"].includes(variant);
+</script>
+
+<a
+	{href}
+	{target}
+	{rel}
+	aria-label={ariaLabel}
+	class={cn("link-hover", `link-hover--${variant}`, className)}
+>
+	{#if needsSpan}
+		<span
+			>{#if children}{@render children()}{/if}</span
+		>
+	{:else if children}
+		{@render children()}
+	{/if}
+
+	{#if variant === "arc"}
+		<svg
+			class="link-hover__graphic link-hover__graphic--stroke link-hover__graphic--arc"
+			width="100%"
+			height="18"
+			viewBox="0 0 59 18"
+			aria-hidden="true"
+		>
+			<path d="M.945.149C12.3 16.142 43.573 22.572 58.785 10.842" pathLength="1" />
+		</svg>
+	{:else if variant === "scribble"}
+		<svg
+			class="link-hover__graphic link-hover__graphic--stroke link-hover__graphic--scribble"
+			width="100%"
+			height="9"
+			viewBox="0 0 101 9"
+			aria-hidden="true"
+		>
+			<path
+				d="M.426 1.973C4.144 1.567 17.77-.514 21.443 1.48 24.296 3.026 24.844 4.627 27.5 7c3.075 2.748 6.642-4.141 10.066-4.688 7.517-1.2 13.237 5.425 17.59 2.745C58.5 3 60.464-1.786 66 2c1.996 1.365 3.174 3.737 5.286 4.41 5.423 1.727 25.34-7.981 29.14-1.294"
+				pathLength="1"
+			/>
+		</svg>
+	{/if}
+</a>
+
+<style>
+	.link-hover {
+		cursor: pointer;
+		position: relative;
+		white-space: nowrap;
+		color: currentColor;
+		text-decoration: none;
+	}
+
+	.link-hover::before,
+	.link-hover::after {
+		position: absolute;
+		width: 100%;
+		height: 1px;
+		background: currentColor;
+		top: 100%;
+		left: 0;
+		pointer-events: none;
+	}
+
+	.link-hover::before {
+		content: "";
+	}
+
+	/* Slide */
+	.link-hover--slide::before {
+		transform-origin: 100% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s;
+	}
+
+	.link-hover--slide:hover::before {
+		transform-origin: 0% 50%;
+		transform: scale3d(1, 1, 1);
+	}
+
+	/* Double */
+	.link-hover--double::before {
+		transform-origin: 100% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s cubic-bezier(0.7, 0, 0.2, 1);
+	}
+
+	.link-hover--double:hover::before {
+		transform-origin: 0% 50%;
+		transform: scale3d(1, 1, 1);
+		transition-timing-function: cubic-bezier(0.4, 1, 0.8, 1);
+	}
+
+	.link-hover--double::after {
+		content: "";
+		top: calc(100% + 4px);
+		transform-origin: 0% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s cubic-bezier(0.7, 0, 0.2, 1);
+	}
+
+	.link-hover--double:hover::after {
+		transform-origin: 100% 50%;
+		transform: scale3d(1, 1, 1);
+		transition-timing-function: cubic-bezier(0.4, 1, 0.8, 1);
+	}
+
+	/* Grow */
+	.link-hover--grow::before {
+		transform-origin: 100% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s cubic-bezier(0.2, 1, 0.8, 1);
+	}
+
+	.link-hover--grow:hover::before {
+		transform-origin: 0% 50%;
+		transform: scale3d(1, 2, 1);
+		transition-timing-function: cubic-bezier(0.7, 0, 0.2, 1);
+	}
+
+	.link-hover--grow::after {
+		content: "";
+		top: calc(100% + 4px);
+		transform-origin: 100% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.4s 0.1s cubic-bezier(0.2, 1, 0.8, 1);
+	}
+
+	.link-hover--grow:hover::after {
+		transform-origin: 0% 50%;
+		transform: scale3d(1, 1, 1);
+		transition-timing-function: cubic-bezier(0.7, 0, 0.2, 1);
+	}
+
+	/* Strike */
+	.link-hover--strike {
+		padding: 0 10px;
+	}
+
+	.link-hover--strike::before {
+		top: 50%;
+		height: 2px;
+		transform-origin: 100% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s cubic-bezier(0.4, 1, 0.8, 1);
+	}
+
+	.link-hover--strike:hover::before {
+		transform-origin: 0% 50%;
+		transform: scale3d(1, 1, 1);
+	}
+
+	.link-hover--strike span {
+		display: inline-block;
+		transition: transform 0.3s cubic-bezier(0.4, 1, 0.8, 1);
+	}
+
+	.link-hover--strike:hover span {
+		transform: scale3d(1.1, 1.1, 1.1);
+	}
+
+	/* Fade */
+	.link-hover--fade::before,
+	.link-hover--fade::after {
+		opacity: 0;
+		transform-origin: 50% 0%;
+		transform: translate3d(0, 3px, 0);
+		transition-property: transform, opacity;
+		transition-duration: 0.3s;
+		transition-timing-function: cubic-bezier(0.2, 1, 0.8, 1);
+	}
+
+	.link-hover--fade:hover::before,
+	.link-hover--fade:hover::after {
+		opacity: 1;
+		transform: translate3d(0, 0, 0);
+		transition-timing-function: cubic-bezier(0.2, 0, 0.3, 1);
+	}
+
+	.link-hover--fade::after {
+		content: "";
+		top: calc(100% + 4px);
+		width: 70%;
+		left: 15%;
+	}
+
+	.link-hover--fade::before,
+	.link-hover--fade:hover::after {
+		transition-delay: 0.1s;
+	}
+
+	.link-hover--fade:hover::before {
+		transition-delay: 0s;
+	}
+
+	/* Pulse */
+	.link-hover--pulse::before {
+		height: 10px;
+		top: 100%;
+		opacity: 0;
+	}
+
+	.link-hover--pulse:hover::before {
+		opacity: 1;
+		animation: lineUp 0.3s ease forwards;
+	}
+
+	@keyframes lineUp {
+		0% {
+			transform-origin: 50% 100%;
+			transform: scale3d(1, 0.045, 1);
+		}
+		50% {
+			transform-origin: 50% 100%;
+			transform: scale3d(1, 1, 1);
+		}
+		51% {
+			transform-origin: 50% 0%;
+			transform: scale3d(1, 1, 1);
+		}
+		100% {
+			transform-origin: 50% 0%;
+			transform: scale3d(1, 0.045, 1);
+		}
+	}
+
+	.link-hover--pulse::after {
+		content: "";
+		transition: opacity 0.3s;
+		opacity: 0;
+		transition-delay: 0s;
+	}
+
+	.link-hover--pulse:hover::after {
+		opacity: 1;
+		transition-delay: 0.3s;
+	}
+
+	/* Swap */
+	.link-hover--swap::before {
+		transform-origin: 0% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s;
+	}
+
+	.link-hover--swap:hover::before {
+		transform: scale3d(1, 1, 1);
+	}
+
+	.link-hover--swap::after {
+		content: "";
+		top: calc(100% + 4px);
+		transition: transform 0.3s;
+		transform-origin: 100% 50%;
+	}
+
+	.link-hover--swap:hover::after {
+		transform: scale3d(0, 1, 1);
+	}
+
+	/* Sweep */
+	.link-hover--sweep::before {
+		height: 100%;
+		top: 0;
+		opacity: 0;
+	}
+
+	.link-hover--sweep:hover::before {
+		opacity: 1;
+		animation: coverUp 0.3s ease forwards;
+	}
+
+	@keyframes coverUp {
+		0% {
+			transform-origin: 50% 100%;
+			transform: scale3d(1, 0.045, 1);
+		}
+		50% {
+			transform-origin: 50% 100%;
+			transform: scale3d(1, 1, 1);
+		}
+		51% {
+			transform-origin: 50% 0%;
+			transform: scale3d(1, 1, 1);
+		}
+		100% {
+			transform-origin: 50% 0%;
+			transform: scale3d(1, 0.045, 1);
+		}
+	}
+
+	.link-hover--sweep::after {
+		content: "";
+		transition: opacity 0.3s;
+	}
+
+	.link-hover--sweep:hover::after {
+		opacity: 0;
+	}
+
+	/* Bounce */
+	.link-hover--bounce::before {
+		height: 7px;
+		border-radius: 20px;
+		transform: scale3d(1, 1, 1);
+		transition:
+			transform 0.2s,
+			opacity 0.2s;
+		transition-timing-function: cubic-bezier(0.2, 0.57, 0.67, 1.53);
+	}
+
+	.link-hover--bounce:hover::before {
+		transition-timing-function: cubic-bezier(0.8, 0, 0.1, 1);
+		transition-duration: 0.4s;
+		opacity: 1;
+		transform: scale3d(1.2, 0.1, 1);
+	}
+
+	.link-hover--bounce span {
+		transform: translate3d(0, -4px, 0);
+		display: inline-block;
+		transition: transform 0.2s 0.05s cubic-bezier(0.2, 0.57, 0.67, 1.53);
+	}
+
+	.link-hover--bounce:hover span {
+		transform: translate3d(0, 0, 0);
+		transition-timing-function: cubic-bezier(0.8, 0, 0.1, 1);
+		transition-duration: 0.4s;
+		transition-delay: 0s;
+	}
+
+	/* SVG Graphics Base */
+	.link-hover__graphic {
+		position: absolute;
+		top: 0;
+		left: 0;
+		pointer-events: none;
+		fill: none;
+		stroke: currentColor;
+		stroke-width: 1px;
+	}
+
+	.link-hover__graphic--stroke :global(path) {
+		stroke-dasharray: 1;
+		stroke-dashoffset: 1;
+	}
+
+	.link-hover:hover .link-hover__graphic--stroke :global(path) {
+		stroke-dashoffset: 0;
+	}
+
+	/* Arc */
+	.link-hover--arc::before {
+		display: none;
+	}
+
+	.link-hover__graphic--arc {
+		top: 73%;
+		left: -23%;
+	}
+
+	.link-hover__graphic--arc :global(path) {
+		transition: stroke-dashoffset 0.4s cubic-bezier(0.7, 0, 0.3, 1);
+	}
+
+	.link-hover:hover .link-hover__graphic--arc :global(path) {
+		transition-timing-function: cubic-bezier(0.8, 1, 0.7, 1);
+		transition-duration: 0.3s;
+	}
+
+	/* Scribble */
+	.link-hover--scribble::before {
+		display: none;
+	}
+
+	.link-hover__graphic--scribble {
+		top: 100%;
+	}
+
+	.link-hover__graphic--scribble :global(path) {
+		transition: stroke-dashoffset 0.6s cubic-bezier(0.7, 0, 0.3, 1);
+	}
+
+	.link-hover:hover .link-hover__graphic--scribble :global(path) {
+		transition-timing-function: cubic-bezier(0.8, 1, 0.7, 1);
+		transition-duration: 0.3s;
+	}
+</style>

--- a/src/lib/fancy-ui/line-hover-link/LineHoverLink.test.ts
+++ b/src/lib/fancy-ui/line-hover-link/LineHoverLink.test.ts
@@ -1,0 +1,66 @@
+import { render, cleanup } from "@testing-library/svelte";
+import { afterEach, describe, it, expect } from "vitest";
+import LineHoverLink from "./LineHoverLink.svelte";
+
+describe("LineHoverLink", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("renders an anchor element", () => {
+		const { container } = render(LineHoverLink, {
+			props: { href: "/about" },
+			context: new Map(),
+		});
+		expect(container.querySelector("a")).toBeTruthy();
+	});
+
+	it("applies the variant class", () => {
+		const { container } = render(LineHoverLink, {
+			props: { variant: "slide", href: "#" },
+		});
+		expect(container.querySelector("a.link-hover--slide")).toBeTruthy();
+	});
+
+	it("defaults to slide variant", () => {
+		const { container } = render(LineHoverLink, { props: { href: "#" } });
+		expect(container.querySelector("a.link-hover--slide")).toBeTruthy();
+	});
+
+	it("wraps children in a span for strike variant", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "strike", href: "#" } });
+		expect(container.querySelector("a.link-hover--strike span")).toBeTruthy();
+	});
+
+	it("wraps children in a span for bounce variant", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "bounce", href: "#" } });
+		expect(container.querySelector("a.link-hover--bounce span")).toBeTruthy();
+	});
+
+	it("renders arc SVG for arc variant", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "arc", href: "#" } });
+		expect(container.querySelector("svg.link-hover__graphic--arc")).toBeTruthy();
+	});
+
+	it("renders scribble SVG for scribble variant", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "scribble", href: "#" } });
+		expect(container.querySelector("svg.link-hover__graphic--scribble")).toBeTruthy();
+	});
+
+	it("does not render SVG for non-svg variants", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "slide", href: "#" } });
+		expect(container.querySelector("svg")).toBeNull();
+	});
+
+	it("forwards href to the anchor", () => {
+		const { container } = render(LineHoverLink, { props: { href: "/contact" } });
+		expect(container.querySelector("a")?.getAttribute("href")).toBe("/contact");
+	});
+
+	it("applies additional class", () => {
+		const { container } = render(LineHoverLink, {
+			props: { class: "text-xl font-bold", href: "#" },
+		});
+		expect(container.querySelector("a.text-xl")).toBeTruthy();
+	});
+});

--- a/src/lib/fancy-ui/line-hover-link/index.ts
+++ b/src/lib/fancy-ui/line-hover-link/index.ts
@@ -1,0 +1,2 @@
+export { default as LineHoverLink } from "./LineHoverLink.svelte";
+export type { LineHoverLinkProps, LineHoverVariant } from "./LineHoverLink.svelte";

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -174,6 +174,16 @@ export const registry: Record<string, ComponentMeta> = {
 		],
 	},
 
+	"line-hover-link": {
+		name: "LineHoverLink",
+		slug: "line-hover-link",
+		description:
+			"Link component with 11 animated underline hover effects — pure CSS, no JS on hover",
+		category: "navigation",
+		status: "done",
+		credits: [{ source: "VengenceUI", url: "https://www.vengence-ui.com/docs/line-hover-link" }],
+	},
+
 	"logo-cloud": {
 		name: "LogoCloud",
 		slug: "logo-cloud",

--- a/src/routes/demo/line-hover-link/+page.svelte
+++ b/src/routes/demo/line-hover-link/+page.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+	import { LineHoverLink } from "$lib/fancy-ui/line-hover-link";
+	import type { LineHoverVariant } from "$lib/fancy-ui/line-hover-link";
+
+	const variants: { variant: LineHoverVariant; label: string }[] = [
+		{ variant: "slide", label: "Slide" },
+		{ variant: "double", label: "Double" },
+		{ variant: "grow", label: "Grow" },
+		{ variant: "strike", label: "Strike" },
+		{ variant: "fade", label: "Fade" },
+		{ variant: "pulse", label: "Pulse" },
+		{ variant: "swap", label: "Swap" },
+		{ variant: "sweep", label: "Sweep" },
+		{ variant: "bounce", label: "Bounce" },
+		{ variant: "arc", label: "Arc" },
+		{ variant: "scribble", label: "Scribble" },
+	];
+</script>
+
+<svelte:head>
+	<title>LineHoverLink — FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto px-4 py-12">
+	<div class="mb-10">
+		<h1 class="text-3xl font-bold tracking-tight">Line Hover Link</h1>
+		<p class="text-muted-foreground mt-2">
+			Link component with 11 animated underline hover effects. Pure CSS — no JS on hover.
+		</p>
+	</div>
+
+	<!-- All variants -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">All Variants</h2>
+		<div class="bg-card flex min-h-[280px] items-center justify-center rounded-lg border p-12">
+			<div class="grid grid-cols-3 gap-x-16 gap-y-10 md:grid-cols-4">
+				{#each variants as { variant, label }}
+					<div class="text-center">
+						<LineHoverLink {variant} href="#" class="text-lg font-medium">
+							{label}
+						</LineHoverLink>
+					</div>
+				{/each}
+			</div>
+		</div>
+	</section>
+
+	<!-- Navigation example -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Navigation Example</h2>
+		<div class="bg-card flex min-h-[120px] items-center justify-center rounded-lg border">
+			<nav class="flex gap-8">
+				<LineHoverLink variant="slide" href="#" class="text-muted-foreground">Home</LineHoverLink>
+				<LineHoverLink variant="slide" href="#" class="text-muted-foreground">About</LineHoverLink>
+				<LineHoverLink variant="slide" href="#" class="text-muted-foreground"
+					>Services</LineHoverLink
+				>
+				<LineHoverLink variant="slide" href="#" class="text-muted-foreground">Contact</LineHoverLink
+				>
+			</nav>
+		</div>
+	</section>
+
+	<!-- SVG variants -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">SVG Variants</h2>
+		<p class="text-muted-foreground mb-4 text-sm">
+			Arc and Scribble draw an SVG stroke on hover using <code
+				class="bg-muted rounded px-1 font-mono text-xs">stroke-dashoffset</code
+			>.
+		</p>
+		<div class="bg-card flex min-h-[120px] items-center justify-center gap-16 rounded-lg border">
+			<LineHoverLink variant="arc" href="#" class="text-xl font-medium">Sign up</LineHoverLink>
+			<LineHoverLink variant="scribble" href="#" class="text-xl font-medium">Writings</LineHoverLink
+			>
+		</div>
+	</section>
+
+	<!-- Props -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Props</h2>
+		<div class="overflow-x-auto rounded-lg border">
+			<table class="w-full text-sm">
+				<thead class="bg-muted/50">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Prop</th>
+						<th class="px-4 py-3 text-left font-medium">Type</th>
+						<th class="px-4 py-3 text-left font-medium">Default</th>
+						<th class="px-4 py-3 text-left font-medium">Description</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y">
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">variant</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">LineHoverVariant</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"slide"</td>
+						<td class="text-muted-foreground px-4 py-3">Animation variant</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">href</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"#"</td>
+						<td class="text-muted-foreground px-4 py-3">Link destination</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">target</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Link target (e.g. "_blank")</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">rel</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Link rel attribute</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">class</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Additional CSS classes</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- Adds `LineHoverLink` component: an anchor element with 11 animated underline hover variants (slide, double, grow, strike, fade, pulse, swap, sweep, bounce, arc, scribble)
- All animations are pure CSS using `::before`/`::after` pseudo-elements and SVG `stroke-dashoffset` for the arc/scribble variants — zero JS on hover
- Inspired by VengenceUI

## Test plan
- [ ] Visit `/demo/line-hover-link` and hover over each variant
- [ ] Verify arc and scribble SVG stroke draws in on hover
- [ ] Verify navigation example looks correct
- [ ] Run `pnpm test --run` — 10 new tests should pass