### PR TITLE
feat(displacement-text): add 3D displacement text component

### DIFF
--- a/.changeset/displacement-text.md
+++ b/.changeset/displacement-text.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": minor
+---
+
+feat(displacement-text): add 3D displacement text component

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"@testing-library/svelte": "^5.3.1",
 		"@types/canvas-confetti": "^1.9.0",
 		"@types/node": "^25.2.3",
+		"@types/three": "^0.183.1",
 		"bits-ui": "^2.15.4",
 		"clsx": "^2.1.1",
 		"jsdom": "^28.0.0",
@@ -71,6 +72,7 @@
 		"canvas-confetti": "^1.9.4",
 		"gsap": "^3.14.2",
 		"marked": "^17.0.3",
-		"nanoid": "^5.1.6"
+		"nanoid": "^5.1.6",
+		"three": "^0.183.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       nanoid:
         specifier: ^5.1.6
         version: 5.1.6
+      three:
+        specifier: ^0.183.2
+        version: 0.183.2
     devDependencies:
       '@changesets/cli':
         specifier: ^2.30.0
@@ -66,6 +69,9 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
+      '@types/three':
+        specifier: ^0.183.1
+        version: 0.183.1
       bits-ui:
         specifier: ^2.15.4
         version: 2.15.4(@internationalized/date@3.10.1)(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
@@ -226,6 +232,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -777,6 +786,9 @@ packages:
       vitest:
         optional: true
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -800,6 +812,15 @@ packages:
 
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.183.1':
+    resolution: {integrity: sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
@@ -829,6 +850,9 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  '@webgpu/types@0.1.69':
+    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -1040,6 +1064,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1274,6 +1301,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meshoptimizer@1.0.1:
+    resolution: {integrity: sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1637,6 +1667,9 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  three@0.183.2:
+    resolution: {integrity: sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2017,6 +2050,8 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.26': {}
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
@@ -2434,6 +2469,8 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
       vitest: 4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/aria-query@5.0.4': {}
 
   '@types/canvas-confetti@1.9.0': {}
@@ -2454,6 +2491,20 @@ snapshots:
   '@types/node@25.2.3':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.183.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      '@webgpu/types': 0.1.69
+      fflate: 0.8.2
+      meshoptimizer: 1.0.1
+
+  '@types/webxr@0.5.24': {}
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -2493,6 +2544,8 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
+
+  '@webgpu/types@0.1.69': {}
 
   acorn@8.15.0: {}
 
@@ -2694,6 +2747,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.2: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -2908,6 +2963,8 @@ snapshots:
   mdn-data@2.12.2: {}
 
   merge2@1.4.1: {}
+
+  meshoptimizer@1.0.1: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -3199,6 +3256,8 @@ snapshots:
   tapable@2.3.0: {}
 
   term-size@2.2.1: {}
+
+  three@0.183.2: {}
 
   tinybench@2.9.0: {}
 

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
@@ -152,7 +152,9 @@
 	<div
 		class="fixed inset-0 z-40 bg-black/80"
 		aria-hidden="true"
-		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion ? 0 : TRANSITION_MS}ms ease;"
+		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion
+			? 0
+			: TRANSITION_MS}ms ease;"
 		onclick={handleCollapse}
 	></div>
 

--- a/src/lib/fancy-ui/displacement-text/DisplacementText.svelte
+++ b/src/lib/fancy-ui/displacement-text/DisplacementText.svelte
@@ -1,0 +1,223 @@
+<script lang="ts" module>
+	export interface DisplacementTextProps {
+		/** Text to display */
+		text?: string;
+		/** Font size in pixels */
+		fontSize?: number;
+		/** Font family */
+		font?: string;
+		/** Fixed text color (overrides theme colors) */
+		color?: string;
+		/** Text color in light mode */
+		lightColor?: string;
+		/** Text color in dark mode */
+		darkColor?: string;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import * as THREE from "three";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		text = "Hover Me",
+		fontSize = 200,
+		font = "Inter, sans-serif",
+		color,
+		lightColor = "#000000",
+		darkColor = "#ffffff",
+		class: className = "",
+	}: DisplacementTextProps = $props();
+
+	let container: HTMLDivElement;
+
+	const vertexShader = `
+		varying vec2 vUv;
+		uniform vec3 uDisplacement;
+
+		float easeInOutCubic(float x) {
+			return x < 0.5 ? 4.0 * x * x * x : 1.0 - pow(-2.0 * x + 2.0, 3.0) / 2.0;
+		}
+
+		float map(float value, float min1, float max1, float min2, float max2) {
+			return min2 + (value - min1) * (max2 - min2) / (max1 - min1);
+		}
+
+		void main() {
+			vUv = uv;
+			vec3 displaced = position;
+			vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+			float dist = length(uDisplacement - worldPosition.rgb);
+			float minDistance = 3.0;
+
+			if (dist < minDistance) {
+				float mapped = map(dist, 0.0, minDistance, 1.0, 0.0);
+				displaced.z += easeInOutCubic(mapped);
+			}
+
+			gl_Position = projectionMatrix * modelViewMatrix * vec4(displaced, 1.0);
+		}
+	`;
+
+	const fragmentShader = `
+		varying vec2 vUv;
+		uniform sampler2D uTexture;
+
+		void main() {
+			gl_FragColor = texture2D(uTexture, vUv);
+		}
+	`;
+
+	function createTextTexture(t: string, size: number, f: string, c: string): THREE.Texture {
+		const canvas = document.createElement("canvas");
+		canvas.width = 2048;
+		canvas.height = 2048;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return new THREE.CanvasTexture(canvas);
+
+		ctx.clearRect(0, 0, canvas.width, canvas.height);
+		ctx.font = `bold ${size}px ${f}`;
+		ctx.fillStyle = c;
+		ctx.textAlign = "center";
+		ctx.textBaseline = "middle";
+		ctx.fillText(t, canvas.width / 2, canvas.height / 2);
+
+		const texture = new THREE.CanvasTexture(canvas);
+		texture.needsUpdate = true;
+		return texture;
+	}
+
+	$effect(() => {
+		if (!container) return;
+
+		const _text = text;
+		const _fontSize = fontSize;
+		const _font = font;
+		const _color = color;
+		const _lightColor = lightColor;
+		const _darkColor = darkColor;
+
+		const rect = container.getBoundingClientRect();
+		const width = rect.width || 1;
+		const height = rect.height || 1;
+		if (height === 0) return;
+
+		const scene = new THREE.Scene();
+		scene.background = null;
+
+		const cameraDistance = 8;
+		const aspect = width / height;
+		const camera = new THREE.OrthographicCamera(
+			-cameraDistance * aspect,
+			cameraDistance * aspect,
+			cameraDistance,
+			-cameraDistance,
+			0.01,
+			1000
+		);
+		camera.position.set(0, -10, 5);
+		camera.lookAt(0, 0, 0);
+
+		const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+		renderer.setClearColor(0x000000, 0);
+		renderer.setPixelRatio(window.devicePixelRatio);
+		renderer.setSize(width, height, false);
+		renderer.domElement.style.width = "100%";
+		renderer.domElement.style.height = "100%";
+		container.appendChild(renderer.domElement);
+
+		const geometry = new THREE.PlaneGeometry(15, 15, 100, 100);
+		const getActiveColor = () =>
+			_color || (document.documentElement.classList.contains("dark") ? _darkColor : _lightColor);
+
+		let currentColor = getActiveColor();
+		let textTexture = createTextTexture(_text, _fontSize, _font, currentColor);
+
+		const shaderMaterial = new THREE.ShaderMaterial({
+			uniforms: {
+				uTexture: { value: textTexture },
+				uDisplacement: { value: new THREE.Vector3(0, 0, 0) },
+			},
+			vertexShader,
+			fragmentShader,
+			transparent: true,
+			depthWrite: false,
+			side: THREE.DoubleSide,
+		});
+
+		const plane = new THREE.Mesh(geometry, shaderMaterial);
+		plane.rotation.z = Math.PI / 4;
+		scene.add(plane);
+
+		const hitPlane = new THREE.Mesh(
+			new THREE.PlaneGeometry(500, 500),
+			new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 })
+		);
+		scene.add(hitPlane);
+
+		const raycaster = new THREE.Raycaster();
+		const pointer = new THREE.Vector2();
+
+		const onPointerMove = (e: PointerEvent) => {
+			const bounds = container.getBoundingClientRect();
+			pointer.x = ((e.clientX - bounds.left) / bounds.width) * 2 - 1;
+			pointer.y = -((e.clientY - bounds.top) / bounds.height) * 2 + 1;
+			raycaster.setFromCamera(pointer, camera);
+			const [hit] = raycaster.intersectObject(hitPlane);
+			if (hit) (shaderMaterial.uniforms.uDisplacement.value as THREE.Vector3).copy(hit.point);
+		};
+
+		container.addEventListener("pointermove", onPointerMove);
+
+		const handleResize = () => {
+			const r = container.getBoundingClientRect();
+			if (r.height === 0) return;
+			const a = r.width / r.height;
+			camera.left = -cameraDistance * a;
+			camera.right = cameraDistance * a;
+			camera.updateProjectionMatrix();
+			renderer.setSize(r.width, r.height, false);
+		};
+
+		window.addEventListener("resize", handleResize);
+
+		let animationId = 0;
+		const animate = () => {
+			animationId = requestAnimationFrame(animate);
+			renderer.render(scene, camera);
+		};
+		animate();
+
+		const observer = new MutationObserver(() => {
+			const next = getActiveColor();
+			if (next !== currentColor) {
+				const tex = createTextTexture(_text, _fontSize, _font, next);
+				shaderMaterial.uniforms.uTexture.value = tex;
+				textTexture.dispose();
+				textTexture = tex;
+				currentColor = next;
+			}
+		});
+		if (!_color)
+			observer.observe(document.documentElement, {
+				attributes: true,
+				attributeFilter: ["class"],
+			});
+
+		return () => {
+			window.removeEventListener("resize", handleResize);
+			container.removeEventListener("pointermove", onPointerMove);
+			cancelAnimationFrame(animationId);
+			observer.disconnect();
+			if (renderer.domElement.parentNode === container) container.removeChild(renderer.domElement);
+			renderer.dispose();
+			textTexture.dispose();
+			geometry.dispose();
+			shaderMaterial.dispose();
+		};
+	});
+</script>
+
+<div bind:this={container} class={cn("relative h-[400px] w-full", className)}></div>

--- a/src/lib/fancy-ui/displacement-text/DisplacementText.svelte
+++ b/src/lib/fancy-ui/displacement-text/DisplacementText.svelte
@@ -151,10 +151,9 @@
 		plane.rotation.z = Math.PI / 4;
 		scene.add(plane);
 
-		const hitPlane = new THREE.Mesh(
-			new THREE.PlaneGeometry(500, 500),
-			new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 })
-		);
+		const hitGeometry = new THREE.PlaneGeometry(500, 500);
+		const hitMaterial = new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 });
+		const hitPlane = new THREE.Mesh(hitGeometry, hitMaterial);
 		scene.add(hitPlane);
 
 		const raycaster = new THREE.Raycaster();
@@ -216,6 +215,8 @@
 			textTexture.dispose();
 			geometry.dispose();
 			shaderMaterial.dispose();
+			hitGeometry.dispose();
+			hitMaterial.dispose();
 		};
 	});
 </script>

--- a/src/lib/fancy-ui/displacement-text/DisplacementText.test.ts
+++ b/src/lib/fancy-ui/displacement-text/DisplacementText.test.ts
@@ -1,0 +1,103 @@
+import { render, cleanup } from "@testing-library/svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import DisplacementText from "./DisplacementText.svelte";
+
+// Three.js uses WebGL which is not available in jsdom — mock the module
+vi.mock("three", () => {
+	function Vector2() {
+		return { x: 0, y: 0 };
+	}
+	function Vector3() {
+		return { x: 0, y: 0, z: 0, copy: vi.fn() };
+	}
+	function CanvasTexture() {
+		return { needsUpdate: false, dispose: vi.fn() };
+	}
+	function ShaderMaterial() {
+		return {
+			uniforms: { uTexture: { value: null }, uDisplacement: { value: { copy: vi.fn() } } },
+			dispose: vi.fn(),
+		};
+	}
+	function PlaneGeometry() {
+		return { dispose: vi.fn() };
+	}
+	function MeshBasicMaterial() {
+		return {};
+	}
+	function Mesh() {
+		return { rotation: { z: 0 } };
+	}
+	function Scene() {
+		return { background: null, add: vi.fn() };
+	}
+	function OrthographicCamera() {
+		return {
+			position: { set: vi.fn() },
+			left: 0,
+			right: 0,
+			updateProjectionMatrix: vi.fn(),
+			lookAt: vi.fn(),
+		};
+	}
+	function Raycaster() {
+		return {
+			setFromCamera: vi.fn(),
+			intersectObject: vi.fn(() => []),
+		};
+	}
+	const domCanvas = document.createElement("canvas");
+	domCanvas.style.width = "";
+	domCanvas.style.height = "";
+	function WebGLRenderer() {
+		return {
+			setClearColor: vi.fn(),
+			setPixelRatio: vi.fn(),
+			setSize: vi.fn(),
+			render: vi.fn(),
+			dispose: vi.fn(),
+			domElement: domCanvas,
+		};
+	}
+
+	return {
+		Scene,
+		OrthographicCamera,
+		WebGLRenderer,
+		PlaneGeometry,
+		ShaderMaterial,
+		Mesh,
+		MeshBasicMaterial,
+		Raycaster,
+		Vector2,
+		Vector3,
+		CanvasTexture,
+		DoubleSide: 2,
+	};
+});
+
+describe("DisplacementText", () => {
+	afterEach(cleanup);
+
+	it("renders a div container", () => {
+		const { container } = render(DisplacementText);
+		expect(container.querySelector("div")).toBeTruthy();
+	});
+
+	it("applies default height class", () => {
+		const { container } = render(DisplacementText);
+		const div = container.querySelector("div");
+		expect(div?.className).toContain("h-[400px]");
+	});
+
+	it("applies additional class", () => {
+		const { container } = render(DisplacementText, { props: { class: "h-[600px]" } });
+		const div = container.querySelector("div");
+		expect(div?.className).toContain("h-[600px]");
+	});
+
+	it("renders with custom text prop", () => {
+		const { container } = render(DisplacementText, { props: { text: "FancyUI" } });
+		expect(container.querySelector("div")).toBeTruthy();
+	});
+});

--- a/src/lib/fancy-ui/displacement-text/DisplacementText.test.ts
+++ b/src/lib/fancy-ui/displacement-text/DisplacementText.test.ts
@@ -1,6 +1,9 @@
 import { render, cleanup } from "@testing-library/svelte";
-import { afterEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import DisplacementText from "./DisplacementText.svelte";
+
+// Holds the last renderer instance created by the mock
+const lastMock = { renderer: null as any };
 
 // Three.js uses WebGL which is not available in jsdom — mock the module
 vi.mock("three", () => {
@@ -23,7 +26,7 @@ vi.mock("three", () => {
 		return { dispose: vi.fn() };
 	}
 	function MeshBasicMaterial() {
-		return {};
+		return { dispose: vi.fn() };
 	}
 	function Mesh() {
 		return { rotation: { z: 0 } };
@@ -46,18 +49,19 @@ vi.mock("three", () => {
 			intersectObject: vi.fn(() => []),
 		};
 	}
-	const domCanvas = document.createElement("canvas");
-	domCanvas.style.width = "";
-	domCanvas.style.height = "";
 	function WebGLRenderer() {
-		return {
+		const instance = {
 			setClearColor: vi.fn(),
 			setPixelRatio: vi.fn(),
 			setSize: vi.fn(),
 			render: vi.fn(),
 			dispose: vi.fn(),
-			domElement: domCanvas,
+			domElement: Object.assign(document.createElement("canvas"), {
+				style: { width: "", height: "" },
+			}),
 		};
+		lastMock.renderer = instance;
+		return instance;
 	}
 
 	return {
@@ -86,18 +90,76 @@ describe("DisplacementText", () => {
 
 	it("applies default height class", () => {
 		const { container } = render(DisplacementText);
-		const div = container.querySelector("div");
-		expect(div?.className).toContain("h-[400px]");
+		expect(container.querySelector("div")?.className).toContain("h-[400px]");
 	});
 
 	it("applies additional class", () => {
 		const { container } = render(DisplacementText, { props: { class: "h-[600px]" } });
-		const div = container.querySelector("div");
-		expect(div?.className).toContain("h-[600px]");
+		expect(container.querySelector("div")?.className).toContain("h-[600px]");
 	});
 
 	it("renders with custom text prop", () => {
 		const { container } = render(DisplacementText, { props: { text: "FancyUI" } });
 		expect(container.querySelector("div")).toBeTruthy();
+	});
+
+	describe("cleanup on unmount", () => {
+		it("removes resize listener", () => {
+			const spy = vi.spyOn(window, "removeEventListener");
+			const { unmount } = render(DisplacementText);
+			unmount();
+			expect(spy).toHaveBeenCalledWith("resize", expect.any(Function));
+			spy.mockRestore();
+		});
+
+		it("cancels animation frame", () => {
+			const spy = vi.spyOn(window, "cancelAnimationFrame");
+			const { unmount } = render(DisplacementText);
+			unmount();
+			expect(spy).toHaveBeenCalled();
+			spy.mockRestore();
+		});
+
+		it("disposes renderer", () => {
+			const { unmount } = render(DisplacementText);
+			const renderer = lastMock.renderer;
+			unmount();
+			expect(renderer.dispose).toHaveBeenCalled();
+		});
+	});
+
+	describe("theme observer", () => {
+		let originalMutationObserver: typeof MutationObserver;
+
+		beforeEach(() => {
+			originalMutationObserver = global.MutationObserver;
+		});
+
+		afterEach(() => {
+			global.MutationObserver = originalMutationObserver;
+		});
+
+		it("does not observe document when color prop is provided", () => {
+			const observeSpy = vi.fn();
+			global.MutationObserver = function MutationObserver() {
+				return { observe: observeSpy, disconnect: vi.fn() };
+			} as unknown as typeof MutationObserver;
+
+			render(DisplacementText, { props: { color: "#ff0000" } });
+			expect(observeSpy).not.toHaveBeenCalled();
+		});
+
+		it("observes document when no fixed color is provided", () => {
+			const observeSpy = vi.fn();
+			global.MutationObserver = function MutationObserver() {
+				return { observe: observeSpy, disconnect: vi.fn() };
+			} as unknown as typeof MutationObserver;
+
+			render(DisplacementText);
+			expect(observeSpy).toHaveBeenCalledWith(
+				document.documentElement,
+				expect.objectContaining({ attributes: true, attributeFilter: ["class"] })
+			);
+		});
 	});
 });

--- a/src/lib/fancy-ui/displacement-text/index.ts
+++ b/src/lib/fancy-ui/displacement-text/index.ts
@@ -1,0 +1,2 @@
+export { default as DisplacementText } from "./DisplacementText.svelte";
+export type { DisplacementTextProps } from "./DisplacementText.svelte";

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -54,6 +54,7 @@ export * from "./ripple/index.js";
 export * from "./text-generate-effect/index.js";
 export * from "./line-shadow-text/index.js";
 export * from "./tracing-beam/index.js";
+export * from "./displacement-text/index.js";
 
 // =============================================================================
 // Registry

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -600,6 +600,14 @@ export const registry: Record<string, ComponentMeta> = {
 			{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/tracing-beam" },
 		],
 	},
+	"displacement-text": {
+		name: "DisplacementText",
+		slug: "displacement-text",
+		description: "3D text with WebGL displacement that follows the cursor using Three.js shaders",
+		category: "text",
+		status: "done",
+		credits: [{ source: "VengenceUI", url: "https://vengenceui.com/docs/liquid-text" }],
+	},
 };
 
 // =============================================================================

--- a/src/routes/demo/displacement-text/+page.svelte
+++ b/src/routes/demo/displacement-text/+page.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import { DisplacementText } from "$lib/fancy-ui/displacement-text";
+</script>
+
+<svelte:head>
+	<title>DisplacementText — FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto px-4 py-12">
+	<div class="mb-10">
+		<h1 class="text-3xl font-bold tracking-tight">3D Displacement Text</h1>
+		<p class="text-muted-foreground mt-2">
+			WebGL text with fluid 3D displacement that follows your cursor. Built with Three.js shaders.
+		</p>
+	</div>
+
+	<!-- Default -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Default</h2>
+		<div class="bg-card rounded-lg border">
+			<DisplacementText text="Hover Me" fontSize={220} />
+		</div>
+	</section>
+
+	<!-- Custom color -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Custom Color</h2>
+		<div class="bg-card rounded-lg border">
+			<DisplacementText text="FancyUI" fontSize={200} color="#6366f1" />
+		</div>
+	</section>
+
+	<!-- Theme aware -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Theme Aware</h2>
+		<p class="text-muted-foreground mb-4 text-sm">
+			Automatically switches color between light and dark mode.
+		</p>
+		<div class="bg-card rounded-lg border">
+			<DisplacementText text="Adaptive" lightColor="#1a1a1a" darkColor="#f5f5f5" />
+		</div>
+	</section>
+
+	<!-- Props -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Props</h2>
+		<div class="overflow-x-auto rounded-lg border">
+			<table class="w-full text-sm">
+				<thead class="bg-muted/50">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Prop</th>
+						<th class="px-4 py-3 text-left font-medium">Type</th>
+						<th class="px-4 py-3 text-left font-medium">Default</th>
+						<th class="px-4 py-3 text-left font-medium">Description</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y">
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">text</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"Hover Me"</td>
+						<td class="text-muted-foreground px-4 py-3">Text to display</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">fontSize</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">number</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">200</td>
+						<td class="text-muted-foreground px-4 py-3">Font size in pixels</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">font</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"Inter, sans-serif"</td>
+						<td class="text-muted-foreground px-4 py-3">Font family</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">color</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Fixed color (overrides theme colors)</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">lightColor</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"#000000"</td>
+						<td class="text-muted-foreground px-4 py-3">Color in light mode</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">darkColor</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"#ffffff"</td>
+						<td class="text-muted-foreground px-4 py-3">Color in dark mode</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">class</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Additional CSS classes</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- New `DisplacementText` component — WebGL text with cursor-following 3D displacement using custom GLSL vertex/fragment shaders via Three.js
- Inspired by VengenceUI's "Liquid Text" (officially named "3D Displacement Text")
- Supports `text`, `fontSize`, `font`, `color`, `lightColor`/`darkColor` (theme-aware), and `class` props
- Proper cleanup on destroy (renderer, textures, geometry, animation loop, event listeners)

## Test plan
- [ ] Visit `/demo/displacement-text` and hover over the text to see displacement
- [ ] Toggle dark mode to verify automatic color switching
- [ ] Pass `color="#6366f1"` to verify fixed color prop
- [ ] Resize the window to verify responsive handling
- [ ] Check all 443 tests pass: `pnpm test --run`