### PR TITLE
feat: add npm package build pipeline

### DIFF
--- a/.changeset/npm-package-pipeline.md
+++ b/.changeset/npm-package-pipeline.md
@@ -1,5 +1,5 @@
 ---
-"fancy-ui": minor
+"fancy-ui": patch
 ---
 
 add npm package build pipeline — consumers can now install via `npm install fancy-ui`

--- a/.changeset/npm-package-pipeline.md
+++ b/.changeset/npm-package-pipeline.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": minor
+---
+
+add npm package build pipeline — consumers can now install via `npm install fancy-ui`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
 
@@ -35,8 +36,9 @@ jobs:
           # Creates/updates the "Version Packages" PR instead of pushing directly to main.
           # This prevents Vercel from triggering a deploy on every changeset commit.
           # When the "Version Packages" PR is merged, the tag and GitHub Release are created.
-          publish: pnpm changeset tag
+          publish: pnpm package && pnpm changeset publish
           commit: "chore: version packages"
           title: "Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ vendor/
 .wrangler
 /.svelte-kit
 /build
+/dist
 
 # Tools
 .claude/

--- a/package.json
+++ b/package.json
@@ -46,8 +46,11 @@
 		"changeset": "changeset",
 		"version": "changeset version",
 		"release": "changeset tag",
-		"package": "svelte-kit sync && svelte-package -i src/lib -o dist && rm -rf dist/builder dist/server dist/stores && publint",
+		"package": "svelte-kit sync && svelte-package -i src/lib -o dist && node -e \"const fs=require('fs'); ['dist/builder','dist/server','dist/stores'].forEach(p=>fs.rmSync(p,{recursive:true,force:true}));\" && publint",
 		"prepublishOnly": "pnpm run package"
+	},
+	"engines": {
+		"node": ">=20.19.0"
 	},
 	"peerDependencies": {
 		"svelte": "^5.0.0",
@@ -57,7 +60,8 @@
 		"canvas-confetti": "^1.9.4",
 		"clsx": "^2.1.1",
 		"gsap": "^3.14.2",
-		"tailwind-merge": "^3.4.0"
+		"tailwind-merge": "^3.4.0",
+		"three": "^0.183.2"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.30.0",
@@ -93,12 +97,5 @@
 		"typescript": "^5.9.3",
 		"vite": "^7.2.6",
 		"vitest": "^4.0.18"
-	},
-	"dependencies": {
-		"canvas-confetti": "^1.9.4",
-		"clsx": "^2.1.1",
-		"gsap": "^3.14.2",
-		"tailwind-merge": "^3.4.0",
-		"three": "^0.183.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,18 @@
 		"ui",
 		"tailwind"
 	],
+	"files": ["dist/fancy-ui", "dist/utils.js", "dist/utils.d.ts", "dist/types.js", "dist/types.d.ts"],
+	"main": "./dist/fancy-ui/index.js",
+	"svelte": "./dist/fancy-ui/index.js",
+	"types": "./dist/fancy-ui/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/fancy-ui/index.d.ts",
+			"svelte": "./dist/fancy-ui/index.js",
+			"default": "./dist/fancy-ui/index.js"
+		},
+		"./tailwind.css": "./dist/fancy-ui/tailwind.css"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -33,7 +45,19 @@
 		"test:e2e:ui": "playwright test --ui",
 		"changeset": "changeset",
 		"version": "changeset version",
-		"release": "changeset tag"
+		"release": "changeset tag",
+		"package": "svelte-kit sync && svelte-package -i src/lib -o dist && rm -rf dist/builder dist/server dist/stores && publint",
+		"prepublishOnly": "pnpm run package"
+	},
+	"peerDependencies": {
+		"svelte": "^5.0.0",
+		"tailwindcss": "^4.0.0"
+	},
+	"dependencies": {
+		"canvas-confetti": "^1.9.4",
+		"clsx": "^2.1.1",
+		"gsap": "^3.14.2",
+		"tailwind-merge": "^3.4.0"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.30.0",
@@ -42,6 +66,7 @@
 		"@playwright/test": "^1.58.2",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/kit": "^2.49.1",
+		"@sveltejs/package": "^2.5.7",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@tailwindcss/forms": "^0.5.10",
 		"@tailwindcss/typography": "^0.5.19",
@@ -50,27 +75,22 @@
 		"@testing-library/svelte": "^5.3.1",
 		"@types/canvas-confetti": "^1.9.0",
 		"@types/node": "^25.2.3",
+		"arctic": "^3.7.0",
 		"bits-ui": "^2.15.4",
-		"clsx": "^2.1.1",
 		"jsdom": "^28.0.0",
+		"marked": "^17.0.3",
+		"nanoid": "^5.1.6",
 		"prettier": "^3.8.1",
 		"prettier-plugin-svelte": "^3.5.0",
 		"prettier-plugin-tailwindcss": "^0.7.2",
+		"publint": "^0.3.18",
 		"svelte": "^5.45.6",
 		"svelte-check": "^4.3.4",
-		"tailwind-merge": "^3.4.0",
 		"tailwind-variants": "^3.2.2",
 		"tailwindcss": "^4.1.17",
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^5.9.3",
 		"vite": "^7.2.6",
 		"vitest": "^4.0.18"
-	},
-	"dependencies": {
-		"arctic": "^3.7.0",
-		"canvas-confetti": "^1.9.4",
-		"gsap": "^3.14.2",
-		"marked": "^17.0.3",
-		"nanoid": "^5.1.6"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,21 +8,18 @@ importers:
 
   .:
     dependencies:
-      arctic:
-        specifier: ^3.7.0
-        version: 3.7.0
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       gsap:
         specifier: ^3.14.2
         version: 3.14.2
-      marked:
-        specifier: ^17.0.3
-        version: 17.0.3
-      nanoid:
-        specifier: ^5.1.6
-        version: 5.1.6
+      tailwind-merge:
+        specifier: ^3.4.0
+        version: 3.4.0
     devDependencies:
       '@changesets/cli':
         specifier: ^2.30.0
@@ -42,6 +39,9 @@ importers:
       '@sveltejs/kit':
         specifier: ^2.49.1
         version: 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@sveltejs/package':
+        specifier: ^2.5.7
+        version: 2.5.7(svelte@5.46.1)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.1
         version: 6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
@@ -66,15 +66,21 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
+      arctic:
+        specifier: ^3.7.0
+        version: 3.7.0
       bits-ui:
         specifier: ^2.15.4
         version: 2.15.4(@internationalized/date@3.10.1)(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
       jsdom:
         specifier: ^28.0.0
         version: 28.0.0
+      marked:
+        specifier: ^17.0.3
+        version: 17.0.3
+      nanoid:
+        specifier: ^5.1.6
+        version: 5.1.6
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -84,15 +90,15 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.7.2
         version: 0.7.2(prettier-plugin-svelte@3.5.0(prettier@3.8.1)(svelte@5.46.1))(prettier@3.8.1)
+      publint:
+        specifier: ^0.3.18
+        version: 0.3.18
       svelte:
         specifier: ^5.45.6
         version: 5.46.1
       svelte-check:
         specifier: ^4.3.4
         version: 4.3.5(picomatch@4.0.3)(svelte@5.46.1)(typescript@5.9.3)
-      tailwind-merge:
-        specifier: ^3.4.0
-        version: 3.4.0
       tailwind-variants:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.1.18)
@@ -478,6 +484,10 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
+
   '@rollup/rollup-android-arm-eabi@4.55.1':
     resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
     cpu: [arm]
@@ -631,6 +641,13 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  '@sveltejs/package@2.5.7':
+    resolution: {integrity: sha512-qqD9xa9H7TDiGFrF6rz7AirOR8k15qDK/9i4MIE8te4vWsv5GEogPks61rrZcLy+yWph+aI6pIj2MdoK3YI8AQ==}
+    engines: {node: ^16.14 || >=18}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.44.0 || ^4.0.0 || ^5.0.0-next.1
 
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2':
     resolution: {integrity: sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==}
@@ -911,6 +928,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -954,6 +975,9 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dedent-js@1.0.1:
+    resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -1337,6 +1361,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -1463,6 +1490,11 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  publint@0.3.18:
+    resolution: {integrity: sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1483,6 +1515,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -1527,6 +1563,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scule@1.3.0:
+    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1603,6 +1642,12 @@ packages:
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.30.2
+
+  svelte2tsx@0.7.52:
+    resolution: {integrity: sha512-svdT1FTrCLpvlU62evO5YdJt/kQ7nxgQxII/9BpQUvKr+GJRVdAXNVw8UWOt0fhoe5uWKyU0WsUTMRVAtRbMQg==}
+    peerDependencies:
+      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
+      typescript: ^4.9.4 || ^5.0.0
 
   svelte@5.46.1:
     resolution: {integrity: sha512-ynjfCHD3nP2el70kN5Pmg37sSi0EjOm9FgHYQdC4giWG/hzO3AatzXXJJgP305uIhGQxSufJLuYWtkY8uK/8RA==}
@@ -2196,6 +2241,8 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@publint/pack@0.1.4': {}
+
   '@rollup/rollup-android-arm-eabi@4.55.1':
     optional: true
 
@@ -2301,6 +2348,17 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@sveltejs/package@2.5.7(svelte@5.46.1)(typescript@5.9.3)':
+    dependencies:
+      chokidar: 5.0.0
+      kleur: 4.1.5
+      sade: 1.8.1
+      semver: 7.7.4
+      svelte: 5.46.1
+      svelte2tsx: 0.7.52(svelte@5.46.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
@@ -2563,6 +2621,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   clsx@2.1.1: {}
 
   cookie@0.6.0: {}
@@ -2601,6 +2663,8 @@ snapshots:
       ms: 2.1.3
 
   decimal.js@10.6.0: {}
+
+  dedent-js@1.0.1: {}
 
   deepmerge@4.3.1: {}
 
@@ -2952,6 +3016,8 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  package-manager-detector@1.6.0: {}
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -3012,6 +3078,13 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  publint@0.3.18:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
@@ -3028,6 +3101,8 @@ snapshots:
       strip-bom: 3.0.0
 
   readdirp@4.1.2: {}
+
+  readdirp@5.0.0: {}
 
   redent@3.0.0:
     dependencies:
@@ -3093,6 +3168,8 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scule@1.3.0: {}
 
   semver@7.7.4: {}
 
@@ -3163,6 +3240,13 @@ snapshots:
       svelte: 5.46.1
     transitivePeerDependencies:
       - '@sveltejs/kit'
+
+  svelte2tsx@0.7.52(svelte@5.46.1)(typescript@5.9.3):
+    dependencies:
+      dedent-js: 1.0.1
+      scule: 1.3.0
+      svelte: 5.46.1
+      typescript: 5.9.3
 
   svelte@5.46.1:
     dependencies:

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
@@ -152,7 +152,9 @@
 	<div
 		class="fixed inset-0 z-40 bg-black/80"
 		aria-hidden="true"
-		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion ? 0 : TRANSITION_MS}ms ease;"
+		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion
+			? 0
+			: TRANSITION_MS}ms ease;"
 		onclick={handleCollapse}
 	></div>
 

--- a/src/lib/fancy-ui/tailwind.css
+++ b/src/lib/fancy-ui/tailwind.css
@@ -1,0 +1,2 @@
+/* Add this to your app's CSS to include fancy-ui Tailwind classes */
+@source "../node_modules/fancy-ui/dist";

--- a/src/lib/fancy-ui/tailwind.css
+++ b/src/lib/fancy-ui/tailwind.css
@@ -1,2 +1,3 @@
-/* Add this to your app's CSS to include fancy-ui Tailwind classes */
-@source "../node_modules/fancy-ui/dist";
+/* Import this file in your app's CSS to include fancy-ui Tailwind classes:
+   @import "fancy-ui/tailwind.css"; */
+@source "..";


### PR DESCRIPTION
## Summary
- Adds `@sveltejs/package` + `publint` build pipeline so the library can be published to npm as `fancy-ui`
- Configures `package.json` with proper `exports`, `files`, `peerDependencies`, and restructured runtime vs dev deps (`clsx`/`tailwind-merge` promoted to `dependencies`; `arctic`/`marked`/`nanoid` moved to `devDependencies`)
- Adds `src/lib/fancy-ui/tailwind.css` with an `@source` directive so consumers can include Tailwind classes in one line
- Updates `.github/workflows/release.yml` to build and publish to npm via `pnpm changeset publish` on release

## Test plan
- [ ] Run `pnpm package` locally — should complete with `publint` reporting "All good!"
- [ ] Run `npm pack --dry-run` — tarball should contain only `dist/fancy-ui/**`, `dist/utils.*`, `dist/types.*`; no `builder/`, `server/`, or `stores/` directories
- [ ] Verify `NPM_TOKEN` secret is added to GitHub repo settings before merging to `main`