### PR TITLE
docs: update Quick Start with npm install instructions

### DIFF
--- a/.changeset/docs-quick-start-npm.md
+++ b/.changeset/docs-quick-start-npm.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": patch
+---
+
+docs: update homepage quick start and roadmap for npm package release

--- a/README.md
+++ b/README.md
@@ -119,19 +119,19 @@ Beautiful animation and UI components for **Svelte 5**.
 **Install via npm:**
 
 ```bash
-npm install fancy-ui-svelte
+npm install fancy-ui
 ```
 
 Then import any component:
 
 ```ts
-import { Marquee, BorderBeam, Confetti } from 'fancy-ui-svelte';
+import { Marquee, BorderBeam, Confetti } from 'fancy-ui';
 ```
 
 To include Tailwind classes, add this to your app's CSS:
 
 ```css
-@import "fancy-ui-svelte/tailwind.css";
+@import "fancy-ui/tailwind.css";
 ```
 
 **Or browse and copy a component:**

--- a/README.md
+++ b/README.md
@@ -116,11 +116,25 @@ Beautiful animation and UI components for **Svelte 5**.
 
 ## Quick Start
 
-> **Status:** Pre-release. No npm package yet — components are available via copy-paste
-> or by cloning the repo. A registry-based install (`npx shadcn-svelte@latest add`) is
-> planned for v0.2.
+**Install via npm:**
 
-**Browse and copy a component:**
+```bash
+npm install fancy-ui-svelte
+```
+
+Then import any component:
+
+```ts
+import { Marquee, BorderBeam, Confetti } from 'fancy-ui-svelte';
+```
+
+To include Tailwind classes, add this to your app's CSS:
+
+```css
+@import "fancy-ui-svelte/tailwind.css";
+```
+
+**Or browse and copy a component:**
 1. Find the component you need in the [live demo](https://fancy-ui.rama.app)
 2. Copy the source from `src/lib/fancy-ui/[component-name]/`
 3. Paste into your project

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -52,7 +52,7 @@
 			status: "In progress",
 			statusColor: "bg-blue-500/10 text-blue-400 border-blue-500/20",
 			items: [
-				{ done: true, text: "npm package — install via npm install fancy-ui-svelte" },
+				{ done: true, text: "npm package — install via npm install fancy-ui" },
 				{ text: "Proper package exports + TypeScript declarations" },
 				{ text: "CHANGELOG + semantic versioning" },
 				{ text: "CONTRIBUTING guide" },
@@ -303,13 +303,13 @@
 			<BorderBeam duration={12} size={120} colorFrom="#9E7AFF" colorTo="#FE8BBB" borderWidth={1} />
 			<div class="p-6 font-mono text-sm">
 				<div class="mb-1 text-white/40"># 1. Install</div>
-				<div class="mb-4 text-emerald-400">npm install fancy-ui-svelte</div>
+				<div class="mb-4 text-emerald-400">npm install fancy-ui</div>
 				<div class="mb-1 text-white/40"># 2. Import any component</div>
 				<div class="mb-1">
 					<span class="text-purple-400">import</span>
 					<span class="text-white"> &#123; BorderBeam, Sparkles, Marquee &#125; </span>
 					<span class="text-purple-400">from</span>
-					<span class="text-amber-300"> 'fancy-ui-svelte'</span>
+					<span class="text-amber-300"> 'fancy-ui'</span>
 				</div>
 				<div class="mb-4 text-xs text-white/30">&nbsp;</div>
 				<div class="mb-1 text-white/40"># 3. Use it</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -52,7 +52,7 @@
 			status: "In progress",
 			statusColor: "bg-blue-500/10 text-blue-400 border-blue-500/20",
 			items: [
-				{ text: "npm package — install with npm install fancy-ui" },
+				{ done: true, text: "npm package — install via npm install fancy-ui-svelte" },
 				{ text: "Proper package exports + TypeScript declarations" },
 				{ text: "CHANGELOG + semantic versioning" },
 				{ text: "CONTRIBUTING guide" },
@@ -302,14 +302,14 @@
 		<div class="border-border relative overflow-hidden rounded-xl border bg-[#0d1117]">
 			<BorderBeam duration={12} size={120} colorFrom="#9E7AFF" colorTo="#FE8BBB" borderWidth={1} />
 			<div class="p-6 font-mono text-sm">
-				<div class="mb-1 text-white/40"># 1. Clone and install</div>
-				<div class="mb-4 text-emerald-400">git clone {GITHUB_URL}</div>
+				<div class="mb-1 text-white/40"># 1. Install</div>
+				<div class="mb-4 text-emerald-400">npm install fancy-ui-svelte</div>
 				<div class="mb-1 text-white/40"># 2. Import any component</div>
 				<div class="mb-1">
 					<span class="text-purple-400">import</span>
 					<span class="text-white"> &#123; BorderBeam, Sparkles, Marquee &#125; </span>
 					<span class="text-purple-400">from</span>
-					<span class="text-amber-300"> '$lib/fancy-ui'</span>
+					<span class="text-amber-300"> 'fancy-ui-svelte'</span>
 				</div>
 				<div class="mb-4 text-xs text-white/30">&nbsp;</div>
 				<div class="mb-1 text-white/40"># 3. Use it</div>


### PR DESCRIPTION
## Summary
- Replace the pre-release status notice with npm install instructions for `fancy-ui-svelte`
- Add import example and Tailwind CSS setup
- Keep the copy-paste and clone options as alternatives