### PR TITLE
feat: add interactive props playground to demo pages

### DIFF
--- a/.changeset/props-playground.md
+++ b/.changeset/props-playground.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+Add interactive props playground to demo pages

--- a/src/lib/components/PropsPlayground.svelte
+++ b/src/lib/components/PropsPlayground.svelte
@@ -1,0 +1,214 @@
+<script lang="ts" module>
+	export type ControlDef =
+		| { key: string; type: 'range'; label: string; min: number; max: number; step?: number }
+		| { key: string; type: 'number'; label: string; min?: number; max?: number; step?: number }
+		| { key: string; type: 'color'; label: string }
+		| { key: string; type: 'text'; label: string }
+		| { key: string; type: 'boolean'; label: string }
+		| { key: string; type: 'select'; label: string; options: { value: string; label: string }[] };
+
+	export type PlaygroundValues = Record<string, string | number | boolean>;
+</script>
+
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		controls: ControlDef[];
+		initialValues: PlaygroundValues;
+		preview: Snippet<[PlaygroundValues]>;
+	}
+
+	let { controls, initialValues, preview }: Props = $props();
+
+	let panelOpen = $state(false);
+	let values = $state<PlaygroundValues>({ ...initialValues });
+
+	function reset() {
+		values = { ...initialValues };
+	}
+</script>
+
+<svelte:window
+	onkeydown={(e) => {
+		if (e.key === 'Escape') panelOpen = false;
+	}}
+/>
+
+<div>
+	<!-- Preview card -->
+	<div class="bg-card rounded-xl border">
+		<div class="flex min-h-48 items-center justify-center p-8">
+			{@render preview(values)}
+		</div>
+		<!-- Footer bar -->
+		<div class="border-t px-4 py-3 flex items-center justify-between">
+			<span class="text-sm font-medium">Playground</span>
+			<button
+				onclick={() => (panelOpen = true)}
+				class="bg-secondary text-secondary-foreground hover:bg-secondary/80 inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					width="14"
+					height="14"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+					<circle cx="12" cy="12" r="3" />
+				</svg>
+				Customize
+			</button>
+		</div>
+	</div>
+
+	<!-- Backdrop -->
+	{#if panelOpen}
+		<button
+			class="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
+			onclick={() => (panelOpen = false)}
+			aria-label="Close panel"
+		></button>
+	{/if}
+
+	<!-- Side panel -->
+	<div
+		role="dialog"
+		aria-modal="true"
+		aria-label="Customize props"
+		class="fixed top-0 right-0 z-50 h-full w-80 flex flex-col bg-background border-l transition-transform duration-300 {panelOpen
+			? 'translate-x-0'
+			: 'translate-x-full'}"
+	>
+		<!-- Panel header -->
+		<div class="flex h-14 shrink-0 items-center justify-between border-b px-4">
+			<span class="font-semibold">Customize</span>
+			<div class="flex items-center gap-2">
+				<button
+					onclick={reset}
+					class="text-muted-foreground hover:text-foreground text-sm transition-colors"
+				>
+					Reset
+				</button>
+				<button
+					onclick={() => (panelOpen = false)}
+					class="text-muted-foreground hover:text-foreground transition-colors"
+					aria-label="Close"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="18"
+						height="18"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<path d="M18 6 6 18" />
+						<path d="m6 6 12 12" />
+					</svg>
+				</button>
+			</div>
+		</div>
+
+		<!-- Controls list -->
+		<div class="flex-1 overflow-y-auto p-4 space-y-5">
+			{#each controls as def}
+				<div>
+					{#if def.type === 'range'}
+						<div class="flex items-center justify-between mb-1.5">
+							<label class="text-sm font-medium" for="ctrl-{def.key}">{def.label}</label>
+							<span class="text-muted-foreground text-sm tabular-nums">{values[def.key]}</span>
+						</div>
+						<input
+							id="ctrl-{def.key}"
+							type="range"
+							min={def.min}
+							max={def.max}
+							step={def.step ?? 1}
+							value={values[def.key] as number}
+							oninput={(e) => (values[def.key] = Number(e.currentTarget.value))}
+							class="w-full accent-foreground"
+						/>
+					{:else if def.type === 'number'}
+						<label class="text-sm font-medium block mb-1.5" for="ctrl-{def.key}">{def.label}</label>
+						<input
+							id="ctrl-{def.key}"
+							type="number"
+							min={def.min}
+							max={def.max}
+							step={def.step ?? 1}
+							value={values[def.key] as number}
+							oninput={(e) => (values[def.key] = Number(e.currentTarget.value))}
+							class="border-input bg-background w-full rounded-md border px-3 py-1.5 text-sm"
+						/>
+					{:else if def.type === 'color'}
+						<div class="flex items-center justify-between mb-1.5">
+							<label class="text-sm font-medium" for="ctrl-{def.key}">{def.label}</label>
+							<span class="text-muted-foreground text-sm">{values[def.key]}</span>
+						</div>
+						<input
+							id="ctrl-{def.key}"
+							type="color"
+							value={values[def.key] as string}
+							oninput={(e) => (values[def.key] = e.currentTarget.value)}
+							class="h-9 w-full cursor-pointer rounded-md border"
+						/>
+					{:else if def.type === 'text'}
+						<label class="text-sm font-medium block mb-1.5" for="ctrl-{def.key}">{def.label}</label>
+						<input
+							id="ctrl-{def.key}"
+							type="text"
+							value={values[def.key] as string}
+							oninput={(e) => (values[def.key] = e.currentTarget.value)}
+							class="border-input bg-background w-full rounded-md border px-3 py-1.5 text-sm"
+						/>
+					{:else if def.type === 'boolean'}
+						<div class="flex items-center justify-between">
+							<label class="text-sm font-medium" for="ctrl-{def.key}">{def.label}</label>
+							<button
+								id="ctrl-{def.key}"
+								role="switch"
+								aria-checked={values[def.key] as boolean}
+								aria-label={def.label}
+								onclick={() => (values[def.key] = !values[def.key])}
+								class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors {values[
+									def.key
+								]
+									? 'bg-foreground'
+									: 'bg-muted'}"
+							>
+								<span
+									class="inline-block h-4 w-4 transform rounded-full bg-background transition-transform {values[
+										def.key
+									]
+										? 'translate-x-6'
+										: 'translate-x-1'}"
+								></span>
+							</button>
+						</div>
+					{:else if def.type === 'select'}
+						<label class="text-sm font-medium block mb-1.5" for="ctrl-{def.key}">{def.label}</label>
+						<select
+							id="ctrl-{def.key}"
+							value={values[def.key] as string}
+							onchange={(e) => (values[def.key] = e.currentTarget.value)}
+							class="border-input bg-background w-full rounded-md border px-3 py-1.5 text-sm"
+						>
+							{#each def.options as opt}
+								<option value={opt.value}>{opt.label}</option>
+							{/each}
+						</select>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	</div>
+</div>

--- a/src/lib/components/PropsPlayground.svelte
+++ b/src/lib/components/PropsPlayground.svelte
@@ -24,9 +24,20 @@
 	let panelOpen = $state(false);
 	let values = $state<PlaygroundValues>({ ...initialValues });
 
+	let customizeButtonRef: HTMLButtonElement | undefined = $state();
+	let closePanelButtonRef: HTMLButtonElement | undefined = $state();
+
 	function reset() {
 		values = { ...initialValues };
 	}
+
+	$effect(() => {
+		if (panelOpen) {
+			closePanelButtonRef?.focus();
+		} else {
+			customizeButtonRef?.focus();
+		}
+	});
 </script>
 
 <svelte:window
@@ -45,6 +56,7 @@
 		<div class="flex items-center justify-between border-t px-4 py-3">
 			<span class="text-sm font-medium">Playground</span>
 			<button
+				bind:this={customizeButtonRef}
 				onclick={() => (panelOpen = true)}
 				class="bg-secondary text-secondary-foreground hover:bg-secondary/80 inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
 			>
@@ -81,8 +93,9 @@
 	<!-- Side panel -->
 	<div
 		role="dialog"
-		aria-modal="true"
+		aria-modal={panelOpen}
 		aria-label="Customize props"
+		inert={!panelOpen}
 		class="bg-background fixed top-0 right-0 z-50 flex h-full w-80 flex-col border-l transition-transform duration-300 {panelOpen
 			? 'translate-x-0'
 			: 'translate-x-full'}"

--- a/src/lib/components/PropsPlayground.svelte
+++ b/src/lib/components/PropsPlayground.svelte
@@ -1,17 +1,17 @@
 <script lang="ts" module>
 	export type ControlDef =
-		| { key: string; type: 'range'; label: string; min: number; max: number; step?: number }
-		| { key: string; type: 'number'; label: string; min?: number; max?: number; step?: number }
-		| { key: string; type: 'color'; label: string }
-		| { key: string; type: 'text'; label: string }
-		| { key: string; type: 'boolean'; label: string }
-		| { key: string; type: 'select'; label: string; options: { value: string; label: string }[] };
+		| { key: string; type: "range"; label: string; min: number; max: number; step?: number }
+		| { key: string; type: "number"; label: string; min?: number; max?: number; step?: number }
+		| { key: string; type: "color"; label: string }
+		| { key: string; type: "text"; label: string }
+		| { key: string; type: "boolean"; label: string }
+		| { key: string; type: "select"; label: string; options: { value: string; label: string }[] };
 
 	export type PlaygroundValues = Record<string, string | number | boolean>;
 </script>
 
 <script lang="ts">
-	import type { Snippet } from 'svelte';
+	import type { Snippet } from "svelte";
 
 	interface Props {
 		controls: ControlDef[];
@@ -31,7 +31,7 @@
 
 <svelte:window
 	onkeydown={(e) => {
-		if (e.key === 'Escape') panelOpen = false;
+		if (e.key === "Escape") panelOpen = false;
 	}}
 />
 
@@ -42,7 +42,7 @@
 			{@render preview(values)}
 		</div>
 		<!-- Footer bar -->
-		<div class="border-t px-4 py-3 flex items-center justify-between">
+		<div class="flex items-center justify-between border-t px-4 py-3">
 			<span class="text-sm font-medium">Playground</span>
 			<button
 				onclick={() => (panelOpen = true)}
@@ -59,7 +59,9 @@
 					stroke-linecap="round"
 					stroke-linejoin="round"
 				>
-					<path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+					<path
+						d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+					/>
 					<circle cx="12" cy="12" r="3" />
 				</svg>
 				Customize
@@ -81,7 +83,7 @@
 		role="dialog"
 		aria-modal="true"
 		aria-label="Customize props"
-		class="fixed top-0 right-0 z-50 h-full w-80 flex flex-col bg-background border-l transition-transform duration-300 {panelOpen
+		class="bg-background fixed top-0 right-0 z-50 flex h-full w-80 flex-col border-l transition-transform duration-300 {panelOpen
 			? 'translate-x-0'
 			: 'translate-x-full'}"
 	>
@@ -119,11 +121,11 @@
 		</div>
 
 		<!-- Controls list -->
-		<div class="flex-1 overflow-y-auto p-4 space-y-5">
+		<div class="flex-1 space-y-5 overflow-y-auto p-4">
 			{#each controls as def}
 				<div>
-					{#if def.type === 'range'}
-						<div class="flex items-center justify-between mb-1.5">
+					{#if def.type === "range"}
+						<div class="mb-1.5 flex items-center justify-between">
 							<label class="text-sm font-medium" for="ctrl-{def.key}">{def.label}</label>
 							<span class="text-muted-foreground text-sm tabular-nums">{values[def.key]}</span>
 						</div>
@@ -135,10 +137,10 @@
 							step={def.step ?? 1}
 							value={values[def.key] as number}
 							oninput={(e) => (values[def.key] = Number(e.currentTarget.value))}
-							class="w-full accent-foreground"
+							class="accent-foreground w-full"
 						/>
-					{:else if def.type === 'number'}
-						<label class="text-sm font-medium block mb-1.5" for="ctrl-{def.key}">{def.label}</label>
+					{:else if def.type === "number"}
+						<label class="mb-1.5 block text-sm font-medium" for="ctrl-{def.key}">{def.label}</label>
 						<input
 							id="ctrl-{def.key}"
 							type="number"
@@ -149,8 +151,8 @@
 							oninput={(e) => (values[def.key] = Number(e.currentTarget.value))}
 							class="border-input bg-background w-full rounded-md border px-3 py-1.5 text-sm"
 						/>
-					{:else if def.type === 'color'}
-						<div class="flex items-center justify-between mb-1.5">
+					{:else if def.type === "color"}
+						<div class="mb-1.5 flex items-center justify-between">
 							<label class="text-sm font-medium" for="ctrl-{def.key}">{def.label}</label>
 							<span class="text-muted-foreground text-sm">{values[def.key]}</span>
 						</div>
@@ -161,8 +163,8 @@
 							oninput={(e) => (values[def.key] = e.currentTarget.value)}
 							class="h-9 w-full cursor-pointer rounded-md border"
 						/>
-					{:else if def.type === 'text'}
-						<label class="text-sm font-medium block mb-1.5" for="ctrl-{def.key}">{def.label}</label>
+					{:else if def.type === "text"}
+						<label class="mb-1.5 block text-sm font-medium" for="ctrl-{def.key}">{def.label}</label>
 						<input
 							id="ctrl-{def.key}"
 							type="text"
@@ -170,7 +172,7 @@
 							oninput={(e) => (values[def.key] = e.currentTarget.value)}
 							class="border-input bg-background w-full rounded-md border px-3 py-1.5 text-sm"
 						/>
-					{:else if def.type === 'boolean'}
+					{:else if def.type === "boolean"}
 						<div class="flex items-center justify-between">
 							<label class="text-sm font-medium" for="ctrl-{def.key}">{def.label}</label>
 							<button
@@ -186,7 +188,7 @@
 									: 'bg-muted'}"
 							>
 								<span
-									class="inline-block h-4 w-4 transform rounded-full bg-background transition-transform {values[
+									class="bg-background inline-block h-4 w-4 transform rounded-full transition-transform {values[
 										def.key
 									]
 										? 'translate-x-6'
@@ -194,8 +196,8 @@
 								></span>
 							</button>
 						</div>
-					{:else if def.type === 'select'}
-						<label class="text-sm font-medium block mb-1.5" for="ctrl-{def.key}">{def.label}</label>
+					{:else if def.type === "select"}
+						<label class="mb-1.5 block text-sm font-medium" for="ctrl-{def.key}">{def.label}</label>
 						<select
 							id="ctrl-{def.key}"
 							value={values[def.key] as string}

--- a/src/routes/demo/border-beam/+page.svelte
+++ b/src/routes/demo/border-beam/+page.svelte
@@ -123,18 +123,28 @@
 		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
 		<PropsPlayground
 			controls={[
-				{ key: 'size', type: 'range', label: 'Size', min: 50, max: 500, step: 10 },
-				{ key: 'duration', type: 'range', label: 'Duration (s)', min: 1, max: 60 },
-				{ key: 'borderWidth', type: 'range', label: 'Border Width', min: 0.5, max: 8, step: 0.5 },
-				{ key: 'anchor', type: 'range', label: 'Anchor', min: 0, max: 100 },
-				{ key: 'colorFrom', type: 'color', label: 'Color From' },
-				{ key: 'colorTo', type: 'color', label: 'Color To' },
-				{ key: 'delay', type: 'number', label: 'Delay (s)', min: 0 },
+				{ key: "size", type: "range", label: "Size", min: 50, max: 500, step: 10 },
+				{ key: "duration", type: "range", label: "Duration (s)", min: 1, max: 60 },
+				{ key: "borderWidth", type: "range", label: "Border Width", min: 0.5, max: 8, step: 0.5 },
+				{ key: "anchor", type: "range", label: "Anchor", min: 0, max: 100 },
+				{ key: "colorFrom", type: "color", label: "Color From" },
+				{ key: "colorTo", type: "color", label: "Color To" },
+				{ key: "delay", type: "number", label: "Delay (s)", min: 0 },
 			]}
-			initialValues={{ size: 200, duration: 15, borderWidth: 1.5, anchor: 90, colorFrom: '#ffaa40', colorTo: '#9c40ff', delay: 0 }}
+			initialValues={{
+				size: 200,
+				duration: 15,
+				borderWidth: 1.5,
+				anchor: 90,
+				colorFrom: "#ffaa40",
+				colorTo: "#9c40ff",
+				delay: 0,
+			}}
 		>
 			{#snippet preview(values)}
-				<div class="relative h-40 w-full max-w-md overflow-hidden rounded-xl border bg-background p-6">
+				<div
+					class="bg-background relative h-40 w-full max-w-md overflow-hidden rounded-xl border p-6"
+				>
 					<p class="text-muted-foreground text-center">Preview</p>
 					<BorderBeam {...values as BorderBeamProps} />
 				</div>

--- a/src/routes/demo/border-beam/+page.svelte
+++ b/src/routes/demo/border-beam/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { BorderBeam } from "$lib/fancy-ui/border-beam";
+	import type { BorderBeamProps } from "$lib/fancy-ui/border-beam/BorderBeam.svelte";
+	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
 </script>
 
 <svelte:head>
@@ -114,5 +116,29 @@
 				<BorderBeam colorFrom="#00ffff" colorTo="#0066ff" delay={7.5} />
 			</div>
 		</div>
+	</section>
+
+	<!-- Playground -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
+		<PropsPlayground
+			controls={[
+				{ key: 'size', type: 'range', label: 'Size', min: 50, max: 500, step: 10 },
+				{ key: 'duration', type: 'range', label: 'Duration (s)', min: 1, max: 60 },
+				{ key: 'borderWidth', type: 'range', label: 'Border Width', min: 0.5, max: 8, step: 0.5 },
+				{ key: 'anchor', type: 'range', label: 'Anchor', min: 0, max: 100 },
+				{ key: 'colorFrom', type: 'color', label: 'Color From' },
+				{ key: 'colorTo', type: 'color', label: 'Color To' },
+				{ key: 'delay', type: 'number', label: 'Delay (s)', min: 0 },
+			]}
+			initialValues={{ size: 200, duration: 15, borderWidth: 1.5, anchor: 90, colorFrom: '#ffaa40', colorTo: '#9c40ff', delay: 0 }}
+		>
+			{#snippet preview(values)}
+				<div class="relative h-40 w-full max-w-md overflow-hidden rounded-xl border bg-background p-6">
+					<p class="text-muted-foreground text-center">Preview</p>
+					<BorderBeam {...values as BorderBeamProps} />
+				</div>
+			{/snippet}
+		</PropsPlayground>
 	</section>
 </div>

--- a/src/routes/demo/border-beam/+page.svelte
+++ b/src/routes/demo/border-beam/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import { BorderBeam } from "$lib/fancy-ui/border-beam";
-	import type { BorderBeamProps } from "$lib/fancy-ui/border-beam/BorderBeam.svelte";
+	import { BorderBeam, type BorderBeamProps } from "$lib/fancy-ui/border-beam";
 	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
 </script>
 

--- a/src/routes/demo/flickering-grid/+page.svelte
+++ b/src/routes/demo/flickering-grid/+page.svelte
@@ -81,13 +81,26 @@
 		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
 		<PropsPlayground
 			controls={[
-				{ key: 'color', type: 'color', label: 'Color' },
-				{ key: 'flickerChance', type: 'range', label: 'Flicker Chance', min: 0.01, max: 1, step: 0.01 },
-				{ key: 'maxOpacity', type: 'range', label: 'Max Opacity', min: 0.05, max: 1, step: 0.05 },
-				{ key: 'squareSize', type: 'range', label: 'Square Size', min: 1, max: 20, step: 1 },
-				{ key: 'gridGap', type: 'range', label: 'Grid Gap', min: 1, max: 20, step: 1 },
+				{ key: "color", type: "color", label: "Color" },
+				{
+					key: "flickerChance",
+					type: "range",
+					label: "Flicker Chance",
+					min: 0.01,
+					max: 1,
+					step: 0.01,
+				},
+				{ key: "maxOpacity", type: "range", label: "Max Opacity", min: 0.05, max: 1, step: 0.05 },
+				{ key: "squareSize", type: "range", label: "Square Size", min: 1, max: 20, step: 1 },
+				{ key: "gridGap", type: "range", label: "Grid Gap", min: 1, max: 20, step: 1 },
 			]}
-			initialValues={{ color: '#000000', flickerChance: 0.3, maxOpacity: 0.3, squareSize: 4, gridGap: 6 }}
+			initialValues={{
+				color: "#000000",
+				flickerChance: 0.3,
+				maxOpacity: 0.3,
+				squareSize: 4,
+				gridGap: 6,
+			}}
 		>
 			{#snippet preview(values)}
 				<div class="bg-background mx-auto h-64 w-full max-w-md overflow-hidden rounded-xl border">

--- a/src/routes/demo/flickering-grid/+page.svelte
+++ b/src/routes/demo/flickering-grid/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { FlickeringGrid } from "$lib/fancy-ui/flickering-grid";
+	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
 </script>
 
 <svelte:head>
@@ -74,5 +75,31 @@
 				<FlickeringGrid flickerChance={0.8} maxOpacity={0.4} />
 			</div>
 		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
+		<PropsPlayground
+			controls={[
+				{ key: 'color', type: 'color', label: 'Color' },
+				{ key: 'flickerChance', type: 'range', label: 'Flicker Chance', min: 0.01, max: 1, step: 0.01 },
+				{ key: 'maxOpacity', type: 'range', label: 'Max Opacity', min: 0.05, max: 1, step: 0.05 },
+				{ key: 'squareSize', type: 'range', label: 'Square Size', min: 1, max: 20, step: 1 },
+				{ key: 'gridGap', type: 'range', label: 'Grid Gap', min: 1, max: 20, step: 1 },
+			]}
+			initialValues={{ color: '#000000', flickerChance: 0.3, maxOpacity: 0.3, squareSize: 4, gridGap: 6 }}
+		>
+			{#snippet preview(values)}
+				<div class="bg-background mx-auto h-64 w-full max-w-md overflow-hidden rounded-xl border">
+					<FlickeringGrid
+						color={values.color as string}
+						flickerChance={values.flickerChance as number}
+						maxOpacity={values.maxOpacity as number}
+						squareSize={values.squareSize as number}
+						gridGap={values.gridGap as number}
+					/>
+				</div>
+			{/snippet}
+		</PropsPlayground>
 	</section>
 </div>

--- a/src/routes/demo/gradient-button/+page.svelte
+++ b/src/routes/demo/gradient-button/+page.svelte
@@ -143,13 +143,19 @@
 		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
 		<PropsPlayground
 			controls={[
-				{ key: 'duration', type: 'range', label: 'Duration (ms)', min: 500, max: 8000, step: 100 },
-				{ key: 'borderWidth', type: 'range', label: 'Border Width', min: 1, max: 8, step: 1 },
-				{ key: 'borderRadius', type: 'range', label: 'Border Radius', min: 0, max: 100, step: 2 },
-				{ key: 'blur', type: 'range', label: 'Blur', min: 0, max: 16, step: 1 },
-				{ key: 'bgColor', type: 'color', label: 'Background Color' },
+				{ key: "duration", type: "range", label: "Duration (ms)", min: 500, max: 8000, step: 100 },
+				{ key: "borderWidth", type: "range", label: "Border Width", min: 1, max: 8, step: 1 },
+				{ key: "borderRadius", type: "range", label: "Border Radius", min: 0, max: 100, step: 2 },
+				{ key: "blur", type: "range", label: "Blur", min: 0, max: 16, step: 1 },
+				{ key: "bgColor", type: "color", label: "Background Color" },
 			]}
-			initialValues={{ duration: 2500, borderWidth: 2, borderRadius: 8, blur: 4, bgColor: '#000000' }}
+			initialValues={{
+				duration: 2500,
+				borderWidth: 2,
+				borderRadius: 8,
+				blur: 4,
+				bgColor: "#000000",
+			}}
 		>
 			{#snippet preview(values)}
 				<div class="flex items-center justify-center py-8">

--- a/src/routes/demo/gradient-button/+page.svelte
+++ b/src/routes/demo/gradient-button/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { GradientButton } from "$lib/fancy-ui/gradient-button";
+	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
 </script>
 
 <svelte:head>
@@ -136,5 +137,34 @@
 			<GradientButton bgColor="#1e293b" class="font-medium text-white">Slate</GradientButton>
 			<GradientButton bgColor="#18181b" class="font-medium text-white">Zinc</GradientButton>
 		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
+		<PropsPlayground
+			controls={[
+				{ key: 'duration', type: 'range', label: 'Duration (ms)', min: 500, max: 8000, step: 100 },
+				{ key: 'borderWidth', type: 'range', label: 'Border Width', min: 1, max: 8, step: 1 },
+				{ key: 'borderRadius', type: 'range', label: 'Border Radius', min: 0, max: 100, step: 2 },
+				{ key: 'blur', type: 'range', label: 'Blur', min: 0, max: 16, step: 1 },
+				{ key: 'bgColor', type: 'color', label: 'Background Color' },
+			]}
+			initialValues={{ duration: 2500, borderWidth: 2, borderRadius: 8, blur: 4, bgColor: '#000000' }}
+		>
+			{#snippet preview(values)}
+				<div class="flex items-center justify-center py-8">
+					<GradientButton
+						duration={values.duration as number}
+						borderWidth={values.borderWidth as number}
+						borderRadius={values.borderRadius as number}
+						blur={values.blur as number}
+						bgColor={values.bgColor as string}
+						class="font-medium text-white"
+					>
+						Click me
+					</GradientButton>
+				</div>
+			{/snippet}
+		</PropsPlayground>
 	</section>
 </div>

--- a/src/routes/demo/marquee/+page.svelte
+++ b/src/routes/demo/marquee/+page.svelte
@@ -112,14 +112,18 @@
 		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
 		<PropsPlayground
 			controls={[
-				{ key: 'reverse', type: 'boolean', label: 'Reverse' },
-				{ key: 'pauseOnHover', type: 'boolean', label: 'Pause on Hover' },
-				{ key: 'vertical', type: 'boolean', label: 'Vertical' },
+				{ key: "reverse", type: "boolean", label: "Reverse" },
+				{ key: "pauseOnHover", type: "boolean", label: "Pause on Hover" },
+				{ key: "vertical", type: "boolean", label: "Vertical" },
 			]}
 			initialValues={{ reverse: false, pauseOnHover: false, vertical: false }}
 		>
 			{#snippet preview(values)}
-				<div class="relative w-full overflow-hidden rounded-xl border bg-background {values.vertical ? 'flex h-56 flex-row' : 'flex flex-col'}">
+				<div
+					class="bg-background relative w-full overflow-hidden rounded-xl border {values.vertical
+						? 'flex h-56 flex-row'
+						: 'flex flex-col'}"
+				>
 					<Marquee
 						reverse={values.reverse as boolean}
 						pauseOnHover={values.pauseOnHover as boolean}
@@ -130,8 +134,12 @@
 							<ReviewCard {...review} />
 						{/each}
 					</Marquee>
-					<div class="from-background pointer-events-none absolute inset-y-0 left-0 w-1/4 bg-gradient-to-r"></div>
-					<div class="from-background pointer-events-none absolute inset-y-0 right-0 w-1/4 bg-gradient-to-l"></div>
+					<div
+						class="from-background pointer-events-none absolute inset-y-0 left-0 w-1/4 bg-gradient-to-r"
+					></div>
+					<div
+						class="from-background pointer-events-none absolute inset-y-0 right-0 w-1/4 bg-gradient-to-l"
+					></div>
 				</div>
 			{/snippet}
 		</PropsPlayground>

--- a/src/routes/demo/marquee/+page.svelte
+++ b/src/routes/demo/marquee/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Marquee, ReviewCard } from "$lib/fancy-ui/marquee";
+	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
 
 	const reviews = [
 		{
@@ -105,6 +106,35 @@
 				class="from-background pointer-events-none absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t"
 			></div>
 		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
+		<PropsPlayground
+			controls={[
+				{ key: 'reverse', type: 'boolean', label: 'Reverse' },
+				{ key: 'pauseOnHover', type: 'boolean', label: 'Pause on Hover' },
+				{ key: 'vertical', type: 'boolean', label: 'Vertical' },
+			]}
+			initialValues={{ reverse: false, pauseOnHover: false, vertical: false }}
+		>
+			{#snippet preview(values)}
+				<div class="relative w-full overflow-hidden rounded-xl border bg-background {values.vertical ? 'flex h-56 flex-row' : 'flex flex-col'}">
+					<Marquee
+						reverse={values.reverse as boolean}
+						pauseOnHover={values.pauseOnHover as boolean}
+						vertical={values.vertical as boolean}
+						class="[--duration:20s]"
+					>
+						{#each firstRow as review}
+							<ReviewCard {...review} />
+						{/each}
+					</Marquee>
+					<div class="from-background pointer-events-none absolute inset-y-0 left-0 w-1/4 bg-gradient-to-r"></div>
+					<div class="from-background pointer-events-none absolute inset-y-0 right-0 w-1/4 bg-gradient-to-l"></div>
+				</div>
+			{/snippet}
+		</PropsPlayground>
 	</section>
 
 	<section class="mb-12">

--- a/src/routes/demo/meteors/+page.svelte
+++ b/src/routes/demo/meteors/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Meteors } from "$lib/fancy-ui/meteors";
+	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
 </script>
 
 <svelte:head>
@@ -65,5 +66,28 @@
 				</div>
 			</div>
 		</div>
+	</section>
+
+	<!-- Playground -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
+		<PropsPlayground
+			controls={[{ key: 'count', type: 'range', label: 'Count', min: 1, max: 80, step: 1 }]}
+			initialValues={{ count: 20 }}
+		>
+			{#snippet preview(values)}
+				<div
+					class="relative mx-auto w-full max-w-sm overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-950 p-8 shadow-xl"
+				>
+					<Meteors count={values.count as number} />
+					<div class="relative z-10">
+						<h3 class="mb-2 text-lg font-bold text-white">Shooting Stars</h3>
+						<p class="text-sm text-zinc-400">
+							A beautiful meteor shower effect for dark-themed cards and hero sections.
+						</p>
+					</div>
+				</div>
+			{/snippet}
+		</PropsPlayground>
 	</section>
 </div>

--- a/src/routes/demo/meteors/+page.svelte
+++ b/src/routes/demo/meteors/+page.svelte
@@ -72,7 +72,7 @@
 	<section class="mb-12">
 		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
 		<PropsPlayground
-			controls={[{ key: 'count', type: 'range', label: 'Count', min: 1, max: 80, step: 1 }]}
+			controls={[{ key: "count", type: "range", label: "Count", min: 1, max: 80, step: 1 }]}
 			initialValues={{ count: 20 }}
 		>
 			{#snippet preview(values)}

--- a/src/routes/demo/neon-border/+page.svelte
+++ b/src/routes/demo/neon-border/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { NeonBorder } from "$lib/fancy-ui/neon-border";
+	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
 </script>
 
 <svelte:head>
@@ -111,5 +112,33 @@
 				</div>
 			</NeonBorder>
 		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
+		<PropsPlayground
+			controls={[
+				{ key: 'color1', type: 'color', label: 'Color 1' },
+				{ key: 'color2', type: 'color', label: 'Color 2' },
+				{ key: 'animationType', type: 'select', label: 'Animation Type', options: [{ value: 'none', label: 'None (static)' }, { value: 'half', label: 'Half' }, { value: 'full', label: 'Full' }] },
+				{ key: 'duration', type: 'range', label: 'Duration (s)', min: 1, max: 20, step: 1 },
+			]}
+			initialValues={{ color1: '#0496ff', color2: '#ff0a54', animationType: 'half', duration: 6 }}
+		>
+			{#snippet preview(values)}
+				<div class="flex items-center justify-center py-8">
+					<NeonBorder
+						color1={values.color1 as string}
+						color2={values.color2 as string}
+						animationType={values.animationType as 'none' | 'half' | 'full'}
+						duration={values.duration as number}
+					>
+						<div class="bg-background flex h-full w-full items-center justify-center rounded-lg px-8 py-3">
+							<span class="font-medium">Neon Border</span>
+						</div>
+					</NeonBorder>
+				</div>
+			{/snippet}
+		</PropsPlayground>
 	</section>
 </div>

--- a/src/routes/demo/neon-border/+page.svelte
+++ b/src/routes/demo/neon-border/+page.svelte
@@ -118,22 +118,33 @@
 		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
 		<PropsPlayground
 			controls={[
-				{ key: 'color1', type: 'color', label: 'Color 1' },
-				{ key: 'color2', type: 'color', label: 'Color 2' },
-				{ key: 'animationType', type: 'select', label: 'Animation Type', options: [{ value: 'none', label: 'None (static)' }, { value: 'half', label: 'Half' }, { value: 'full', label: 'Full' }] },
-				{ key: 'duration', type: 'range', label: 'Duration (s)', min: 1, max: 20, step: 1 },
+				{ key: "color1", type: "color", label: "Color 1" },
+				{ key: "color2", type: "color", label: "Color 2" },
+				{
+					key: "animationType",
+					type: "select",
+					label: "Animation Type",
+					options: [
+						{ value: "none", label: "None (static)" },
+						{ value: "half", label: "Half" },
+						{ value: "full", label: "Full" },
+					],
+				},
+				{ key: "duration", type: "range", label: "Duration (s)", min: 1, max: 20, step: 1 },
 			]}
-			initialValues={{ color1: '#0496ff', color2: '#ff0a54', animationType: 'half', duration: 6 }}
+			initialValues={{ color1: "#0496ff", color2: "#ff0a54", animationType: "half", duration: 6 }}
 		>
 			{#snippet preview(values)}
 				<div class="flex items-center justify-center py-8">
 					<NeonBorder
 						color1={values.color1 as string}
 						color2={values.color2 as string}
-						animationType={values.animationType as 'none' | 'half' | 'full'}
+						animationType={values.animationType as "none" | "half" | "full"}
 						duration={values.duration as number}
 					>
-						<div class="bg-background flex h-full w-full items-center justify-center rounded-lg px-8 py-3">
+						<div
+							class="bg-background flex h-full w-full items-center justify-center rounded-lg px-8 py-3"
+						>
 							<span class="font-medium">Neon Border</span>
 						</div>
 					</NeonBorder>

--- a/src/routes/demo/number-ticker/+page.svelte
+++ b/src/routes/demo/number-ticker/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { NumberTicker } from "$lib/fancy-ui/number-ticker";
 	import ReplayButton from "$lib/components/ReplayButton.svelte";
+	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
 
 	let replayKey1 = $state(0);
 	let replayKey2 = $state(0);
@@ -78,5 +79,32 @@
 				</div>
 			{/key}
 		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
+		<PropsPlayground
+			controls={[
+				{ key: 'value', type: 'range', label: 'Value', min: 0, max: 100000, step: 100 },
+				{ key: 'duration', type: 'range', label: 'Duration (ms)', min: 200, max: 5000, step: 100 },
+				{ key: 'delay', type: 'range', label: 'Delay (ms)', min: 0, max: 2000, step: 100 },
+				{ key: 'decimalPlaces', type: 'range', label: 'Decimal Places', min: 0, max: 4, step: 1 },
+				{ key: 'direction', type: 'select', label: 'Direction', options: [{ value: 'up', label: 'Up' }, { value: 'down', label: 'Down' }] },
+			]}
+			initialValues={{ value: 1234, duration: 1000, delay: 0, decimalPlaces: 0, direction: 'up' }}
+		>
+			{#snippet preview(values)}
+				<div class="flex items-center justify-center rounded-xl p-12">
+					<NumberTicker
+						value={values.value as number}
+						duration={values.duration as number}
+						delay={values.delay as number}
+						decimalPlaces={values.decimalPlaces as number}
+						direction={values.direction as 'up' | 'down'}
+						class="text-6xl font-bold"
+					/>
+				</div>
+			{/snippet}
+		</PropsPlayground>
 	</section>
 </div>

--- a/src/routes/demo/number-ticker/+page.svelte
+++ b/src/routes/demo/number-ticker/+page.svelte
@@ -85,13 +85,21 @@
 		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
 		<PropsPlayground
 			controls={[
-				{ key: 'value', type: 'range', label: 'Value', min: 0, max: 100000, step: 100 },
-				{ key: 'duration', type: 'range', label: 'Duration (ms)', min: 200, max: 5000, step: 100 },
-				{ key: 'delay', type: 'range', label: 'Delay (ms)', min: 0, max: 2000, step: 100 },
-				{ key: 'decimalPlaces', type: 'range', label: 'Decimal Places', min: 0, max: 4, step: 1 },
-				{ key: 'direction', type: 'select', label: 'Direction', options: [{ value: 'up', label: 'Up' }, { value: 'down', label: 'Down' }] },
+				{ key: "value", type: "range", label: "Value", min: 0, max: 100000, step: 100 },
+				{ key: "duration", type: "range", label: "Duration (ms)", min: 200, max: 5000, step: 100 },
+				{ key: "delay", type: "range", label: "Delay (ms)", min: 0, max: 2000, step: 100 },
+				{ key: "decimalPlaces", type: "range", label: "Decimal Places", min: 0, max: 4, step: 1 },
+				{
+					key: "direction",
+					type: "select",
+					label: "Direction",
+					options: [
+						{ value: "up", label: "Up" },
+						{ value: "down", label: "Down" },
+					],
+				},
 			]}
-			initialValues={{ value: 1234, duration: 1000, delay: 0, decimalPlaces: 0, direction: 'up' }}
+			initialValues={{ value: 1234, duration: 1000, delay: 0, decimalPlaces: 0, direction: "up" }}
 		>
 			{#snippet preview(values)}
 				<div class="flex items-center justify-center rounded-xl p-12">
@@ -100,7 +108,7 @@
 						duration={values.duration as number}
 						delay={values.delay as number}
 						decimalPlaces={values.decimalPlaces as number}
-						direction={values.direction as 'up' | 'down'}
+						direction={values.direction as "up" | "down"}
 						class="text-6xl font-bold"
 					/>
 				</div>

--- a/src/routes/demo/ripple/+page.svelte
+++ b/src/routes/demo/ripple/+page.svelte
@@ -34,16 +34,50 @@
 		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
 		<PropsPlayground
 			controls={[
-				{ key: 'numberOfCircles', type: 'range', label: 'Number of Circles', min: 1, max: 12, step: 1 },
-				{ key: 'baseCircleSize', type: 'range', label: 'Base Circle Size', min: 50, max: 400, step: 10 },
-				{ key: 'spaceBetweenCircle', type: 'range', label: 'Space Between', min: 20, max: 200, step: 10 },
-				{ key: 'baseCircleOpacity', type: 'range', label: 'Base Opacity', min: 0.05, max: 0.8, step: 0.05 },
-				{ key: 'waveSpeed', type: 'range', label: 'Wave Speed (ms)', min: 10, max: 300, step: 10 },
+				{
+					key: "numberOfCircles",
+					type: "range",
+					label: "Number of Circles",
+					min: 1,
+					max: 12,
+					step: 1,
+				},
+				{
+					key: "baseCircleSize",
+					type: "range",
+					label: "Base Circle Size",
+					min: 50,
+					max: 400,
+					step: 10,
+				},
+				{
+					key: "spaceBetweenCircle",
+					type: "range",
+					label: "Space Between",
+					min: 20,
+					max: 200,
+					step: 10,
+				},
+				{
+					key: "baseCircleOpacity",
+					type: "range",
+					label: "Base Opacity",
+					min: 0.05,
+					max: 0.8,
+					step: 0.05,
+				},
+				{ key: "waveSpeed", type: "range", label: "Wave Speed (ms)", min: 10, max: 300, step: 10 },
 			]}
-			initialValues={{ numberOfCircles: 7, baseCircleSize: 210, spaceBetweenCircle: 70, baseCircleOpacity: 0.24, waveSpeed: 80 }}
+			initialValues={{
+				numberOfCircles: 7,
+				baseCircleSize: 210,
+				spaceBetweenCircle: 70,
+				baseCircleOpacity: 0.24,
+				waveSpeed: 80,
+			}}
 		>
 			{#snippet preview(values)}
-				<div class="relative h-80 w-full overflow-hidden rounded-xl border bg-card">
+				<div class="bg-card relative h-80 w-full overflow-hidden rounded-xl border">
 					<Ripple
 						numberOfCircles={values.numberOfCircles as number}
 						baseCircleSize={values.baseCircleSize as number}

--- a/src/routes/demo/ripple/+page.svelte
+++ b/src/routes/demo/ripple/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Ripple } from "$lib/fancy-ui/ripple";
+	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
 </script>
 
 <svelte:head>
@@ -27,5 +28,31 @@
 				spaceBetweenCircle={90}
 			/>
 		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
+		<PropsPlayground
+			controls={[
+				{ key: 'numberOfCircles', type: 'range', label: 'Number of Circles', min: 1, max: 12, step: 1 },
+				{ key: 'baseCircleSize', type: 'range', label: 'Base Circle Size', min: 50, max: 400, step: 10 },
+				{ key: 'spaceBetweenCircle', type: 'range', label: 'Space Between', min: 20, max: 200, step: 10 },
+				{ key: 'baseCircleOpacity', type: 'range', label: 'Base Opacity', min: 0.05, max: 0.8, step: 0.05 },
+				{ key: 'waveSpeed', type: 'range', label: 'Wave Speed (ms)', min: 10, max: 300, step: 10 },
+			]}
+			initialValues={{ numberOfCircles: 7, baseCircleSize: 210, spaceBetweenCircle: 70, baseCircleOpacity: 0.24, waveSpeed: 80 }}
+		>
+			{#snippet preview(values)}
+				<div class="relative h-80 w-full overflow-hidden rounded-xl border bg-card">
+					<Ripple
+						numberOfCircles={values.numberOfCircles as number}
+						baseCircleSize={values.baseCircleSize as number}
+						spaceBetweenCircle={values.spaceBetweenCircle as number}
+						baseCircleOpacity={values.baseCircleOpacity as number}
+						waveSpeed={values.waveSpeed as number}
+					/>
+				</div>
+			{/snippet}
+		</PropsPlayground>
 	</section>
 </div>

--- a/src/routes/demo/sparkles/+page.svelte
+++ b/src/routes/demo/sparkles/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Sparkles } from "$lib/fancy-ui/sparkles";
+	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
 </script>
 
 <svelte:head>
@@ -35,5 +36,22 @@
 				maxSize={4}
 			/>
 		</div>
+	</section>
+
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
+		<PropsPlayground
+			controls={[
+				{ key: 'background', type: 'color', label: 'Background' },
+				{ key: 'particleColor', type: 'color', label: 'Particle Color' },
+			]}
+			initialValues={{ background: '#0d47a1', particleColor: '#ffffff' }}
+		>
+			{#snippet preview(values)}
+				<div class="h-64 w-full overflow-hidden rounded-xl border">
+					<Sparkles background={values.background as string} particleColor={values.particleColor as string} />
+				</div>
+			{/snippet}
+		</PropsPlayground>
 	</section>
 </div>

--- a/src/routes/demo/sparkles/+page.svelte
+++ b/src/routes/demo/sparkles/+page.svelte
@@ -42,14 +42,17 @@
 		<h2 class="mb-4 text-xl font-semibold">Interactive Playground</h2>
 		<PropsPlayground
 			controls={[
-				{ key: 'background', type: 'color', label: 'Background' },
-				{ key: 'particleColor', type: 'color', label: 'Particle Color' },
+				{ key: "background", type: "color", label: "Background" },
+				{ key: "particleColor", type: "color", label: "Particle Color" },
 			]}
-			initialValues={{ background: '#0d47a1', particleColor: '#ffffff' }}
+			initialValues={{ background: "#0d47a1", particleColor: "#ffffff" }}
 		>
 			{#snippet preview(values)}
 				<div class="h-64 w-full overflow-hidden rounded-xl border">
-					<Sparkles background={values.background as string} particleColor={values.particleColor as string} />
+					<Sparkles
+						background={values.background as string}
+						particleColor={values.particleColor as string}
+					/>
 				</div>
 			{/snippet}
 		</PropsPlayground>


### PR DESCRIPTION
## Summary
- Add `PropsPlayground` component with a slide-in panel for live-editing component props via range, number, color, text, boolean toggle, and select controls
- Integrate playground into 9 demo pages: border-beam, meteors, ripple, sparkles, number-ticker, marquee, flickering-grid, neon-border, gradient-button

## Test plan
- [x] Navigate to `/demo/border-beam` — scroll to bottom, click "Customize", drag sliders and change colors, verify live updates
- [x] Click "Reset" — values return to defaults
- [x] Press Escape or click backdrop — panel closes
- [x] Repeat on `/demo/meteors`, `/demo/ripple`, `/demo/number-ticker`, `/demo/neon-border`, `/demo/gradient-button`, `/demo/flickering-grid`, `/demo/marquee`, `/demo/sparkles`