### PR TITLE
fix: ui bug fixes — compare corners, animated-tooltip image, flip-words layout shift

### DIFF
--- a/.changeset/apple-card-carousel.md
+++ b/.changeset/apple-card-carousel.md
@@ -1,5 +1,5 @@
 ---
-"fancy-ui": minor
+"fancy-ui": patch
 ---
 
 feat: add AppleCardCarousel component — horizontal card carousel with spring-animated full-screen expansion, inspired by Apple's App Store UI

--- a/.changeset/apple-card-carousel.md
+++ b/.changeset/apple-card-carousel.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": minor
+---
+
+feat: add AppleCardCarousel component — horizontal card carousel with spring-animated full-screen expansion, inspired by Apple's App Store UI

--- a/.changeset/compare-animated-tooltip-fixes.md
+++ b/.changeset/compare-animated-tooltip-fixes.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": patch
+---
+
+fix compare corner overflow and broken animated-tooltip image

--- a/.changeset/displacement-text.md
+++ b/.changeset/displacement-text.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": minor
+---
+
+feat(displacement-text): add 3D displacement text component

--- a/.changeset/flip-words-layout-fix.md
+++ b/.changeset/flip-words-layout-fix.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": patch
+---
+
+fix(flip-words): prevent layout shift during word transition

--- a/.changeset/line-hover-link.md
+++ b/.changeset/line-hover-link.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": minor
+---
+
+feat: add LineHoverLink component — link with 11 animated underline hover effects, pure CSS

--- a/.changeset/line-hover-link.md
+++ b/.changeset/line-hover-link.md
@@ -1,5 +1,5 @@
 ---
-"fancy-ui": minor
+"fancy-ui": patch
 ---
 
 feat: add LineHoverLink component — link with 11 animated underline hover effects, pure CSS

--- a/.changeset/npm-package-pipeline.md
+++ b/.changeset/npm-package-pipeline.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": patch
+---
+
+add npm package build pipeline — consumers can now install via `npm install fancy-ui`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check for changeset
+        # Skip this check for the automated "Version Packages" PR
+        if: ${{ github.head_ref != 'changeset-release/main' }}
         run: |
-          if [[ "${{ github.head_ref }}" == "changeset-release/main" ]]; then
-            echo "✅ Skipped for Version Packages PR."
-            exit 0
-          fi
           if ! ls .changeset/*.md 2>/dev/null | grep -qv README.md; then
             echo "❌ No changeset file found. Run 'pnpm changeset' and commit the generated file."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
 
@@ -35,8 +36,9 @@ jobs:
           # Creates/updates the "Version Packages" PR instead of pushing directly to main.
           # This prevents Vercel from triggering a deploy on every changeset commit.
           # When the "Version Packages" PR is merged, the tag and GitHub Release are created.
-          publish: pnpm changeset tag
+          publish: pnpm package && pnpm changeset publish
           commit: "chore: version packages"
           title: "Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ vendor/
 .wrangler
 /.svelte-kit
 /build
+/dist
 
 # Tools
 .claude/

--- a/package.json
+++ b/package.json
@@ -20,6 +20,18 @@
 		"ui",
 		"tailwind"
 	],
+	"files": ["dist/fancy-ui", "dist/utils.js", "dist/utils.d.ts", "dist/types.js", "dist/types.d.ts"],
+	"main": "./dist/fancy-ui/index.js",
+	"svelte": "./dist/fancy-ui/index.js",
+	"types": "./dist/fancy-ui/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/fancy-ui/index.d.ts",
+			"svelte": "./dist/fancy-ui/index.js",
+			"default": "./dist/fancy-ui/index.js"
+		},
+		"./tailwind.css": "./dist/fancy-ui/tailwind.css"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -33,7 +45,23 @@
 		"test:e2e:ui": "playwright test --ui",
 		"changeset": "changeset",
 		"version": "changeset version",
-		"release": "changeset tag"
+		"release": "changeset tag",
+		"package": "svelte-kit sync && svelte-package -i src/lib -o dist && node -e \"const fs=require('fs'); ['dist/builder','dist/server','dist/stores'].forEach(p=>fs.rmSync(p,{recursive:true,force:true}));\" && publint",
+		"prepublishOnly": "pnpm run package"
+	},
+	"engines": {
+		"node": ">=20.19.0"
+	},
+	"peerDependencies": {
+		"svelte": "^5.0.0",
+		"tailwindcss": "^4.0.0"
+	},
+	"dependencies": {
+		"canvas-confetti": "^1.9.4",
+		"clsx": "^2.1.1",
+		"gsap": "^3.14.2",
+		"tailwind-merge": "^3.4.0",
+		"three": "^0.183.2"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.30.0",
@@ -42,6 +70,7 @@
 		"@playwright/test": "^1.58.2",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/kit": "^2.49.1",
+		"@sveltejs/package": "^2.5.7",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@tailwindcss/forms": "^0.5.10",
 		"@tailwindcss/typography": "^0.5.19",
@@ -51,28 +80,22 @@
 		"@types/canvas-confetti": "^1.9.0",
 		"@types/node": "^25.2.3",
 		"@types/three": "^0.183.1",
+		"arctic": "^3.7.0",
 		"bits-ui": "^2.15.4",
-		"clsx": "^2.1.1",
 		"jsdom": "^28.0.0",
+		"marked": "^17.0.3",
+		"nanoid": "^5.1.6",
 		"prettier": "^3.8.1",
 		"prettier-plugin-svelte": "^3.5.0",
 		"prettier-plugin-tailwindcss": "^0.7.2",
+		"publint": "^0.3.18",
 		"svelte": "^5.45.6",
 		"svelte-check": "^4.3.4",
-		"tailwind-merge": "^3.4.0",
 		"tailwind-variants": "^3.2.2",
 		"tailwindcss": "^4.1.17",
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^5.9.3",
 		"vite": "^7.2.6",
 		"vitest": "^4.0.18"
-	},
-	"dependencies": {
-		"arctic": "^3.7.0",
-		"canvas-confetti": "^1.9.4",
-		"gsap": "^3.14.2",
-		"marked": "^17.0.3",
-		"nanoid": "^5.1.6",
-		"three": "^0.183.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"@testing-library/svelte": "^5.3.1",
 		"@types/canvas-confetti": "^1.9.0",
 		"@types/node": "^25.2.3",
+		"@types/three": "^0.183.1",
 		"bits-ui": "^2.15.4",
 		"clsx": "^2.1.1",
 		"jsdom": "^28.0.0",
@@ -71,6 +72,7 @@
 		"canvas-confetti": "^1.9.4",
 		"gsap": "^3.14.2",
 		"marked": "^17.0.3",
-		"nanoid": "^5.1.6"
+		"nanoid": "^5.1.6",
+		"three": "^0.183.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,21 +8,18 @@ importers:
 
   .:
     dependencies:
-      arctic:
-        specifier: ^3.7.0
-        version: 3.7.0
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       gsap:
         specifier: ^3.14.2
         version: 3.14.2
-      marked:
-        specifier: ^17.0.3
-        version: 17.0.3
-      nanoid:
-        specifier: ^5.1.6
-        version: 5.1.6
+      tailwind-merge:
+        specifier: ^3.4.0
+        version: 3.4.0
       three:
         specifier: ^0.183.2
         version: 0.183.2
@@ -45,6 +42,9 @@ importers:
       '@sveltejs/kit':
         specifier: ^2.49.1
         version: 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@sveltejs/package':
+        specifier: ^2.5.7
+        version: 2.5.7(svelte@5.46.1)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.1
         version: 6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
@@ -72,15 +72,21 @@ importers:
       '@types/three':
         specifier: ^0.183.1
         version: 0.183.1
+      arctic:
+        specifier: ^3.7.0
+        version: 3.7.0
       bits-ui:
         specifier: ^2.15.4
         version: 2.15.4(@internationalized/date@3.10.1)(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
       jsdom:
         specifier: ^28.0.0
         version: 28.0.0
+      marked:
+        specifier: ^17.0.3
+        version: 17.0.3
+      nanoid:
+        specifier: ^5.1.6
+        version: 5.1.6
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -90,15 +96,15 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.7.2
         version: 0.7.2(prettier-plugin-svelte@3.5.0(prettier@3.8.1)(svelte@5.46.1))(prettier@3.8.1)
+      publint:
+        specifier: ^0.3.18
+        version: 0.3.18
       svelte:
         specifier: ^5.45.6
         version: 5.46.1
       svelte-check:
         specifier: ^4.3.4
         version: 4.3.5(picomatch@4.0.3)(svelte@5.46.1)(typescript@5.9.3)
-      tailwind-merge:
-        specifier: ^3.4.0
-        version: 3.4.0
       tailwind-variants:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.1.18)
@@ -487,6 +493,10 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
+
   '@rollup/rollup-android-arm-eabi@4.55.1':
     resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
     cpu: [arm]
@@ -640,6 +650,13 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  '@sveltejs/package@2.5.7':
+    resolution: {integrity: sha512-qqD9xa9H7TDiGFrF6rz7AirOR8k15qDK/9i4MIE8te4vWsv5GEogPks61rrZcLy+yWph+aI6pIj2MdoK3YI8AQ==}
+    engines: {node: ^16.14 || >=18}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.44.0 || ^4.0.0 || ^5.0.0-next.1
 
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2':
     resolution: {integrity: sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==}
@@ -935,6 +952,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -978,6 +999,9 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dedent-js@1.0.1:
+    resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -1367,6 +1391,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -1493,6 +1520,11 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  publint@0.3.18:
+    resolution: {integrity: sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1513,6 +1545,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -1557,6 +1593,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scule@1.3.0:
+    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1633,6 +1672,12 @@ packages:
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.30.2
+
+  svelte2tsx@0.7.52:
+    resolution: {integrity: sha512-svdT1FTrCLpvlU62evO5YdJt/kQ7nxgQxII/9BpQUvKr+GJRVdAXNVw8UWOt0fhoe5uWKyU0WsUTMRVAtRbMQg==}
+    peerDependencies:
+      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
+      typescript: ^4.9.4 || ^5.0.0
 
   svelte@5.46.1:
     resolution: {integrity: sha512-ynjfCHD3nP2el70kN5Pmg37sSi0EjOm9FgHYQdC4giWG/hzO3AatzXXJJgP305uIhGQxSufJLuYWtkY8uK/8RA==}
@@ -2231,6 +2276,8 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@publint/pack@0.1.4': {}
+
   '@rollup/rollup-android-arm-eabi@4.55.1':
     optional: true
 
@@ -2336,6 +2383,17 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@sveltejs/package@2.5.7(svelte@5.46.1)(typescript@5.9.3)':
+    dependencies:
+      chokidar: 5.0.0
+      kleur: 4.1.5
+      sade: 1.8.1
+      semver: 7.7.4
+      svelte: 5.46.1
+      svelte2tsx: 0.7.52(svelte@5.46.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
@@ -2616,6 +2674,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   clsx@2.1.1: {}
 
   cookie@0.6.0: {}
@@ -2654,6 +2716,8 @@ snapshots:
       ms: 2.1.3
 
   decimal.js@10.6.0: {}
+
+  dedent-js@1.0.1: {}
 
   deepmerge@4.3.1: {}
 
@@ -3009,6 +3073,8 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  package-manager-detector@1.6.0: {}
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -3069,6 +3135,13 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  publint@0.3.18:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
@@ -3085,6 +3158,8 @@ snapshots:
       strip-bom: 3.0.0
 
   readdirp@4.1.2: {}
+
+  readdirp@5.0.0: {}
 
   redent@3.0.0:
     dependencies:
@@ -3150,6 +3225,8 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scule@1.3.0: {}
 
   semver@7.7.4: {}
 
@@ -3220,6 +3297,13 @@ snapshots:
       svelte: 5.46.1
     transitivePeerDependencies:
       - '@sveltejs/kit'
+
+  svelte2tsx@0.7.52(svelte@5.46.1)(typescript@5.9.3):
+    dependencies:
+      dedent-js: 1.0.1
+      scule: 1.3.0
+      svelte: 5.46.1
+      typescript: 5.9.3
 
   svelte@5.46.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       nanoid:
         specifier: ^5.1.6
         version: 5.1.6
+      three:
+        specifier: ^0.183.2
+        version: 0.183.2
     devDependencies:
       '@changesets/cli':
         specifier: ^2.30.0
@@ -66,6 +69,9 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
+      '@types/three':
+        specifier: ^0.183.1
+        version: 0.183.1
       bits-ui:
         specifier: ^2.15.4
         version: 2.15.4(@internationalized/date@3.10.1)(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
@@ -226,6 +232,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -777,6 +786,9 @@ packages:
       vitest:
         optional: true
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -800,6 +812,15 @@ packages:
 
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.183.1':
+    resolution: {integrity: sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
@@ -829,6 +850,9 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  '@webgpu/types@0.1.69':
+    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -1040,6 +1064,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1274,6 +1301,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meshoptimizer@1.0.1:
+    resolution: {integrity: sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1637,6 +1667,9 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  three@0.183.2:
+    resolution: {integrity: sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2017,6 +2050,8 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.26': {}
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
@@ -2434,6 +2469,8 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
       vitest: 4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/aria-query@5.0.4': {}
 
   '@types/canvas-confetti@1.9.0': {}
@@ -2454,6 +2491,20 @@ snapshots:
   '@types/node@25.2.3':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.183.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      '@webgpu/types': 0.1.69
+      fflate: 0.8.2
+      meshoptimizer: 1.0.1
+
+  '@types/webxr@0.5.24': {}
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -2493,6 +2544,8 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
+
+  '@webgpu/types@0.1.69': {}
 
   acorn@8.15.0: {}
 
@@ -2694,6 +2747,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.2: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -2908,6 +2963,8 @@ snapshots:
   mdn-data@2.12.2: {}
 
   merge2@1.4.1: {}
+
+  meshoptimizer@1.0.1: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -3199,6 +3256,8 @@ snapshots:
   tapable@2.3.0: {}
 
   term-size@2.2.1: {}
+
+  three@0.183.2: {}
 
   tinybench@2.9.0: {}
 

--- a/src/lib/fancy-ui/animated-testimonials/AnimatedTestimonials.svelte
+++ b/src/lib/fancy-ui/animated-testimonials/AnimatedTestimonials.svelte
@@ -77,20 +77,21 @@
 		};
 	});
 
-	let activeTestimonial = $derived(
-		testimonials.length > 0 ? testimonials[activeIndex] : null
-	);
+	let activeTestimonial = $derived(testimonials.length > 0 ? testimonials[activeIndex] : null);
 </script>
 
 <div
-	class={cn("relative mx-auto max-w-sm md:max-w-4xl antialiased font-sans px-4 md:px-8 lg:px-12 py-20", className)}
+	class={cn(
+		"relative mx-auto max-w-sm px-4 py-20 font-sans antialiased md:max-w-4xl md:px-8 lg:px-12",
+		className
+	)}
 	onmouseenter={() => (isHovered = true)}
 	onmouseleave={() => (isHovered = false)}
 	role="region"
 	aria-label="Testimonials"
 >
 	{#if testimonials.length === 0}
-		<p class="text-center text-muted-foreground">No testimonials available.</p>
+		<p class="text-muted-foreground text-center">No testimonials available.</p>
 	{:else}
 		<div class="relative grid grid-cols-1 gap-20 md:grid-cols-2">
 			<!-- Image column -->
@@ -100,8 +101,8 @@
 						class={cn(
 							"absolute inset-0 h-full w-full origin-bottom rounded-3xl transition-all ease-in-out",
 							index === activeIndex
-								? "z-20 opacity-100 scale-100 translate-y-0 rotate-0"
-								: "z-10 opacity-0 scale-95 translate-y-4",
+								? "z-20 translate-y-0 scale-100 rotate-0 opacity-100"
+								: "z-10 translate-y-4 scale-95 opacity-0",
 							index !== activeIndex && direction === "next"
 								? "-translate-y-4"
 								: index !== activeIndex
@@ -127,9 +128,9 @@
 						"ease-in-out",
 						isAnimating
 							? direction === "next"
-								? "opacity-0 translate-y-4"
-								: "opacity-0 -translate-y-4"
-							: "opacity-100 translate-y-0"
+								? "translate-y-4 opacity-0"
+								: "-translate-y-4 opacity-0"
+							: "translate-y-0 opacity-100"
 					)}
 					style="transition: opacity {TRANSITION_DURATION}ms, transform {TRANSITION_DURATION}ms"
 				>

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
@@ -13,45 +13,54 @@
 		/** Rich content shown in the expanded view (takes precedence over description) */
 		content?: Snippet;
 	}
+
+	/** Shared transition duration — must stay in sync with the CSS transition below */
+	export const TRANSITION_MS = 400;
 </script>
 
 <script lang="ts">
-	import { onMount } from "svelte";
+	import { tick } from "svelte";
 	import { cn } from "$lib/utils.js";
 
 	interface Props {
 		card: AppleCardData;
 		index: number;
 		expandedIndex: number;
+		reducedMotion: boolean;
 		onExpand: (index: number) => void;
 		onCollapse: () => void;
 		class?: string;
 	}
 
-	let { card, index, expandedIndex, onExpand, onCollapse, class: className = "" }: Props = $props();
+	let {
+		card,
+		index,
+		expandedIndex,
+		reducedMotion,
+		onExpand,
+		onCollapse,
+		class: className = "",
+	}: Props = $props();
 
 	let cardEl: HTMLDivElement;
+	let dialogEl: HTMLDivElement;
+	let closeBtn: HTMLButtonElement;
 	let rect = $state<{ top: number; left: number; width: number; height: number } | null>(null);
 	let overlayVisible = $state(false);
 	let fullyExpanded = $state(false);
-	let reducedMotion = $state(false);
+	let previousFocus: HTMLElement | null = null;
 
-	onMount(() => {
-		const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-		reducedMotion = mq.matches;
-		const handler = (e: MediaQueryListEvent) => {
-			reducedMotion = e.matches;
-		};
-		mq.addEventListener("change", handler);
-		return () => mq.removeEventListener("change", handler);
-	});
-
-	function handleExpand() {
+	async function handleExpand() {
 		if (expandedIndex !== -1) return;
+		previousFocus = document.activeElement as HTMLElement;
 		const r = cardEl.getBoundingClientRect();
 		rect = { top: r.top, left: r.left, width: r.width, height: r.height };
 		overlayVisible = true;
 		onExpand(index);
+
+		// Wait for the overlay to be in the DOM before focusing
+		await tick();
+		closeBtn?.focus();
 
 		if (reducedMotion) {
 			fullyExpanded = true;
@@ -66,11 +75,13 @@
 
 	function handleCollapse() {
 		fullyExpanded = false;
-		const delay = reducedMotion ? 0 : 400;
+		const delay = reducedMotion ? 0 : TRANSITION_MS;
 		setTimeout(() => {
 			overlayVisible = false;
 			onCollapse();
 			rect = null;
+			previousFocus?.focus();
+			previousFocus = null;
 		}, delay);
 	}
 
@@ -82,7 +93,28 @@
 	}
 
 	function handleOverlayKeydown(e: KeyboardEvent) {
-		if (e.key === "Escape") handleCollapse();
+		if (e.key === "Escape") {
+			handleCollapse();
+			return;
+		}
+		// Simple focus trap: cycle focus within the dialog on Tab
+		if (e.key === "Tab" && dialogEl) {
+			const focusable = Array.from(
+				dialogEl.querySelectorAll<HTMLElement>(
+					'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+				)
+			);
+			if (focusable.length === 0) return;
+			const first = focusable[0];
+			const last = focusable[focusable.length - 1];
+			if (e.shiftKey && document.activeElement === first) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && document.activeElement === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
 	}
 </script>
 
@@ -120,11 +152,12 @@
 	<div
 		class="fixed inset-0 z-40 bg-black/80"
 		aria-hidden="true"
-		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion ? 0 : 400}ms ease;"
+		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion ? 0 : TRANSITION_MS}ms ease;"
 		onclick={handleCollapse}
 	></div>
 
 	<div
+		bind:this={dialogEl}
 		role="dialog"
 		aria-modal="true"
 		aria-label={card.title}
@@ -138,12 +171,13 @@
 			border-radius: {fullyExpanded ? '0px' : '1.5rem'};
 			transition: {reducedMotion
 			? 'none'
-			: 'top 0.4s cubic-bezier(0.32,0.72,0,1), left 0.4s cubic-bezier(0.32,0.72,0,1), width 0.4s cubic-bezier(0.32,0.72,0,1), height 0.4s cubic-bezier(0.32,0.72,0,1), border-radius 0.4s cubic-bezier(0.32,0.72,0,1)'};
+			: `top ${TRANSITION_MS}ms cubic-bezier(0.32,0.72,0,1), left ${TRANSITION_MS}ms cubic-bezier(0.32,0.72,0,1), width ${TRANSITION_MS}ms cubic-bezier(0.32,0.72,0,1), height ${TRANSITION_MS}ms cubic-bezier(0.32,0.72,0,1), border-radius ${TRANSITION_MS}ms cubic-bezier(0.32,0.72,0,1)`};
 		"
 		onkeydown={handleOverlayKeydown}
 	>
 		<!-- Close button -->
 		<button
+			bind:this={closeBtn}
 			class="absolute top-4 right-4 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-black/20 backdrop-blur-sm transition-colors hover:bg-black/30"
 			aria-label="Close"
 			onclick={handleCollapse}

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
@@ -1,0 +1,190 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	export interface AppleCardData {
+		/** Category label shown above the title */
+		category: string;
+		/** Main card title */
+		title: string;
+		/** URL of the card background image */
+		src: string;
+		/** Short description shown in the expanded view */
+		description?: string;
+		/** Rich content shown in the expanded view (takes precedence over description) */
+		content?: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { cn } from "$lib/utils.js";
+
+	interface Props {
+		card: AppleCardData;
+		index: number;
+		expandedIndex: number;
+		onExpand: (index: number) => void;
+		onCollapse: () => void;
+		class?: string;
+	}
+
+	let { card, index, expandedIndex, onExpand, onCollapse, class: className = "" }: Props = $props();
+
+	let cardEl: HTMLDivElement;
+	let rect = $state<{ top: number; left: number; width: number; height: number } | null>(null);
+	let overlayVisible = $state(false);
+	let fullyExpanded = $state(false);
+	let reducedMotion = $state(false);
+
+	onMount(() => {
+		const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+		reducedMotion = mq.matches;
+		const handler = (e: MediaQueryListEvent) => {
+			reducedMotion = e.matches;
+		};
+		mq.addEventListener("change", handler);
+		return () => mq.removeEventListener("change", handler);
+	});
+
+	function handleExpand() {
+		if (expandedIndex !== -1) return;
+		const r = cardEl.getBoundingClientRect();
+		rect = { top: r.top, left: r.left, width: r.width, height: r.height };
+		overlayVisible = true;
+		onExpand(index);
+
+		if (reducedMotion) {
+			fullyExpanded = true;
+		} else {
+			requestAnimationFrame(() => {
+				requestAnimationFrame(() => {
+					fullyExpanded = true;
+				});
+			});
+		}
+	}
+
+	function handleCollapse() {
+		fullyExpanded = false;
+		const delay = reducedMotion ? 0 : 400;
+		setTimeout(() => {
+			overlayVisible = false;
+			onCollapse();
+			rect = null;
+		}, delay);
+	}
+
+	function handleCardKeydown(e: KeyboardEvent) {
+		if (e.key === "Enter" || e.key === " ") {
+			e.preventDefault();
+			handleExpand();
+		}
+	}
+
+	function handleOverlayKeydown(e: KeyboardEvent) {
+		if (e.key === "Escape") handleCollapse();
+	}
+</script>
+
+<!-- Collapsed card in the carousel -->
+<div
+	bind:this={cardEl}
+	class={cn(
+		"relative h-80 w-56 shrink-0 cursor-pointer snap-start overflow-hidden rounded-3xl md:h-96 md:w-72",
+		className
+	)}
+	role="button"
+	tabindex="0"
+	aria-label="Open {card.title}"
+	onclick={handleExpand}
+	onkeydown={handleCardKeydown}
+>
+	<img
+		src={card.src}
+		alt={card.title}
+		class="absolute inset-0 h-full w-full object-cover transition-transform duration-500 hover:scale-105"
+		draggable="false"
+	/>
+	<div class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent"></div>
+	<div class="absolute bottom-0 left-0 p-5">
+		<p class="mb-1 text-xs font-semibold tracking-widest text-white/70 uppercase">
+			{card.category}
+		</p>
+		<h3 class="text-base font-semibold text-white md:text-lg">{card.title}</h3>
+	</div>
+</div>
+
+<!-- Expanded overlay -->
+{#if overlayVisible && rect !== null}
+	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+	<div
+		class="fixed inset-0 z-40 bg-black/80"
+		aria-hidden="true"
+		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion ? 0 : 400}ms ease;"
+		onclick={handleCollapse}
+	></div>
+
+	<div
+		role="dialog"
+		aria-modal="true"
+		aria-label={card.title}
+		tabindex="-1"
+		class="fixed z-50 overflow-y-auto bg-white dark:bg-neutral-900"
+		style="
+			top: {fullyExpanded ? '0px' : rect.top + 'px'};
+			left: {fullyExpanded ? '0px' : rect.left + 'px'};
+			width: {fullyExpanded ? '100vw' : rect.width + 'px'};
+			height: {fullyExpanded ? '100vh' : rect.height + 'px'};
+			border-radius: {fullyExpanded ? '0px' : '1.5rem'};
+			transition: {reducedMotion
+			? 'none'
+			: 'top 0.4s cubic-bezier(0.32,0.72,0,1), left 0.4s cubic-bezier(0.32,0.72,0,1), width 0.4s cubic-bezier(0.32,0.72,0,1), height 0.4s cubic-bezier(0.32,0.72,0,1), border-radius 0.4s cubic-bezier(0.32,0.72,0,1)'};
+		"
+		onkeydown={handleOverlayKeydown}
+	>
+		<!-- Close button -->
+		<button
+			class="absolute top-4 right-4 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-black/20 backdrop-blur-sm transition-colors hover:bg-black/30"
+			aria-label="Close"
+			onclick={handleCollapse}
+		>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="18"
+				height="18"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="white"
+				stroke-width="2.5"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="M18 6 6 18" />
+				<path d="m6 6 12 12" />
+			</svg>
+		</button>
+
+		<!-- Hero image -->
+		<div class="relative h-72 w-full shrink-0 md:h-96">
+			<img src={card.src} alt={card.title} class="h-full w-full object-cover" draggable="false" />
+			<div
+				class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent"
+			></div>
+			<div class="absolute bottom-0 left-0 p-6 md:p-8">
+				<p class="mb-2 text-xs font-semibold tracking-widest text-white/70 uppercase">
+					{card.category}
+				</p>
+				<h2 class="text-2xl font-bold text-white md:text-3xl">{card.title}</h2>
+			</div>
+		</div>
+
+		<!-- Content area -->
+		<div class="p-6 md:p-8">
+			{#if card.content}
+				{@render card.content()}
+			{:else if card.description}
+				<p class="leading-relaxed text-gray-600 dark:text-neutral-400">{card.description}</p>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCard.svelte
@@ -152,7 +152,9 @@
 	<div
 		class="fixed inset-0 z-40 bg-black/80"
 		aria-hidden="true"
-		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion ? 0 : TRANSITION_MS}ms ease;"
+		style="opacity: {fullyExpanded ? 1 : 0}; transition: opacity {reducedMotion
+			? 0
+			: TRANSITION_MS}ms ease;"
 		onclick={handleCollapse}
 	></div>
 

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.svelte
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.svelte
@@ -11,12 +11,24 @@
 </script>
 
 <script lang="ts">
+	import { onMount } from "svelte";
 	import { cn } from "$lib/utils.js";
 	import AppleCard from "./AppleCard.svelte";
 
 	let { cards, class: className = "" }: AppleCardCarouselProps = $props();
 
 	let expandedIndex = $state(-1);
+	let reducedMotion = $state(false);
+
+	onMount(() => {
+		const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+		reducedMotion = mq.matches;
+		const handler = (e: MediaQueryListEvent) => {
+			reducedMotion = e.matches;
+		};
+		mq.addEventListener("change", handler);
+		return () => mq.removeEventListener("change", handler);
+	});
 </script>
 
 <div class={cn("relative w-full", className)}>
@@ -28,6 +40,7 @@
 				{card}
 				index={i}
 				{expandedIndex}
+				{reducedMotion}
 				onExpand={(idx) => (expandedIndex = idx)}
 				onCollapse={() => (expandedIndex = -1)}
 			/>

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.svelte
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.svelte
@@ -1,0 +1,36 @@
+<script lang="ts" module>
+	import type { AppleCardData } from "./AppleCard.svelte";
+	export type { AppleCardData };
+
+	export interface AppleCardCarouselProps {
+		/** Cards to display in the carousel */
+		cards: AppleCardData[];
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import AppleCard from "./AppleCard.svelte";
+
+	let { cards, class: className = "" }: AppleCardCarouselProps = $props();
+
+	let expandedIndex = $state(-1);
+</script>
+
+<div class={cn("relative w-full", className)}>
+	<div
+		class="flex snap-x snap-mandatory gap-4 overflow-x-auto px-4 pb-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+	>
+		{#each cards as card, i}
+			<AppleCard
+				{card}
+				index={i}
+				{expandedIndex}
+				onExpand={(idx) => (expandedIndex = idx)}
+				onCollapse={() => (expandedIndex = -1)}
+			/>
+		{/each}
+	</div>
+</div>

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.test.ts
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.test.ts
@@ -78,6 +78,17 @@ describe("AppleCardCarousel", () => {
 		expect(getAllByRole("dialog")).toHaveLength(1);
 	});
 
+	it("clicking the backdrop collapses the card", () => {
+		const { getByLabelText, queryByRole } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		// The backdrop has aria-hidden="true"; target it via its class
+		const backdrop = document.querySelector(".fixed.z-40") as HTMLElement;
+		fireEvent.click(backdrop);
+		flushSync(() => vi.advanceTimersByTime(400));
+		expect(queryByRole("dialog")).toBeNull();
+	});
+
 	it("shows description text in the expanded view", () => {
 		const { getByLabelText, getByText } = render(AppleCardCarousel, { props: { cards } });
 		fireEvent.click(getByLabelText("Open Mountains"));

--- a/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.test.ts
+++ b/src/lib/fancy-ui/apple-card-carousel/AppleCardCarousel.test.ts
@@ -1,0 +1,87 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { flushSync } from "svelte";
+import AppleCardCarousel from "./AppleCardCarousel.svelte";
+import type { AppleCardData } from "./AppleCard.svelte";
+
+const cards: AppleCardData[] = [
+	{ category: "Nature", title: "Mountains", src: "mountains.jpg", description: "High peaks." },
+	{ category: "City", title: "Skyline", src: "skyline.jpg", description: "Urban lights." },
+	{ category: "Ocean", title: "Waves", src: "waves.jpg", description: "Deep blue." },
+];
+
+describe("AppleCardCarousel", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		cleanup();
+	});
+
+	it("renders all cards", () => {
+		const { getByText } = render(AppleCardCarousel, { props: { cards } });
+		expect(getByText("Mountains")).toBeTruthy();
+		expect(getByText("Skyline")).toBeTruthy();
+		expect(getByText("Waves")).toBeTruthy();
+	});
+
+	it("renders gracefully with no cards", () => {
+		const { container } = render(AppleCardCarousel, { props: { cards: [] } });
+		expect(container.querySelector("[role='button']")).toBeNull();
+	});
+
+	it("clicking a card shows the expanded dialog", () => {
+		const { getByLabelText } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		expect(getByLabelText("Mountains")).toBeTruthy();
+	});
+
+	it("expanded dialog has correct ARIA attributes", () => {
+		const { getByLabelText, getByRole } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		const dialog = getByRole("dialog");
+		expect(dialog).toBeTruthy();
+		expect(dialog.getAttribute("aria-modal")).toBe("true");
+	});
+
+	it("clicking the close button collapses the card", () => {
+		const { getByLabelText, queryByRole } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		fireEvent.click(getByLabelText("Close"));
+		flushSync(() => vi.advanceTimersByTime(400));
+		expect(queryByRole("dialog")).toBeNull();
+	});
+
+	it("pressing Escape collapses the card", () => {
+		const { getByLabelText, queryByRole } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		const dialog = getByLabelText("Mountains");
+		fireEvent.keyDown(dialog, { key: "Escape" });
+		flushSync(() => vi.advanceTimersByTime(400));
+		expect(queryByRole("dialog")).toBeNull();
+	});
+
+	it("only one card can be expanded at a time", () => {
+		const { getByLabelText, getAllByRole } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		expect(getAllByRole("dialog")).toHaveLength(1);
+		// Clicking another card while one is open should be a no-op
+		fireEvent.click(getByLabelText("Open Skyline"));
+		flushSync();
+		expect(getAllByRole("dialog")).toHaveLength(1);
+	});
+
+	it("shows description text in the expanded view", () => {
+		const { getByLabelText, getByText } = render(AppleCardCarousel, { props: { cards } });
+		fireEvent.click(getByLabelText("Open Mountains"));
+		flushSync();
+		expect(getByText("High peaks.")).toBeTruthy();
+	});
+});

--- a/src/lib/fancy-ui/apple-card-carousel/index.ts
+++ b/src/lib/fancy-ui/apple-card-carousel/index.ts
@@ -1,0 +1,3 @@
+export { default as AppleCardCarousel } from "./AppleCardCarousel.svelte";
+export { default as AppleCard } from "./AppleCard.svelte";
+export type { AppleCardCarouselProps, AppleCardData } from "./AppleCardCarousel.svelte";

--- a/src/lib/fancy-ui/compare/Compare.svelte
+++ b/src/lib/fancy-ui/compare/Compare.svelte
@@ -285,7 +285,7 @@
 	<!-- Second Content -->
 	<div
 		class={cn(
-			"absolute top-0 left-0 z-[19] h-full w-full rounded-2xl select-none",
+			"absolute top-0 left-0 z-[19] h-full w-full overflow-hidden rounded-2xl select-none",
 			secondContentClass
 		)}
 		style:pointer-events={isInteracting ? "none" : "auto"}

--- a/src/lib/fancy-ui/displacement-text/DisplacementText.svelte
+++ b/src/lib/fancy-ui/displacement-text/DisplacementText.svelte
@@ -1,0 +1,224 @@
+<script lang="ts" module>
+	export interface DisplacementTextProps {
+		/** Text to display */
+		text?: string;
+		/** Font size in pixels */
+		fontSize?: number;
+		/** Font family */
+		font?: string;
+		/** Fixed text color (overrides theme colors) */
+		color?: string;
+		/** Text color in light mode */
+		lightColor?: string;
+		/** Text color in dark mode */
+		darkColor?: string;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import * as THREE from "three";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		text = "Hover Me",
+		fontSize = 200,
+		font = "Inter, sans-serif",
+		color,
+		lightColor = "#000000",
+		darkColor = "#ffffff",
+		class: className = "",
+	}: DisplacementTextProps = $props();
+
+	let container: HTMLDivElement;
+
+	const vertexShader = `
+		varying vec2 vUv;
+		uniform vec3 uDisplacement;
+
+		float easeInOutCubic(float x) {
+			return x < 0.5 ? 4.0 * x * x * x : 1.0 - pow(-2.0 * x + 2.0, 3.0) / 2.0;
+		}
+
+		float map(float value, float min1, float max1, float min2, float max2) {
+			return min2 + (value - min1) * (max2 - min2) / (max1 - min1);
+		}
+
+		void main() {
+			vUv = uv;
+			vec3 displaced = position;
+			vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+			float dist = length(uDisplacement - worldPosition.rgb);
+			float minDistance = 3.0;
+
+			if (dist < minDistance) {
+				float mapped = map(dist, 0.0, minDistance, 1.0, 0.0);
+				displaced.z += easeInOutCubic(mapped);
+			}
+
+			gl_Position = projectionMatrix * modelViewMatrix * vec4(displaced, 1.0);
+		}
+	`;
+
+	const fragmentShader = `
+		varying vec2 vUv;
+		uniform sampler2D uTexture;
+
+		void main() {
+			gl_FragColor = texture2D(uTexture, vUv);
+		}
+	`;
+
+	function createTextTexture(t: string, size: number, f: string, c: string): THREE.Texture {
+		const canvas = document.createElement("canvas");
+		canvas.width = 2048;
+		canvas.height = 2048;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return new THREE.CanvasTexture(canvas);
+
+		ctx.clearRect(0, 0, canvas.width, canvas.height);
+		ctx.font = `bold ${size}px ${f}`;
+		ctx.fillStyle = c;
+		ctx.textAlign = "center";
+		ctx.textBaseline = "middle";
+		ctx.fillText(t, canvas.width / 2, canvas.height / 2);
+
+		const texture = new THREE.CanvasTexture(canvas);
+		texture.needsUpdate = true;
+		return texture;
+	}
+
+	$effect(() => {
+		if (!container) return;
+
+		const _text = text;
+		const _fontSize = fontSize;
+		const _font = font;
+		const _color = color;
+		const _lightColor = lightColor;
+		const _darkColor = darkColor;
+
+		const rect = container.getBoundingClientRect();
+		const width = rect.width || 1;
+		const height = rect.height || 1;
+		if (height === 0) return;
+
+		const scene = new THREE.Scene();
+		scene.background = null;
+
+		const cameraDistance = 8;
+		const aspect = width / height;
+		const camera = new THREE.OrthographicCamera(
+			-cameraDistance * aspect,
+			cameraDistance * aspect,
+			cameraDistance,
+			-cameraDistance,
+			0.01,
+			1000
+		);
+		camera.position.set(0, -10, 5);
+		camera.lookAt(0, 0, 0);
+
+		const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+		renderer.setClearColor(0x000000, 0);
+		renderer.setPixelRatio(window.devicePixelRatio);
+		renderer.setSize(width, height, false);
+		renderer.domElement.style.width = "100%";
+		renderer.domElement.style.height = "100%";
+		container.appendChild(renderer.domElement);
+
+		const geometry = new THREE.PlaneGeometry(15, 15, 100, 100);
+		const getActiveColor = () =>
+			_color || (document.documentElement.classList.contains("dark") ? _darkColor : _lightColor);
+
+		let currentColor = getActiveColor();
+		let textTexture = createTextTexture(_text, _fontSize, _font, currentColor);
+
+		const shaderMaterial = new THREE.ShaderMaterial({
+			uniforms: {
+				uTexture: { value: textTexture },
+				uDisplacement: { value: new THREE.Vector3(0, 0, 0) },
+			},
+			vertexShader,
+			fragmentShader,
+			transparent: true,
+			depthWrite: false,
+			side: THREE.DoubleSide,
+		});
+
+		const plane = new THREE.Mesh(geometry, shaderMaterial);
+		plane.rotation.z = Math.PI / 4;
+		scene.add(plane);
+
+		const hitGeometry = new THREE.PlaneGeometry(500, 500);
+		const hitMaterial = new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 });
+		const hitPlane = new THREE.Mesh(hitGeometry, hitMaterial);
+		scene.add(hitPlane);
+
+		const raycaster = new THREE.Raycaster();
+		const pointer = new THREE.Vector2();
+
+		const onPointerMove = (e: PointerEvent) => {
+			const bounds = container.getBoundingClientRect();
+			pointer.x = ((e.clientX - bounds.left) / bounds.width) * 2 - 1;
+			pointer.y = -((e.clientY - bounds.top) / bounds.height) * 2 + 1;
+			raycaster.setFromCamera(pointer, camera);
+			const [hit] = raycaster.intersectObject(hitPlane);
+			if (hit) (shaderMaterial.uniforms.uDisplacement.value as THREE.Vector3).copy(hit.point);
+		};
+
+		container.addEventListener("pointermove", onPointerMove);
+
+		const handleResize = () => {
+			const r = container.getBoundingClientRect();
+			if (r.height === 0) return;
+			const a = r.width / r.height;
+			camera.left = -cameraDistance * a;
+			camera.right = cameraDistance * a;
+			camera.updateProjectionMatrix();
+			renderer.setSize(r.width, r.height, false);
+		};
+
+		window.addEventListener("resize", handleResize);
+
+		let animationId = 0;
+		const animate = () => {
+			animationId = requestAnimationFrame(animate);
+			renderer.render(scene, camera);
+		};
+		animate();
+
+		const observer = new MutationObserver(() => {
+			const next = getActiveColor();
+			if (next !== currentColor) {
+				const tex = createTextTexture(_text, _fontSize, _font, next);
+				shaderMaterial.uniforms.uTexture.value = tex;
+				textTexture.dispose();
+				textTexture = tex;
+				currentColor = next;
+			}
+		});
+		if (!_color)
+			observer.observe(document.documentElement, {
+				attributes: true,
+				attributeFilter: ["class"],
+			});
+
+		return () => {
+			window.removeEventListener("resize", handleResize);
+			container.removeEventListener("pointermove", onPointerMove);
+			cancelAnimationFrame(animationId);
+			observer.disconnect();
+			if (renderer.domElement.parentNode === container) container.removeChild(renderer.domElement);
+			renderer.dispose();
+			textTexture.dispose();
+			geometry.dispose();
+			shaderMaterial.dispose();
+			hitGeometry.dispose();
+			hitMaterial.dispose();
+		};
+	});
+</script>
+
+<div bind:this={container} class={cn("relative h-[400px] w-full", className)}></div>

--- a/src/lib/fancy-ui/displacement-text/DisplacementText.test.ts
+++ b/src/lib/fancy-ui/displacement-text/DisplacementText.test.ts
@@ -1,0 +1,165 @@
+import { render, cleanup } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import DisplacementText from "./DisplacementText.svelte";
+
+// Holds the last renderer instance created by the mock
+const lastMock = { renderer: null as any };
+
+// Three.js uses WebGL which is not available in jsdom — mock the module
+vi.mock("three", () => {
+	function Vector2() {
+		return { x: 0, y: 0 };
+	}
+	function Vector3() {
+		return { x: 0, y: 0, z: 0, copy: vi.fn() };
+	}
+	function CanvasTexture() {
+		return { needsUpdate: false, dispose: vi.fn() };
+	}
+	function ShaderMaterial() {
+		return {
+			uniforms: { uTexture: { value: null }, uDisplacement: { value: { copy: vi.fn() } } },
+			dispose: vi.fn(),
+		};
+	}
+	function PlaneGeometry() {
+		return { dispose: vi.fn() };
+	}
+	function MeshBasicMaterial() {
+		return { dispose: vi.fn() };
+	}
+	function Mesh() {
+		return { rotation: { z: 0 } };
+	}
+	function Scene() {
+		return { background: null, add: vi.fn() };
+	}
+	function OrthographicCamera() {
+		return {
+			position: { set: vi.fn() },
+			left: 0,
+			right: 0,
+			updateProjectionMatrix: vi.fn(),
+			lookAt: vi.fn(),
+		};
+	}
+	function Raycaster() {
+		return {
+			setFromCamera: vi.fn(),
+			intersectObject: vi.fn(() => []),
+		};
+	}
+	function WebGLRenderer() {
+		const instance = {
+			setClearColor: vi.fn(),
+			setPixelRatio: vi.fn(),
+			setSize: vi.fn(),
+			render: vi.fn(),
+			dispose: vi.fn(),
+			domElement: Object.assign(document.createElement("canvas"), {
+				style: { width: "", height: "" },
+			}),
+		};
+		lastMock.renderer = instance;
+		return instance;
+	}
+
+	return {
+		Scene,
+		OrthographicCamera,
+		WebGLRenderer,
+		PlaneGeometry,
+		ShaderMaterial,
+		Mesh,
+		MeshBasicMaterial,
+		Raycaster,
+		Vector2,
+		Vector3,
+		CanvasTexture,
+		DoubleSide: 2,
+	};
+});
+
+describe("DisplacementText", () => {
+	afterEach(cleanup);
+
+	it("renders a div container", () => {
+		const { container } = render(DisplacementText);
+		expect(container.querySelector("div")).toBeTruthy();
+	});
+
+	it("applies default height class", () => {
+		const { container } = render(DisplacementText);
+		expect(container.querySelector("div")?.className).toContain("h-[400px]");
+	});
+
+	it("applies additional class", () => {
+		const { container } = render(DisplacementText, { props: { class: "h-[600px]" } });
+		expect(container.querySelector("div")?.className).toContain("h-[600px]");
+	});
+
+	it("renders with custom text prop", () => {
+		const { container } = render(DisplacementText, { props: { text: "FancyUI" } });
+		expect(container.querySelector("div")).toBeTruthy();
+	});
+
+	describe("cleanup on unmount", () => {
+		it("removes resize listener", () => {
+			const spy = vi.spyOn(window, "removeEventListener");
+			const { unmount } = render(DisplacementText);
+			unmount();
+			expect(spy).toHaveBeenCalledWith("resize", expect.any(Function));
+			spy.mockRestore();
+		});
+
+		it("cancels animation frame", () => {
+			const spy = vi.spyOn(window, "cancelAnimationFrame");
+			const { unmount } = render(DisplacementText);
+			unmount();
+			expect(spy).toHaveBeenCalled();
+			spy.mockRestore();
+		});
+
+		it("disposes renderer", () => {
+			const { unmount } = render(DisplacementText);
+			const renderer = lastMock.renderer;
+			unmount();
+			expect(renderer.dispose).toHaveBeenCalled();
+		});
+	});
+
+	describe("theme observer", () => {
+		let originalMutationObserver: typeof MutationObserver;
+
+		beforeEach(() => {
+			originalMutationObserver = global.MutationObserver;
+		});
+
+		afterEach(() => {
+			global.MutationObserver = originalMutationObserver;
+		});
+
+		it("does not observe document when color prop is provided", () => {
+			const observeSpy = vi.fn();
+			global.MutationObserver = function MutationObserver() {
+				return { observe: observeSpy, disconnect: vi.fn() };
+			} as unknown as typeof MutationObserver;
+
+			render(DisplacementText, { props: { color: "#ff0000" } });
+			expect(observeSpy).not.toHaveBeenCalled();
+		});
+
+		it("observes document when no fixed color is provided", () => {
+			const observeSpy = vi.fn();
+			global.MutationObserver = function MutationObserver() {
+				return { observe: observeSpy, disconnect: vi.fn() };
+			} as unknown as typeof MutationObserver;
+
+			render(DisplacementText);
+			expect(observeSpy).toHaveBeenCalledWith(
+				document.documentElement,
+				expect.objectContaining({ attributes: true, attributeFilter: ["class"] })
+			);
+		});
+	});
+});

--- a/src/lib/fancy-ui/displacement-text/index.ts
+++ b/src/lib/fancy-ui/displacement-text/index.ts
@@ -1,0 +1,2 @@
+export { default as DisplacementText } from "./DisplacementText.svelte";
+export type { DisplacementTextProps } from "./DisplacementText.svelte";

--- a/src/lib/fancy-ui/flip-words/FlipWords.svelte
+++ b/src/lib/fancy-ui/flip-words/FlipWords.svelte
@@ -23,7 +23,7 @@
 	let { words, duration = 3000, class: className }: FlipWordsProps = $props();
 
 	let currentIndex = $state(0);
-	let isVisible = $state(true);
+	let isExiting = $state(false);
 	let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
 	let currentWord = $derived(words[currentIndex] ?? "");
@@ -35,11 +35,11 @@
 	);
 
 	function startAnimation() {
-		isVisible = false;
+		isExiting = true;
 
 		setTimeout(() => {
+			isExiting = false;
 			currentIndex = (currentIndex + 1) % words.length;
-			isVisible = true;
 		}, 600);
 	}
 
@@ -49,7 +49,9 @@
 	}
 
 	$effect(() => {
-		if (isVisible) {
+		// Re-schedule whenever a new word becomes active (not during exit)
+		if (!isExiting) {
+			void currentIndex; // track dependency
 			scheduleNext();
 		}
 	});
@@ -62,10 +64,11 @@
 </script>
 
 <div class="flip-words relative inline-block px-2">
-	{#if isVisible}
+	{#key currentIndex}
 		<div
 			class={cn(
-				"flip-words-enter relative z-10 inline-block text-left text-neutral-900 dark:text-neutral-100",
+				"relative z-10 inline-block text-left text-neutral-900 dark:text-neutral-100",
+				isExiting ? "flip-words-exit" : "flip-words-enter",
 				className
 			)}
 		>
@@ -86,7 +89,7 @@
 				</span>
 			{/each}
 		</div>
-	{/if}
+	{/key}
 </div>
 
 <style>
@@ -127,9 +130,26 @@
 				transform: translateY(0);
 			}
 		}
+
+		@keyframes flipExitWord {
+			0% {
+				opacity: 1;
+				transform: translateY(0);
+				filter: blur(0);
+			}
+			100% {
+				opacity: 0;
+				transform: translateY(-10px);
+				filter: blur(8px);
+			}
+		}
 	}
 
 	.flip-words-enter {
 		animation: flipEnterWord 0.6s ease-in-out forwards;
+	}
+
+	.flip-words-exit {
+		animation: flipExitWord 0.6s ease-in-out forwards;
 	}
 </style>

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -55,6 +55,7 @@ export * from "./ripple/index.js";
 export * from "./text-generate-effect/index.js";
 export * from "./line-shadow-text/index.js";
 export * from "./tracing-beam/index.js";
+export * from "./displacement-text/index.js";
 
 // =============================================================================
 // Registry

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -6,6 +6,7 @@
 // =============================================================================
 
 export * from "./apple-card-carousel/index.js";
+export * from "./line-hover-link/index.js";
 export * from "./animated-beam/index.js";
 export * from "./animated-testimonials/index.js";
 export * from "./fluid-cursor/index.js";

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -5,6 +5,7 @@
 // Components
 // =============================================================================
 
+export * from "./apple-card-carousel/index.js";
 export * from "./animated-beam/index.js";
 export * from "./animated-testimonials/index.js";
 export * from "./fluid-cursor/index.js";

--- a/src/lib/fancy-ui/line-hover-link/LineHoverLink.svelte
+++ b/src/lib/fancy-ui/line-hover-link/LineHoverLink.svelte
@@ -1,0 +1,450 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	/**
+	 * Line Hover Link Variants
+	 *
+	 * slide    - Line slides in from right to left
+	 * double   - Two lines animate with different timings
+	 * grow     - Line grows thicker on hover
+	 * strike   - Strikethrough effect with text scale
+	 * fade     - Lines fade up with stagger delay
+	 * pulse    - Line pulses up and down
+	 * swap     - Two lines go opposite directions
+	 * sweep    - Full background cover sweep
+	 * bounce   - Bouncy squish animation
+	 * arc      - SVG arc stroke draws in
+	 * scribble - SVG scribble stroke draws in
+	 */
+	export type LineHoverVariant =
+		| "slide"
+		| "double"
+		| "grow"
+		| "strike"
+		| "fade"
+		| "pulse"
+		| "swap"
+		| "sweep"
+		| "bounce"
+		| "arc"
+		| "scribble";
+
+	export interface LineHoverLinkProps {
+		/** The animation variant */
+		variant?: LineHoverVariant;
+		/** Link href */
+		href?: string;
+		/** Link target */
+		target?: string;
+		/** Link rel */
+		rel?: string;
+		/** Accessible label */
+		"aria-label"?: string;
+		/** Additional CSS classes */
+		class?: string;
+		children?: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let {
+		variant = "slide",
+		href = "#",
+		target,
+		rel,
+		"aria-label": ariaLabel,
+		class: className = "",
+		children,
+	}: LineHoverLinkProps = $props();
+
+	const needsSpan = $derived(["strike", "bounce", "arc", "scribble"].includes(variant));
+	const relValue = $derived(target === "_blank" ? (rel ?? "noopener noreferrer") : rel);
+</script>
+
+<a
+	{href}
+	{target}
+	aria-label={ariaLabel}
+	rel={relValue}
+	class={cn("link-hover", `link-hover--${variant}`, className)}
+>
+	{#if needsSpan}
+		<span
+			>{#if children}{@render children()}{/if}</span
+		>
+	{:else if children}
+		{@render children()}
+	{/if}
+
+	{#if variant === "arc"}
+		<svg
+			class="link-hover__graphic link-hover__graphic--stroke link-hover__graphic--arc"
+			width="100%"
+			height="18"
+			viewBox="0 0 59 18"
+			aria-hidden="true"
+		>
+			<path d="M.945.149C12.3 16.142 43.573 22.572 58.785 10.842" pathLength="1" />
+		</svg>
+	{:else if variant === "scribble"}
+		<svg
+			class="link-hover__graphic link-hover__graphic--stroke link-hover__graphic--scribble"
+			width="100%"
+			height="9"
+			viewBox="0 0 101 9"
+			aria-hidden="true"
+		>
+			<path
+				d="M.426 1.973C4.144 1.567 17.77-.514 21.443 1.48 24.296 3.026 24.844 4.627 27.5 7c3.075 2.748 6.642-4.141 10.066-4.688 7.517-1.2 13.237 5.425 17.59 2.745C58.5 3 60.464-1.786 66 2c1.996 1.365 3.174 3.737 5.286 4.41 5.423 1.727 25.34-7.981 29.14-1.294"
+				pathLength="1"
+			/>
+		</svg>
+	{/if}
+</a>
+
+<style>
+	.link-hover {
+		cursor: pointer;
+		position: relative;
+		white-space: nowrap;
+		color: currentColor;
+		text-decoration: none;
+	}
+
+	.link-hover::before,
+	.link-hover::after {
+		position: absolute;
+		width: 100%;
+		height: 1px;
+		background: currentColor;
+		top: 100%;
+		left: 0;
+		pointer-events: none;
+	}
+
+	.link-hover::before {
+		content: "";
+	}
+
+	/* Slide */
+	.link-hover--slide::before {
+		transform-origin: 100% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s;
+	}
+
+	.link-hover--slide:is(:hover, :focus-visible)::before {
+		transform-origin: 0% 50%;
+		transform: scale3d(1, 1, 1);
+	}
+
+	/* Double */
+	.link-hover--double::before {
+		transform-origin: 100% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s cubic-bezier(0.7, 0, 0.2, 1);
+	}
+
+	.link-hover--double:is(:hover, :focus-visible)::before {
+		transform-origin: 0% 50%;
+		transform: scale3d(1, 1, 1);
+		transition-timing-function: cubic-bezier(0.4, 1, 0.8, 1);
+	}
+
+	.link-hover--double::after {
+		content: "";
+		top: calc(100% + 4px);
+		transform-origin: 0% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s cubic-bezier(0.7, 0, 0.2, 1);
+	}
+
+	.link-hover--double:is(:hover, :focus-visible)::after {
+		transform-origin: 100% 50%;
+		transform: scale3d(1, 1, 1);
+		transition-timing-function: cubic-bezier(0.4, 1, 0.8, 1);
+	}
+
+	/* Grow */
+	.link-hover--grow::before {
+		transform-origin: 100% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s cubic-bezier(0.2, 1, 0.8, 1);
+	}
+
+	.link-hover--grow:is(:hover, :focus-visible)::before {
+		transform-origin: 0% 50%;
+		transform: scale3d(1, 2, 1);
+		transition-timing-function: cubic-bezier(0.7, 0, 0.2, 1);
+	}
+
+	.link-hover--grow::after {
+		content: "";
+		top: calc(100% + 4px);
+		transform-origin: 100% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.4s 0.1s cubic-bezier(0.2, 1, 0.8, 1);
+	}
+
+	.link-hover--grow:is(:hover, :focus-visible)::after {
+		transform-origin: 0% 50%;
+		transform: scale3d(1, 1, 1);
+		transition-timing-function: cubic-bezier(0.7, 0, 0.2, 1);
+	}
+
+	/* Strike */
+	.link-hover--strike {
+		padding: 0 10px;
+	}
+
+	.link-hover--strike::before {
+		top: 50%;
+		height: 2px;
+		transform-origin: 100% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s cubic-bezier(0.4, 1, 0.8, 1);
+	}
+
+	.link-hover--strike:is(:hover, :focus-visible)::before {
+		transform-origin: 0% 50%;
+		transform: scale3d(1, 1, 1);
+	}
+
+	.link-hover--strike span {
+		display: inline-block;
+		transition: transform 0.3s cubic-bezier(0.4, 1, 0.8, 1);
+	}
+
+	.link-hover--strike:is(:hover, :focus-visible) span {
+		transform: scale3d(1.1, 1.1, 1.1);
+	}
+
+	/* Fade */
+	.link-hover--fade::before,
+	.link-hover--fade::after {
+		opacity: 0;
+		transform-origin: 50% 0%;
+		transform: translate3d(0, 3px, 0);
+		transition-property: transform, opacity;
+		transition-duration: 0.3s;
+		transition-timing-function: cubic-bezier(0.2, 1, 0.8, 1);
+	}
+
+	.link-hover--fade:is(:hover, :focus-visible)::before,
+	.link-hover--fade:is(:hover, :focus-visible)::after {
+		opacity: 1;
+		transform: translate3d(0, 0, 0);
+		transition-timing-function: cubic-bezier(0.2, 0, 0.3, 1);
+	}
+
+	.link-hover--fade::after {
+		content: "";
+		top: calc(100% + 4px);
+		width: 70%;
+		left: 15%;
+	}
+
+	.link-hover--fade::before,
+	.link-hover--fade:is(:hover, :focus-visible)::after {
+		transition-delay: 0.1s;
+	}
+
+	.link-hover--fade:is(:hover, :focus-visible)::before {
+		transition-delay: 0s;
+	}
+
+	/* Pulse */
+	.link-hover--pulse::before {
+		height: 10px;
+		top: 100%;
+		opacity: 0;
+	}
+
+	.link-hover--pulse:is(:hover, :focus-visible)::before {
+		opacity: 1;
+		animation: lineUp 0.3s ease forwards;
+	}
+
+	@keyframes lineUp {
+		0% {
+			transform-origin: 50% 100%;
+			transform: scale3d(1, 0.045, 1);
+		}
+		50% {
+			transform-origin: 50% 100%;
+			transform: scale3d(1, 1, 1);
+		}
+		51% {
+			transform-origin: 50% 0%;
+			transform: scale3d(1, 1, 1);
+		}
+		100% {
+			transform-origin: 50% 0%;
+			transform: scale3d(1, 0.045, 1);
+		}
+	}
+
+	.link-hover--pulse::after {
+		content: "";
+		transition: opacity 0.3s;
+		opacity: 0;
+		transition-delay: 0s;
+	}
+
+	.link-hover--pulse:is(:hover, :focus-visible)::after {
+		opacity: 1;
+		transition-delay: 0.3s;
+	}
+
+	/* Swap */
+	.link-hover--swap::before {
+		transform-origin: 0% 50%;
+		transform: scale3d(0, 1, 1);
+		transition: transform 0.3s;
+	}
+
+	.link-hover--swap:is(:hover, :focus-visible)::before {
+		transform: scale3d(1, 1, 1);
+	}
+
+	.link-hover--swap::after {
+		content: "";
+		top: calc(100% + 4px);
+		transition: transform 0.3s;
+		transform-origin: 100% 50%;
+	}
+
+	.link-hover--swap:is(:hover, :focus-visible)::after {
+		transform: scale3d(0, 1, 1);
+	}
+
+	/* Sweep */
+	.link-hover--sweep::before {
+		height: 100%;
+		top: 0;
+		opacity: 0;
+	}
+
+	.link-hover--sweep:is(:hover, :focus-visible)::before {
+		opacity: 1;
+		animation: coverUp 0.3s ease forwards;
+	}
+
+	@keyframes coverUp {
+		0% {
+			transform-origin: 50% 100%;
+			transform: scale3d(1, 0.045, 1);
+		}
+		50% {
+			transform-origin: 50% 100%;
+			transform: scale3d(1, 1, 1);
+		}
+		51% {
+			transform-origin: 50% 0%;
+			transform: scale3d(1, 1, 1);
+		}
+		100% {
+			transform-origin: 50% 0%;
+			transform: scale3d(1, 0.045, 1);
+		}
+	}
+
+	.link-hover--sweep::after {
+		content: "";
+		transition: opacity 0.3s;
+	}
+
+	.link-hover--sweep:is(:hover, :focus-visible)::after {
+		opacity: 0;
+	}
+
+	/* Bounce */
+	.link-hover--bounce::before {
+		height: 7px;
+		border-radius: 20px;
+		transform: scale3d(1, 1, 1);
+		transition:
+			transform 0.2s,
+			opacity 0.2s;
+		transition-timing-function: cubic-bezier(0.2, 0.57, 0.67, 1.53);
+	}
+
+	.link-hover--bounce:is(:hover, :focus-visible)::before {
+		transition-timing-function: cubic-bezier(0.8, 0, 0.1, 1);
+		transition-duration: 0.4s;
+		opacity: 1;
+		transform: scale3d(1.2, 0.1, 1);
+	}
+
+	.link-hover--bounce span {
+		transform: translate3d(0, -4px, 0);
+		display: inline-block;
+		transition: transform 0.2s 0.05s cubic-bezier(0.2, 0.57, 0.67, 1.53);
+	}
+
+	.link-hover--bounce:is(:hover, :focus-visible) span {
+		transform: translate3d(0, 0, 0);
+		transition-timing-function: cubic-bezier(0.8, 0, 0.1, 1);
+		transition-duration: 0.4s;
+		transition-delay: 0s;
+	}
+
+	/* SVG Graphics Base */
+	.link-hover__graphic {
+		position: absolute;
+		top: 0;
+		left: 0;
+		pointer-events: none;
+		fill: none;
+		stroke: currentColor;
+		stroke-width: 1px;
+	}
+
+	.link-hover__graphic--stroke :global(path) {
+		stroke-dasharray: 1;
+		stroke-dashoffset: 1;
+	}
+
+	.link-hover:is(:hover, :focus-visible) .link-hover__graphic--stroke :global(path) {
+		stroke-dashoffset: 0;
+	}
+
+	/* Arc */
+	.link-hover--arc::before {
+		display: none;
+	}
+
+	.link-hover__graphic--arc {
+		top: 73%;
+		left: -23%;
+	}
+
+	.link-hover__graphic--arc :global(path) {
+		transition: stroke-dashoffset 0.4s cubic-bezier(0.7, 0, 0.3, 1);
+	}
+
+	.link-hover:is(:hover, :focus-visible) .link-hover__graphic--arc :global(path) {
+		transition-timing-function: cubic-bezier(0.8, 1, 0.7, 1);
+		transition-duration: 0.3s;
+	}
+
+	/* Scribble */
+	.link-hover--scribble::before {
+		display: none;
+	}
+
+	.link-hover__graphic--scribble {
+		top: 100%;
+	}
+
+	.link-hover__graphic--scribble :global(path) {
+		transition: stroke-dashoffset 0.6s cubic-bezier(0.7, 0, 0.3, 1);
+	}
+
+	.link-hover:is(:hover, :focus-visible) .link-hover__graphic--scribble :global(path) {
+		transition-timing-function: cubic-bezier(0.8, 1, 0.7, 1);
+		transition-duration: 0.3s;
+	}
+</style>

--- a/src/lib/fancy-ui/line-hover-link/LineHoverLink.test.ts
+++ b/src/lib/fancy-ui/line-hover-link/LineHoverLink.test.ts
@@ -1,0 +1,66 @@
+import { render, cleanup } from "@testing-library/svelte";
+import { afterEach, describe, it, expect } from "vitest";
+import LineHoverLink from "./LineHoverLink.svelte";
+
+describe("LineHoverLink", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("renders an anchor element", () => {
+		const { container } = render(LineHoverLink, {
+			props: { href: "/about" },
+			context: new Map(),
+		});
+		expect(container.querySelector("a")).toBeTruthy();
+	});
+
+	it("applies the variant class", () => {
+		const { container } = render(LineHoverLink, {
+			props: { variant: "slide", href: "#" },
+		});
+		expect(container.querySelector("a.link-hover--slide")).toBeTruthy();
+	});
+
+	it("defaults to slide variant", () => {
+		const { container } = render(LineHoverLink, { props: { href: "#" } });
+		expect(container.querySelector("a.link-hover--slide")).toBeTruthy();
+	});
+
+	it("wraps children in a span for strike variant", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "strike", href: "#" } });
+		expect(container.querySelector("a.link-hover--strike span")).toBeTruthy();
+	});
+
+	it("wraps children in a span for bounce variant", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "bounce", href: "#" } });
+		expect(container.querySelector("a.link-hover--bounce span")).toBeTruthy();
+	});
+
+	it("renders arc SVG for arc variant", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "arc", href: "#" } });
+		expect(container.querySelector("svg.link-hover__graphic--arc")).toBeTruthy();
+	});
+
+	it("renders scribble SVG for scribble variant", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "scribble", href: "#" } });
+		expect(container.querySelector("svg.link-hover__graphic--scribble")).toBeTruthy();
+	});
+
+	it("does not render SVG for non-svg variants", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "slide", href: "#" } });
+		expect(container.querySelector("svg")).toBeNull();
+	});
+
+	it("forwards href to the anchor", () => {
+		const { container } = render(LineHoverLink, { props: { href: "/contact" } });
+		expect(container.querySelector("a")?.getAttribute("href")).toBe("/contact");
+	});
+
+	it("applies additional class", () => {
+		const { container } = render(LineHoverLink, {
+			props: { class: "text-xl font-bold", href: "#" },
+		});
+		expect(container.querySelector("a.text-xl")).toBeTruthy();
+	});
+});

--- a/src/lib/fancy-ui/line-hover-link/index.ts
+++ b/src/lib/fancy-ui/line-hover-link/index.ts
@@ -1,0 +1,2 @@
+export { default as LineHoverLink } from "./LineHoverLink.svelte";
+export type { LineHoverLinkProps, LineHoverVariant } from "./LineHoverLink.svelte";

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -610,6 +610,14 @@ export const registry: Record<string, ComponentMeta> = {
 			{ source: "Aceternity UI", url: "https://ui.aceternity.com/components/tracing-beam" },
 		],
 	},
+	"displacement-text": {
+		name: "DisplacementText",
+		slug: "displacement-text",
+		description: "3D text with WebGL displacement that follows the cursor using Three.js shaders",
+		category: "text",
+		status: "done",
+		credits: [{ source: "VengenceUI", url: "https://vengenceui.com/docs/liquid-text" }],
+	},
 };
 
 // =============================================================================

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -74,6 +74,21 @@ export const registry: Record<string, ComponentMeta> = {
 	// Done - Fully implemented and tested
 	// =========================================================================
 
+	"apple-card-carousel": {
+		name: "AppleCardCarousel",
+		slug: "apple-card-carousel",
+		description:
+			"Horizontal card carousel with spring-animated full-screen expansion, inspired by Apple's App Store UI",
+		category: "cards",
+		status: "done",
+		credits: [
+			{
+				source: "Aceternity UI",
+				url: "https://ui.aceternity.com/components/apple-cards-carousel",
+			},
+		],
+	},
+
 	"animated-beam": {
 		name: "AnimatedBeam",
 		slug: "animated-beam",

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -174,6 +174,16 @@ export const registry: Record<string, ComponentMeta> = {
 		],
 	},
 
+	"line-hover-link": {
+		name: "LineHoverLink",
+		slug: "line-hover-link",
+		description:
+			"Link component with 11 animated underline hover effects — pure CSS, no JS on hover",
+		category: "navigation",
+		status: "done",
+		credits: [{ source: "VengenceUI", url: "https://www.vengence-ui.com/docs/line-hover-link" }],
+	},
+
 	"logo-cloud": {
 		name: "LogoCloud",
 		slug: "logo-cloud",

--- a/src/lib/fancy-ui/tailwind.css
+++ b/src/lib/fancy-ui/tailwind.css
@@ -1,0 +1,3 @@
+/* Import this file in your app's CSS to include fancy-ui Tailwind classes:
+   @import "fancy-ui/tailwind.css"; */
+@source "..";

--- a/src/routes/demo/animated-testimonials/+page.svelte
+++ b/src/routes/demo/animated-testimonials/+page.svelte
@@ -50,7 +50,7 @@
 <div class="container mx-auto px-4 py-12">
 	<div class="mb-10">
 		<h1 class="text-3xl font-bold tracking-tight">Animated Testimonials</h1>
-		<p class="mt-2 text-muted-foreground">
+		<p class="text-muted-foreground mt-2">
 			Testimonial carousel with smooth slide animations, navigation arrows, and optional autoplay.
 		</p>
 	</div>
@@ -58,7 +58,7 @@
 	<!-- Basic Usage -->
 	<section class="mb-12">
 		<h2 class="mb-4 text-xl font-semibold">Basic Usage</h2>
-		<div class="rounded-lg border bg-card flex items-center justify-center min-h-[400px]">
+		<div class="bg-card flex min-h-[400px] items-center justify-center rounded-lg border">
 			<AnimatedTestimonials {testimonials} />
 		</div>
 	</section>
@@ -66,10 +66,10 @@
 	<!-- With Autoplay -->
 	<section class="mb-12">
 		<h2 class="mb-4 text-xl font-semibold">With Autoplay</h2>
-		<p class="mb-4 text-sm text-muted-foreground">
+		<p class="text-muted-foreground mb-4 text-sm">
 			Auto-advances every 3 seconds. Pauses on hover.
 		</p>
-		<div class="rounded-lg border bg-card flex items-center justify-center min-h-[400px]">
+		<div class="bg-card flex min-h-[400px] items-center justify-center rounded-lg border">
 			<AnimatedTestimonials testimonials={autoplayTestimonials} autoplay interval={3000} />
 		</div>
 	</section>
@@ -89,28 +89,28 @@
 				</thead>
 				<tbody class="divide-y">
 					<tr>
-						<td class="px-4 py-3 font-mono text-primary">testimonials</td>
-						<td class="px-4 py-3 font-mono text-muted-foreground">Testimonial[]</td>
-						<td class="px-4 py-3 text-muted-foreground">required</td>
-						<td class="px-4 py-3 text-muted-foreground">Array of testimonial objects</td>
+						<td class="text-primary px-4 py-3 font-mono">testimonials</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">Testimonial[]</td>
+						<td class="text-muted-foreground px-4 py-3">required</td>
+						<td class="text-muted-foreground px-4 py-3">Array of testimonial objects</td>
 					</tr>
 					<tr>
-						<td class="px-4 py-3 font-mono text-primary">autoplay</td>
-						<td class="px-4 py-3 font-mono text-muted-foreground">boolean</td>
-						<td class="px-4 py-3 font-mono text-muted-foreground">false</td>
-						<td class="px-4 py-3 text-muted-foreground">Auto-advance testimonials</td>
+						<td class="text-primary px-4 py-3 font-mono">autoplay</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">boolean</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">false</td>
+						<td class="text-muted-foreground px-4 py-3">Auto-advance testimonials</td>
 					</tr>
 					<tr>
-						<td class="px-4 py-3 font-mono text-primary">interval</td>
-						<td class="px-4 py-3 font-mono text-muted-foreground">number</td>
-						<td class="px-4 py-3 font-mono text-muted-foreground">5000</td>
-						<td class="px-4 py-3 text-muted-foreground">Autoplay interval in milliseconds</td>
+						<td class="text-primary px-4 py-3 font-mono">interval</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">number</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">5000</td>
+						<td class="text-muted-foreground px-4 py-3">Autoplay interval in milliseconds</td>
 					</tr>
 					<tr>
-						<td class="px-4 py-3 font-mono text-primary">class</td>
-						<td class="px-4 py-3 font-mono text-muted-foreground">string</td>
-						<td class="px-4 py-3 font-mono text-muted-foreground">undefined</td>
-						<td class="px-4 py-3 text-muted-foreground">Additional CSS classes</td>
+						<td class="text-primary px-4 py-3 font-mono">class</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Additional CSS classes</td>
 					</tr>
 				</tbody>
 			</table>
@@ -131,24 +131,24 @@
 				</thead>
 				<tbody class="divide-y">
 					<tr>
-						<td class="px-4 py-3 font-mono text-primary">quote</td>
-						<td class="px-4 py-3 font-mono text-muted-foreground">string</td>
-						<td class="px-4 py-3 text-muted-foreground">The testimonial text</td>
+						<td class="text-primary px-4 py-3 font-mono">quote</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">The testimonial text</td>
 					</tr>
 					<tr>
-						<td class="px-4 py-3 font-mono text-primary">name</td>
-						<td class="px-4 py-3 font-mono text-muted-foreground">string</td>
-						<td class="px-4 py-3 text-muted-foreground">Author's full name</td>
+						<td class="text-primary px-4 py-3 font-mono">name</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">Author's full name</td>
 					</tr>
 					<tr>
-						<td class="px-4 py-3 font-mono text-primary">designation</td>
-						<td class="px-4 py-3 font-mono text-muted-foreground">string</td>
-						<td class="px-4 py-3 text-muted-foreground">Author's title or role</td>
+						<td class="text-primary px-4 py-3 font-mono">designation</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">Author's title or role</td>
 					</tr>
 					<tr>
-						<td class="px-4 py-3 font-mono text-primary">src</td>
-						<td class="px-4 py-3 font-mono text-muted-foreground">string</td>
-						<td class="px-4 py-3 text-muted-foreground">URL to the author's avatar image</td>
+						<td class="text-primary px-4 py-3 font-mono">src</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">URL to the author's avatar image</td>
 					</tr>
 				</tbody>
 			</table>

--- a/src/routes/demo/animated-tooltip/+page.svelte
+++ b/src/routes/demo/animated-tooltip/+page.svelte
@@ -6,7 +6,7 @@
 			id: 1,
 			name: "John Doe",
 			designation: "Software Engineer",
-			image: "https://images.unsplash.com/photo-1599566150163-29194dcabd36?w=100&h=100&fit=crop",
+			image: "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=100&h=100&fit=crop",
 		},
 		{
 			id: 2,

--- a/src/routes/demo/apple-card-carousel/+page.svelte
+++ b/src/routes/demo/apple-card-carousel/+page.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+	import { AppleCardCarousel } from "$lib/fancy-ui/apple-card-carousel";
+	import type { AppleCardData } from "$lib/fancy-ui/apple-card-carousel";
+
+	const cards: AppleCardData[] = [
+		{
+			category: "Nature",
+			title: "Misty Mountains",
+			src: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop&q=60",
+			description:
+				"A breathtaking view of misty mountains at dawn, where layers of fog weave between ancient peaks. The gentle interplay of light and shadow creates a landscape that feels both timeless and dreamlike.",
+		},
+		{
+			category: "Architecture",
+			title: "Brutalist Forms",
+			src: "https://images.unsplash.com/photo-1486325212027-8081e485255e?w=800&auto=format&fit=crop&q=60",
+			description:
+				"Raw concrete and bold geometry define this brutalist landmark. Every angle is deliberate, every surface a statement — architecture stripped of ornament and reduced to pure, honest form.",
+		},
+		{
+			category: "Ocean",
+			title: "Deep Blue",
+			src: "https://images.unsplash.com/photo-1505118380757-91f5f5632de0?w=800&auto=format&fit=crop&q=60",
+			description:
+				"Beneath the surface, an entire world exists in silence. The ocean holds ancient secrets in its depths — creatures of light, corridors of coral, and the steady hum of currents that have shaped continents.",
+		},
+		{
+			category: "Urban",
+			title: "City Lights",
+			src: "https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?w=800&auto=format&fit=crop&q=60",
+			description:
+				"The city never sleeps. From dusk to dawn, millions of lives intersect across glowing grids of steel and glass. Each light in a window is a story — ambition, rest, love, or loss.",
+		},
+		{
+			category: "Desert",
+			title: "Sand & Silence",
+			src: "https://images.unsplash.com/photo-1509316785289-025f5b846b35?w=800&auto=format&fit=crop&q=60",
+			description:
+				"The desert teaches patience. Endless dunes shift imperceptibly under a relentless sun, sculpted by winds that have carved canyons over millennia. Here, time moves at a different scale.",
+		},
+	];
+</script>
+
+<svelte:head>
+	<title>AppleCardCarousel — FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto px-4 py-12">
+	<div class="mb-10">
+		<h1 class="text-3xl font-bold tracking-tight">Apple Card Carousel</h1>
+		<p class="text-muted-foreground mt-2">
+			Horizontal card carousel with spring-animated full-screen expansion, inspired by Apple's App
+			Store UI.
+		</p>
+	</div>
+
+	<!-- Basic Usage -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Basic Usage</h2>
+		<p class="text-muted-foreground mb-4 text-sm">
+			Click any card to expand it. Press <kbd
+				class="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">Esc</kbd
+			> or click the backdrop to dismiss.
+		</p>
+		<div class="bg-card overflow-hidden rounded-lg border py-8">
+			<AppleCardCarousel {cards} />
+		</div>
+	</section>
+
+	<!-- Props -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Props</h2>
+		<div class="overflow-x-auto rounded-lg border">
+			<table class="w-full text-sm">
+				<thead class="bg-muted/50">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Prop</th>
+						<th class="px-4 py-3 text-left font-medium">Type</th>
+						<th class="px-4 py-3 text-left font-medium">Default</th>
+						<th class="px-4 py-3 text-left font-medium">Description</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y">
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">cards</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">AppleCardData[]</td>
+						<td class="text-muted-foreground px-4 py-3">required</td>
+						<td class="text-muted-foreground px-4 py-3">Array of card data objects</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">class</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Additional CSS classes</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+
+	<!-- AppleCardData type -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">AppleCardData Type</h2>
+		<div class="overflow-x-auto rounded-lg border">
+			<table class="w-full text-sm">
+				<thead class="bg-muted/50">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Field</th>
+						<th class="px-4 py-3 text-left font-medium">Type</th>
+						<th class="px-4 py-3 text-left font-medium">Description</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y">
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">category</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">Label shown above the title</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">title</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">Main card title</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">src</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">URL of the card background image</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">description</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3">Optional text shown in the expanded view</td
+						>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">content</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">Snippet</td>
+						<td class="text-muted-foreground px-4 py-3"
+							>Optional rich content snippet for the expanded view (takes precedence over
+							description)</td
+						>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+</div>

--- a/src/routes/demo/displacement-text/+page.svelte
+++ b/src/routes/demo/displacement-text/+page.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import { DisplacementText } from "$lib/fancy-ui/displacement-text";
+</script>
+
+<svelte:head>
+	<title>DisplacementText — FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto px-4 py-12">
+	<div class="mb-10">
+		<h1 class="text-3xl font-bold tracking-tight">3D Displacement Text</h1>
+		<p class="text-muted-foreground mt-2">
+			WebGL text with fluid 3D displacement that follows your cursor. Built with Three.js shaders.
+		</p>
+	</div>
+
+	<!-- Default -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Default</h2>
+		<div class="bg-card rounded-lg border">
+			<DisplacementText text="Hover Me" fontSize={220} />
+		</div>
+	</section>
+
+	<!-- Custom color -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Custom Color</h2>
+		<div class="bg-card rounded-lg border">
+			<DisplacementText text="FancyUI" fontSize={200} color="#6366f1" />
+		</div>
+	</section>
+
+	<!-- Theme aware -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Theme Aware</h2>
+		<p class="text-muted-foreground mb-4 text-sm">
+			Automatically switches color between light and dark mode.
+		</p>
+		<div class="bg-card rounded-lg border">
+			<DisplacementText text="Adaptive" lightColor="#1a1a1a" darkColor="#f5f5f5" />
+		</div>
+	</section>
+
+	<!-- Props -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Props</h2>
+		<div class="overflow-x-auto rounded-lg border">
+			<table class="w-full text-sm">
+				<thead class="bg-muted/50">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Prop</th>
+						<th class="px-4 py-3 text-left font-medium">Type</th>
+						<th class="px-4 py-3 text-left font-medium">Default</th>
+						<th class="px-4 py-3 text-left font-medium">Description</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y">
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">text</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"Hover Me"</td>
+						<td class="text-muted-foreground px-4 py-3">Text to display</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">fontSize</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">number</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">200</td>
+						<td class="text-muted-foreground px-4 py-3">Font size in pixels</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">font</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"Inter, sans-serif"</td>
+						<td class="text-muted-foreground px-4 py-3">Font family</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">color</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Fixed color (overrides theme colors)</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">lightColor</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"#000000"</td>
+						<td class="text-muted-foreground px-4 py-3">Color in light mode</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">darkColor</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"#ffffff"</td>
+						<td class="text-muted-foreground px-4 py-3">Color in dark mode</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">class</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Additional CSS classes</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+</div>

--- a/src/routes/demo/line-hover-link/+page.svelte
+++ b/src/routes/demo/line-hover-link/+page.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+	import { LineHoverLink } from "$lib/fancy-ui/line-hover-link";
+	import type { LineHoverVariant } from "$lib/fancy-ui/line-hover-link";
+
+	const variants: { variant: LineHoverVariant; label: string }[] = [
+		{ variant: "slide", label: "Slide" },
+		{ variant: "double", label: "Double" },
+		{ variant: "grow", label: "Grow" },
+		{ variant: "strike", label: "Strike" },
+		{ variant: "fade", label: "Fade" },
+		{ variant: "pulse", label: "Pulse" },
+		{ variant: "swap", label: "Swap" },
+		{ variant: "sweep", label: "Sweep" },
+		{ variant: "bounce", label: "Bounce" },
+		{ variant: "arc", label: "Arc" },
+		{ variant: "scribble", label: "Scribble" },
+	];
+</script>
+
+<svelte:head>
+	<title>LineHoverLink — FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto px-4 py-12">
+	<div class="mb-10">
+		<h1 class="text-3xl font-bold tracking-tight">Line Hover Link</h1>
+		<p class="text-muted-foreground mt-2">
+			Link component with 11 animated underline hover effects. Pure CSS — no JS on hover.
+		</p>
+	</div>
+
+	<!-- All variants -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">All Variants</h2>
+		<div class="bg-card flex min-h-[280px] items-center justify-center rounded-lg border p-12">
+			<div class="grid grid-cols-3 gap-x-16 gap-y-10 md:grid-cols-4">
+				{#each variants as { variant, label }}
+					<div class="text-center">
+						<LineHoverLink {variant} href="#" class="text-lg font-medium">
+							{label}
+						</LineHoverLink>
+					</div>
+				{/each}
+			</div>
+		</div>
+	</section>
+
+	<!-- Navigation example -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Navigation Example</h2>
+		<div class="bg-card flex min-h-[120px] items-center justify-center rounded-lg border">
+			<nav class="flex gap-8">
+				<LineHoverLink variant="slide" href="#" class="text-muted-foreground">Home</LineHoverLink>
+				<LineHoverLink variant="slide" href="#" class="text-muted-foreground">About</LineHoverLink>
+				<LineHoverLink variant="slide" href="#" class="text-muted-foreground"
+					>Services</LineHoverLink
+				>
+				<LineHoverLink variant="slide" href="#" class="text-muted-foreground">Contact</LineHoverLink
+				>
+			</nav>
+		</div>
+	</section>
+
+	<!-- SVG variants -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">SVG Variants</h2>
+		<p class="text-muted-foreground mb-4 text-sm">
+			Arc and Scribble draw an SVG stroke on hover using <code
+				class="bg-muted rounded px-1 font-mono text-xs">stroke-dashoffset</code
+			>.
+		</p>
+		<div class="bg-card flex min-h-[120px] items-center justify-center gap-16 rounded-lg border">
+			<LineHoverLink variant="arc" href="#" class="text-xl font-medium">Sign up</LineHoverLink>
+			<LineHoverLink variant="scribble" href="#" class="text-xl font-medium">Writings</LineHoverLink
+			>
+		</div>
+	</section>
+
+	<!-- Props -->
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Props</h2>
+		<div class="overflow-x-auto rounded-lg border">
+			<table class="w-full text-sm">
+				<thead class="bg-muted/50">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Prop</th>
+						<th class="px-4 py-3 text-left font-medium">Type</th>
+						<th class="px-4 py-3 text-left font-medium">Default</th>
+						<th class="px-4 py-3 text-left font-medium">Description</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y">
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">variant</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">LineHoverVariant</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"slide"</td>
+						<td class="text-muted-foreground px-4 py-3">Animation variant</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">href</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">"#"</td>
+						<td class="text-muted-foreground px-4 py-3">Link destination</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">target</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Link target (e.g. "_blank")</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">rel</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Link rel attribute</td>
+					</tr>
+					<tr>
+						<td class="text-primary px-4 py-3 font-mono">class</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">string</td>
+						<td class="text-muted-foreground px-4 py-3 font-mono">undefined</td>
+						<td class="text-muted-foreground px-4 py-3">Additional CSS classes</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary
- **Compare**: add `overflow-hidden` to second content div to prevent background color bleeding into rounded corners
- **AnimatedTooltip**: replace broken Unsplash image URL for "John Doe"
- **FlipWords**: replace `{#if isVisible}` with `{#key currentIndex}` + CSS exit animation to prevent layout shift during word transitions

## Test plan
- [ ] Visit `/demo/compare` — no red color visible in corners of the custom content demo
- [ ] Visit `/demo/animated-tooltip` — John Doe avatar displays correctly
- [ ] Visit homepage (`/`) — hero tagline cycles words without layout shift/jump between transitions