### PR TITLE
fix: ui bug fixes, compare corners, animated-tooltip image, flip-words layout shift

### DIFF
--- a/.changeset/compare-animated-tooltip-fixes.md
+++ b/.changeset/compare-animated-tooltip-fixes.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": patch
+---
+
+fix compare corner overflow and broken animated-tooltip image

--- a/.changeset/flip-words-layout-fix.md
+++ b/.changeset/flip-words-layout-fix.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": patch
+---
+
+fix(flip-words): prevent layout shift during word transition

--- a/src/lib/fancy-ui/compare/Compare.svelte
+++ b/src/lib/fancy-ui/compare/Compare.svelte
@@ -285,7 +285,7 @@
 	<!-- Second Content -->
 	<div
 		class={cn(
-			"absolute top-0 left-0 z-[19] h-full w-full rounded-2xl select-none",
+			"absolute top-0 left-0 z-[19] h-full w-full overflow-hidden rounded-2xl select-none",
 			secondContentClass
 		)}
 		style:pointer-events={isInteracting ? "none" : "auto"}

--- a/src/lib/fancy-ui/flip-words/FlipWords.svelte
+++ b/src/lib/fancy-ui/flip-words/FlipWords.svelte
@@ -23,7 +23,7 @@
 	let { words, duration = 3000, class: className }: FlipWordsProps = $props();
 
 	let currentIndex = $state(0);
-	let isVisible = $state(true);
+	let isExiting = $state(false);
 	let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
 	let currentWord = $derived(words[currentIndex] ?? "");
@@ -35,11 +35,11 @@
 	);
 
 	function startAnimation() {
-		isVisible = false;
+		isExiting = true;
 
 		setTimeout(() => {
+			isExiting = false;
 			currentIndex = (currentIndex + 1) % words.length;
-			isVisible = true;
 		}, 600);
 	}
 
@@ -49,7 +49,9 @@
 	}
 
 	$effect(() => {
-		if (isVisible) {
+		// Re-schedule whenever a new word becomes active (not during exit)
+		if (!isExiting) {
+			void currentIndex; // track dependency
 			scheduleNext();
 		}
 	});
@@ -62,10 +64,11 @@
 </script>
 
 <div class="flip-words relative inline-block px-2">
-	{#if isVisible}
+	{#key currentIndex}
 		<div
 			class={cn(
-				"flip-words-enter relative z-10 inline-block text-left text-neutral-900 dark:text-neutral-100",
+				"relative z-10 inline-block text-left text-neutral-900 dark:text-neutral-100",
+				isExiting ? "flip-words-exit" : "flip-words-enter",
 				className
 			)}
 		>
@@ -86,7 +89,7 @@
 				</span>
 			{/each}
 		</div>
-	{/if}
+	{/key}
 </div>
 
 <style>
@@ -127,9 +130,26 @@
 				transform: translateY(0);
 			}
 		}
+
+		@keyframes flipExitWord {
+			0% {
+				opacity: 1;
+				transform: translateY(0);
+				filter: blur(0);
+			}
+			100% {
+				opacity: 0;
+				transform: translateY(-10px);
+				filter: blur(8px);
+			}
+		}
 	}
 
 	.flip-words-enter {
 		animation: flipEnterWord 0.6s ease-in-out forwards;
+	}
+
+	.flip-words-exit {
+		animation: flipExitWord 0.6s ease-in-out forwards;
 	}
 </style>

--- a/src/lib/fancy-ui/flip-words/FlipWords.svelte
+++ b/src/lib/fancy-ui/flip-words/FlipWords.svelte
@@ -20,11 +20,14 @@
 	import { cn } from "$lib/utils.js";
 	import { onMount } from "svelte";
 
+	const EXIT_MS = 600;
+
 	let { words, duration = 3000, class: className }: FlipWordsProps = $props();
 
 	let currentIndex = $state(0);
 	let isExiting = $state(false);
 	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+	let exitTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 	let currentWord = $derived(words[currentIndex] ?? "");
 	let splitWords = $derived(
@@ -35,30 +38,35 @@
 	);
 
 	function startAnimation() {
+		if (words.length < 2) return;
+
 		isExiting = true;
 
-		setTimeout(() => {
+		if (exitTimeoutId) clearTimeout(exitTimeoutId);
+		exitTimeoutId = setTimeout(() => {
 			isExiting = false;
 			currentIndex = (currentIndex + 1) % words.length;
-		}, 600);
+		}, EXIT_MS);
 	}
 
-	function scheduleNext() {
+	function scheduleNext(index: number, d: number) {
+		if (words.length < 2) return;
 		if (timeoutId) clearTimeout(timeoutId);
-		timeoutId = setTimeout(startAnimation, duration);
+		timeoutId = setTimeout(startAnimation, d);
 	}
 
 	$effect(() => {
-		// Re-schedule whenever a new word becomes active (not during exit)
+		// Re-schedule whenever a new word becomes active (not during exit).
+		// Reference currentIndex and duration directly so the effect re-runs on changes.
 		if (!isExiting) {
-			void currentIndex; // track dependency
-			scheduleNext();
+			scheduleNext(currentIndex, duration);
 		}
 	});
 
 	onMount(() => {
 		return () => {
 			if (timeoutId) clearTimeout(timeoutId);
+			if (exitTimeoutId) clearTimeout(exitTimeoutId);
 		};
 	});
 </script>
@@ -145,11 +153,15 @@
 		}
 	}
 
+	.flip-words {
+		--flip-words-ms: 0.6s;
+	}
+
 	.flip-words-enter {
-		animation: flipEnterWord 0.6s ease-in-out forwards;
+		animation: flipEnterWord var(--flip-words-ms) ease-in-out forwards;
 	}
 
 	.flip-words-exit {
-		animation: flipExitWord 0.6s ease-in-out forwards;
+		animation: flipExitWord var(--flip-words-ms) ease-in-out forwards;
 	}
 </style>

--- a/src/routes/demo/animated-tooltip/+page.svelte
+++ b/src/routes/demo/animated-tooltip/+page.svelte
@@ -6,7 +6,7 @@
 			id: 1,
 			name: "John Doe",
 			designation: "Software Engineer",
-			image: "https://images.unsplash.com/photo-1599566150163-29194dcabd36?w=100&h=100&fit=crop",
+			image: "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=100&h=100&fit=crop",
 		},
 		{
 			id: 2,


### PR DESCRIPTION
## Summary
- **Compare**: add `overflow-hidden` to second content div to prevent background color bleeding into rounded corners
- **AnimatedTooltip**: replace broken Unsplash image URL for "John Doe"
- **FlipWords**: replace `{#if isVisible}` with `{#key currentIndex}` + CSS exit animation to prevent layout shift during word transitions

## Test plan
- [ ] Visit `/demo/compare` — no red color visible in corners of the custom content demo
- [ ] Visit `/demo/animated-tooltip` — John Doe avatar displays correctly
- [ ] Visit homepage (`/`) — hero tagline cycles words without layout shift/jump between transitions