### PR TITLE
feat: add MatrixRain and TerminalText components

### DIFF
--- a/.changeset/matrix-rain-terminal-text.md
+++ b/.changeset/matrix-rain-terminal-text.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+add MatrixRain and TerminalText components with interactive demo

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -56,6 +56,8 @@ export * from "./text-generate-effect/index.js";
 export * from "./line-shadow-text/index.js";
 export * from "./tracing-beam/index.js";
 export * from "./displacement-text/index.js";
+export * from "./matrix-rain/index.js";
+export * from "./terminal-text/index.js";
 
 // =============================================================================
 // Registry

--- a/src/lib/fancy-ui/matrix-rain/MatrixRain.svelte
+++ b/src/lib/fancy-ui/matrix-rain/MatrixRain.svelte
@@ -1,0 +1,117 @@
+<script lang="ts" module>
+	export interface MatrixRainProps {
+		color?: string;
+		speed?: number;
+		density?: number;
+		glyphSize?: number;
+		fadeOpacity?: number;
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let {
+		color = "#00ff41",
+		speed = 1.0,
+		density = 1.0,
+		glyphSize = 16,
+		fadeOpacity = 0.05,
+		class: className,
+	}: MatrixRainProps = $props();
+
+	const GLYPHS =
+		"アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲンABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#$%&";
+
+	let canvas: HTMLCanvasElement;
+	let rafId: number;
+	let columns: number[] = [];
+	let frameCount = 0;
+
+	function randomGlyph(): string {
+		return GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
+	}
+
+	function init(w: number, h: number) {
+		const colCount = Math.floor(w / (glyphSize * density));
+		columns = Array.from({ length: colCount }, () => Math.floor(Math.random() * (h / glyphSize)));
+	}
+
+	function draw() {
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return;
+
+		const w = canvas.width;
+		const h = canvas.height;
+
+		// Fade trail
+		ctx.fillStyle = `rgba(0, 0, 0, ${fadeOpacity})`;
+		ctx.fillRect(0, 0, w, h);
+
+		ctx.font = `${glyphSize}px monospace`;
+		ctx.shadowBlur = 8;
+		ctx.shadowColor = color;
+
+		const rowsPerFrame = Math.max(1, speed);
+		frameCount++;
+
+		// Only advance every N frames to control speed below 1x
+		const shouldAdvance = speed >= 1 || frameCount % Math.round(1 / speed) === 0;
+
+		if (shouldAdvance) {
+			for (let i = 0; i < columns.length; i++) {
+				const x = i * glyphSize * density;
+				const y = columns[i] * glyphSize;
+
+				// Head character (bright white)
+				ctx.fillStyle = "#ffffff";
+				ctx.fillText(randomGlyph(), x, y);
+
+				// Body glyph one step behind (dimmer)
+				if (columns[i] > 1) {
+					ctx.fillStyle = color;
+					ctx.fillText(randomGlyph(), x, y - glyphSize);
+				}
+
+				// Reset column when it exits bottom, with random delay
+				if (y > h && Math.random() > 0.975) {
+					columns[i] = 0;
+				} else {
+					columns[i] += rowsPerFrame;
+				}
+			}
+		}
+
+		ctx.shadowBlur = 0;
+		rafId = requestAnimationFrame(draw);
+	}
+
+	$effect(() => {
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return;
+
+		// Set canvas size to container size
+		const resize = () => {
+			canvas.width = canvas.offsetWidth;
+			canvas.height = canvas.offsetHeight;
+			ctx.fillStyle = "black";
+			ctx.fillRect(0, 0, canvas.width, canvas.height);
+			init(canvas.width, canvas.height);
+		};
+
+		resize();
+
+		const observer = new ResizeObserver(resize);
+		observer.observe(canvas);
+
+		rafId = requestAnimationFrame(draw);
+
+		return () => {
+			cancelAnimationFrame(rafId);
+			observer.disconnect();
+		};
+	});
+</script>
+
+<canvas bind:this={canvas} class={cn("block h-full w-full bg-black", className)}></canvas>

--- a/src/lib/fancy-ui/matrix-rain/MatrixRain.svelte
+++ b/src/lib/fancy-ui/matrix-rain/MatrixRain.svelte
@@ -25,25 +25,31 @@
 		"アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲンABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#$%&";
 
 	let canvas: HTMLCanvasElement;
+	let ctx: CanvasRenderingContext2D | null = null;
 	let rafId: number;
 	let columns: number[] = [];
 	let frameCount = 0;
+	let canvasW = 0;
+	let canvasH = 0;
 
 	function randomGlyph(): string {
 		return GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
 	}
 
 	function init(w: number, h: number) {
-		const colCount = Math.floor(w / (glyphSize * density));
-		columns = Array.from({ length: colCount }, () => Math.floor(Math.random() * (h / glyphSize)));
+		const safeGlyphSize = Math.max(1, glyphSize);
+		const safeDensity = Math.max(0.1, density);
+		const colCount = Math.max(1, Math.floor(w / (safeGlyphSize * safeDensity)));
+		columns = Array.from({ length: colCount }, () =>
+			Math.floor(Math.random() * (h / safeGlyphSize))
+		);
 	}
 
 	function draw() {
-		const ctx = canvas.getContext("2d");
 		if (!ctx) return;
 
-		const w = canvas.width;
-		const h = canvas.height;
+		const w = canvasW;
+		const h = canvasH;
 
 		// Fade trail
 		ctx.fillStyle = `rgba(0, 0, 0, ${fadeOpacity})`;
@@ -88,16 +94,20 @@
 	}
 
 	$effect(() => {
-		const ctx = canvas.getContext("2d");
+		ctx = canvas.getContext("2d");
 		if (!ctx) return;
 
-		// Set canvas size to container size
+		// Set canvas size to container size with HiDPI scaling
 		const resize = () => {
-			canvas.width = canvas.offsetWidth;
-			canvas.height = canvas.offsetHeight;
-			ctx.fillStyle = "black";
-			ctx.fillRect(0, 0, canvas.width, canvas.height);
-			init(canvas.width, canvas.height);
+			const dpr = window.devicePixelRatio || 1;
+			canvasW = canvas.clientWidth;
+			canvasH = canvas.clientHeight;
+			canvas.width = Math.floor(canvasW * dpr);
+			canvas.height = Math.floor(canvasH * dpr);
+			ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+			ctx!.fillStyle = "black";
+			ctx!.fillRect(0, 0, canvasW, canvasH);
+			init(canvasW, canvasH);
 		};
 
 		resize();

--- a/src/lib/fancy-ui/matrix-rain/index.ts
+++ b/src/lib/fancy-ui/matrix-rain/index.ts
@@ -1,0 +1,4 @@
+import MatrixRain from "./MatrixRain.svelte";
+import type { MatrixRainProps } from "./MatrixRain.svelte";
+
+export { MatrixRain, type MatrixRainProps };

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -618,6 +618,24 @@ export const registry: Record<string, ComponentMeta> = {
 		status: "done",
 		credits: [{ source: "VengenceUI", url: "https://vengenceui.com/docs/liquid-text" }],
 	},
+
+	"matrix-rain": {
+		name: "MatrixRain",
+		slug: "matrix-rain",
+		description:
+			"Canvas-based Matrix-style falling glyph rain with configurable color, speed, and density",
+		category: "backgrounds",
+		status: "done",
+	},
+
+	"terminal-text": {
+		name: "TerminalText",
+		slug: "terminal-text",
+		description:
+			"Terminal-style text streamer with per-character animation, blinking cursor, and glitch effect",
+		category: "text",
+		status: "done",
+	},
 };
 
 // =============================================================================

--- a/src/lib/fancy-ui/terminal-text/TerminalText.svelte
+++ b/src/lib/fancy-ui/terminal-text/TerminalText.svelte
@@ -1,0 +1,177 @@
+<script lang="ts" module>
+	export interface TerminalTextProps {
+		lines: string[];
+		speed?: number;
+		delay?: number;
+		cursor?: boolean;
+		cursorChar?: string;
+		glitch?: boolean;
+		class?: string;
+		onComplete?: () => void;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let {
+		lines,
+		speed = 40,
+		delay = 0,
+		cursor = true,
+		cursorChar = "█",
+		glitch = false,
+		class: className,
+		onComplete,
+	}: TerminalTextProps = $props();
+
+	const GLITCH_GLYPHS = "アイウエオ@#$%&!?░▒▓█▄▀■□▪▫";
+
+	let displayedLines = $state<string[]>([]);
+	let done = $state(false);
+	let glitchState = $state<{ lineIdx: number; charIdx: number; original: string } | null>(null);
+
+	let timeouts: ReturnType<typeof setTimeout>[] = [];
+
+	function scheduleTimeout(fn: () => void, ms: number) {
+		const id = setTimeout(fn, ms);
+		timeouts.push(id);
+		return id;
+	}
+
+	function clearAllTimeouts() {
+		timeouts.forEach(clearTimeout);
+		timeouts = [];
+	}
+
+	function streamLines() {
+		clearAllTimeouts();
+		displayedLines = [];
+		done = false;
+		glitchState = null;
+
+		let totalDelay = delay;
+
+		for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+			const line = lines[lineIdx];
+
+			// Push empty line placeholder
+			const capturedIdx = lineIdx;
+			scheduleTimeout(() => {
+				displayedLines = [...displayedLines, ""];
+			}, totalDelay);
+
+			// Stream characters one by one
+			for (let charIdx = 0; charIdx < line.length; charIdx++) {
+				const capturedChar = charIdx;
+				const capturedLine = line;
+				totalDelay += speed;
+				scheduleTimeout(() => {
+					displayedLines = displayedLines.map((l, i) =>
+						i === capturedIdx ? capturedLine.slice(0, capturedChar + 1) : l
+					);
+				}, totalDelay);
+			}
+
+			// Small pause between lines
+			totalDelay += speed * 3;
+		}
+
+		// Mark done
+		scheduleTimeout(() => {
+			done = true;
+			onComplete?.();
+		}, totalDelay);
+	}
+
+	function startGlitchLoop() {
+		function glitchOnce() {
+			if (displayedLines.length === 0) return;
+
+			// Pick a random line with content
+			const linesWithContent = displayedLines
+				.map((l, i) => ({ l, i }))
+				.filter(({ l }) => l.length > 0);
+			if (linesWithContent.length === 0) return;
+
+			const { l, i } = linesWithContent[Math.floor(Math.random() * linesWithContent.length)];
+			const charIdx = Math.floor(Math.random() * l.length);
+			const original = l[charIdx];
+			const fakeGlyph = GLITCH_GLYPHS[Math.floor(Math.random() * GLITCH_GLYPHS.length)];
+
+			glitchState = { lineIdx: i, charIdx, original };
+
+			// Temporarily replace char in display via glitchState, restore after 100ms
+			displayedLines = displayedLines.map((line, idx) => {
+				if (idx !== i) return line;
+				return line.slice(0, charIdx) + fakeGlyph + line.slice(charIdx + 1);
+			});
+
+			scheduleTimeout(() => {
+				if (glitchState && glitchState.lineIdx === i && glitchState.charIdx === charIdx) {
+					displayedLines = displayedLines.map((line, idx) => {
+						if (idx !== i) return line;
+						return line.slice(0, charIdx) + original + line.slice(charIdx + 1);
+					});
+					glitchState = null;
+				}
+			}, 100);
+		}
+
+		function scheduleGlitch() {
+			// Random interval between 2s and 4s
+			const interval = 2000 + Math.random() * 2000;
+			scheduleTimeout(() => {
+				if (glitch) glitchOnce();
+				scheduleGlitch();
+			}, interval);
+		}
+
+		scheduleGlitch();
+	}
+
+	$effect(() => {
+		// React to lines/speed/delay changes
+		void lines;
+		void speed;
+		void delay;
+
+		streamLines();
+		if (glitch) startGlitchLoop();
+
+		return () => {
+			clearAllTimeouts();
+		};
+	});
+</script>
+
+<div class={cn("font-mono text-sm leading-relaxed", className)}>
+	{#each displayedLines as line, i}
+		<div class="min-h-[1.4em]">
+			<span>{line}</span>{#if cursor && i === displayedLines.length - 1 && !done}<span
+					class="cursor-blink">{cursorChar}</span
+				>{/if}
+		</div>
+	{/each}
+	{#if cursor && done}
+		<div class="min-h-[1.4em]">
+			<span class="cursor-blink">{cursorChar}</span>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.cursor-blink {
+		animation: blink 1s step-end infinite;
+	}
+
+	@keyframes blink {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/terminal-text/TerminalText.svelte
+++ b/src/lib/fancy-ui/terminal-text/TerminalText.svelte
@@ -131,17 +131,27 @@
 	}
 
 	$effect(() => {
-		// React to lines/speed/delay changes
+		// React only to lines/speed/delay — changing glitch won't restart the stream
 		void lines;
 		void speed;
 		void delay;
 
 		streamLines();
-		if (glitch) startGlitchLoop();
 
 		return () => {
 			clearAllTimeouts();
 		};
+	});
+
+	$effect(() => {
+		// React to glitch changes without restarting the stream
+		void glitch;
+
+		if (glitch) {
+			startGlitchLoop();
+		} else {
+			glitchState = null;
+		}
 	});
 </script>
 

--- a/src/lib/fancy-ui/terminal-text/index.ts
+++ b/src/lib/fancy-ui/terminal-text/index.ts
@@ -1,0 +1,4 @@
+import TerminalText from "./TerminalText.svelte";
+import type { TerminalTextProps } from "./TerminalText.svelte";
+
+export { TerminalText, type TerminalTextProps };

--- a/src/routes/demo/matrix-rain/+page.svelte
+++ b/src/routes/demo/matrix-rain/+page.svelte
@@ -10,11 +10,11 @@
 	let inputEl: HTMLInputElement;
 	let terminalBodyEl: HTMLDivElement;
 
-	const RESPONSES: Record<string, string[]> = {
+	const RESPONSES: Record<string, string[] | (() => string[])> = {
 		help: ["Available commands: help, whoami, ls, date, clear, hack, exit"],
 		whoami: ["operator — clearance level: OMEGA"],
 		ls: ["payload.enc  mainframe.key  rabbit.hole  /dev/null"],
-		date: [new Date().toUTCString()],
+		date: () => [new Date().toUTCString()],
 		hack: [
 			"initiating hack sequence...",
 			"bypassing firewall... done",
@@ -36,7 +36,13 @@
 			return;
 		}
 
-		const lines = RESPONSES[cmd] ?? [`bash: ${cmd}: command not found`];
+		const entry = RESPONSES[cmd];
+		const lines =
+			entry == null
+				? [`bash: ${cmd}: command not found`]
+				: typeof entry === "function"
+					? entry()
+					: entry;
 		history = [...history, ...lines.map((text) => ({ type: "output" as const, text }))];
 
 		// Scroll to bottom after DOM update
@@ -198,10 +204,18 @@
 			<code class="bg-muted rounded px-1.5 py-0.5">help</code> pour voir les commandes.
 		</p>
 
-		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 		<div
 			class="terminal-window rounded-lg border border-green-900 bg-black font-mono"
+			role="button"
+			tabindex="0"
+			aria-label="Focus terminal input"
 			onclick={focusInput}
+			onkeydown={(e) => {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					focusInput();
+				}
+			}}
 		>
 			<!-- Title bar -->
 			<div class="flex items-center gap-2 border-b border-green-900 px-4 py-2">

--- a/src/routes/demo/matrix-rain/+page.svelte
+++ b/src/routes/demo/matrix-rain/+page.svelte
@@ -1,0 +1,336 @@
+<script lang="ts">
+	import { MatrixRain } from "$lib/fancy-ui/matrix-rain";
+	import { TerminalText } from "$lib/fancy-ui/terminal-text";
+	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
+
+	// ── Interactive terminal state ─────────────────────────────
+	let terminalReady = $state(false);
+	let inputValue = $state("");
+	let history = $state<{ type: "cmd" | "output"; text: string }[]>([]);
+	let inputEl: HTMLInputElement;
+	let terminalBodyEl: HTMLDivElement;
+
+	const RESPONSES: Record<string, string[]> = {
+		help: ["Available commands: help, whoami, ls, date, clear, hack, exit"],
+		whoami: ["operator — clearance level: OMEGA"],
+		ls: ["payload.enc  mainframe.key  rabbit.hole  /dev/null"],
+		date: [new Date().toUTCString()],
+		hack: [
+			"initiating hack sequence...",
+			"bypassing firewall... done",
+			"injecting payload......... done",
+			"you're in.",
+		],
+		exit: ["there is no exit."],
+	};
+
+	function handleCommand() {
+		const cmd = inputValue.trim().toLowerCase();
+		inputValue = "";
+		if (!cmd) return;
+
+		history = [...history, { type: "cmd", text: `operator@mainframe:~$ ${cmd}` }];
+
+		if (cmd === "clear") {
+			history = [];
+			return;
+		}
+
+		const lines = RESPONSES[cmd] ?? [`bash: ${cmd}: command not found`];
+		history = [...history, ...lines.map((text) => ({ type: "output" as const, text }))];
+
+		// Scroll to bottom after DOM update
+		setTimeout(() => {
+			terminalBodyEl?.scrollTo({ top: terminalBodyEl.scrollHeight, behavior: "smooth" });
+		}, 10);
+	}
+
+	function focusInput() {
+		inputEl?.focus();
+	}
+
+	const heroLines = [
+		"> initializing neural interface...",
+		"> connecting to mainframe...",
+		"> access granted. welcome, operator.",
+		"> system status: all nodes online",
+		"> awaiting input_",
+	];
+
+	const logLines = [
+		"[INFO]  2077-04-02 03:14:07 — boot sequence complete",
+		"[WARN]  memory fragmentation at sector 0x4A2F",
+		"[INFO]  kernel patch applied successfully",
+		"[ERROR] unauthorized access attempt from 192.168.0.42",
+		"[INFO]  firewall rule updated — threat neutralized",
+		"[OK]    all systems nominal",
+	];
+
+	const glitchLines = [
+		"> scanning network topology...",
+		"> found 1,337 vulnerable endpoints",
+		"> deploying countermeasures...",
+		"> done. the matrix has you.",
+	];
+</script>
+
+<svelte:head>
+	<title>MatrixRain + TerminalText — FancyUI</title>
+</svelte:head>
+
+<div class="mx-auto max-w-4xl space-y-16 px-4 py-12">
+	<div>
+		<h1 class="mb-2 text-3xl font-bold">MatrixRain + TerminalText</h1>
+		<p class="text-muted-foreground">
+			Canvas-based falling glyph rain and a terminal-style text streamer — composable cyberpunk
+			effects.
+		</p>
+	</div>
+
+	<!-- =========================================================
+		 1. HERO — MatrixRain canvas + TerminalText overlay
+	========================================================== -->
+	<section>
+		<h2 class="mb-4 text-xl font-semibold">Composed: Hero</h2>
+		<div class="relative h-64 w-full overflow-hidden rounded-lg">
+			<MatrixRain class="absolute inset-0 h-full w-full" />
+			<div class="absolute inset-0 flex items-center justify-center">
+				<div class="rounded-md bg-black/70 p-6 text-green-400 backdrop-blur-sm">
+					<TerminalText lines={heroLines} speed={45} />
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- =========================================================
+		 2. MatrixRain standalone + playground
+	========================================================== -->
+	<section>
+		<h2 class="mb-4 text-xl font-semibold">MatrixRain</h2>
+		<p class="text-muted-foreground mb-4 text-sm">
+			Canvas-based falling katakana + latin glyph rain. Configurable via
+			<code class="bg-muted rounded px-1.5 py-0.5">color</code>,
+			<code class="bg-muted rounded px-1.5 py-0.5">speed</code>,
+			<code class="bg-muted rounded px-1.5 py-0.5">density</code>, and
+			<code class="bg-muted rounded px-1.5 py-0.5">glyphSize</code>.
+		</p>
+
+		<PropsPlayground
+			controls={[
+				{ key: "color", type: "color", label: "Color" },
+				{ key: "speed", type: "range", label: "Speed", min: 0.2, max: 4, step: 0.1 },
+				{ key: "density", type: "range", label: "Density", min: 0.5, max: 3, step: 0.1 },
+				{ key: "glyphSize", type: "range", label: "Glyph Size (px)", min: 8, max: 32, step: 2 },
+				{
+					key: "fadeOpacity",
+					type: "range",
+					label: "Fade Opacity",
+					min: 0.01,
+					max: 0.3,
+					step: 0.01,
+				},
+			]}
+			initialValues={{
+				color: "#00ff41",
+				speed: 1.0,
+				density: 1.0,
+				glyphSize: 16,
+				fadeOpacity: 0.05,
+			}}
+		>
+			{#snippet preview(values)}
+				<div class="h-64 w-full overflow-hidden rounded-lg">
+					<MatrixRain
+						color={values.color as string}
+						speed={values.speed as number}
+						density={values.density as number}
+						glyphSize={values.glyphSize as number}
+						fadeOpacity={values.fadeOpacity as number}
+					/>
+				</div>
+			{/snippet}
+		</PropsPlayground>
+	</section>
+
+	<!-- =========================================================
+		 3. TerminalText standalone examples
+	========================================================== -->
+	<section>
+		<h2 class="mb-4 text-xl font-semibold">TerminalText</h2>
+		<div class="space-y-6">
+			<!-- Log stream -->
+			<div>
+				<p class="text-muted-foreground mb-2 text-sm font-medium">Multiline log stream</p>
+				<div class="rounded-lg border bg-black p-5 text-green-400">
+					<TerminalText lines={logLines} speed={25} />
+				</div>
+			</div>
+
+			<!-- Glitch enabled -->
+			<div>
+				<p class="text-muted-foreground mb-2 text-sm font-medium">With glitch effect</p>
+				<div class="rounded-lg border bg-black p-5 text-green-400">
+					<TerminalText lines={glitchLines} speed={50} glitch={true} />
+				</div>
+			</div>
+
+			<!-- Fast, no cursor -->
+			<div>
+				<p class="text-muted-foreground mb-2 text-sm font-medium">Fast speed, no cursor</p>
+				<div class="rounded-lg border bg-black p-5 text-cyan-400">
+					<TerminalText
+						lines={["> ping 8.8.8.8 — 3ms", "> traceroute complete", "> done."]}
+						speed={15}
+						cursor={false}
+					/>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- =========================================================
+		 4. Composed: Terminal Window (interactive)
+	========================================================== -->
+	<section>
+		<h2 class="mb-4 text-xl font-semibold">Composed: Terminal Window</h2>
+		<p class="text-muted-foreground mb-4 text-sm">
+			MatrixRain en fond, TerminalText pour l'intro, puis terminal interactif. Tape
+			<code class="bg-muted rounded px-1.5 py-0.5">help</code> pour voir les commandes.
+		</p>
+
+		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+		<div
+			class="terminal-window rounded-lg border border-green-900 bg-black font-mono"
+			onclick={focusInput}
+		>
+			<!-- Title bar -->
+			<div class="flex items-center gap-2 border-b border-green-900 px-4 py-2">
+				<span class="h-3 w-3 rounded-full bg-red-500"></span>
+				<span class="h-3 w-3 rounded-full bg-yellow-500"></span>
+				<span class="h-3 w-3 rounded-full bg-green-500"></span>
+				<span class="ml-2 text-xs text-green-700">operator@mainframe — bash</span>
+			</div>
+
+			<!-- Content area -->
+			<div class="relative overflow-hidden" style="height: 320px;">
+				<!-- Matrix rain behind -->
+				<MatrixRain class="absolute inset-0 h-full w-full opacity-20" />
+				<!-- Scanline overlay -->
+				<div class="scanlines pointer-events-none absolute inset-0"></div>
+
+				<!-- Scrollable terminal body -->
+				<div bind:this={terminalBodyEl} class="absolute inset-0 overflow-y-auto p-4 text-green-400">
+					{#if !terminalReady}
+						<!-- Intro animation -->
+						<TerminalText
+							lines={[
+								"> sudo access granted",
+								"> loading encrypted payload...",
+								"> decryption complete",
+								"> WARNING: you are being watched",
+								"> follow the white rabbit.",
+							]}
+							speed={60}
+							delay={300}
+							glitch={true}
+							cursor={false}
+							onComplete={() => {
+								terminalReady = true;
+								setTimeout(() => inputEl?.focus(), 50);
+							}}
+						/>
+					{:else}
+						<!-- History -->
+						{#each history as entry}
+							<div class="leading-relaxed {entry.type === 'cmd' ? 'text-white' : 'text-green-400'}">
+								{entry.text}
+							</div>
+						{/each}
+
+						<!-- Active prompt -->
+						<div class="flex items-center gap-1 leading-relaxed">
+							<span class="text-green-600">operator@mainframe:~$</span>
+							<input
+								bind:this={inputEl}
+								bind:value={inputValue}
+								class="min-w-0 flex-1 bg-transparent text-white caret-green-400 outline-none"
+								spellcheck="false"
+								autocomplete="off"
+								onkeydown={(e) => e.key === "Enter" && handleCommand()}
+							/>
+						</div>
+					{/if}
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- =========================================================
+		 5. Props tables
+	========================================================== -->
+	<section class="space-y-8">
+		<h2 class="mb-4 text-xl font-semibold">Props</h2>
+
+		<div>
+			<h3 class="mb-3 font-semibold">MatrixRain</h3>
+			<div class="overflow-x-auto rounded-lg border">
+				<table class="w-full text-sm">
+					<thead class="bg-muted text-muted-foreground">
+						<tr>
+							<th class="px-4 py-2 text-left font-medium">Prop</th>
+							<th class="px-4 py-2 text-left font-medium">Type</th>
+							<th class="px-4 py-2 text-left font-medium">Default</th>
+							<th class="px-4 py-2 text-left font-medium">Description</th>
+						</tr>
+					</thead>
+					<tbody class="divide-y">
+						{#each [["color", "string", '"#00ff41"', "Glyph and glow color"], ["speed", "number", "1.0", "Multiplier for fall speed"], ["density", "number", "1.0", "Column spacing multiplier"], ["glyphSize", "number", "16", "Font size in px"], ["fadeOpacity", "number", "0.05", "Trail fade per frame (lower = longer trails)"], ["class", "string", "—", "Additional CSS classes"]] as row}
+							<tr class="hover:bg-muted/50">
+								{#each row as cell, i}
+									<td class="px-4 py-2{i < 2 ? ' font-mono text-xs' : ''}">{cell}</td>
+								{/each}
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</div>
+
+		<div>
+			<h3 class="mb-3 font-semibold">TerminalText</h3>
+			<div class="overflow-x-auto rounded-lg border">
+				<table class="w-full text-sm">
+					<thead class="bg-muted text-muted-foreground">
+						<tr>
+							<th class="px-4 py-2 text-left font-medium">Prop</th>
+							<th class="px-4 py-2 text-left font-medium">Type</th>
+							<th class="px-4 py-2 text-left font-medium">Default</th>
+							<th class="px-4 py-2 text-left font-medium">Description</th>
+						</tr>
+					</thead>
+					<tbody class="divide-y">
+						{#each [["lines", "string[]", "required", "Lines to stream one by one"], ["speed", "number", "40", "Milliseconds per character"], ["delay", "number", "0", "Initial delay before streaming starts"], ["cursor", "boolean", "true", "Show blinking cursor"], ["cursorChar", "string", '"█"', "Cursor character"], ["glitch", "boolean", "false", "Enable random character glitch effect"], ["class", "string", "—", "Additional CSS classes"], ["onComplete", "() => void", "—", "Callback when all lines are done"]] as row}
+							<tr class="hover:bg-muted/50">
+								{#each row as cell, i}
+									<td class="px-4 py-2{i < 2 ? ' font-mono text-xs' : ''}">{cell}</td>
+								{/each}
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</section>
+</div>
+
+<style>
+	.scanlines {
+		background: repeating-linear-gradient(
+			to bottom,
+			transparent,
+			transparent 2px,
+			rgba(0, 0, 0, 0.15) 2px,
+			rgba(0, 0, 0, 0.15) 4px
+		);
+	}
+</style>


### PR DESCRIPTION
## Summary
- **MatrixRain**: canvas-based falling katakana/latin glyph rain with green glow, ResizeObserver, and configurable color, speed, density, glyphSize, fadeOpacity props
- **TerminalText**: per-character text streamer with blinking cursor, optional glitch effect, and `onComplete` callback (Svelte 5 runes, `setTimeout` chains)
- **Demo page** at `/demo/matrix-rain`: hero with overlay, MatrixRain PropsPlayground, TerminalText examples (log stream, glitch, fast/no cursor), and an interactive terminal window where you can type commands after the intro animation

## Test plan
- [x] Visit `/demo/matrix-rain` — canvas renders and glyphs fall
- [x] Tweak sliders in the MatrixRain playground — canvas updates live
- [x] TerminalText examples stream character by character with blinking cursor
- [x] Glitch example shows random character swaps every ~3s
- [ ] Terminal Window: intro animation plays, then prompt appears — type `help`, `hack`, `clear`, etc.
- [ ] `pnpm check` — 0 errors
- [ ] `pnpm test` — 458 tests pass