### PR TITLE
feat: add Component Copilot AI chat demo

### DIFF
--- a/.changeset/component-copilot.md
+++ b/.changeset/component-copilot.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+add Component Copilot AI chat demo at /demo/component-copilot

--- a/.env.example
+++ b/.env.example
@@ -29,5 +29,5 @@ GITHUB_REPO_NAME=your_repo_name
 # FILESYSTEM_STORAGE_DIR=./content/pages
 
 # Component Copilot (AI chat demo)
-OPENAI_API_KEY=sk-...
+OPENAI_API_KEY=
 # Ollama: no key needed. Run: ollama serve && ollama pull llama3.2

--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,7 @@ GITHUB_REPO_NAME=your_repo_name
 
 # Optional: custom directory for filesystem storage (default: ./content/pages)
 # FILESYSTEM_STORAGE_DIR=./content/pages
+
+# Component Copilot (AI chat demo)
+OPENAI_API_KEY=sk-...
+# Ollama: no key needed. Run: ollama serve && ollama pull llama3.2

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ CLAUDE.md
 # App-specific routes and components (not part of the component library)
 src/routes/portfolio/
 src/routes/auth/
-src/routes/api/
 src/routes/pages/
 src/lib/portfolio/
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
 		"@types/three": "^0.183.1",
 		"arctic": "^3.7.0",
 		"bits-ui": "^2.15.4",
+		"isomorphic-dompurify": "^3.7.1",
 		"jsdom": "^28.0.0",
 		"marked": "^17.0.3",
 		"nanoid": "^5.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       bits-ui:
         specifier: ^2.15.4
         version: 2.15.4(@internationalized/date@3.10.1)(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
+      isomorphic-dompurify:
+        specifier: ^3.7.1
+        version: 3.7.1
       jsdom:
         specifier: ^28.0.0
         version: 28.0.0
@@ -135,8 +138,16 @@ packages:
   '@asamuzakjp/css-color@4.1.1':
     resolution: {integrity: sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==}
 
+  '@asamuzakjp/css-color@5.1.5':
+    resolution: {integrity: sha512-8cMAA1bE66Mb/tfmkhcfJLjEPgyT7SSy6lW6id5XL113ai1ky76d/1L27sGnXCMsLfq66DInAU3OzuahB4lu9Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   '@asamuzakjp/dom-selector@6.7.7':
     resolution: {integrity: sha512-8CO/UQ4tzDd7ula+/CVimJIVWez99UJlbMyIgk8xOnhAVPKLnBZmUFYVgugS441v2ZqUq5EnSh6B0Ua0liSFAA==}
+
+  '@asamuzakjp/dom-selector@7.0.6':
+    resolution: {integrity: sha512-Tgmk6EQM0nc9xvp7sEHRVavbknhb/vGKht+04yAT3t5KQwZ02CSobCtcFgaHH04ZrjD1BhEKNA8tRhzFV20gkA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
@@ -152,6 +163,10 @@ packages:
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
 
   '@changesets/apply-release-plan@7.1.0':
     resolution: {integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==}
@@ -212,12 +227,23 @@ packages:
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
     engines: {node: '>=18'}
 
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
   '@csstools/css-calc@2.1.4':
     resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
   '@csstools/css-color-parser@3.1.0':
     resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
@@ -226,18 +252,43 @@ packages:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
   '@csstools/css-parser-algorithms@3.0.5':
     resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
   '@csstools/css-syntax-patches-for-csstree@1.0.26':
     resolution: {integrity: sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==}
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
 
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -400,6 +451,15 @@ packages:
 
   '@exodus/bytes@1.11.0':
     resolution: {integrity: sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
       '@noble/hashes': ^1.8.0 || ^2.0.0
@@ -836,6 +896,9 @@ packages:
   '@types/three@0.183.1':
     resolution: {integrity: sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
@@ -972,6 +1035,10 @@ packages:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -1031,6 +1098,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
@@ -1192,6 +1262,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-dompurify@3.7.1:
+    resolution: {integrity: sha512-ChhzwwCm7k8h8ANiq1Vc7geCWeHGaAPusgXU5N4mu7Y2wChgn2JHvbUe6aH/XQOUG3+KV+GmqSq95MntW/V1ng==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -1210,6 +1284,15 @@ packages:
   jsdom@28.0.0:
     resolution: {integrity: sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsdom@29.0.1:
+    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
     peerDependencies:
       canvas: ^3.0.0
     peerDependenciesMeta:
@@ -1307,6 +1390,10 @@ packages:
     resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -1321,6 +1408,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1750,6 +1840,10 @@ packages:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -1770,6 +1864,10 @@ packages:
 
   undici@7.20.0:
     resolution: {integrity: sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
 
   universalify@0.1.2:
@@ -1877,6 +1975,10 @@ packages:
     resolution: {integrity: sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1911,6 +2013,14 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 11.2.5
 
+  '@asamuzakjp/css-color@5.1.5':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.7
+
   '@asamuzakjp/dom-selector@6.7.7':
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
@@ -1918,6 +2028,14 @@ snapshots:
       css-tree: 3.1.0
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.2.5
+
+  '@asamuzakjp/dom-selector@7.0.6':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
@@ -1930,6 +2048,10 @@ snapshots:
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/runtime@7.28.6': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@changesets/apply-release-plan@7.1.0':
     dependencies:
@@ -2076,10 +2198,17 @@ snapshots:
 
   '@csstools/color-helpers@5.1.0': {}
 
+  '@csstools/color-helpers@6.0.2': {}
+
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
 
   '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -2088,13 +2217,30 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
 
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
   '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
   '@csstools/css-syntax-patches-for-csstree@1.0.26': {}
 
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -2177,6 +2323,8 @@ snapshots:
     optional: true
 
   '@exodus/bytes@1.11.0': {}
+
+  '@exodus/bytes@1.15.0': {}
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -2562,6 +2710,9 @@ snapshots:
       fflate: 0.8.2
       meshoptimizer: 1.0.1
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/webxr@0.5.24': {}
 
   '@vitest/expect@4.0.18':
@@ -2693,6 +2844,11 @@ snapshots:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
@@ -2736,6 +2892,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   enhanced-resolve@5.18.4:
     dependencies:
@@ -2912,6 +3072,14 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic-dompurify@3.7.1:
+    dependencies:
+      dompurify: 3.3.3
+      jsdom: 29.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - canvas
+
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
@@ -2950,6 +3118,32 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
       - supports-color
+
+  jsdom@29.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.5
+      '@asamuzakjp/dom-selector': 7.0.6
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.7
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -3016,6 +3210,8 @@ snapshots:
 
   lru-cache@11.2.5: {}
 
+  lru-cache@11.2.7: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -3025,6 +3221,8 @@ snapshots:
   marked@17.0.3: {}
 
   mdn-data@2.12.2: {}
+
+  mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
 
@@ -3370,6 +3568,10 @@ snapshots:
     dependencies:
       tldts: 7.0.21
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.21
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -3383,6 +3585,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici@7.20.0: {}
+
+  undici@7.24.7: {}
 
   universalify@0.1.2: {}
 
@@ -3455,6 +3659,14 @@ snapshots:
   whatwg-url@16.0.0:
     dependencies:
       '@exodus/bytes': 1.11.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -1,0 +1,32 @@
+import { getAllComponents, categoryLabels, categories } from "$lib/fancy-ui/registry.js";
+
+function buildSystemPrompt(): string {
+	const byCategory: Record<string, string[]> = {};
+	for (const comp of getAllComponents()) {
+		(byCategory[comp.category] ??= []).push(`- ${comp.name} — ${comp.description}`);
+	}
+
+	const sections = categories
+		.filter((cat) => byCategory[cat]?.length)
+		.map((cat) => `## ${categoryLabels[cat]}\n${byCategory[cat].join("\n")}`)
+		.join("\n\n");
+
+	return `You are FancyUI Copilot, an expert assistant for the FancyUI Svelte 5 component library.
+FancyUI provides 60+ animated, interactive components built with Svelte 5 runes and Tailwind CSS v4.
+
+INSTALLATION: pnpm add fancy-ui-svelte
+USAGE: import { ComponentName } from 'fancy-ui-svelte';
+
+AVAILABLE COMPONENTS:
+
+${sections}
+
+GUIDELINES:
+- Suggest the most fitting component(s) for the user's UI need
+- Provide concise Svelte 5 usage snippets (runes syntax, no Options API)
+- Explain key props when relevant
+- When multiple components fit, compare trade-offs briefly
+- Format code with markdown fenced blocks`;
+}
+
+export const SYSTEM_PROMPT: string = buildSystemPrompt();

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -1,63 +1,121 @@
-import { error, type RequestHandler } from '@sveltejs/kit';
-import { env } from '$env/dynamic/private';
-import { SYSTEM_PROMPT } from '$lib/ai/system-prompt.js';
+import { error, type RequestHandler } from "@sveltejs/kit";
+import { env } from "$env/dynamic/private";
+import { SYSTEM_PROMPT } from "$lib/ai/system-prompt.js";
 
-interface Message {
-	role: 'system' | 'user' | 'assistant';
+// Only user/assistant roles are accepted from the client.
+// "system" is reserved for the server-injected SYSTEM_PROMPT.
+interface ClientMessage {
+	role: "user" | "assistant";
 	content: string;
 }
 
-interface RequestBody {
-	messages: Message[];
-	model: string;
-	provider: 'openai' | 'ollama';
+interface Message {
+	role: "system" | "user" | "assistant";
+	content: string;
+}
+
+const MAX_MESSAGES = 50;
+const MAX_MESSAGE_LENGTH = 20_000;
+const ALLOWED_PROVIDERS = ["openai", "ollama"] as const;
+type Provider = (typeof ALLOWED_PROVIDERS)[number];
+
+const ALLOWED_MODELS: Record<Provider, readonly string[]> = {
+	openai: ["gpt-4o-mini", "gpt-4o", "gpt-4-turbo"],
+	ollama: ["llama3.2", "llama3.1", "mistral", "phi3", "gemma2"],
+};
+
+function badRequest(msg: string): Response {
+	return new Response(msg, { status: 400 });
+}
+
+function isAllowedProvider(value: unknown): value is Provider {
+	return typeof value === "string" && (ALLOWED_PROVIDERS as readonly string[]).includes(value);
+}
+
+function parseClientMessages(raw: unknown): ClientMessage[] | null {
+	if (!Array.isArray(raw) || raw.length === 0 || raw.length > MAX_MESSAGES) return null;
+	const result: ClientMessage[] = [];
+	for (const item of raw) {
+		if (typeof item !== "object" || item === null) return null;
+		const { role, content } = item as Record<string, unknown>;
+		if (role !== "user" && role !== "assistant") return null;
+		if (typeof content !== "string" || content.length === 0 || content.length > MAX_MESSAGE_LENGTH)
+			return null;
+		result.push({ role, content });
+	}
+	return result;
 }
 
 export const POST: RequestHandler = async ({ request }) => {
-	const body: RequestBody = await request.json();
-	const { messages, model, provider } = body;
+	let parsed: unknown;
+	try {
+		parsed = await request.json();
+	} catch {
+		return badRequest("Invalid JSON request body.");
+	}
 
-	const allMessages: Message[] = [{ role: 'system', content: SYSTEM_PROMPT }, ...messages];
+	if (typeof parsed !== "object" || parsed === null) return badRequest("Invalid request body.");
 
-	if (provider === 'openai') {
-		return handleOpenAI(allMessages, model);
+	const { provider, model, messages: rawMessages } = parsed as Record<string, unknown>;
+
+	if (!isAllowedProvider(provider)) return badRequest("Invalid provider.");
+	if (typeof model !== "string" || !ALLOWED_MODELS[provider].includes(model))
+		return badRequest("Invalid model for the selected provider.");
+
+	const clientMessages = parseClientMessages(rawMessages);
+	if (!clientMessages) return badRequest("Invalid messages.");
+
+	const allMessages: Message[] = [{ role: "system", content: SYSTEM_PROMPT }, ...clientMessages];
+
+	if (provider === "openai") {
+		return handleOpenAI(allMessages, model, request.signal);
 	} else {
-		return handleOllama(allMessages, model);
+		return handleOllama(allMessages, model, request.signal);
 	}
 };
 
-async function handleOpenAI(messages: Message[], model: string): Promise<Response> {
+async function handleOpenAI(
+	messages: Message[],
+	model: string,
+	clientSignal: AbortSignal
+): Promise<Response> {
 	if (!env.OPENAI_API_KEY) {
-		error(401, 'OPENAI_API_KEY is not set. Add it to your .env file.');
+		error(401, "OPENAI_API_KEY is not set. Add it to your .env file.");
 	}
+
+	const controller = new AbortController();
+	const onAbort = () => controller.abort();
+	clientSignal.addEventListener("abort", onAbort, { once: true });
 
 	let upstream: globalThis.Response;
 	try {
-		upstream = await fetch('https://api.openai.com/v1/chat/completions', {
-			method: 'POST',
+		upstream = await fetch("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
 			headers: {
-				'Content-Type': 'application/json',
-				Authorization: `Bearer ${env.OPENAI_API_KEY}`
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${env.OPENAI_API_KEY}`,
 			},
 			body: JSON.stringify({ model, messages, stream: true }),
-			signal: AbortSignal.timeout(30_000)
+			signal: AbortSignal.any([controller.signal, AbortSignal.timeout(30_000)]),
 		});
 	} catch (e) {
-		error(503, 'Could not reach OpenAI. Check your network connection.');
+		clientSignal.removeEventListener("abort", onAbort);
+		error(503, "Could not reach OpenAI. Check your network connection.");
 	}
 
 	if (!upstream.ok) {
-		if (upstream.status === 401) error(401, 'Invalid OpenAI API key.');
-		if (upstream.status === 429) error(429, 'OpenAI rate limit reached. Try again shortly.');
+		clientSignal.removeEventListener("abort", onAbort);
+		if (upstream.status === 401) error(401, "Invalid OpenAI API key.");
+		if (upstream.status === 429) error(429, "OpenAI rate limit reached. Try again shortly.");
 		error(upstream.status, `OpenAI error: ${upstream.statusText}`);
 	}
 
 	const readable = new ReadableStream({
-		async start(controller) {
+		async start(ctrl) {
 			let closed = false;
 			const reader = upstream.body!.getReader();
 			const dec = new TextDecoder();
-			let buf = '';
+			let buf = "";
 
 			try {
 				while (true) {
@@ -65,24 +123,22 @@ async function handleOpenAI(messages: Message[], model: string): Promise<Respons
 					if (done) {
 						if (!closed) {
 							closed = true;
-							controller.close();
+							ctrl.close();
 						}
 						break;
 					}
 					buf += dec.decode(value, { stream: true });
-					const lines = buf.split('\n');
-					buf = lines.pop() ?? '';
+					const lines = buf.split("\n");
+					buf = lines.pop() ?? "";
 
 					for (const line of lines) {
 						const trimmed = line.trim();
-						if (!trimmed || trimmed === 'data: [DONE]') continue;
-						if (!trimmed.startsWith('data: ')) continue;
+						if (!trimmed || trimmed === "data: [DONE]") continue;
+						if (!trimmed.startsWith("data: ")) continue;
 						try {
 							const json = JSON.parse(trimmed.slice(6));
 							const chunk = json.choices?.[0]?.delta?.content;
-							if (chunk) {
-								controller.enqueue(new TextEncoder().encode(chunk));
-							}
+							if (chunk) ctrl.enqueue(new TextEncoder().encode(chunk));
 						} catch {
 							// skip malformed lines
 						}
@@ -91,44 +147,57 @@ async function handleOpenAI(messages: Message[], model: string): Promise<Respons
 			} catch (e) {
 				if (!closed) {
 					closed = true;
-					controller.error(e);
+					ctrl.error(e);
 				}
+			} finally {
+				clientSignal.removeEventListener("abort", onAbort);
 			}
-		}
+		},
+		cancel() {
+			controller.abort();
+		},
 	});
 
-	return new Response(readable, {
-		headers: { 'Content-Type': 'text/plain; charset=utf-8' }
-	});
+	return new Response(readable, { headers: { "Content-Type": "text/plain; charset=utf-8" } });
 }
 
-async function handleOllama(messages: Message[], model: string): Promise<Response> {
+async function handleOllama(
+	messages: Message[],
+	model: string,
+	clientSignal: AbortSignal
+): Promise<Response> {
+	const controller = new AbortController();
+	const onAbort = () => controller.abort();
+	clientSignal.addEventListener("abort", onAbort, { once: true });
+
 	let upstream: globalThis.Response;
 	try {
-		upstream = await fetch('http://localhost:11434/api/chat', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
+		upstream = await fetch("http://localhost:11434/api/chat", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ model, messages, stream: true }),
-			signal: AbortSignal.timeout(60_000)
+			signal: AbortSignal.any([controller.signal, AbortSignal.timeout(60_000)]),
 		});
 	} catch (e) {
-		error(503, 'Ollama is not running. Start with: ollama serve');
+		clientSignal.removeEventListener("abort", onAbort);
+		error(503, "Ollama is not running. Start with: ollama serve");
 	}
 
 	if (!upstream.ok) {
+		clientSignal.removeEventListener("abort", onAbort);
 		const body = await upstream.text();
-		if (body.includes('model not found')) {
+		if (body.includes("model not found")) {
 			error(404, `Model "${model}" not found. Pull with: ollama pull ${model}`);
 		}
 		error(upstream.status, `Ollama error: ${upstream.statusText}`);
 	}
 
 	const readable = new ReadableStream({
-		async start(controller) {
+		async start(ctrl) {
 			let closed = false;
 			const reader = upstream.body!.getReader();
 			const dec = new TextDecoder();
-			let buf = '';
+			let buf = "";
 
 			try {
 				while (true) {
@@ -136,13 +205,13 @@ async function handleOllama(messages: Message[], model: string): Promise<Respons
 					if (done) {
 						if (!closed) {
 							closed = true;
-							controller.close();
+							ctrl.close();
 						}
 						break;
 					}
 					buf += dec.decode(value, { stream: true });
-					const lines = buf.split('\n');
-					buf = lines.pop() ?? '';
+					const lines = buf.split("\n");
+					buf = lines.pop() ?? "";
 
 					for (const line of lines) {
 						const trimmed = line.trim();
@@ -152,14 +221,12 @@ async function handleOllama(messages: Message[], model: string): Promise<Respons
 							if (json.done) {
 								if (!closed) {
 									closed = true;
-									controller.close();
+									ctrl.close();
 								}
 								return;
 							}
 							const chunk = json.message?.content;
-							if (chunk) {
-								controller.enqueue(new TextEncoder().encode(chunk));
-							}
+							if (chunk) ctrl.enqueue(new TextEncoder().encode(chunk));
 						} catch {
 							// skip malformed lines
 						}
@@ -168,13 +235,16 @@ async function handleOllama(messages: Message[], model: string): Promise<Respons
 			} catch (e) {
 				if (!closed) {
 					closed = true;
-					controller.error(e);
+					ctrl.error(e);
 				}
+			} finally {
+				clientSignal.removeEventListener("abort", onAbort);
 			}
-		}
+		},
+		cancel() {
+			controller.abort();
+		},
 	});
 
-	return new Response(readable, {
-		headers: { 'Content-Type': 'text/plain; charset=utf-8' }
-	});
+	return new Response(readable, { headers: { "Content-Type": "text/plain; charset=utf-8" } });
 }

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -1,0 +1,180 @@
+import { error, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { SYSTEM_PROMPT } from '$lib/ai/system-prompt.js';
+
+interface Message {
+	role: 'system' | 'user' | 'assistant';
+	content: string;
+}
+
+interface RequestBody {
+	messages: Message[];
+	model: string;
+	provider: 'openai' | 'ollama';
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+	const body: RequestBody = await request.json();
+	const { messages, model, provider } = body;
+
+	const allMessages: Message[] = [{ role: 'system', content: SYSTEM_PROMPT }, ...messages];
+
+	if (provider === 'openai') {
+		return handleOpenAI(allMessages, model);
+	} else {
+		return handleOllama(allMessages, model);
+	}
+};
+
+async function handleOpenAI(messages: Message[], model: string): Promise<Response> {
+	if (!env.OPENAI_API_KEY) {
+		error(401, 'OPENAI_API_KEY is not set. Add it to your .env file.');
+	}
+
+	let upstream: globalThis.Response;
+	try {
+		upstream = await fetch('https://api.openai.com/v1/chat/completions', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${env.OPENAI_API_KEY}`
+			},
+			body: JSON.stringify({ model, messages, stream: true }),
+			signal: AbortSignal.timeout(30_000)
+		});
+	} catch (e) {
+		error(503, 'Could not reach OpenAI. Check your network connection.');
+	}
+
+	if (!upstream.ok) {
+		if (upstream.status === 401) error(401, 'Invalid OpenAI API key.');
+		if (upstream.status === 429) error(429, 'OpenAI rate limit reached. Try again shortly.');
+		error(upstream.status, `OpenAI error: ${upstream.statusText}`);
+	}
+
+	const readable = new ReadableStream({
+		async start(controller) {
+			let closed = false;
+			const reader = upstream.body!.getReader();
+			const dec = new TextDecoder();
+			let buf = '';
+
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) {
+						if (!closed) {
+							closed = true;
+							controller.close();
+						}
+						break;
+					}
+					buf += dec.decode(value, { stream: true });
+					const lines = buf.split('\n');
+					buf = lines.pop() ?? '';
+
+					for (const line of lines) {
+						const trimmed = line.trim();
+						if (!trimmed || trimmed === 'data: [DONE]') continue;
+						if (!trimmed.startsWith('data: ')) continue;
+						try {
+							const json = JSON.parse(trimmed.slice(6));
+							const chunk = json.choices?.[0]?.delta?.content;
+							if (chunk) {
+								controller.enqueue(new TextEncoder().encode(chunk));
+							}
+						} catch {
+							// skip malformed lines
+						}
+					}
+				}
+			} catch (e) {
+				if (!closed) {
+					closed = true;
+					controller.error(e);
+				}
+			}
+		}
+	});
+
+	return new Response(readable, {
+		headers: { 'Content-Type': 'text/plain; charset=utf-8' }
+	});
+}
+
+async function handleOllama(messages: Message[], model: string): Promise<Response> {
+	let upstream: globalThis.Response;
+	try {
+		upstream = await fetch('http://localhost:11434/api/chat', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ model, messages, stream: true }),
+			signal: AbortSignal.timeout(60_000)
+		});
+	} catch (e) {
+		error(503, 'Ollama is not running. Start with: ollama serve');
+	}
+
+	if (!upstream.ok) {
+		const body = await upstream.text();
+		if (body.includes('model not found')) {
+			error(404, `Model "${model}" not found. Pull with: ollama pull ${model}`);
+		}
+		error(upstream.status, `Ollama error: ${upstream.statusText}`);
+	}
+
+	const readable = new ReadableStream({
+		async start(controller) {
+			let closed = false;
+			const reader = upstream.body!.getReader();
+			const dec = new TextDecoder();
+			let buf = '';
+
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) {
+						if (!closed) {
+							closed = true;
+							controller.close();
+						}
+						break;
+					}
+					buf += dec.decode(value, { stream: true });
+					const lines = buf.split('\n');
+					buf = lines.pop() ?? '';
+
+					for (const line of lines) {
+						const trimmed = line.trim();
+						if (!trimmed) continue;
+						try {
+							const json = JSON.parse(trimmed);
+							if (json.done) {
+								if (!closed) {
+									closed = true;
+									controller.close();
+								}
+								return;
+							}
+							const chunk = json.message?.content;
+							if (chunk) {
+								controller.enqueue(new TextEncoder().encode(chunk));
+							}
+						} catch {
+							// skip malformed lines
+						}
+					}
+				}
+			} catch (e) {
+				if (!closed) {
+					closed = true;
+					controller.error(e);
+				}
+			}
+		}
+	});
+
+	return new Response(readable, {
+		headers: { 'Content-Type': 'text/plain; charset=utf-8' }
+	});
+}

--- a/src/routes/demo/component-copilot/+page.svelte
+++ b/src/routes/demo/component-copilot/+page.svelte
@@ -1,0 +1,309 @@
+<script lang="ts">
+	import { nanoid } from "nanoid";
+	import { marked } from "marked";
+	import { Send, RotateCcw, Trash2 } from "@lucide/svelte";
+	import { SparklesText } from "$lib/fancy-ui/sparkles-text";
+	import { GlowBorder } from "$lib/fancy-ui/glow-border";
+	import { BorderBeam } from "$lib/fancy-ui/border-beam";
+	import { TextGenerateEffect } from "$lib/fancy-ui/text-generate-effect";
+	import { ShimmerButton } from "$lib/fancy-ui/shimmer-button";
+	import { Meteors } from "$lib/fancy-ui/meteors";
+
+	type Role = "user" | "assistant";
+	interface Message {
+		id: string;
+		role: Role;
+		content: string;
+	}
+
+	let messages = $state<Message[]>([]);
+	let streamingContent = $state("");
+	let isStreaming = $state(false);
+	let error = $state<string | null>(null);
+	let provider = $state<"openai" | "ollama">("openai");
+	let selectedModel = $state("gpt-4o-mini");
+	let inputValue = $state("");
+	let messagesEnd: HTMLDivElement | undefined = $state();
+	let welcomeKey = $state(0);
+
+	$effect(() => {
+		void streamingContent;
+		void messages.length;
+		messagesEnd?.scrollIntoView({ behavior: "smooth" });
+	});
+
+	$effect(() => {
+		selectedModel = provider === "openai" ? "gpt-4o-mini" : "llama3.2";
+	});
+
+	function render(md: string): string {
+		return marked.parse(md) as string;
+	}
+
+	const PROMPTS = [
+		"What animated backgrounds are available?",
+		"Show me a button with a shimmer or glow effect",
+		"How do I add a BorderBeam to a card?",
+		"What components work best for a hero section?",
+		"I need a text animation for a heading",
+	];
+
+	const openaiModels = ["gpt-4o-mini", "gpt-4o", "gpt-4-turbo"];
+	const ollamaModels = ["llama3.2", "llama3.1", "mistral", "phi3", "gemma2"];
+
+	async function sendMessage(content: string) {
+		if (!content.trim() || isStreaming) return;
+
+		messages = [...messages, { id: nanoid(), role: "user", content: content.trim() }];
+		inputValue = "";
+		isStreaming = true;
+		error = null;
+		streamingContent = "";
+
+		try {
+			const response = await fetch("/api/chat", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ messages, model: selectedModel, provider }),
+			});
+
+			if (!response.ok) {
+				error = await response.text();
+				return;
+			}
+
+			const reader = response.body!.getReader();
+			const dec = new TextDecoder();
+
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				streamingContent += dec.decode(value, { stream: true });
+			}
+
+			messages = [...messages, { id: nanoid(), role: "assistant", content: streamingContent }];
+			streamingContent = "";
+		} catch (e) {
+			error = e instanceof Error ? e.message : "An unexpected error occurred.";
+		} finally {
+			isStreaming = false;
+		}
+	}
+
+	function retryLastMessage() {
+		const lastUser = [...messages].reverse().find((m) => m.role === "user");
+		if (!lastUser) return;
+		const idx = messages.lastIndexOf(lastUser);
+		messages = messages.slice(0, idx);
+		error = null;
+		sendMessage(lastUser.content);
+	}
+
+	function clearChat() {
+		messages = [];
+		streamingContent = "";
+		error = null;
+		welcomeKey++;
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault();
+			sendMessage(inputValue);
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Component Copilot — FancyUI</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-4xl px-4 py-8">
+	<!-- Header -->
+	<div class="mb-6 text-center">
+		<div class="mb-2 flex justify-center">
+			<SparklesText text="Component Copilot" class="text-3xl font-bold" />
+		</div>
+		<p class="text-muted-foreground">
+			Ask me anything about FancyUI components — I'll help you find, understand, and use them.
+		</p>
+	</div>
+
+	<!-- Controls -->
+	<div class="mb-4 flex flex-wrap items-center gap-3">
+		<!-- Provider toggle -->
+		<div class="bg-muted flex rounded-lg p-1 text-sm">
+			<button
+				class="rounded-md px-3 py-1.5 font-medium transition-colors {provider === 'openai'
+					? 'bg-background text-foreground shadow-sm'
+					: 'text-muted-foreground hover:text-foreground'}"
+				onclick={() => (provider = "openai")}
+			>
+				OpenAI
+			</button>
+			<button
+				class="rounded-md px-3 py-1.5 font-medium transition-colors {provider === 'ollama'
+					? 'bg-background text-foreground shadow-sm'
+					: 'text-muted-foreground hover:text-foreground'}"
+				onclick={() => (provider = "ollama")}
+			>
+				Ollama
+			</button>
+		</div>
+
+		<!-- Model select -->
+		<select
+			bind:value={selectedModel}
+			class="bg-background border-input text-foreground rounded-lg border px-3 py-1.5 text-sm"
+		>
+			{#each provider === "openai" ? openaiModels : ollamaModels as model}
+				<option value={model}>{model}</option>
+			{/each}
+		</select>
+
+		<!-- Clear button -->
+		{#if messages.length > 0}
+			<button
+				onclick={clearChat}
+				class="text-muted-foreground hover:text-foreground ml-auto flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm transition-colors"
+			>
+				<Trash2 size={14} />
+				Clear
+			</button>
+		{/if}
+	</div>
+
+	<!-- Chat window -->
+	<div class="relative flex min-h-[500px] flex-col overflow-hidden rounded-xl border">
+		<!-- Decorative glow -->
+		<GlowBorder color={["#3b82f6", "#8b5cf6", "#ec4899"]} borderRadius={12} borderWidth={1} />
+
+		<!-- Streaming indicator -->
+		{#if isStreaming}
+			<BorderBeam size={200} duration={2} />
+		{/if}
+
+		<!-- Messages area -->
+		<div class="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
+			{#if messages.length === 0 && !isStreaming}
+				<!-- Empty state -->
+				<div class="relative flex flex-1 flex-col items-center justify-center py-12">
+					<Meteors count={8} class="pointer-events-none" />
+					<div class="relative z-10 mb-8 max-w-lg text-center">
+						{#key welcomeKey}
+							<TextGenerateEffect
+								words="Ask me about any FancyUI component — I can help you find the right one, show you how to use it, and explain the props."
+								class="text-muted-foreground text-sm"
+							/>
+						{/key}
+					</div>
+					<div class="relative z-10 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+						{#each PROMPTS as prompt}
+							<button
+								onclick={() => sendMessage(prompt)}
+								class="bg-muted/60 hover:bg-muted text-muted-foreground hover:text-foreground rounded-lg px-3 py-2 text-left text-xs transition-colors"
+							>
+								{prompt}
+							</button>
+						{/each}
+					</div>
+				</div>
+			{/if}
+
+			<!-- Message history -->
+			{#each messages as msg (msg.id)}
+				{#if msg.role === "user"}
+					<div class="flex justify-end">
+						<div class="bg-accent text-accent-foreground max-w-[80%] rounded-xl px-4 py-2 text-sm">
+							{msg.content}
+						</div>
+					</div>
+				{:else}
+					<div class="flex justify-start">
+						<div class="bg-card max-w-[85%] rounded-xl border px-4 py-2 text-sm">
+							<div class="prose prose-sm dark:prose-invert max-w-none">
+								{@html render(msg.content)}
+							</div>
+						</div>
+					</div>
+				{/if}
+			{/each}
+
+			<!-- Streaming bubble -->
+			{#if isStreaming}
+				<div class="flex justify-start">
+					<div class="bg-card max-w-[85%] rounded-xl border px-4 py-2 text-sm">
+						{#if streamingContent}
+							<div class="prose prose-sm dark:prose-invert max-w-none">
+								{@html render(streamingContent)}
+							</div>
+						{:else}
+							<div class="flex gap-1">
+								<span
+									class="bg-muted-foreground/50 h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:0ms]"
+								></span>
+								<span
+									class="bg-muted-foreground/50 h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:150ms]"
+								></span>
+								<span
+									class="bg-muted-foreground/50 h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:300ms]"
+								></span>
+							</div>
+						{/if}
+						{#if streamingContent}
+							<span class="animate-pulse">▋</span>
+						{/if}
+					</div>
+				</div>
+			{/if}
+
+			<!-- Error state -->
+			{#if error}
+				<div class="rounded-xl border border-red-500/30 bg-red-500/10 p-4">
+					<p class="mb-3 text-sm text-red-600 dark:text-red-400">{error}</p>
+					<ShimmerButton
+						onclick={retryLastMessage}
+						shimmerColor="#ef4444"
+						background="rgba(239, 68, 68, 0.1)"
+						class="text-sm"
+					>
+						<span class="flex items-center gap-1.5">
+							<RotateCcw size={14} />
+							Retry
+						</span>
+					</ShimmerButton>
+				</div>
+			{/if}
+
+			<div bind:this={messagesEnd}></div>
+		</div>
+
+		<!-- Input area -->
+		<div class="border-t p-3">
+			<div class="flex gap-2">
+				<textarea
+					bind:value={inputValue}
+					onkeydown={handleKeydown}
+					placeholder="Ask about a component, describe your UI need..."
+					rows={1}
+					disabled={isStreaming}
+					class="bg-background text-foreground placeholder:text-muted-foreground flex-1 resize-none rounded-lg border px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500/50 focus:outline-none disabled:opacity-50"
+					style="field-sizing: content; max-height: 120px;"
+				></textarea>
+				<ShimmerButton
+					onclick={() => sendMessage(inputValue)}
+					disabled={isStreaming || !inputValue.trim()}
+					class="self-end"
+				>
+					<span class="flex items-center gap-1.5 text-sm">
+						<Send size={14} />
+						Send
+					</span>
+				</ShimmerButton>
+			</div>
+			<p class="text-muted-foreground mt-1.5 px-1 text-xs">
+				Enter to send · Shift+Enter for newline
+			</p>
+		</div>
+	</div>
+</div>

--- a/src/routes/demo/component-copilot/+page.svelte
+++ b/src/routes/demo/component-copilot/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { nanoid } from "nanoid";
 	import { marked } from "marked";
+	import DOMPurify from "isomorphic-dompurify";
 	import { Send, RotateCcw, Trash2 } from "@lucide/svelte";
 	import { SparklesText } from "$lib/fancy-ui/sparkles-text";
 	import { GlowBorder } from "$lib/fancy-ui/glow-border";
@@ -25,11 +26,27 @@
 	let inputValue = $state("");
 	let messagesEnd: HTMLDivElement | undefined = $state();
 	let welcomeKey = $state(0);
+	let prevMessagesLength = 0;
+	let scrollFrame: number | null = null;
 
 	$effect(() => {
 		void streamingContent;
-		void messages.length;
-		messagesEnd?.scrollIntoView({ behavior: "smooth" });
+		const addedMessage = messages.length > prevMessagesLength;
+		prevMessagesLength = messages.length;
+		const behavior: ScrollBehavior = isStreaming || !addedMessage ? "auto" : "smooth";
+
+		if (scrollFrame !== null) cancelAnimationFrame(scrollFrame);
+		scrollFrame = requestAnimationFrame(() => {
+			messagesEnd?.scrollIntoView({ behavior });
+			scrollFrame = null;
+		});
+
+		return () => {
+			if (scrollFrame !== null) {
+				cancelAnimationFrame(scrollFrame);
+				scrollFrame = null;
+			}
+		};
 	});
 
 	$effect(() => {
@@ -37,7 +54,7 @@
 	});
 
 	function render(md: string): string {
-		return marked.parse(md) as string;
+		return DOMPurify.sanitize(marked.parse(md) as string);
 	}
 
 	const PROMPTS = [
@@ -74,14 +91,42 @@
 
 			const reader = response.body!.getReader();
 			const dec = new TextDecoder();
+			let fullContent = "";
+			let pendingContent = "";
+			let flushScheduled = false;
+
+			const flush = () => {
+				if (!pendingContent) {
+					flushScheduled = false;
+					return;
+				}
+				streamingContent += pendingContent;
+				pendingContent = "";
+				flushScheduled = false;
+			};
+			const scheduleFlush = () => {
+				if (flushScheduled) return;
+				flushScheduled = true;
+				requestAnimationFrame(flush);
+			};
 
 			while (true) {
 				const { done, value } = await reader.read();
 				if (done) break;
-				streamingContent += dec.decode(value, { stream: true });
+				const chunk = dec.decode(value, { stream: true });
+				fullContent += chunk;
+				pendingContent += chunk;
+				scheduleFlush();
 			}
 
-			messages = [...messages, { id: nanoid(), role: "assistant", content: streamingContent }];
+			const tail = dec.decode();
+			if (tail) {
+				fullContent += tail;
+				pendingContent += tail;
+			}
+			flush();
+
+			messages = [...messages, { id: nanoid(), role: "assistant", content: fullContent }];
 			streamingContent = "";
 		} catch (e) {
 			error = e instanceof Error ? e.message : "An unexpected error occurred.";
@@ -234,9 +279,8 @@
 				<div class="flex justify-start">
 					<div class="bg-card max-w-[85%] rounded-xl border px-4 py-2 text-sm">
 						{#if streamingContent}
-							<div class="prose prose-sm dark:prose-invert max-w-none">
-								{@html render(streamingContent)}
-							</div>
+							<!-- Plain text during streaming to avoid partial HTML / XSS from in-flight content -->
+							<p class="text-sm whitespace-pre-wrap">{streamingContent}</p>
 						{:else}
 							<div class="flex gap-1">
 								<span


### PR DESCRIPTION
## Summary
- Adds a streaming AI chat demo at `/demo/component-copilot` powered by OpenAI or Ollama
- Implements `POST /api/chat` SvelteKit endpoint that proxies to the selected LLM provider with a system prompt built from the live component registry (RAG-lite)
- Showcases FancyUI components in context: SparklesText, GlowBorder, BorderBeam, TextGenerateEffect, ShimmerButton, Meteors

## Test plan
- [x] Add `OPENAI_API_KEY` to `.env`, run `pnpm dev`, visit `/demo/component-copilot` and send a message — response should stream token-by-token
- [x] Switch to Ollama provider, run `ollama serve && ollama pull llama3.2`, send a message — should stream from local model
- [ ] Remove API key → error state should appear with Retry button
- [x] Stop Ollama → should show "not running" error message
- [x] Verify quick-start prompts, clear chat, and Shift+Enter newline all work