### PR TITLE
chore: rename package from fancy-ui-svelte to fancy-ui

### DIFF
--- a/.changeset/component-copilot.md
+++ b/.changeset/component-copilot.md
@@ -1,5 +1,5 @@
 ---
-"fancy-ui-svelte": minor
+"fancy-ui": minor
 ---
 
 add Component Copilot AI chat demo at /demo/component-copilot

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "fancy-ui-svelte",
+	"name": "fancy-ui",
 	"private": false,
 	"version": "0.3.0",
 	"type": "module",

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -14,8 +14,8 @@ function buildSystemPrompt(): string {
 	return `You are FancyUI Copilot, an expert assistant for the FancyUI Svelte 5 component library.
 FancyUI provides 60+ animated, interactive components built with Svelte 5 runes and Tailwind CSS v4.
 
-INSTALLATION: pnpm add fancy-ui-svelte
-USAGE: import { ComponentName } from 'fancy-ui-svelte';
+INSTALLATION: pnpm add fancy-ui
+USAGE: import { ComponentName } from 'fancy-ui';
 
 AVAILABLE COMPONENTS:
 

--- a/src/lib/fancy-ui/tailwind.css
+++ b/src/lib/fancy-ui/tailwind.css
@@ -1,3 +1,3 @@
-/* Import this file in your app's CSS to include fancy-ui-svelte Tailwind classes:
-   @import "fancy-ui-svelte/tailwind.css"; */
+/* Import this file in your app's CSS to include fancy-ui Tailwind classes:
+   @import "fancy-ui/tailwind.css"; */
 @source "..";


### PR DESCRIPTION
## Summary
- Rename package from `fancy-ui-svelte` to `fancy-ui` in `package.json`
- Update all references in `system-prompt.ts`, `tailwind.css`, and the changeset file