### PR TITLE
feat(fluid-cursor): add color control props

### DIFF
--- a/.changeset/fluid-cursor-color-props.md
+++ b/.changeset/fluid-cursor-color-props.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+add fluidColor, fluidColors, colorIntensity props and hex backColor support to FluidCursor

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -52,14 +52,18 @@
 
 	function hexToRgb(hex: string): ColorRGB {
 		const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-		return result
-			? {
-					r: parseInt(result[1], 16) / 255,
-					g: parseInt(result[2], 16) / 255,
-					b: parseInt(result[3], 16) / 255,
-				}
-			: { r: 1, g: 1, b: 1 };
+		if (!result) {
+			console.warn(`[FluidCursor] Invalid hex color: "${hex}". Expected format: "#rrggbb". Falling back to white.`);
+			return { r: 1, g: 1, b: 1 };
+		}
+		return {
+			r: parseInt(result[1], 16) / 255,
+			g: parseInt(result[2], 16) / 255,
+			b: parseInt(result[3], 16) / 255,
+		};
 	}
+
+	const clampedColorIntensity = Math.max(0, Math.min(1, colorIntensity));
 
 	const resolvedBackColor: ColorRGB =
 		typeof backColor === "string" ? hexToRgb(backColor) : backColor;
@@ -959,6 +963,33 @@
 		let colorIndex = 0;
 		let animationFrameId: number;
 
+		// Cached pre-scaled colors to avoid re-parsing hex on every splat
+		let cachedFluidColorHex: string | undefined;
+		let cachedFluidColor: ColorRGB | null = null;
+		let cachedFluidColorsRef: string[] | undefined;
+		let cachedFluidColorsScaled: ColorRGB[] = [];
+
+		function getScaledColor(hex: string): ColorRGB {
+			const { r, g, b } = hexToRgb(hex);
+			return { r: r * clampedColorIntensity, g: g * clampedColorIntensity, b: b * clampedColorIntensity };
+		}
+
+		function getCachedFluidColor(hex: string): ColorRGB {
+			if (cachedFluidColor === null || cachedFluidColorHex !== hex) {
+				cachedFluidColorHex = hex;
+				cachedFluidColor = getScaledColor(hex);
+			}
+			return cachedFluidColor;
+		}
+
+		function getCachedFluidColors(colors: string[]): ColorRGB[] {
+			if (cachedFluidColorsRef !== colors) {
+				cachedFluidColorsRef = colors;
+				cachedFluidColorsScaled = colors.map(getScaledColor);
+			}
+			return cachedFluidColorsScaled;
+		}
+
 		function updateFrame() {
 			const dt = calcDeltaTime();
 			if (resizeCanvas()) initFramebuffers();
@@ -1254,19 +1285,18 @@
 
 		function generateColor(): ColorRGB {
 			if (fluidColor) {
-				const { r, g, b } = hexToRgb(fluidColor);
-				return { r: r * colorIntensity, g: g * colorIntensity, b: b * colorIntensity };
+				return getCachedFluidColor(fluidColor);
 			}
 			if (fluidColors && fluidColors.length > 0) {
-				const idx = colorIndex % fluidColors.length;
+				const colors = getCachedFluidColors(fluidColors);
+				const idx = colorIndex % colors.length;
 				colorIndex++;
-				const { r, g, b } = hexToRgb(fluidColors[idx]);
-				return { r: r * colorIntensity, g: g * colorIntensity, b: b * colorIntensity };
+				return colors[idx];
 			}
 			const c = HSVtoRGB(Math.random(), 1.0, 1.0);
-			c.r *= colorIntensity;
-			c.g *= colorIntensity;
-			c.b *= colorIntensity;
+			c.r *= clampedColorIntensity;
+			c.g *= clampedColorIntensity;
+			c.b *= clampedColorIntensity;
 			return c;
 		}
 

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -21,8 +21,11 @@
 		splatForce?: number;
 		shading?: boolean;
 		colorUpdateSpeed?: number;
-		backColor?: ColorRGB;
+		backColor?: ColorRGB | string;
 		transparent?: boolean;
+		fluidColor?: string;
+		fluidColors?: string[];
+		colorIntensity?: number;
 		class?: string;
 	}
 
@@ -41,8 +44,25 @@
 		colorUpdateSpeed = 10,
 		backColor = { r: 0.5, g: 0, b: 0 },
 		transparent = true,
+		fluidColor,
+		fluidColors,
+		colorIntensity = 0.15,
 		class: className = "",
 	}: Props = $props();
+
+	function hexToRgb(hex: string): ColorRGB {
+		const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+		return result
+			? {
+					r: parseInt(result[1], 16) / 255,
+					g: parseInt(result[2], 16) / 255,
+					b: parseInt(result[3], 16) / 255,
+				}
+			: { r: 1, g: 1, b: 1 };
+	}
+
+	const resolvedBackColor: ColorRGB =
+		typeof backColor === "string" ? hexToRgb(backColor) : backColor;
 
 	let canvasRef: HTMLCanvasElement;
 
@@ -94,7 +114,7 @@
 			SHADING: shading,
 			COLOR_UPDATE_SPEED: colorUpdateSpeed,
 			PAUSED: false,
-			BACK_COLOR: backColor,
+			BACK_COLOR: resolvedBackColor,
 			TRANSPARENT: transparent,
 		};
 
@@ -936,6 +956,7 @@
 
 		let lastUpdateTime = Date.now();
 		let colorUpdateTimer = 0.0;
+		let colorIndex = 0;
 		let animationFrameId: number;
 
 		function updateFrame() {
@@ -1232,10 +1253,20 @@
 		}
 
 		function generateColor(): ColorRGB {
+			if (fluidColor) {
+				const { r, g, b } = hexToRgb(fluidColor);
+				return { r: r * colorIntensity, g: g * colorIntensity, b: b * colorIntensity };
+			}
+			if (fluidColors && fluidColors.length > 0) {
+				const idx = colorIndex % fluidColors.length;
+				colorIndex++;
+				const { r, g, b } = hexToRgb(fluidColors[idx]);
+				return { r: r * colorIntensity, g: g * colorIntensity, b: b * colorIntensity };
+			}
 			const c = HSVtoRGB(Math.random(), 1.0, 1.0);
-			c.r *= 0.15;
-			c.g *= 0.15;
-			c.b *= 0.15;
+			c.r *= colorIntensity;
+			c.g *= colorIntensity;
+			c.b *= colorIntensity;
 			return c;
 		}
 

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
@@ -1,5 +1,5 @@
 import { render, cleanup } from "@testing-library/svelte";
-import { afterEach, describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import FluidCursor from "./FluidCursor.svelte";
 
 describe("FluidCursor", () => {
@@ -45,5 +45,46 @@ describe("FluidCursor", () => {
 		const { container } = render(FluidCursor, { props: { class: "my-fluid" } });
 		const div = container.firstElementChild as HTMLElement;
 		expect(div?.className).toContain("my-fluid");
+	});
+
+	describe("color props", () => {
+		it("renders without error when fluidColor is provided", () => {
+			const { container } = render(FluidCursor, { props: { fluidColor: "#00ffcc" } });
+			expect(container.querySelector("canvas")).toBeInTheDocument();
+		});
+
+		it("renders without error when fluidColors is provided", () => {
+			const { container } = render(FluidCursor, {
+				props: { fluidColors: ["#ff0080", "#00ffcc", "#7700ff"] },
+			});
+			expect(container.querySelector("canvas")).toBeInTheDocument();
+		});
+
+		it("renders without error when fluidColor and fluidColors are both provided (fluidColor takes priority)", () => {
+			// Both props accepted without throw — fluidColor priority is exercised at runtime
+			const { container } = render(FluidCursor, {
+				props: { fluidColor: "#ff0000", fluidColors: ["#00ffcc", "#7700ff"] },
+			});
+			expect(container.querySelector("canvas")).toBeInTheDocument();
+		});
+
+		it("renders without error when backColor is a hex string", () => {
+			const { container } = render(FluidCursor, { props: { backColor: "#1a1a2e" } });
+			expect(container.querySelector("canvas")).toBeInTheDocument();
+		});
+
+		it("warns and falls back when an invalid hex string is passed to backColor", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			render(FluidCursor, { props: { backColor: "not-a-color" } });
+			expect(warn).toHaveBeenCalledWith(
+				expect.stringContaining("[FluidCursor] Invalid hex color")
+			);
+			warn.mockRestore();
+		});
+
+		it("renders without error when colorIntensity is out of [0,1] range (clamped internally)", () => {
+			const { container } = render(FluidCursor, { props: { colorIntensity: 5 } });
+			expect(container.querySelector("canvas")).toBeInTheDocument();
+		});
 	});
 });

--- a/src/lib/fancy-ui/fluid-cursor/README.md
+++ b/src/lib/fancy-ui/fluid-cursor/README.md
@@ -9,6 +9,7 @@ A WebGL-based fluid simulation that follows the cursor, creating beautiful flowi
 - Configurable simulation parameters
 - Transparent background support
 - Automatic canvas resizing
+- Controllable fluid colors via hex strings (fixed color, palette cycling, or random)
 
 ## Implementation Notes
 
@@ -26,6 +27,30 @@ The component implements a full Navier-Stokes fluid simulation with:
 - Pressure solving with iterative Jacobi method
 - Advection for both velocity and dye
 - Gradient subtraction for incompressible flow
+
+## Color Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `fluidColor` | `string` (hex) | — | Fixed fluid color. Disables random cycling. |
+| `fluidColors` | `string[]` (hex) | — | Palette to cycle through on each splat. |
+| `colorIntensity` | `number` | `0.15` | Intensity multiplier applied to fluid colors (0–1). |
+| `backColor` | `{ r, g, b }` or `string` (hex) | `{ r: 0.5, g: 0, b: 0 }` | Background color — accepts RGB object or hex string. |
+
+**Priority**: `fluidColor` > `fluidColors` > random HSV
+
+### Examples
+
+```svelte
+<!-- Fixed teal fluid -->
+<FluidCursor fluidColor="#00ffcc" />
+
+<!-- Cycling palette -->
+<FluidCursor fluidColors={["#ff0080", "#00ffcc", "#7700ff"]} colorIntensity={0.3} />
+
+<!-- Hex background -->
+<FluidCursor backColor="#1a1a2e" />
+```
 
 ### Event Handling
 

--- a/src/routes/demo/fluid-cursor/+page.svelte
+++ b/src/routes/demo/fluid-cursor/+page.svelte
@@ -1,18 +1,54 @@
 <script lang="ts">
 	import { FluidCursor } from "$lib/fancy-ui/fluid-cursor";
+
+	const demos = [
+		{ label: "Default (random)", props: {} },
+		{ label: "Fixed color — teal", props: { fluidColor: "#00ffcc", colorIntensity: 0.4 } },
+		{
+			label: "Palette cycling",
+			props: { fluidColors: ["#ff0080", "#00ffcc", "#7700ff"], colorIntensity: 0.3 },
+		},
+		{
+			label: "Warm palette",
+			props: { fluidColors: ["#ff6b35", "#f7c59f", "#ffaa40"], colorIntensity: 0.35 },
+		},
+	];
+
+	let activeDemo = $state(0);
 </script>
 
 <svelte:head>
 	<title>FluidCursor - FancyUI</title>
 </svelte:head>
 
-<FluidCursor />
+<FluidCursor {...demos[activeDemo].props} />
 
 <div class="relative z-10 container mx-auto px-4 py-12">
 	<h1 class="mb-2 text-3xl font-bold">FluidCursor</h1>
 	<p class="text-muted-foreground mb-8">
 		A WebGL fluid simulation that follows your cursor. Move your mouse around to see the effect.
 	</p>
+
+	<section class="mb-12">
+		<h2 class="mb-4 text-xl font-semibold">Color demos</h2>
+		<div class="mb-4 flex flex-wrap gap-2">
+			{#each demos as demo, i}
+				<button
+					class="rounded-md border px-3 py-1.5 text-sm transition-colors {i === activeDemo
+						? 'bg-white text-black'
+						: 'text-muted-foreground hover:text-foreground'}"
+					onclick={() => (activeDemo = i)}
+				>
+					{demo.label}
+				</button>
+			{/each}
+		</div>
+		<div
+			class="flex h-48 items-center justify-center rounded-lg border border-dashed border-white/10"
+		>
+			<p class="text-sm text-white/20 select-none">Move your cursor here</p>
+		</div>
+	</section>
 
 	<section class="mb-12">
 		<h2 class="mb-4 text-xl font-semibold">Usage</h2>
@@ -26,16 +62,11 @@
   import {"{"} FluidCursor {"}"} from '$lib/fancy-ui/fluid-cursor';
 {"<"}/script{">"}
 
-{"<"}FluidCursor /{">"}</code
+{"<!-- Fixed color -->"}
+{"<"}FluidCursor fluidColor="#00ffcc" colorIntensity={"{"}0.4{"}"} /{">\n"}
+{"<!-- Cycling palette -->"}
+{"<"}FluidCursor fluidColors={"{"}{`["#ff0080", "#00ffcc", "#7700ff"]`}{"}"} /{">"}</code
 				></pre>
-		</div>
-	</section>
-
-	<section class="mb-12">
-		<div
-			class="flex h-96 items-center justify-center rounded-lg border border-dashed border-white/10"
-		>
-			<p class="text-sm text-white/20 select-none">Move your cursor here</p>
 		</div>
 	</section>
 
@@ -112,11 +143,35 @@
 						<td class="px-4 py-3 font-mono text-xs">10</td>
 						<td class="px-4 py-3">Speed of color cycling</td>
 					</tr>
-					<tr>
+					<tr class="border-b">
 						<td class="px-4 py-3 font-mono text-xs">transparent</td>
 						<td class="px-4 py-3 font-mono text-xs">boolean</td>
 						<td class="px-4 py-3 font-mono text-xs">true</td>
 						<td class="px-4 py-3">Enable transparent background</td>
+					</tr>
+					<tr class="border-b">
+						<td class="px-4 py-3 font-mono text-xs">fluidColor</td>
+						<td class="px-4 py-3 font-mono text-xs">string</td>
+						<td class="px-4 py-3 font-mono text-xs">—</td>
+						<td class="px-4 py-3">Fixed fluid color (hex). Disables random cycling.</td>
+					</tr>
+					<tr class="border-b">
+						<td class="px-4 py-3 font-mono text-xs">fluidColors</td>
+						<td class="px-4 py-3 font-mono text-xs">string[]</td>
+						<td class="px-4 py-3 font-mono text-xs">—</td>
+						<td class="px-4 py-3">Palette of hex colors to cycle through on each splat.</td>
+					</tr>
+					<tr class="border-b">
+						<td class="px-4 py-3 font-mono text-xs">colorIntensity</td>
+						<td class="px-4 py-3 font-mono text-xs">number</td>
+						<td class="px-4 py-3 font-mono text-xs">0.15</td>
+						<td class="px-4 py-3">Intensity multiplier applied to fluid colors (0–1).</td>
+					</tr>
+					<tr>
+						<td class="px-4 py-3 font-mono text-xs">backColor</td>
+						<td class="px-4 py-3 font-mono text-xs">{"{ r, g, b }"} | string</td>
+						<td class="px-4 py-3 font-mono text-xs">{"{ r: 0.5, g: 0, b: 0 }"}</td>
+						<td class="px-4 py-3">Background color — RGB object or hex string.</td>
 					</tr>
 				</tbody>
 			</table>

--- a/src/routes/demo/fluid-cursor/+page.svelte
+++ b/src/routes/demo/fluid-cursor/+page.svelte
@@ -46,7 +46,7 @@
 		<div
 			class="flex h-48 items-center justify-center rounded-lg border border-dashed border-white/10"
 		>
-			<p class="text-sm text-white/20 select-none">Move your cursor here</p>
+			<p class="text-sm text-white/20 select-none">Move your cursor anywhere</p>
 		</div>
 	</section>
 


### PR DESCRIPTION
## Summary
- Add `fluidColor` (fixed hex color), `fluidColors` (cycling palette), and `colorIntensity` (brightness multiplier) props to `FluidCursor`
- Extend `backColor` to accept a hex string in addition to the existing `{ r, g, b }` object
- Update demo page with an interactive switcher showcasing 4 color presets

## Test plan
- [x] `pnpm dev` → `/demo/fluid-cursor` — verify default random behavior unchanged
- [x] Click "Fixed color — teal" button — fluid should render in teal (`#00ffcc`)
- [x] Click "Palette cycling" — fluid should cycle through pink/teal/purple
- [x] Click "Warm palette" — fluid should cycle through warm tones
- [x] Test `backColor="#1a1a2e"` directly — verify hex conversion works
- [x] `pnpm check` → 0 TypeScript errors