### PR TITLE
feat: add Vercel Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 		"tailwindcss": "^4.0.0"
 	},
 	"dependencies": {
+		"@vercel/analytics": "^2.0.1",
 		"canvas-confetti": "^1.9.4",
 		"clsx": "^2.1.1",
 		"gsap": "^3.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
@@ -901,6 +904,35 @@ packages:
 
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
@@ -2714,6 +2746,11 @@ snapshots:
     optional: true
 
   '@types/webxr@0.5.24': {}
+
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)':
+    optionalDependencies:
+      '@sveltejs/kit': 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      svelte: 5.46.1
 
   '@vitest/expect@4.0.18':
     dependencies:

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import "./layout.css";
 	import AnimatedFavicon from "$lib/components/AnimatedFavicon.svelte";
+	import { injectAnalytics } from "@vercel/analytics/sveltekit";
+
+	injectAnalytics();
 
 	let { children } = $props();
 </script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import "./layout.css";
 	import AnimatedFavicon from "$lib/components/AnimatedFavicon.svelte";
+	import { browser, dev } from "$app/environment";
 	import { injectAnalytics } from "@vercel/analytics/sveltekit";
 
-	injectAnalytics();
+	if (browser && !dev) {
+		injectAnalytics();
+	}
 
 	let { children } = $props();
 </script>


### PR DESCRIPTION
## What does this PR do?

- Installs `@vercel/analytics` and injects it in the root layout
- Gated to `browser && !dev` — no SSR execution, no local/dev traffic collected

## Type of change

- [x] Chore / infra

## Checklist

- [x] `pnpm check` passes

## Breaking changes

None