### PR TITLE
feat(fluid-cursor-advanced): add interaction & autonomous animation props

### DIFF
--- a/.changeset/fluid-cursor-advanced-props.md
+++ b/.changeset/fluid-cursor-advanced-props.md
@@ -1,5 +1,5 @@
 ---
-"fancy-ui": minor
+"fancy-ui": patch
 ---
 
 Add interaction and autonomous animation props to FluidCursorAdvanced: `interactive`, `autoSplat`, `autoSplatInterval`, `pauseWhenHidden`, `splatOnMount`

--- a/.changeset/fluid-cursor-advanced-props.md
+++ b/.changeset/fluid-cursor-advanced-props.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": minor
+---
+
+Add interaction and autonomous animation props to FluidCursorAdvanced: `interactive`, `autoSplat`, `autoSplatInterval`, `pauseWhenHidden`, `splatOnMount`

--- a/.changeset/fluid-cursor-advanced.md
+++ b/.changeset/fluid-cursor-advanced.md
@@ -1,5 +1,5 @@
 ---
-"fancy-ui-svelte": minor
+"fancy-ui-svelte": patch
 ---
 
 Add FluidCursorAdvanced component that confines the WebGL fluid simulation to a parent container element

--- a/.changeset/fluid-cursor-color-props.md
+++ b/.changeset/fluid-cursor-color-props.md
@@ -1,5 +1,5 @@
 ---
-"fancy-ui-svelte": minor
+"fancy-ui-svelte": patch
 ---
 
 add fluidColor, fluidColors, colorIntensity props and hex backColor support to FluidCursor

--- a/.changeset/homepage-redesign.md
+++ b/.changeset/homepage-redesign.md
@@ -1,5 +1,5 @@
 ---
-"fancy-ui": minor
+"fancy-ui": patch
 ---
 
 add new root exports (FluidCursor, InteractiveGridPattern) and remove hardcoded `tracking-wider` from NumberTicker

--- a/src/lib/fancy-ui/animated-beam/README.md
+++ b/src/lib/fancy-ui/animated-beam/README.md
@@ -12,27 +12,6 @@ Creates animated SVG beams that connect two elements with smooth gradients and c
 - Reversible animation direction
 - Position offsets for fine-tuning
 
-## Implementation Notes
-
-### Vue → Svelte Conversions
-- `ref()` → `$state()`
-- `computed()` → `$derived()`
-- `watchEffect()` → `$effect()` (via `onMount`)
-- Template refs → `bind:this`
-- Props handling with destructuring defaults
-
-### Key Differences
-1. **Element References**: Svelte uses `bind:this` instead of Vue's `ref` template attribute
-2. **Lifecycle**: Setup logic moved to `onMount` with cleanup return
-3. **Derived Values**: Functions returning derived values (x1, x2, y1, y2) instead of computed refs
-4. **Conditional Rendering**: Used `{#if}` blocks to ensure refs are defined before rendering beams
-
-### Implementation Details
-- ResizeObserver for responsive path updates
-- SVG path calculation using quadratic Bezier curves (Q command)
-- Direction detection for vertical/horizontal beams
-- Unique gradient IDs to prevent conflicts with multiple instances
-
 ## Demo
 See `/demo/animated-beam` for usage examples.
 

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -53,7 +53,9 @@
 	function hexToRgb(hex: string): ColorRGB {
 		const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
 		if (!result) {
-			console.warn(`[FluidCursor] Invalid hex color: "${hex}". Expected format: "#rrggbb". Falling back to white.`);
+			console.warn(
+				`[FluidCursor] Invalid hex color: "${hex}". Expected format: "#rrggbb". Falling back to white.`
+			);
 			return { r: 1, g: 1, b: 1 };
 		}
 		return {
@@ -971,7 +973,11 @@
 
 		function getScaledColor(hex: string): ColorRGB {
 			const { r, g, b } = hexToRgb(hex);
-			return { r: r * clampedColorIntensity, g: g * clampedColorIntensity, b: b * clampedColorIntensity };
+			return {
+				r: r * clampedColorIntensity,
+				g: g * clampedColorIntensity,
+				b: b * clampedColorIntensity,
+			};
 		}
 
 		function getCachedFluidColor(hex: string): ColorRGB {

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursorAdvanced.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursorAdvanced.svelte
@@ -27,6 +27,11 @@
 		fluidColors?: string[];
 		colorIntensity?: number;
 		class?: string;
+		autoSplat?: boolean;
+		autoSplatInterval?: number;
+		interactive?: boolean;
+		pauseWhenHidden?: boolean;
+		splatOnMount?: boolean;
 	}
 
 	let {
@@ -48,6 +53,11 @@
 		fluidColors,
 		colorIntensity = 0.15,
 		class: className = "",
+		autoSplat = false,
+		autoSplatInterval = 1500,
+		interactive = true,
+		pauseWhenHidden = true,
+		splatOnMount = false,
 	}: Props = $props();
 
 	const contained = true;
@@ -1274,6 +1284,30 @@
 			dye.swap();
 		}
 
+		function multipleSplats(steps: number) {
+			// Simulate a cursor sweep along a random arc — each step on its own frame
+			// so the velocity field has time to evolve between injections.
+			const angle = Math.random() * Math.PI * 2;
+			const cx = 0.25 + Math.random() * 0.5;
+			const cy = 0.25 + Math.random() * 0.5;
+			const arcSpan = Math.PI * (0.8 + Math.random() * 0.8);
+			let i = 0;
+
+			function step() {
+				if (i >= steps) return;
+				const t = i / Math.max(1, steps - 1);
+				const a = angle + t * arcSpan;
+				const r = 0.15 + 0.05 * Math.sin(t * Math.PI);
+				const x = cx + Math.cos(a) * r;
+				const y = cy + Math.sin(a) * r;
+				const color = generateColor();
+				splat(x, y, -Math.sin(a) * config.SPLAT_FORCE * 0.5, Math.cos(a) * config.SPLAT_FORCE * 0.5, color);
+				i++;
+				if (i < steps) requestAnimationFrame(step);
+			}
+			requestAnimationFrame(step);
+		}
+
 		function correctRadius(radius: number) {
 			const aspectRatio = canvas.width / canvas.height;
 			if (aspectRatio > 1) radius *= aspectRatio;
@@ -1435,40 +1469,64 @@
 		}
 
 		// Add event listeners
-		window.addEventListener("mousedown", handleMouseDown);
-		document.body.addEventListener("mousemove", handleFirstMouseMove);
-		window.addEventListener("mousemove", handleMouseMove);
-		document.body.addEventListener("touchstart", handleFirstTouchStart);
-		window.addEventListener("touchstart", handleTouchStart, false);
-		window.addEventListener("touchmove", handleTouchMove, false);
+		if (interactive) {
+			window.addEventListener("mousedown", handleMouseDown);
+			document.body.addEventListener("mousemove", handleFirstMouseMove);
+			window.addEventListener("mousemove", handleMouseMove);
+			document.body.addEventListener("touchstart", handleFirstTouchStart);
+			window.addEventListener("touchstart", handleTouchStart, false);
+			window.addEventListener("touchmove", handleTouchMove, false);
+		}
 
 		// Pause animation when scrolled out of view
-		const observer = new IntersectionObserver(
-			([entry]) => {
-				const wasVisible = isVisible;
-				isVisible = entry.isIntersecting;
-				if (isVisible && !wasVisible) {
-					lastUpdateTime = Date.now();
-					animationFrameId = requestAnimationFrame(updateFrame);
-				}
-			},
-			{ threshold: 0 }
-		);
-		observer.observe(canvas);
+		let observer: IntersectionObserver | null = null;
+		if (pauseWhenHidden) {
+			observer = new IntersectionObserver(
+				([entry]) => {
+					const wasVisible = isVisible;
+					isVisible = entry.isIntersecting;
+					if (isVisible && !wasVisible) {
+						lastUpdateTime = Date.now();
+						animationFrameId = requestAnimationFrame(updateFrame);
+					}
+				},
+				{ threshold: 0 }
+			);
+			observer.observe(canvas);
+		}
 
 		// Start animation
 		updateFrame();
+		if (splatOnMount) multipleSplats(Math.floor(Math.random() * 6) + 10);
+
+		// Auto-splat timer
+		let autoSplatTimer: ReturnType<typeof setInterval> | null = null;
+		if (autoSplat) {
+			autoSplatTimer = setInterval(() => {
+				const color = generateColor();
+				splat(
+					Math.random(),
+					Math.random(),
+					(Math.random() - 0.5) * 200,
+					(Math.random() - 0.5) * 200,
+					color
+				);
+			}, autoSplatInterval);
+		}
 
 		// Cleanup
 		return () => {
 			cancelAnimationFrame(animationFrameId);
-			observer.disconnect();
-			window.removeEventListener("mousedown", handleMouseDown);
-			document.body.removeEventListener("mousemove", handleFirstMouseMove);
-			window.removeEventListener("mousemove", handleMouseMove);
-			document.body.removeEventListener("touchstart", handleFirstTouchStart);
-			window.removeEventListener("touchstart", handleTouchStart);
-			window.removeEventListener("touchmove", handleTouchMove);
+			if (observer) observer.disconnect();
+			if (autoSplatTimer) clearInterval(autoSplatTimer);
+			if (interactive) {
+				window.removeEventListener("mousedown", handleMouseDown);
+				document.body.removeEventListener("mousemove", handleFirstMouseMove);
+				window.removeEventListener("mousemove", handleMouseMove);
+				document.body.removeEventListener("touchstart", handleFirstTouchStart);
+				window.removeEventListener("touchstart", handleTouchStart);
+				window.removeEventListener("touchmove", handleTouchMove);
+			}
 			if (contained) {
 				window.removeEventListener("resize", updateCanvasRectCache);
 				window.removeEventListener("scroll", updateCanvasRectCache);

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursorAdvanced.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursorAdvanced.svelte
@@ -1301,7 +1301,13 @@
 				const x = cx + Math.cos(a) * r;
 				const y = cy + Math.sin(a) * r;
 				const color = generateColor();
-				splat(x, y, -Math.sin(a) * config.SPLAT_FORCE * 0.5, Math.cos(a) * config.SPLAT_FORCE * 0.5, color);
+				splat(
+					x,
+					y,
+					-Math.sin(a) * config.SPLAT_FORCE * 0.5,
+					Math.cos(a) * config.SPLAT_FORCE * 0.5,
+					color
+				);
 				i++;
 				if (i < steps) requestAnimationFrame(step);
 			}

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursorAdvanced.test.ts
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursorAdvanced.test.ts
@@ -1,5 +1,5 @@
 import { render, cleanup } from "@testing-library/svelte";
-import { afterEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import FluidCursorAdvanced from "./FluidCursorAdvanced.svelte";
 
 describe("FluidCursorAdvanced", () => {
@@ -47,6 +47,34 @@ describe("FluidCursorAdvanced", () => {
 		const { container } = render(FluidCursorAdvanced, { props: { class: "my-advanced" } });
 		const div = container.firstElementChild as HTMLElement;
 		expect(div?.className).toContain("my-advanced");
+	});
+
+	describe("interaction props", () => {
+		it("interactive={false} does not register mouse event listeners", () => {
+			const addSpy = vi.spyOn(window, "addEventListener");
+			render(FluidCursorAdvanced, { props: { interactive: false } });
+			const mousedownCalls = addSpy.mock.calls.filter(([event]) => event === "mousedown");
+			expect(mousedownCalls).toHaveLength(0);
+			const mousemoveCalls = addSpy.mock.calls.filter(([event]) => event === "mousemove");
+			expect(mousemoveCalls).toHaveLength(0);
+			addSpy.mockRestore();
+		});
+
+		it("mounts without error with autoSplat={true} and splatOnMount={true}", () => {
+			const { container } = render(FluidCursorAdvanced, {
+				props: { autoSplat: true, splatOnMount: true },
+			});
+			expect(container.querySelector("canvas")).toBeInTheDocument();
+		});
+
+		it("pauseWhenHidden={false} does not instantiate IntersectionObserver", () => {
+			const observeSpy = vi.fn();
+			const mockObserver = vi.fn(() => ({ observe: observeSpy, disconnect: vi.fn() }));
+			vi.stubGlobal("IntersectionObserver", mockObserver);
+			render(FluidCursorAdvanced, { props: { pauseWhenHidden: false } });
+			expect(mockObserver).not.toHaveBeenCalled();
+			vi.unstubAllGlobals();
+		});
 	});
 
 	describe("color props", () => {

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursorAdvanced.test.ts
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursorAdvanced.test.ts
@@ -94,7 +94,7 @@ describe("FluidCursorAdvanced", () => {
 			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 			render(FluidCursorAdvanced, { props: { backColor: "not-a-color" } });
 			expect(warn).toHaveBeenCalledWith(
-				expect.stringContaining("[FluidCursorAdvanced] Invalid hex color"),
+				expect.stringContaining("[FluidCursorAdvanced] Invalid hex color")
 			);
 			warn.mockRestore();
 		});

--- a/src/routes/demo/fluid-cursor-advanced/+page.svelte
+++ b/src/routes/demo/fluid-cursor-advanced/+page.svelte
@@ -65,6 +65,17 @@
 		},
 	];
 	let activeContainer = $state<string | null>(null);
+
+	// ── Autonomous mode ───────────────────────────────────────────────────────
+	const speedOptions = [
+		{ label: "Slow", ms: 3000 },
+		{ label: "Normal", ms: 1500 },
+		{ label: "Fast", ms: 600 },
+	];
+	let autonomousSpeed = $state(1500);
+
+	// ── Splat on mount ────────────────────────────────────────────────────────
+	let remountCounter = $state(0);
 </script>
 
 <svelte:head>
@@ -162,6 +173,78 @@
 				Move your cursor inside the card — the fluid stays contained ✦
 			</p>
 		{/if}
+	</section>
+
+	<!-- ── Autonomous mode ──────────────────────────────────────────────────────── -->
+	<section class="mb-12">
+		<h2 class="mb-2 text-xl font-semibold">Autonomous mode</h2>
+		<p class="text-muted-foreground mb-6 text-sm">
+			Combine <code class="bg-muted rounded px-1.5 py-0.5">autoSplat</code> with
+			<code class="bg-muted rounded px-1.5 py-0.5">interactive={`{false}`}</code> for a fluid
+			background that animates without any cursor interaction — great for mobile and above-the-fold
+			heroes.
+		</p>
+
+		<div class="mb-4 flex flex-wrap gap-2">
+			{#each speedOptions as opt}
+				<button
+					class="rounded-md border px-3 py-1.5 text-sm transition-colors {opt.ms ===
+					autonomousSpeed
+						? 'bg-foreground text-background'
+						: 'text-muted-foreground hover:text-foreground'}"
+					onclick={() => (autonomousSpeed = opt.ms)}
+				>
+					{opt.label}
+				</button>
+			{/each}
+		</div>
+
+		<div class="relative h-48 overflow-hidden rounded-xl border">
+			{#key autonomousSpeed}
+				<FluidCursorAdvanced
+					autoSplat={true}
+					autoSplatInterval={autonomousSpeed}
+					interactive={false}
+					fluidColors={["#6366f1", "#ec4899", "#06b6d4"]}
+					colorIntensity={0.4}
+					backColor={{ r: 0.04, g: 0.04, b: 0.08 }}
+				/>
+			{/key}
+			<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+				<p class="text-muted-foreground text-sm">No cursor needed — works on mobile too</p>
+			</div>
+		</div>
+	</section>
+
+	<!-- ── Splat on mount ────────────────────────────────────────────────────────── -->
+	<section class="mb-12">
+		<h2 class="mb-2 text-xl font-semibold">Splat on mount</h2>
+		<p class="text-muted-foreground mb-6 text-sm">
+			<code class="bg-muted rounded px-1.5 py-0.5">splatOnMount</code> fires 3–5 random splats the
+			moment the component mounts — useful for an immediate "alive" feeling.
+		</p>
+
+		<div class="relative h-48 overflow-hidden rounded-xl border">
+			{#key remountCounter}
+				<FluidCursorAdvanced
+					splatOnMount={true}
+					fluidColors={["#ff6b35", "#f7c59f", "#ffaa40"]}
+					colorIntensity={0.4}
+					backColor={{ r: 0.05, g: 0.02, b: 0 }}
+				/>
+			{/key}
+			<div class="pointer-events-none absolute inset-0 flex items-end justify-center pb-4">
+				<p class="text-muted-foreground text-xs">Move your cursor to interact</p>
+			</div>
+		</div>
+		<div class="mt-3 flex justify-center">
+			<button
+				class="bg-foreground text-background rounded-md px-4 py-2 text-sm transition-opacity hover:opacity-80"
+				onclick={() => remountCounter++}
+			>
+				Remount
+			</button>
+		</div>
 	</section>
 
 	<!-- ── Usage ────────────────────────────────────────────────────────────────── -->
@@ -263,6 +346,43 @@
 						<td class="px-4 py-3 font-mono text-xs">boolean</td>
 						<td class="px-4 py-3 font-mono text-xs">true</td>
 						<td class="px-4 py-3">Enable transparent background.</td>
+					</tr>
+					<tr class="border-b">
+						<td class="px-4 py-3 font-mono text-xs">interactive</td>
+						<td class="px-4 py-3 font-mono text-xs">boolean</td>
+						<td class="px-4 py-3 font-mono text-xs">true</td>
+						<td class="px-4 py-3"
+							>When <code class="bg-muted rounded px-1 py-0.5">false</code>, removes all
+							mouse/touch listeners. Combine with
+							<code class="bg-muted rounded px-1 py-0.5">autoSplat</code> for ambient animations.</td
+						>
+					</tr>
+					<tr class="border-b">
+						<td class="px-4 py-3 font-mono text-xs">autoSplat</td>
+						<td class="px-4 py-3 font-mono text-xs">boolean</td>
+						<td class="px-4 py-3 font-mono text-xs">false</td>
+						<td class="px-4 py-3">Fires random splats at a fixed interval without user interaction.</td
+						>
+					</tr>
+					<tr class="border-b">
+						<td class="px-4 py-3 font-mono text-xs">autoSplatInterval</td>
+						<td class="px-4 py-3 font-mono text-xs">number</td>
+						<td class="px-4 py-3 font-mono text-xs">1500</td>
+						<td class="px-4 py-3">Interval in ms between auto splats.</td>
+					</tr>
+					<tr class="border-b">
+						<td class="px-4 py-3 font-mono text-xs">splatOnMount</td>
+						<td class="px-4 py-3 font-mono text-xs">boolean</td>
+						<td class="px-4 py-3 font-mono text-xs">false</td>
+						<td class="px-4 py-3">Fires 3–5 random splats when the component mounts.</td>
+					</tr>
+					<tr>
+						<td class="px-4 py-3 font-mono text-xs">pauseWhenHidden</td>
+						<td class="px-4 py-3 font-mono text-xs">boolean</td>
+						<td class="px-4 py-3 font-mono text-xs">true</td>
+						<td class="px-4 py-3"
+							>Pauses the animation loop when the canvas is scrolled out of view.</td
+						>
 					</tr>
 				</tbody>
 			</table>

--- a/src/routes/demo/fluid-cursor-advanced/+page.svelte
+++ b/src/routes/demo/fluid-cursor-advanced/+page.svelte
@@ -180,16 +180,14 @@
 		<h2 class="mb-2 text-xl font-semibold">Autonomous mode</h2>
 		<p class="text-muted-foreground mb-6 text-sm">
 			Combine <code class="bg-muted rounded px-1.5 py-0.5">autoSplat</code> with
-			<code class="bg-muted rounded px-1.5 py-0.5">interactive={`{false}`}</code> for a fluid
-			background that animates without any cursor interaction — great for mobile and above-the-fold
-			heroes.
+			<code class="bg-muted rounded px-1.5 py-0.5">interactive={`{false}`}</code> for a fluid background
+			that animates without any cursor interaction — great for mobile and above-the-fold heroes.
 		</p>
 
 		<div class="mb-4 flex flex-wrap gap-2">
 			{#each speedOptions as opt}
 				<button
-					class="rounded-md border px-3 py-1.5 text-sm transition-colors {opt.ms ===
-					autonomousSpeed
+					class="rounded-md border px-3 py-1.5 text-sm transition-colors {opt.ms === autonomousSpeed
 						? 'bg-foreground text-background'
 						: 'text-muted-foreground hover:text-foreground'}"
 					onclick={() => (autonomousSpeed = opt.ms)}
@@ -220,8 +218,8 @@
 	<section class="mb-12">
 		<h2 class="mb-2 text-xl font-semibold">Splat on mount</h2>
 		<p class="text-muted-foreground mb-6 text-sm">
-			<code class="bg-muted rounded px-1.5 py-0.5">splatOnMount</code> fires 3–5 random splats the
-			moment the component mounts — useful for an immediate "alive" feeling.
+			<code class="bg-muted rounded px-1.5 py-0.5">splatOnMount</code> fires 3–5 random splats the moment
+			the component mounts — useful for an immediate "alive" feeling.
 		</p>
 
 		<div class="relative h-48 overflow-hidden rounded-xl border">
@@ -352,8 +350,8 @@
 						<td class="px-4 py-3 font-mono text-xs">boolean</td>
 						<td class="px-4 py-3 font-mono text-xs">true</td>
 						<td class="px-4 py-3"
-							>When <code class="bg-muted rounded px-1 py-0.5">false</code>, removes all
-							mouse/touch listeners. Combine with
+							>When <code class="bg-muted rounded px-1 py-0.5">false</code>, removes all mouse/touch
+							listeners. Combine with
 							<code class="bg-muted rounded px-1 py-0.5">autoSplat</code> for ambient animations.</td
 						>
 					</tr>
@@ -361,7 +359,8 @@
 						<td class="px-4 py-3 font-mono text-xs">autoSplat</td>
 						<td class="px-4 py-3 font-mono text-xs">boolean</td>
 						<td class="px-4 py-3 font-mono text-xs">false</td>
-						<td class="px-4 py-3">Fires random splats at a fixed interval without user interaction.</td
+						<td class="px-4 py-3"
+							>Fires random splats at a fixed interval without user interaction.</td
 						>
 					</tr>
 					<tr class="border-b">


### PR DESCRIPTION
## Summary
- Add `interactive` prop to disable all mouse/touch listeners (enables pure ambient mode)
- Add `autoSplat` + `autoSplatInterval` for timer-driven splats without user interaction
- Add `splatOnMount` to fire a simulated cursor sweep arc on mount (sequential rAF, tangential velocity)
- Add `pauseWhenHidden` to make the IntersectionObserver opt-out
- Demo page: new "Autonomous mode" and "Splat on mount" sections, updated props table

## Test plan
- [ ] `pnpm test --run` — all 477 tests pass
- [ ] `/demo/fluid-cursor-advanced` → "Autonomous mode": fluid animates without touching the mouse, speed buttons work
- [ ] `/demo/fluid-cursor-advanced` → "Splat on mount": clicking "Remount" shows a fluid sweep arc
- [ ] `interactive={false}` + `autoSplat={true}` works on mobile (no cursor needed)