### PR TITLE
fix(confetti): rename manualstart prop to manualStart

### DIFF
--- a/.changeset/confetti-manualstart-casing.md
+++ b/.changeset/confetti-manualstart-casing.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui": patch
+---
+
+fix(confetti): rename manualstart prop to manualStart

--- a/src/lib/builder/registry/builder-registry.ts
+++ b/src/lib/builder/registry/builder-registry.ts
@@ -1247,7 +1247,7 @@ const fancyComponents: Record<string, BuilderComponentMeta> = {
 		paletteCategory: "effects",
 		acceptsChildren: false,
 		propSchemas: {
-			manualstart: {
+			manualStart: {
 				type: "boolean",
 				label: "Manual Start",
 				default: false,

--- a/src/lib/fancy-ui/confetti/Confetti.svelte
+++ b/src/lib/fancy-ui/confetti/Confetti.svelte
@@ -11,7 +11,7 @@
 	interface Props {
 		options?: ConfettiOptions;
 		globalOptions?: ConfettiGlobalOptions;
-		manualstart?: boolean;
+		manualStart?: boolean;
 		class?: string;
 		children?: Snippet;
 	}
@@ -19,7 +19,7 @@
 	let {
 		options = {},
 		globalOptions = {},
-		manualstart = false,
+		manualStart = false,
 		class: className = "",
 		children,
 	}: Props = $props();
@@ -39,7 +39,7 @@
 			resize: true,
 		});
 
-		if (!manualstart) {
+		if (!manualStart) {
 			fire();
 		}
 

--- a/src/lib/fancy-ui/confetti/README.md
+++ b/src/lib/fancy-ui/confetti/README.md
@@ -11,7 +11,7 @@ Canvas wrapper that creates a confetti instance.
 |------|------|---------|-------------|
 | `options` | `ConfettiOptions` | `{}` | Default confetti options |
 | `globalOptions` | `ConfettiGlobalOptions` | `{}` | Canvas creation options |
-| `manualstart` | `boolean` | `false` | Skip auto-fire on mount |
+| `manualStart` | `boolean` | `false` | Skip auto-fire on mount |
 | `class` | `string` | `''` | Canvas CSS classes |
 
 ### ConfettiButton


### PR DESCRIPTION
## Summary
- Renames `manualstart` to `manualStart` in `Confetti.svelte`, `builder-registry.ts`, and `README.md` to follow camelCase convention used throughout the codebase

## Test plan
- [ ] `pnpm check` — 0 errors
- [ ] `/demo/confetti` — confetti fires on mount (manualStart defaults to false)