### PR TITLE
feat(fluid-cursor-advanced): add singleton instance management

### DIFF
--- a/.changeset/fluid-cursor-singleton.md
+++ b/.changeset/fluid-cursor-singleton.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+feat(fluid-cursor-advanced): add singleton instance management with `allowMultiple` prop

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursorAdvanced.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursorAdvanced.svelte
@@ -2,6 +2,9 @@
 	import { cn } from "$lib/utils.js";
 	import { onMount } from "svelte";
 
+	// Module-level singleton registry
+	let activeInstance: (() => void) | null = null;
+
 	interface ColorRGB {
 		r: number;
 		g: number;
@@ -32,6 +35,7 @@
 		interactive?: boolean;
 		pauseWhenHidden?: boolean;
 		splatOnMount?: boolean;
+		allowMultiple?: boolean;
 	}
 
 	let {
@@ -58,6 +62,7 @@
 		interactive = true,
 		pauseWhenHidden = true,
 		splatOnMount = false,
+		allowMultiple = false,
 	}: Props = $props();
 
 	const contained = true;
@@ -1521,7 +1526,7 @@
 		}
 
 		// Cleanup
-		return () => {
+		function cleanup() {
 			cancelAnimationFrame(animationFrameId);
 			if (observer) observer.disconnect();
 			if (autoSplatTimer) clearInterval(autoSplatTimer);
@@ -1537,7 +1542,27 @@
 				window.removeEventListener("resize", updateCanvasRectCache);
 				window.removeEventListener("scroll", updateCanvasRectCache);
 			}
-		};
+		}
+
+		if (!allowMultiple) {
+			if (activeInstance) {
+				if (import.meta.env.DEV) {
+					console.warn(
+						"[FluidCursorAdvanced] Destroying previous instance. Only one instance is allowed by default. Use `allowMultiple={true}` to opt out of singleton behavior."
+					);
+				}
+				activeInstance();
+			}
+			activeInstance = cleanup;
+			return () => {
+				cleanup();
+				if (activeInstance === cleanup) {
+					activeInstance = null;
+				}
+			};
+		}
+
+		return cleanup;
 	});
 </script>
 


### PR DESCRIPTION
## Summary
- Add `allowMultiple` prop (default `false`) to FluidCursorAdvanced preventing multiple instances from accumulating on SPA route changes
- When singleton mode destroys a previous instance, a dev-mode console warning is emitted
- Pass `allowMultiple={true}` to opt out and run multiple independent instances

## Test plan
- [ ] Mount component twice without `allowMultiple` → only 1 canvas active, console.warn fired in dev
- [ ] Mount with `allowMultiple={true}` → both instances work independently
- [ ] Unmount/remount → no leaked listeners or animation frames
- [ ] Single instance usage unchanged (no behavioral difference)