### PR TITLE
docs: add variant selector and CSS setup to docs

### DIFF
--- a/src/lib/components/docs/examples/image-trail-cursor/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/image-trail-cursor/BasicUsage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { ImageTrailCursor } from "$lib/fancy-ui/image-trail-cursor";
+	import type { VariantType } from "$lib/fancy-ui/image-trail-cursor";
 
 	const images = [
 		"https://picsum.photos/seed/trail1/400/440",
@@ -11,11 +12,38 @@
 		"https://picsum.photos/seed/trail7/400/440",
 		"https://picsum.photos/seed/trail8/400/440",
 	];
+
+	const variants: { type: VariantType; label: string }[] = [
+		{ type: "type1", label: "Fade & Scale" },
+		{ type: "type2", label: "Brightness" },
+		{ type: "type3", label: "Float-up" },
+		{ type: "type4", label: "Momentum" },
+		{ type: "type5", label: "Rotation" },
+		{ type: "type6", label: "Speed-reactive" },
+		{ type: "type7", label: "Stacking" },
+		{ type: "type8", label: "3D Perspective" },
+	];
+
+	let selectedVariant: VariantType = $state("type1");
 </script>
 
-<div class="relative h-[500px] cursor-crosshair overflow-hidden rounded-lg border">
-	<ImageTrailCursor {images} variant="type1" />
-	<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
-		<p class="text-muted-foreground/50 text-lg select-none">Move your cursor here</p>
+<div class="w-full">
+	<div class="mb-4 flex flex-wrap gap-2">
+		{#each variants as v}
+			<button
+				class="rounded-lg border px-3 py-1.5 text-sm transition-colors {selectedVariant === v.type
+					? 'border-primary bg-primary text-primary-foreground'
+					: 'border-border bg-card hover:bg-accent'}"
+				onclick={() => (selectedVariant = v.type)}
+			>
+				{v.label}
+			</button>
+		{/each}
+	</div>
+	<div class="relative h-[500px] cursor-crosshair overflow-hidden rounded-lg border">
+		<ImageTrailCursor {images} variant={selectedVariant} />
+		<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+			<p class="text-muted-foreground text-lg font-medium select-none">Move your cursor here</p>
+		</div>
 	</div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -186,12 +186,6 @@
 		<div class="mt-4 flex flex-wrap items-center justify-center gap-3">
 			<RainbowButton href={DEMO_URL}>Browse components</RainbowButton>
 			<a
-				href={DOCS_URL}
-				class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-5 py-2.5 text-sm font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
-			>
-				Documentation
-			</a>
-			<a
 				href={GITHUB_URL}
 				target="_blank"
 				rel="noopener noreferrer"

--- a/src/routes/docs/getting-started/theming/+page.svx
+++ b/src/routes/docs/getting-started/theming/+page.svx
@@ -10,6 +10,15 @@ title: Theming
 
 FancyUI uses CSS custom properties (OKLCh color space) for theming, fully compatible with shadcn-svelte conventions.
 
+## CSS Setup
+
+Import the FancyUI stylesheet in your app's CSS (e.g. `src/app.css`):
+
+```css
+@import "tailwindcss";
+@import "fancy-ui-svelte/tailwind.css";
+```
+
 ## Color System
 
 All colors use the **OKLCh** color space for perceptually uniform gradients:


### PR DESCRIPTION
## Summary
- Add interactive variant selector to ImageTrailCursor BasicUsage example (all 8 animation types)
- Add CSS import instructions to theming docs page
- Remove redundant Documentation button from landing page

## Test plan
- [ ] Verify variant selector buttons work on ImageTrailCursor docs page
- [ ] Verify theming page shows CSS setup section
- [ ] Verify landing page no longer has Documentation button