### PR TITLE
fix(pnpm): allow esbuild build scripts in pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
-  esbuild: set this to true or false
+  esbuild: true
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## What failed

`pnpm install --frozen-lockfile` exited with code 1:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.2
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

esbuild's postinstall script (which downloads the platform-specific binary) was blocked, leaving the package broken.

## Root cause

`pnpm-workspace.yaml` had an uncommitted `allowBuilds` stanza with a literal placeholder string as the value:

```yaml
allowBuilds:
  esbuild: set this to true or false   # ← invalid; pnpm treats this as falsy/blocked
onlyBuiltDependencies:
  - esbuild
```

In pnpm 11, the `allowBuilds` map takes precedence. Because `esbuild` was mapped to the non-boolean string `"set this to true or false"` instead of `true`, pnpm blocked esbuild's build scripts even though `onlyBuiltDependencies` already listed it.

## Fix

Set `allowBuilds.esbuild: true` in `pnpm-workspace.yaml` so the value is a valid boolean and esbuild's postinstall runs normally.

## CI results after fix

| Step | Result |
|---|---|
| `pnpm install --frozen-lockfile` | ✅ clean (esbuild postinstall ran) |
| `pnpm check` (svelte-check) | ✅ 0 errors, 25 pre-existing warnings |
| `pnpm test` (vitest) | ✅ 55 files, 467 tests passed |
| `pnpm package` (svelte-package + publint) | ✅ All good! |

---
_Generated by [Claude Code](https://claude.ai/code/session_01NENbPtRUepaCg41qjzdRUD)_