### PR TITLE
fix(fluid-cursor): singleton, splat auto-scale, FBO clamp, pointer bounds

### DIFF
--- a/.changeset/fluid-cursor-audit-fixes.md
+++ b/.changeset/fluid-cursor-audit-fixes.md
@@ -1,0 +1,10 @@
+---
+"fancy-ui-svelte": patch
+---
+
+FluidCursor fixes from audit:
+
+- Fix broken singleton: the instance registry now lives in a module script, so a second instance correctly destroys the first (previously the variable was per-instance and the singleton never engaged).
+- Auto-scale splat radius in contained mode so the fluid effect has the same on-screen size as fullscreen usage, instead of shrinking with the container height.
+- Clamp simulation/dye framebuffer resolution to the canvas size, avoiding oversized GPU buffers in wide, short containers.
+- Ignore pointer events outside the container in contained mode: no more click splats or wasted GPU work when interacting elsewhere on the page.

--- a/src/lib/components/docs/examples/fluid-cursor/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/fluid-cursor/BasicUsage.svelte
@@ -2,8 +2,8 @@
 	import { FluidCursor } from "$lib/fancy-ui/fluid-cursor";
 </script>
 
-<div class="relative h-64 w-full overflow-hidden rounded-lg border">
-	<FluidCursor />
+<div class="relative h-80 w-full overflow-hidden rounded-lg border">
+	<FluidCursor splatOnMount allowMultiple />
 	<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
 		<p class="text-muted-foreground text-sm select-none">Move your cursor here</p>
 	</div>

--- a/src/lib/components/docs/examples/fluid-cursor/CustomColors.svelte
+++ b/src/lib/components/docs/examples/fluid-cursor/CustomColors.svelte
@@ -2,8 +2,8 @@
 	import { FluidCursor } from "$lib/fancy-ui/fluid-cursor";
 </script>
 
-<div class="relative h-64 w-full overflow-hidden rounded-lg border">
-	<FluidCursor fluidColor="#00ffcc" colorIntensity={0.4} />
+<div class="relative h-80 w-full overflow-hidden rounded-lg border">
+	<FluidCursor fluidColor="#00ffcc" colorIntensity={0.4} allowMultiple />
 	<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
 		<p class="text-muted-foreground text-sm select-none">Teal fluid color</p>
 	</div>

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -1,9 +1,11 @@
+<script lang="ts" module>
+	// Module-level singleton registry, shared across all instances
+	let activeInstance: (() => void) | null = null;
+</script>
+
 <script lang="ts">
 	import { cn } from "$lib/utils.js";
 	import { onMount } from "svelte";
-
-	// Module-level singleton registry
-	let activeInstance: (() => void) | null = null;
 
 	interface ColorRGB {
 		r: number;
@@ -962,10 +964,12 @@
 			const aspect = aspectRatio < 1 ? 1 / aspectRatio : aspectRatio;
 			const min = Math.round(resolution);
 			const max = Math.round(resolution * aspect);
+			// No point rendering more texels than the canvas has — in small
+			// wide containers the aspect-scaled size would balloon FBO memory.
 			if (w > h) {
-				return { width: max, height: min };
+				return { width: Math.min(max, w), height: Math.min(min, h) };
 			}
-			return { width: min, height: max };
+			return { width: Math.min(min, w), height: Math.min(max, h) };
 		}
 
 		function scaleByPixelRatio(input: number) {
@@ -1320,6 +1324,21 @@
 		}
 
 		function correctRadius(radius: number) {
+			if (contained) {
+				// The splat shader measures distance in canvas-height units, so a
+				// radius that looks right fullscreen shrinks with the container.
+				// Express the radius in viewport units, then convert to canvas
+				// units so the on-screen splat size matches fullscreen usage.
+				const winW = scaleByPixelRatio(window.innerWidth);
+				const winH = scaleByPixelRatio(window.innerHeight);
+				const winAspect = winW / winH;
+				if (winAspect > 1) radius *= winAspect;
+				radius *= (winH / canvas.height) ** 2;
+				// Cap so a single splat can't dwarf a small container
+				// (core radius ≤ 30% of the smaller canvas dimension).
+				const maxCore = (0.3 * Math.min(canvas.width, canvas.height)) / canvas.height;
+				return Math.min(radius, maxCore * maxCore);
+			}
 			const aspectRatio = canvas.width / canvas.height;
 			if (aspectRatio > 1) radius *= aspectRatio;
 			return radius;
@@ -1430,9 +1449,14 @@
 		}
 
 		// Event Listeners
+		function isInsideCanvas(posX: number, posY: number) {
+			return posX >= 0 && posX <= canvas.width && posY >= 0 && posY <= canvas.height;
+		}
+
 		function handleMouseDown(e: MouseEvent) {
 			const pointer = pointers[0];
 			const { x: posX, y: posY } = getCanvasPos(e.clientX, e.clientY);
+			if (contained && !isInsideCanvas(posX, posY)) return;
 			updatePointerDownData(pointer, -1, posX, posY);
 			clickSplat(pointer);
 		}
@@ -1449,6 +1473,9 @@
 			const pointer = pointers[0];
 			const { x: posX, y: posY } = getCanvasPos(e.clientX, e.clientY);
 			updatePointerMoveData(pointer, posX, posY, pointer.color);
+			// Keep tracking coords outside the container (so re-entry is smooth)
+			// but don't splat for movement that happens out of bounds.
+			if (contained && !isInsideCanvas(posX, posY)) pointer.moved = false;
 		}
 
 		function handleFirstTouchStart(e: TouchEvent) {
@@ -1476,6 +1503,7 @@
 			for (let i = 0; i < touches.length; i++) {
 				const { x: posX, y: posY } = getCanvasPos(touches[i].clientX, touches[i].clientY);
 				updatePointerMoveData(pointer, posX, posY, pointer.color);
+				if (contained && !isInsideCanvas(posX, posY)) pointer.moved = false;
 			}
 		}
 

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -1570,6 +1570,11 @@
 				window.removeEventListener("resize", updateCanvasRectCache);
 				window.removeEventListener("scroll", updateCanvasRectCache);
 			}
+			// When destroyed by the singleton (component still mounted), the
+			// canvas would otherwise keep showing its last rendered frame.
+			gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+			gl.clearColor(0, 0, 0, 0);
+			gl.clear(gl.COLOR_BUFFER_BIT);
 		}
 
 		if (!allowMultiple) {

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
@@ -44,6 +44,13 @@ describe("FluidCursor", () => {
 		expect(div?.className).toContain("z-50");
 	});
 
+	it("mounts two instances without error (singleton destroys the first when WebGL is available)", () => {
+		const first = render(FluidCursor);
+		const second = render(FluidCursor);
+		expect(first.container.querySelector("canvas")).toBeInTheDocument();
+		expect(second.container.querySelector("canvas")).toBeInTheDocument();
+	});
+
 	it("applies custom class names", () => {
 		const { container } = render(FluidCursor, { props: { class: "my-fluid" } });
 		const div = container.firstElementChild as HTMLElement;


### PR DESCRIPTION
## Context

Audit triggered by the docs page: the fluid effect looked tiny in the demo preview. Root cause — the splat radius is expressed in canvas-height units, so in the `h-64` demo box splats rendered ~half their fullscreen size inside a much smaller area. The audit surfaced three more real bugs, fixed here.

## Changes

- **Broken singleton**: `activeInstance` lived in the instance `<script>`, so each component had its own registry and the singleton never engaged. Moved to `<script module>`.
- **Splat auto-scale (contained mode)**: `correctRadius` now expresses the radius in viewport units and converts to canvas units, so the on-screen splat size matches fullscreen usage regardless of container size (capped at 30% of the smaller canvas dimension). Fullscreen (`contained={false}`) behavior unchanged.
- **FBO clamp**: `getResolution` no longer exceeds the drawing buffer size — the aspect-scaled dye buffer reached ~6200×1440 RGBA16F (~140MB GPU) in the wide, short demo box.
- **Pointer bounds**: in contained mode, clicks outside the container no longer splat and out-of-bounds mouse/touch movement no longer triggers per-frame splat passes; coords keep tracking so re-entry is smooth.
- **Docs demos**: `h-80` preview, `splatOnMount` for instant visual, `allowMultiple` (the docs page renders three instances — preview + two examples — which the fixed singleton would otherwise destroy).

## Verification

- `vitest`: 473 passed (the one failing suite is the pre-existing missing `@chenglou/pretext` dep in LineReveal, unrelated)
- `svelte-check`: no new errors (fluid-cursor warnings pre-existing)
- Playwright against dev server: splat fills the preview at fullscreen-equivalent size, mount animation plays, outside click produces no splat, inside click does, no console errors

## Audit follow-ups (out of scope)

- `backColor`, `transparent`, `captureResolution` props are documented but dead (never used by the render path)
- No shader compile/link status checks (silent black canvas on failure)
- Contained rect cache only refreshes on window resize/scroll (layout shifts need a ResizeObserver)
- Sim props are captured once in `onMount` and not reactive afterwards
- `fluid-cursor-advanced` still listed as a separate component in `registry.ts`