### PR TITLE
fix(pnpm): add allowBuilds.esbuild to unblock CI in pnpm v11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
+allowBuilds:
+  esbuild: true
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## What failed

Nightly CI health check found that `pnpm install --frozen-lockfile` exits with code 1:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.2
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

Because pnpm runs an install-integrity check before executing scripts, this cascades: `pnpm check`, `pnpm test`, and `pnpm package` all fail immediately with the same install error before any Svelte/TypeScript work begins.

## Root cause

pnpm v11 introduced a new `allowBuilds` map in `pnpm-workspace.yaml` as an explicit per-package build-script allowlist. The previous `onlyBuiltDependencies` list (which was sufficient in pnpm ≤10) is no longer enough on its own — pnpm v11 also requires a matching `allowBuilds.<package>: true` entry, or it blocks the postinstall script and exits non-zero.

The repo's `pnpm-workspace.yaml` only had `onlyBuiltDependencies: [esbuild]` with no `allowBuilds` section.

## Fix

Added `allowBuilds: esbuild: true` alongside the existing `onlyBuiltDependencies` entry. One-line change.

## Verified green after fix

| Step | Result |
|---|---|
| `pnpm install` | ✅ esbuild postinstall ran, exit 0 |
| `pnpm check` (svelte-kit sync + svelte-check) | ✅ 0 errors, 25 pre-existing warnings |
| `pnpm test` (vitest run) | ✅ 467 tests passed across 55 files |
| `pnpm package` (svelte-package + publint) | ✅ "All good!" |

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRPcN58YPWGYJPtcJg6FCE)_