### PR TITLE
feat: add FrostedGlass component (turbulence-noise glass refraction)

### DIFF
--- a/.changeset/frosted-glass-component.md
+++ b/.changeset/frosted-glass-component.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+feat: add FrostedGlass component — turbulence-noise glass refraction (alternative to LiquidGlass)

--- a/src/lib/components/docs/DemoRenderer.svelte
+++ b/src/lib/components/docs/DemoRenderer.svelte
@@ -178,6 +178,7 @@
 		"noise-reveal",
 		"line-reveal",
 		"editorial-engine",
+		"frosted-glass",
 	]);
 
 	function getComponent() {

--- a/src/lib/components/docs/examples/frosted-glass/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/frosted-glass/BasicUsage.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { FrostedGlass } from "$lib/fancy-ui/frosted-glass";
+</script>
+
+<div
+	class="relative flex h-[400px] w-full items-center justify-center overflow-hidden rounded-lg border"
+>
+	<div
+		class="absolute top-1/4 left-1/4 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-sky-500/30 blur-3xl"
+	></div>
+	<div
+		class="absolute right-1/4 bottom-1/3 h-64 w-64 rounded-full bg-emerald-500/30 blur-3xl"
+	></div>
+	<div
+		class="absolute bottom-1/4 left-1/2 h-56 w-56 -translate-x-1/2 rounded-full bg-amber-500/25 blur-3xl"
+	></div>
+
+	<div class="absolute inset-0 z-[1] overflow-y-auto" style="scrollbar-width: none;">
+		<div class="space-y-8 px-10 py-20" style="min-height: 220%;">
+			{#each Array(6) as _, i}
+				<div class="flex gap-4">
+					{#each Array(5) as _, j}
+						<div
+							class="h-20 flex-1 rounded-xl"
+							style="background: hsl({(i * 5 + j) * 28}, 65%, 55%); opacity: 0.75;"
+						></div>
+					{/each}
+				</div>
+				<p class="px-1 text-base font-medium text-white/50">Turbulence refraction in action.</p>
+			{/each}
+		</div>
+	</div>
+
+	<div class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
+		<div class="pointer-events-auto">
+			<FrostedGlass radius={9999}>
+				<div
+					class="flex min-h-16 w-full items-center justify-center px-12 py-4 text-base font-medium text-gray-900"
+				>
+					Frosted Glass. Try scrolling.
+				</div>
+			</FrostedGlass>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/docs/examples/frosted-glass/Navbar.svelte
+++ b/src/lib/components/docs/examples/frosted-glass/Navbar.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { FrostedGlass } from "$lib/fancy-ui/frosted-glass";
+</script>
+
+<div class="relative h-[440px] w-full overflow-hidden rounded-lg border bg-[#fafafa]">
+	<div class="absolute inset-0 overflow-y-auto" style="scrollbar-width: none;">
+		<!-- Hero -->
+		<div class="flex min-h-[420px] flex-col items-center justify-center px-8 pt-24 text-center">
+			<span
+				class="rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-500"
+			>
+				Now available for macOS
+			</span>
+			<h1 class="mt-5 max-w-md text-4xl leading-tight font-semibold tracking-tight text-gray-900">
+				Your UI, at the speed of thought.
+			</h1>
+			<p class="mt-4 max-w-sm text-sm text-gray-500">
+				FancyOS turns your voice into polished interfaces. Speak naturally, ship beautifully.
+			</p>
+			<div class="mt-6 flex items-center gap-3">
+				<span class="rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white">
+					Download
+				</span>
+				<span class="px-3 py-2.5 text-sm font-medium text-gray-600">Watch demo</span>
+			</div>
+		</div>
+
+		<!-- Colorful sections to scroll behind the nav -->
+		<div class="space-y-6 px-8 pb-12">
+			{#each Array(6) as _, i}
+				<div
+					class="flex h-32 items-end rounded-3xl p-5"
+					style="background: linear-gradient(120deg, hsl({210 + i * 40}, 75%, 62%), hsl({250 +
+						i * 40}, 70%, 55%));"
+				>
+					<p class="text-sm font-semibold text-white/90">Feature {i + 1}</p>
+				</div>
+			{/each}
+		</div>
+	</div>
+
+	<!-- Fixed pill nav -->
+	<div class="pointer-events-none absolute inset-x-0 top-4 z-10 flex justify-center px-6">
+		<div class="pointer-events-auto w-full max-w-lg">
+			<FrostedGlass radius={9999} containerClass="w-full">
+				<nav class="flex w-full items-center justify-between px-6 py-3">
+					<span class="flex items-center gap-1.5 text-sm font-bold tracking-tight text-gray-900">
+						<span class="inline-block size-4 rounded-full bg-gray-900"></span>
+						FancyOS
+					</span>
+					<div class="flex items-center gap-5 text-[13px] font-medium text-gray-800">
+						<span class="hidden sm:inline">Manifesto</span>
+						<span class="hidden sm:inline">Pricing</span>
+						<span class="hidden sm:inline">Blog</span>
+						<span class="rounded-full bg-gray-900 px-3.5 py-1.5 text-xs font-semibold text-white">
+							Download
+						</span>
+					</div>
+				</nav>
+			</FrostedGlass>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/docs/examples/registry.ts
+++ b/src/lib/components/docs/examples/registry.ts
@@ -320,6 +320,14 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 	],
 	"smooth-cursor": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"liquid-glass": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"frosted-glass": [
+		{ name: "BasicUsage", title: "Basic Usage" },
+		{
+			name: "Navbar",
+			title: "Landing Page Navbar",
+			description: "Landing page with a glass pill navigation.",
+		},
+	],
 	"tracing-beam": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"image-trail-cursor": [
 		{ name: "BasicUsage", title: "Basic Usage" },

--- a/src/lib/fancy-ui/frosted-glass/FrostedGlass.svelte
+++ b/src/lib/fancy-ui/frosted-glass/FrostedGlass.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+	import { cn } from "$lib/utils";
+	import { onMount } from "svelte";
+	import type { Snippet } from "svelte";
+
+	interface Props {
+		radius?: number;
+		baseFrequency?: number;
+		numOctaves?: number;
+		seed?: number;
+		noiseBlur?: number;
+		scale?: number;
+		tint?: string;
+		highlight?: string;
+		border?: boolean;
+		fallbackBlur?: number;
+		fallbackSaturation?: number;
+		class?: string;
+		containerClass?: string;
+		children?: Snippet;
+	}
+
+	let {
+		radius = 24,
+		baseFrequency = 0.008,
+		numOctaves = 2,
+		seed = 92,
+		noiseBlur = 2,
+		scale = 70,
+		tint = "hsla(0, 0%, 100%, 0.25)",
+		highlight = "hsla(0, 0%, 100%, 0.75)",
+		border = true,
+		fallbackBlur = 20,
+		fallbackSaturation = 180,
+		class: className = "",
+		containerClass = "",
+		children,
+	}: Props = $props();
+
+	let filterId = $state("");
+
+	let containerStyle = $derived(
+		`border-radius:${radius}px;--fg-tint:${tint};--fg-highlight:${highlight};` +
+			`--fg-fallback-blur:${fallbackBlur}px;--fg-fallback-saturation:${fallbackSaturation}%;`
+	);
+
+	onMount(() => {
+		filterId = `fg-dist-${Math.random().toString(36).slice(2, 8)}`;
+	});
+</script>
+
+<div
+	class={cn("frosted-glass", border && "frosted-glass-border", containerClass)}
+	style={containerStyle}
+>
+	{#if filterId}
+		<div class="frosted-glass-filter" style="filter:url(#{filterId});"></div>
+
+		<svg class="frosted-glass-defs" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+			<defs>
+				<filter
+					id={filterId}
+					x="-50%"
+					y="-50%"
+					width="200%"
+					height="200%"
+					filterUnits="objectBoundingBox"
+					primitiveUnits="userSpaceOnUse"
+					color-interpolation-filters="linearRGB"
+				>
+					<feTurbulence
+						type="fractalNoise"
+						baseFrequency="{baseFrequency} {baseFrequency}"
+						{numOctaves}
+						{seed}
+						stitchTiles="stitch"
+						result="noise"
+					/>
+					<feGaussianBlur in="noise" stdDeviation={noiseBlur} result="blurred" />
+					<feDisplacementMap
+						in="SourceGraphic"
+						in2="blurred"
+						{scale}
+						xChannelSelector="R"
+						yChannelSelector="G"
+					/>
+				</filter>
+			</defs>
+		</svg>
+	{/if}
+
+	<div class="frosted-glass-overlay"></div>
+	<div class="frosted-glass-specular"></div>
+
+	<div class={cn("frosted-glass-content", className)}>
+		{#if children}
+			{@render children()}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.frosted-glass {
+		position: relative;
+		display: flex;
+		background: transparent;
+		overflow: hidden;
+		contain: layout paint;
+		box-shadow:
+			0 2px 4px rgba(0, 0, 0, 0.1),
+			0 0 8px rgba(0, 0, 0, 0.05);
+	}
+
+	.frosted-glass-border::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		z-index: 4;
+		border-radius: inherit;
+		padding: 1px;
+		background:
+			conic-gradient(
+				from -75deg at 50% 50%,
+				rgba(20, 60, 120, 0.5),
+				rgba(150, 200, 255, 0.1) 5% 40%,
+				rgba(20, 60, 120, 0.5) 50%,
+				rgba(150, 200, 255, 0.1) 60% 95%,
+				rgba(20, 60, 120, 0.5)
+			),
+			linear-gradient(180deg, rgba(220, 240, 255, 0.5), rgba(240, 250, 255, 0.5));
+		box-shadow: inset 0 0 0 0.5px rgba(220, 240, 255, 0.5);
+		pointer-events: none;
+		mask:
+			linear-gradient(#fff 0 0) content-box,
+			linear-gradient(#fff 0 0);
+		mask-composite: exclude;
+	}
+
+	/* backdrop-filter: blur(0) pulls the backdrop into this layer so the SVG
+	   displacement filter can distort it */
+	.frosted-glass-filter {
+		position: absolute;
+		inset: 0;
+		z-index: 0;
+		backdrop-filter: blur(0);
+		isolation: isolate;
+		transform: translateZ(0);
+		will-change: filter;
+		animation: frosted-glass-settle 0.22s ease-out;
+	}
+
+	@keyframes frosted-glass-settle {
+		0% {
+			opacity: 0;
+		}
+	}
+
+	/* Safari can't combine filter:url() with backdrop-filter — fall back to
+	   plain frosted blur */
+	@supports (-webkit-hyphens: none) {
+		.frosted-glass-filter {
+			filter: none !important;
+			backdrop-filter: blur(var(--fg-fallback-blur)) saturate(var(--fg-fallback-saturation));
+		}
+
+		.frosted-glass-overlay {
+			background: hsla(0, 0%, 100%, 0.5);
+		}
+	}
+
+	.frosted-glass-defs {
+		position: absolute;
+		width: 0;
+		height: 0;
+	}
+
+	.frosted-glass-overlay {
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+		background: var(--fg-tint);
+	}
+
+	.frosted-glass-specular {
+		position: absolute;
+		inset: 0;
+		z-index: 2;
+		border-radius: inherit;
+		overflow: hidden;
+		box-shadow:
+			inset 1px 1px 0 var(--fg-highlight),
+			inset 0 0 5px var(--fg-highlight);
+	}
+
+	.frosted-glass-content {
+		position: relative;
+		z-index: 3;
+		display: flex;
+		align-items: center;
+		width: 100%;
+	}
+</style>

--- a/src/lib/fancy-ui/frosted-glass/FrostedGlass.test.ts
+++ b/src/lib/fancy-ui/frosted-glass/FrostedGlass.test.ts
@@ -1,0 +1,57 @@
+import { render, cleanup } from "@testing-library/svelte";
+import { afterEach, describe, it, expect } from "vitest";
+import FrostedGlass from "./FrostedGlass.svelte";
+
+describe("FrostedGlass", () => {
+	afterEach(cleanup);
+
+	it("renders the component", () => {
+		const { container } = render(FrostedGlass);
+		const wrapper = container.querySelector(".frosted-glass");
+		expect(wrapper).toBeInTheDocument();
+	});
+
+	it("renders the layer stack", () => {
+		const { container } = render(FrostedGlass);
+		expect(container.querySelector(".frosted-glass-overlay")).toBeInTheDocument();
+		expect(container.querySelector(".frosted-glass-specular")).toBeInTheDocument();
+		expect(container.querySelector(".frosted-glass-content")).toBeInTheDocument();
+	});
+
+	it("applies custom container class", () => {
+		const { container } = render(FrostedGlass, {
+			props: { containerClass: "my-container" },
+		});
+		const wrapper = container.querySelector(".frosted-glass");
+		expect(wrapper?.className).toContain("my-container");
+	});
+
+	it("applies custom class to content", () => {
+		const { container } = render(FrostedGlass, { props: { class: "my-content" } });
+		const content = container.querySelector(".frosted-glass-content");
+		expect(content?.className).toContain("my-content");
+	});
+
+	it("sets border radius", () => {
+		const { container } = render(FrostedGlass, { props: { radius: 9999 } });
+		const wrapper = container.querySelector(".frosted-glass") as HTMLElement;
+		expect(wrapper.style.borderRadius).toBe("9999px");
+	});
+
+	it("sets tint CSS variable", () => {
+		const { container } = render(FrostedGlass, {
+			props: { tint: "hsla(0, 0%, 0%, 0.3)" },
+		});
+		const wrapper = container.querySelector(".frosted-glass") as HTMLElement;
+		expect(wrapper.style.getPropertyValue("--fg-tint")).toBe("hsla(0, 0%, 0%, 0.3)");
+	});
+
+	it("renders border layer by default and hides it when border=false", () => {
+		const withBorder = render(FrostedGlass);
+		expect(withBorder.container.querySelector(".frosted-glass-border")).toBeInTheDocument();
+		cleanup();
+
+		const withoutBorder = render(FrostedGlass, { props: { border: false } });
+		expect(withoutBorder.container.querySelector(".frosted-glass-border")).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/fancy-ui/frosted-glass/README.md
+++ b/src/lib/fancy-ui/frosted-glass/README.md
@@ -1,0 +1,59 @@
+# FrostedGlass
+
+Frosted glass surface with an organic, wavy refraction of the content behind it. An alternative to [LiquidGlass](../liquid-glass/README.md): where LiquidGlass produces chromatic (rainbow-edge) refraction from gradient displacement maps, FrostedGlass distorts the backdrop with fractal turbulence noise for a softer, rippled-glass look — the effect used by glassy pill navbars.
+
+## How it works
+
+The effect stacks four layers inside a rounded container:
+
+1. **Filter layer** — `backdrop-filter: blur(0)` pulls the backdrop into the element's own rendering, then a CSS `filter: url(#...)` pointing at an inline SVG filter distorts it: `feTurbulence` (fractal noise) → `feGaussianBlur` → `feDisplacementMap`.
+2. **Overlay** — translucent tint (`tint` prop).
+3. **Specular** — inset highlights simulating a lit glass rim (`highlight` prop).
+4. **Content** — your slotted content.
+
+An optional conic-gradient border (`border` prop) frames the container.
+
+Safari cannot combine `filter: url()` with `backdrop-filter`, so it falls back to a plain `blur() saturate()` frosted look (tunable via `fallbackBlur` / `fallbackSaturation`).
+
+## Usage
+
+```svelte
+<script>
+	import { FrostedGlass } from "fancy-ui-svelte";
+</script>
+
+<FrostedGlass radius={9999}>
+	<nav class="flex w-full items-center justify-between px-7 py-4">
+		<span class="font-semibold">Brand</span>
+		<a href="/download">Download</a>
+	</nav>
+</FrostedGlass>
+```
+
+## Props
+
+| Prop                 | Type      | Default                     | Description                                       |
+| -------------------- | --------- | --------------------------- | ------------------------------------------------- |
+| `radius`             | `number`  | `24`                        | Border radius in pixels                           |
+| `baseFrequency`      | `number`  | `0.008`                     | Turbulence noise frequency (lower = wider waves)  |
+| `numOctaves`         | `number`  | `2`                         | Turbulence octaves (detail of the noise)          |
+| `seed`               | `number`  | `92`                        | Turbulence random seed                            |
+| `noiseBlur`          | `number`  | `2`                         | Gaussian blur softening the noise before displace |
+| `scale`              | `number`  | `70`                        | Displacement intensity                            |
+| `tint`               | `string`  | `"hsla(0, 0%, 100%, 0.25)"` | Overlay tint color                                |
+| `highlight`          | `string`  | `"hsla(0, 0%, 100%, 0.75)"` | Specular rim highlight color                      |
+| `border`             | `boolean` | `true`                      | Show the conic-gradient glass border              |
+| `fallbackBlur`       | `number`  | `20`                        | Backdrop blur (px) for the Safari fallback        |
+| `fallbackSaturation` | `number`  | `180`                       | Backdrop saturation (%) for the Safari fallback   |
+| `class`              | `string`  | `""`                        | CSS classes for the content layer                 |
+| `containerClass`     | `string`  | `""`                        | CSS classes for the outer container               |
+
+## Slots
+
+| Slot       | Description                          |
+| ---------- | ------------------------------------ |
+| `children` | Content rendered on top of the glass |
+
+## Notes
+
+- The displacement only shows over content that scrolls or moves behind the glass; over a flat background the effect reads as a subtle frost.

--- a/src/lib/fancy-ui/frosted-glass/index.ts
+++ b/src/lib/fancy-ui/frosted-glass/index.ts
@@ -1,0 +1,1 @@
+export { default as FrostedGlass } from "./FrostedGlass.svelte";

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -49,6 +49,7 @@ export * from "./text-reveal-card/index.js";
 export * from "./container-scroll/index.js";
 export * from "./container-text-flip/index.js";
 export * from "./focus/index.js";
+export * from "./frosted-glass/index.js";
 export * from "./liquid-glass/index.js";
 export * from "./smooth-cursor/index.js";
 export * from "./sparkles/index.js";

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -1694,6 +1694,76 @@ export const registry: Record<string, ComponentMeta> = {
 		],
 	},
 
+	"frosted-glass": {
+		name: "FrostedGlass",
+		slug: "frosted-glass",
+		description:
+			"Frosted glass surface with organic turbulence-noise refraction, an alternative to LiquidGlass",
+		category: "effects",
+		status: "done",
+		tags: ["glass", "effect", "svg", "filter", "turbulence", "displacement", "blur", "navbar"],
+		props: [
+			{ name: "radius", type: "number", default: "24", description: "Border radius in pixels" },
+			{
+				name: "baseFrequency",
+				type: "number",
+				default: "0.008",
+				description: "Turbulence noise frequency (lower = wider waves)",
+			},
+			{
+				name: "numOctaves",
+				type: "number",
+				default: "2",
+				description: "Turbulence octaves controlling noise detail",
+			},
+			{ name: "seed", type: "number", default: "92", description: "Turbulence random seed" },
+			{
+				name: "noiseBlur",
+				type: "number",
+				default: "2",
+				description: "Gaussian blur softening the noise before displacement",
+			},
+			{ name: "scale", type: "number", default: "70", description: "Displacement intensity" },
+			{
+				name: "tint",
+				type: "string",
+				default: '"hsla(0, 0%, 100%, 0.25)"',
+				description: "Overlay tint color",
+			},
+			{
+				name: "highlight",
+				type: "string",
+				default: '"hsla(0, 0%, 100%, 0.75)"',
+				description: "Specular rim highlight color",
+			},
+			{
+				name: "border",
+				type: "boolean",
+				default: "true",
+				description: "Show the conic-gradient glass border",
+			},
+			{
+				name: "fallbackBlur",
+				type: "number",
+				default: "20",
+				description: "Backdrop blur in pixels for the Safari fallback",
+			},
+			{
+				name: "fallbackSaturation",
+				type: "number",
+				default: "180",
+				description: "Backdrop saturation percentage for the Safari fallback",
+			},
+			{
+				name: "containerClass",
+				type: "string",
+				default: '""',
+				description: "CSS classes for the outer container",
+			},
+		],
+		slots: [{ name: "children", description: "Content rendered on top of the glass" }],
+	},
+
 	"liquid-glass": {
 		name: "LiquidGlass",
 		slug: "liquid-glass",


### PR DESCRIPTION
## Summary
- New `FrostedGlass` component: turbulence-noise glass refraction as an alternative to `LiquidGlass` — backdrop pulled into the layer via `backdrop-filter: blur(0)` then distorted by an SVG `feTurbulence → feGaussianBlur → feDisplacementMap` chain, with tint overlay, specular rim, conic-gradient border, and Safari blur/saturate fallback
- Registry entry, barrel exports, unit tests, README, and two docs examples (Basic Usage + landing-page navbar); `frosted-glass` added to `DemoRenderer` skipDirectRender so the preview renders the example
- Rebased onto the recreated `develop` (was previously merged as #130, reverted, and resubmitted here)

## Test plan
- [ ] `pnpm test` — FrostedGlass suite green
- [ ] `pnpm check` — 0 errors
- [ ] `/docs/components/frosted-glass` — preview renders, both examples show wavy refraction when scrolling content behind the glass
- [ ] Safari — falls back to plain frosted blur