### PR TITLE
feat: add Storybook 10 with SvelteKit integration

### DIFF
--- a/.changeset/storybook-integration.md
+++ b/.changeset/storybook-integration.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": patch
+---
+
+chore: add Storybook 10 with SvelteKit integration for component development and documentation

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+*storybook.log
+storybook-static

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,9 @@
+import type { StorybookConfig } from "@storybook/sveltekit";
+
+const config: StorybookConfig = {
+	stories: ["../src/stories/**/*.mdx", "../src/stories/**/*.stories.@(js|ts|svelte)"],
+	addons: ["@storybook/addon-svelte-csf", "@storybook/addon-a11y", "@storybook/addon-docs"],
+	framework: "@storybook/sveltekit",
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,44 @@
+import type { Preview } from "@storybook/sveltekit";
+import "../src/routes/layout.css";
+
+const preview: Preview = {
+	parameters: {
+		controls: {
+			matchers: {
+				color: /(background|color)$/i,
+				date: /Date$/i,
+			},
+		},
+		a11y: {
+			test: "todo",
+		},
+		backgrounds: { disable: true },
+	},
+	globalTypes: {
+		theme: {
+			description: "Color scheme",
+			toolbar: {
+				title: "Theme",
+				icon: "mirror",
+				items: [
+					{ value: "light", title: "Light" },
+					{ value: "dark", title: "Dark" },
+				],
+				dynamicTitle: true,
+			},
+		},
+	},
+	initialGlobals: {
+		theme: "light",
+	},
+	decorators: [
+		(story, context) => {
+			const theme = context.globals.theme ?? "light";
+			document.documentElement.classList.toggle("dark", theme === "dark");
+			document.body.classList.add("bg-background", "text-foreground");
+			return story();
+		},
+	],
+};
+
+export default preview;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ The dev server runs at `http://localhost:5173`. Component demos are at `/demo/<s
 1. **Copy the template** — duplicate `src/lib/fancy-ui/_template/` and rename it to your component slug (e.g. `src/lib/fancy-ui/my-component/`).
 
 2. **Register it** — add an entry to `src/lib/fancy-ui/registry.ts`:
+
    ```ts
    "my-component": {
      name: "MyComponent",
@@ -47,6 +48,59 @@ pnpm check         # svelte-check type checking
 ```
 
 `pnpm test` and `pnpm test:e2e` must pass. `pnpm check` must pass for any files you touched — pre-existing errors in unrelated files are acceptable.
+
+## Storybook
+
+Storybook documents and develops components in isolation, with live prop controls and autodocs.
+
+```bash
+pnpm storybook        # dev server on http://localhost:6006
+pnpm build-storybook  # static build in storybook-static/ (gitignored)
+```
+
+### Where stories live
+
+- All stories go in **`src/stories/`** — never in `src/lib/`, because everything under `src/lib` is published to npm by `svelte-package`.
+- One file per component: `src/stories/<component-slug>.stories.svelte`, where the slug matches the component folder in `src/lib/fancy-ui/<slug>/`.
+- Docs pages use MDX: `src/stories/*.mdx` (see `Introduction.mdx`).
+
+### Naming conventions
+
+- File: `shimmer-button.stories.svelte` (kebab-case slug).
+- Meta title: `"<Category>/<ComponentName>"` — e.g. `"Buttons/ShimmerButton"`. Categories mirror the registry categories (`Buttons`, `Cards`, `Text`, `Effects`, …).
+- Story names: `"Default"` first, then descriptive variants (`"Custom Shimmer"`, `"Thick Border"`).
+
+### Writing a story
+
+Svelte CSF via `@storybook/addon-svelte-csf` (Svelte 5, `defineMeta`):
+
+```svelte
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ShimmerButton } from "$lib/fancy-ui/shimmer-button";
+
+	const { Story } = defineMeta({
+		title: "Buttons/ShimmerButton",
+		component: ShimmerButton,
+		tags: ["autodocs"],
+		args: { shimmerColor: "#ffffff" },
+	});
+</script>
+
+{#snippet template(args: any)}
+	<ShimmerButton {...args}>Click me</ShimmerButton>
+{/snippet}
+
+<Story name="Default" {template} />
+```
+
+Rules: use **real props only** (check the component's exported `Props` type); default state first, then 2–3 useful variants; `tags: ["autodocs"]` generates the docs page from props + JSDoc comments.
+
+### Configuration
+
+- `.storybook/main.ts` — stories glob (`src/stories/`), addons (`svelte-csf`, `a11y`, `docs`), framework `@storybook/sveltekit`.
+- `.storybook/preview.ts` — imports the app's global stylesheet (`src/routes/layout.css`: Tailwind v4 + design tokens), and provides a light/dark toolbar toggle (toggles the `.dark` class).
+- Tailwind and the `$lib` alias work out of the box: `@storybook/sveltekit` reuses the project's `vite.config.ts`.
 
 ## PR process
 
@@ -83,10 +137,10 @@ feat: add SpinnerButton component
 
 ### Bump type guide
 
-| Change | Bump |
-|---|---|
-| Bug fix, CSS correction, accessibility improvement, perf, docs | `patch` |
-| New component, new optional prop (with default), new export | `minor` |
+| Change                                                                                    | Bump                           |
+| ----------------------------------------------------------------------------------------- | ------------------------------ |
+| Bug fix, CSS correction, accessibility improvement, perf, docs                            | `patch`                        |
+| New component, new optional prop (with default), new export                               | `minor`                        |
 | Renamed/removed component or prop, changed prop type, raised Svelte/Tailwind/Node minimum | `minor` (0.x) → `major` (≥1.0) |
 
 **Breaking changes in a copy-paste library** — because users own the code they copy,

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ pnpm build        # Production build
 pnpm storybook    # Component workshop on :6006
 ```
 
-Component stories live in `src/stories/` — see [docs/storybook.md](./docs/storybook.md).
+Component stories live in `src/stories/` — see the [Storybook section in CONTRIBUTING.md](./CONTRIBUTING.md#storybook).
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -31,88 +31,88 @@ Beautiful animation and UI components for **Svelte 5**.
 
 ### Buttons
 
-| Component | Description | Demo |
-|-----------|-------------|------|
-| RainbowButton | Animated rainbow gradient border effect | [Demo](https://fancy-ui.rama.app/demo/rainbow-button) |
-| RippleButton | Ripple click effect | [Demo](https://fancy-ui.rama.app/demo/ripple-button) |
-| ShimmerButton | Rotating conic-gradient shimmer border | [Demo](https://fancy-ui.rama.app/demo/shimmer-button) |
-| GradientButton | Rotating conic-gradient rainbow border | [Demo](https://fancy-ui.rama.app/demo/gradient-button) |
+| Component              | Description                              | Demo                                                            |
+| ---------------------- | ---------------------------------------- | --------------------------------------------------------------- |
+| RainbowButton          | Animated rainbow gradient border effect  | [Demo](https://fancy-ui.rama.app/demo/rainbow-button)           |
+| RippleButton           | Ripple click effect                      | [Demo](https://fancy-ui.rama.app/demo/ripple-button)            |
+| ShimmerButton          | Rotating conic-gradient shimmer border   | [Demo](https://fancy-ui.rama.app/demo/shimmer-button)           |
+| GradientButton         | Rotating conic-gradient rainbow border   | [Demo](https://fancy-ui.rama.app/demo/gradient-button)          |
 | InteractiveHoverButton | Hover effect revealing alternate content | [Demo](https://fancy-ui.rama.app/demo/interactive-hover-button) |
 
 ### Cards
 
-| Component | Description | Demo |
-|-----------|-------------|------|
-| Card3D | 3D tilt card with mouse tracking | [Demo](https://fancy-ui.rama.app/demo/card-3d) |
-| CardSpotlight | Spotlight effect following mouse | [Demo](https://fancy-ui.rama.app/demo/card-spotlight) |
+| Component           | Description                                  | Demo                                                         |
+| ------------------- | -------------------------------------------- | ------------------------------------------------------------ |
+| Card3D              | 3D tilt card with mouse tracking             | [Demo](https://fancy-ui.rama.app/demo/card-3d)               |
+| CardSpotlight       | Spotlight effect following mouse             | [Demo](https://fancy-ui.rama.app/demo/card-spotlight)        |
 | DirectionAwareHover | Overlay slides in from mouse entry direction | [Demo](https://fancy-ui.rama.app/demo/direction-aware-hover) |
-| FlipCard | Two-sided card with flip animation | [Demo](https://fancy-ui.rama.app/demo/flip-card) |
-| GlareCard | Glare reflection effect on hover | [Demo](https://fancy-ui.rama.app/demo/glare-card) |
-| TextRevealCard | Text reveal on hover | [Demo](https://fancy-ui.rama.app/demo/text-reveal-card) |
+| FlipCard            | Two-sided card with flip animation           | [Demo](https://fancy-ui.rama.app/demo/flip-card)             |
+| GlareCard           | Glare reflection effect on hover             | [Demo](https://fancy-ui.rama.app/demo/glare-card)            |
+| TextRevealCard      | Text reveal on hover                         | [Demo](https://fancy-ui.rama.app/demo/text-reveal-card)      |
 
 ### Text & Typography
 
-| Component | Description | Demo |
-|-----------|-------------|------|
-| BlurReveal | Scroll-triggered blur-to-clear reveal | [Demo](https://fancy-ui.rama.app/demo/blur-reveal) |
-| BoxReveal | Sliding colored box reveal animation | [Demo](https://fancy-ui.rama.app/demo/box-reveal) |
-| ColourfulText | Per-character color animation | [Demo](https://fancy-ui.rama.app/demo/colourful-text) |
-| ContainerTextFlip | Text flipping inside a container | [Demo](https://fancy-ui.rama.app/demo/container-text-flip) |
-| FlipWords | Cycling word animation with per-letter effects | [Demo](https://fancy-ui.rama.app/demo/flip-words) |
-| HyperText | Character scramble on hover | [Demo](https://fancy-ui.rama.app/demo/hyper-text) |
-| LetterPullup | Staggered letter pull-up animation | [Demo](https://fancy-ui.rama.app/demo/letter-pullup) |
-| LineShadowText | Text with animated line shadow | [Demo](https://fancy-ui.rama.app/demo/line-shadow-text) |
-| NumberTicker | Animated number counter with easing | [Demo](https://fancy-ui.rama.app/demo/number-ticker) |
-| SparklesText | Animated SVG sparkle stars overlay | [Demo](https://fancy-ui.rama.app/demo/sparkles-text) |
-| TextGenerateEffect | Word-by-word text generation effect | [Demo](https://fancy-ui.rama.app/demo/text-generate-effect) |
+| Component          | Description                                    | Demo                                                        |
+| ------------------ | ---------------------------------------------- | ----------------------------------------------------------- |
+| BlurReveal         | Scroll-triggered blur-to-clear reveal          | [Demo](https://fancy-ui.rama.app/demo/blur-reveal)          |
+| BoxReveal          | Sliding colored box reveal animation           | [Demo](https://fancy-ui.rama.app/demo/box-reveal)           |
+| ColourfulText      | Per-character color animation                  | [Demo](https://fancy-ui.rama.app/demo/colourful-text)       |
+| ContainerTextFlip  | Text flipping inside a container               | [Demo](https://fancy-ui.rama.app/demo/container-text-flip)  |
+| FlipWords          | Cycling word animation with per-letter effects | [Demo](https://fancy-ui.rama.app/demo/flip-words)           |
+| HyperText          | Character scramble on hover                    | [Demo](https://fancy-ui.rama.app/demo/hyper-text)           |
+| LetterPullup       | Staggered letter pull-up animation             | [Demo](https://fancy-ui.rama.app/demo/letter-pullup)        |
+| LineShadowText     | Text with animated line shadow                 | [Demo](https://fancy-ui.rama.app/demo/line-shadow-text)     |
+| NumberTicker       | Animated number counter with easing            | [Demo](https://fancy-ui.rama.app/demo/number-ticker)        |
+| SparklesText       | Animated SVG sparkle stars overlay             | [Demo](https://fancy-ui.rama.app/demo/sparkles-text)        |
+| TextGenerateEffect | Word-by-word text generation effect            | [Demo](https://fancy-ui.rama.app/demo/text-generate-effect) |
 
 ### Backgrounds
 
-| Component | Description | Demo |
-|-----------|-------------|------|
-| FallingStarsBg | Canvas 3D starfield with motion trails | [Demo](https://fancy-ui.rama.app/demo/bg-falling-stars) |
-| FlickeringGrid | Canvas grid with flickering opacity | [Demo](https://fancy-ui.rama.app/demo/flickering-grid) |
-| InteractiveGridPattern | SVG grid with hover highlights | [Demo](https://fancy-ui.rama.app/demo/interactive-grid-pattern) |
-| StarsBackground | Starfield with parallax mouse tracking | [Demo](https://fancy-ui.rama.app/demo/bg-stars) |
+| Component              | Description                            | Demo                                                            |
+| ---------------------- | -------------------------------------- | --------------------------------------------------------------- |
+| FallingStarsBg         | Canvas 3D starfield with motion trails | [Demo](https://fancy-ui.rama.app/demo/bg-falling-stars)         |
+| FlickeringGrid         | Canvas grid with flickering opacity    | [Demo](https://fancy-ui.rama.app/demo/flickering-grid)          |
+| InteractiveGridPattern | SVG grid with hover highlights         | [Demo](https://fancy-ui.rama.app/demo/interactive-grid-pattern) |
+| StarsBackground        | Starfield with parallax mouse tracking | [Demo](https://fancy-ui.rama.app/demo/bg-stars)                 |
 
 ### Effects & Animations
 
-| Component | Description | Demo |
-|-----------|-------------|------|
-| AnimatedBeam | SVG beams connecting elements | [Demo](https://fancy-ui.rama.app/demo/animated-beam) |
-| BorderBeam | Beam effect traveling around borders | [Demo](https://fancy-ui.rama.app/demo/border-beam) |
-| Confetti | Configurable confetti burst | [Demo](https://fancy-ui.rama.app/demo/confetti) |
-| FluidCursor | WebGL fluid simulation following cursor | [Demo](https://fancy-ui.rama.app/demo/fluid-cursor) |
-| GlowBorder | Animated glowing border with gradients | [Demo](https://fancy-ui.rama.app/demo/glow-border) |
-| GlowingEffect | Glowing highlight on hover | [Demo](https://fancy-ui.rama.app/demo/glowing-effect) |
+| Component        | Description                               | Demo                                                      |
+| ---------------- | ----------------------------------------- | --------------------------------------------------------- |
+| AnimatedBeam     | SVG beams connecting elements             | [Demo](https://fancy-ui.rama.app/demo/animated-beam)      |
+| BorderBeam       | Beam effect traveling around borders      | [Demo](https://fancy-ui.rama.app/demo/border-beam)        |
+| Confetti         | Configurable confetti burst               | [Demo](https://fancy-ui.rama.app/demo/confetti)           |
+| FluidCursor      | WebGL fluid simulation following cursor   | [Demo](https://fancy-ui.rama.app/demo/fluid-cursor)       |
+| GlowBorder       | Animated glowing border with gradients    | [Demo](https://fancy-ui.rama.app/demo/glow-border)        |
+| GlowingEffect    | Glowing highlight on hover                | [Demo](https://fancy-ui.rama.app/demo/glowing-effect)     |
 | ImageTrailCursor | Cursor-following image trail (8 variants) | [Demo](https://fancy-ui.rama.app/demo/image-trail-cursor) |
-| LiquidGlass | Liquid glass morphism effect | [Demo](https://fancy-ui.rama.app/demo/liquid-glass) |
-| Meteors | Animated meteor shower effect | [Demo](https://fancy-ui.rama.app/demo/meteors) |
-| NeonBorder | Dual-color neon glow border | [Demo](https://fancy-ui.rama.app/demo/neon-border) |
-| Ripple | Expanding ripple rings | [Demo](https://fancy-ui.rama.app/demo/ripple) |
-| SmoothCursor | Smooth lagging cursor follower | [Demo](https://fancy-ui.rama.app/demo/smooth-cursor) |
-| Sparkles | Particle sparkle canvas | [Demo](https://fancy-ui.rama.app/demo/sparkles) |
-| TracingBeam | Scroll-driven tracing beam | [Demo](https://fancy-ui.rama.app/demo/tracing-beam) |
+| LiquidGlass      | Liquid glass morphism effect              | [Demo](https://fancy-ui.rama.app/demo/liquid-glass)       |
+| Meteors          | Animated meteor shower effect             | [Demo](https://fancy-ui.rama.app/demo/meteors)            |
+| NeonBorder       | Dual-color neon glow border               | [Demo](https://fancy-ui.rama.app/demo/neon-border)        |
+| Ripple           | Expanding ripple rings                    | [Demo](https://fancy-ui.rama.app/demo/ripple)             |
+| SmoothCursor     | Smooth lagging cursor follower            | [Demo](https://fancy-ui.rama.app/demo/smooth-cursor)      |
+| Sparkles         | Particle sparkle canvas                   | [Demo](https://fancy-ui.rama.app/demo/sparkles)           |
+| TracingBeam      | Scroll-driven tracing beam                | [Demo](https://fancy-ui.rama.app/demo/tracing-beam)       |
 
 ### Layout
 
-| Component | Description | Demo |
-|-----------|-------------|------|
-| BentoGrid | Bento-style responsive grid layout | [Demo](https://fancy-ui.rama.app/demo/bento-grid) |
-| Book | 3D book flip animation | [Demo](https://fancy-ui.rama.app/demo/book) |
-| ContainerScroll | 3D scroll perspective container | [Demo](https://fancy-ui.rama.app/demo/container-scroll) |
-| Focus | Focus-expand card layout | [Demo](https://fancy-ui.rama.app/demo/focus) |
-| Marquee | Infinite scrolling for text, images, or cards | [Demo](https://fancy-ui.rama.app/demo/marquee) |
+| Component       | Description                                   | Demo                                                    |
+| --------------- | --------------------------------------------- | ------------------------------------------------------- |
+| BentoGrid       | Bento-style responsive grid layout            | [Demo](https://fancy-ui.rama.app/demo/bento-grid)       |
+| Book            | 3D book flip animation                        | [Demo](https://fancy-ui.rama.app/demo/book)             |
+| ContainerScroll | 3D scroll perspective container               | [Demo](https://fancy-ui.rama.app/demo/container-scroll) |
+| Focus           | Focus-expand card layout                      | [Demo](https://fancy-ui.rama.app/demo/focus)            |
+| Marquee         | Infinite scrolling for text, images, or cards | [Demo](https://fancy-ui.rama.app/demo/marquee)          |
 
 ### Navigation & Display
 
-| Component | Description | Demo |
-|-----------|-------------|------|
-| AnimatedTooltip | Avatar row with mouse-following tooltips | [Demo](https://fancy-ui.rama.app/demo/animated-tooltip) |
-| Compare | Before/after image comparison slider | [Demo](https://fancy-ui.rama.app/demo/compare) |
-| Dock | macOS-style dock with icon magnification | [Demo](https://fancy-ui.rama.app/demo/dock) |
-| LogoCloud | Marquee, grid, and icon logo layouts | [Demo](https://fancy-ui.rama.app/demo/logo-cloud) |
-| Timeline | Vertical timeline with scroll-driven progress | [Demo](https://fancy-ui.rama.app/demo/timeline) |
+| Component       | Description                                   | Demo                                                    |
+| --------------- | --------------------------------------------- | ------------------------------------------------------- |
+| AnimatedTooltip | Avatar row with mouse-following tooltips      | [Demo](https://fancy-ui.rama.app/demo/animated-tooltip) |
+| Compare         | Before/after image comparison slider          | [Demo](https://fancy-ui.rama.app/demo/compare)          |
+| Dock            | macOS-style dock with icon magnification      | [Demo](https://fancy-ui.rama.app/demo/dock)             |
+| LogoCloud       | Marquee, grid, and icon logo layouts          | [Demo](https://fancy-ui.rama.app/demo/logo-cloud)       |
+| Timeline        | Vertical timeline with scroll-driven progress | [Demo](https://fancy-ui.rama.app/demo/timeline)         |
 
 ## Quick Start
 
@@ -125,7 +125,7 @@ npm install fancy-ui-svelte
 Then import any component:
 
 ```ts
-import { Marquee, BorderBeam, Confetti } from 'fancy-ui-svelte';
+import { Marquee, BorderBeam, Confetti } from "fancy-ui-svelte";
 ```
 
 Add the Tailwind integration to your app's CSS (e.g. `src/app.css`):
@@ -146,9 +146,11 @@ This single import tells Tailwind v4 to scan the library's components so all uti
 ```
 
 The path is relative to your CSS file location.
+
 </details>
 
 **Or browse and copy a component:**
+
 1. Find the component you need in the [live demo](https://fancy-ui.rama.app)
 2. Copy the source from `src/lib/fancy-ui/[component-name]/`
 3. Paste into your project
@@ -189,7 +191,10 @@ pnpm check        # Run Svelte type checker
 pnpm test         # Run tests
 pnpm test:watch   # Run tests in watch mode
 pnpm build        # Production build
+pnpm storybook    # Component workshop on :6006
 ```
+
+Component stories live in `src/stories/` — see [docs/storybook.md](./docs/storybook.md).
 
 ## Project Structure
 
@@ -226,15 +231,15 @@ Contributions are welcome! 56 components and counting — PRs for new components
 
 ## Tech Stack
 
-| Technology | Version | Purpose |
-|------------|---------|---------|
-| [Svelte](https://svelte.dev) | 5 | UI framework |
-| [SvelteKit](https://svelte.dev/docs/kit) | 2 | App framework |
-| [Tailwind CSS](https://tailwindcss.com) | 4 | Styling |
-| [TypeScript](https://www.typescriptlang.org) | 5 | Type safety |
-| [Vitest](https://vitest.dev) | 4 | Testing |
-| [bits-ui](https://bits-ui.com) | 2 | Headless primitives |
-| [GSAP](https://gsap.com) | 3 | Advanced animations |
+| Technology                                   | Version | Purpose             |
+| -------------------------------------------- | ------- | ------------------- |
+| [Svelte](https://svelte.dev)                 | 5       | UI framework        |
+| [SvelteKit](https://svelte.dev/docs/kit)     | 2       | App framework       |
+| [Tailwind CSS](https://tailwindcss.com)      | 4       | Styling             |
+| [TypeScript](https://www.typescriptlang.org) | 5       | Type safety         |
+| [Vitest](https://vitest.dev)                 | 4       | Testing             |
+| [bits-ui](https://bits-ui.com)               | 2       | Headless primitives |
+| [GSAP](https://gsap.com)                     | 3       | Advanced animations |
 
 ## Credits
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
 		"version": "changeset version",
 		"release": "changeset tag",
 		"package": "svelte-kit sync && svelte-package -i src/lib -o dist && node -e \"const fs=require('fs'); ['dist/builder','dist/server','dist/stores'].forEach(p=>fs.rmSync(p,{recursive:true,force:true}));\" && publint",
-		"prepublishOnly": "pnpm run package"
+		"prepublishOnly": "pnpm run package",
+		"storybook": "storybook dev -p 6006",
+		"build-storybook": "storybook build"
 	},
 	"engines": {
 		"node": ">=20.19.0"
@@ -81,6 +83,10 @@
 		"@internationalized/date": "^3.10.1",
 		"@lucide/svelte": "^0.562.0",
 		"@playwright/test": "^1.58.2",
+		"@storybook/addon-a11y": "^10.4.6",
+		"@storybook/addon-docs": "^10.4.6",
+		"@storybook/addon-svelte-csf": "^5.1.2",
+		"@storybook/sveltekit": "^10.4.6",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/kit": "^2.49.1",
 		"@sveltejs/package": "^2.5.7",
@@ -105,6 +111,7 @@
 		"prettier-plugin-tailwindcss": "^0.7.2",
 		"publint": "^0.3.18",
 		"shiki": "^4.0.2",
+		"storybook": "^10.4.6",
 		"svelte": "^5.45.6",
 		"svelte-check": "^4.3.4",
 		"tailwind-variants": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,18 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      '@storybook/addon-a11y':
+        specifier: ^10.4.6
+        version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))
+      '@storybook/addon-docs':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react@19.2.17)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@storybook/addon-svelte-csf':
+        specifier: ^5.1.2
+        version: 5.1.2(@storybook/svelte@10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1))(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@storybook/sveltekit':
+        specifier: ^10.4.6
+        version: 10.4.6(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
       '@sveltejs/adapter-auto':
         specifier: ^7.0.0
         version: 7.0.0(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))
@@ -65,7 +77,7 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.3.1
-        version: 5.3.1(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2))
+        version: 5.3.1(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18)
       '@types/canvas-confetti':
         specifier: ^1.9.0
         version: 1.9.0
@@ -77,7 +89,7 @@ importers:
         version: 0.183.1
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)
+        version: 2.0.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(react@19.2.7)(svelte@5.46.1)
       arctic:
         specifier: ^3.7.0
         version: 3.7.0
@@ -114,6 +126,9 @@ importers:
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
+      storybook:
+        specifier: ^10.4.6
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7)
       svelte:
         specifier: ^5.45.6
         version: 5.46.1
@@ -137,7 +152,7 @@ importers:
         version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
+        version: 4.0.18(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
 
 packages:
 
@@ -307,6 +322,24 @@ packages:
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -530,6 +563,18 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -559,6 +604,239 @@ packages:
 
   '@oslojs/jwt@0.2.0':
     resolution: {integrity: sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==}
+
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    resolution: {integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    resolution: {integrity: sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    resolution: {integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    resolution: {integrity: sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    resolution: {integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    resolution: {integrity: sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    resolution: {integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    resolution: {integrity: sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    resolution: {integrity: sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.23.0':
+    resolution: {integrity: sha512-8IJyWRLVAyhTfe9/TIEbQqSQnl5rUqYJrUOS6Dkr+Mq9FGHMxDGeiEmwkBqCvDP5KckpPh/GYSgbag66O6JsCw==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.23.0':
+    resolution: {integrity: sha512-pprVojnNhHxupwTT2gdeUlkxll6XEvWWBk3oVicOSNVWQC99OBnDhMQDoirqnzrE1bScQSMS2JgPpqdlrhz/Fg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.23.0':
+    resolution: {integrity: sha512-mbIrWIMAJeytyee36OyUP5XH92TP7FaKaQ2m5AjokKy7STgjrhRt7SMXqpqLjhGm6Xn721Xmsg6H3Rtd9YQETw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.23.0':
+    resolution: {integrity: sha512-UnIphmZ1LazUCr9DXWaKYWtKDefPMbgLsywaoYxRqVCNHhq4MM6d2q1Nz1i9Vzxt5i+cE2nRUYpAUHr/lijNYA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.23.0':
+    resolution: {integrity: sha512-aaZ/cSEYFkSxgS2hOrobT6RQcsWNviOX8dW6CEkVx2/UYkAf9MeHbjl3W0usWV53rVV//ndBdn2nb1y7jsu4lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.23.0':
+    resolution: {integrity: sha512-IoJLvO5SjLSVMaq83BNTrPCb1FppvoJc1IhZ5CoUVl3PykUBku7D+LK1j0GSurhJcIc6zfjghsvaZNpq5ev6Mg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.23.0':
+    resolution: {integrity: sha512-vskFpwg44T/LFsfjSCnVZ5ygcuqzPC1yUzVEiKa8BgHAQz0+QLQQW3EGWLPVi8EXFghzjR4EtgPBtOhCjU4jdw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.23.0':
+    resolution: {integrity: sha512-//TcHVhrChyw5RYtgts6WO7KcWq9387c1Z5Zvhqpk/ktAbyaRYgBZrpSY1GDCFq50ASt6B6jhh+JxB1rB45IAg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.23.0':
+    resolution: {integrity: sha512-ZFqlwiTf7CXLLSGyAR9tYiO33LiaeIEXW+xm42d8mnUGpDgPltyrCGYtQezyMMEXvjhOgCz1X+i7sbDTJEx+bg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.23.0':
+    resolution: {integrity: sha512-oZ5LeN5+H1R19dRjTAxKrxQguH+AsemHcnthEfFxf4OjmBSty2doHLeSmMunKy3zpTHJQ3lh3Af+dNS+W6dYeA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.23.0':
+    resolution: {integrity: sha512-O4ciFDyX5ebQd0qkb1bjAIg8IEfiLT03GbSeylwlwlUMK9KwBWaALwrxSbc0Msaz4U6iPj+T9eRXpD5mxBfmvA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.23.0':
+    resolution: {integrity: sha512-P3o8Y9kISYjcxadmbO+94ThRwLhwGuDAbA7dcdd4+YLpfeF+mmobz8fXf4NmSdfSqjyRSkceJDBRZha9NVYkiQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.23.0':
+    resolution: {integrity: sha512-oj03m1E3RmTFczKhcKJDzHaEDKJnPIsDcQFVxBJsSdXGSuIPdt5TvcM332FfMQgzI6yDJqyl4InrnFfXrmUTKQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.23.0':
+    resolution: {integrity: sha512-BqJxbSC8FdP7mSuSpRePTGHm0hXWV+dfz//f7SjsteZncLaBgWTBmi/OZNv7sX6CyG/Pt/eJkPorP+DkMOhMwQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.23.0':
+    resolution: {integrity: sha512-utmw+VmUrW4K8LI5/6jhg4aGYKJHOIjQ9syYOOA6pF3w7haKu4r4enTe2U0C04/HbUvkq/Zif43xFsKW1Pnq9w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.23.0':
+    resolution: {integrity: sha512-V6lbRrthHa4TbvsLjPtg+EkXT1tRY+s4I8rYLXUfiHlZzGx3sLv1EH9CEOOevjvUYHLsbe/gqCIc73XnQfPb9A==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.23.0':
+    resolution: {integrity: sha512-gRoOxQPdnAmIAjxcuQNBxfihvx+wjTaQM/9/eP12xwnGNawOG/+Zz9RHN4WNSxT45b5CrscK4NB8aPh+oZQXAQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.23.0':
+    resolution: {integrity: sha512-CgTGMYsJVe1eUiCdJTpGw21svXw79ITsemN1h0hcNkiswasDbN5MoibSLY+gRMWP5syfEz5iffrjZnwEP8xeUA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.23.0':
+    resolution: {integrity: sha512-gUGJpr+Rn6zMxm5juApV0K3U845i8t47o8k+rbO0BHbi4PoJIfSPeQmrE2dgohQm2g5k6iviNFyXCGqvmaYUpw==}
+    cpu: [x64]
+    os: [win32]
 
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
@@ -744,6 +1022,99 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@storybook/addon-a11y@10.4.6':
+    resolution: {integrity: sha512-XCJy+f0DFOiCgUU9knRDlLDxVFI+AAQ3/wE/NF85zB9iDPPS2DwkSN+mas3zDgHt66zhN8Cq3/UiyCDUweV9Zw==}
+    peerDependencies:
+      storybook: ^10.4.6
+
+  '@storybook/addon-docs@10.4.6':
+    resolution: {integrity: sha512-aWAfP5JMiT5a3zBJizwroCRzOCqZwDTJmvsYvwMD3ilIEa/kT1vhf6Xrbk4XIPhDwbh8Hpb/Gfnka1xBYEISWg==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.6
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@storybook/addon-svelte-csf@5.1.2':
+    resolution: {integrity: sha512-NpImknEb48J7yr/ArTYpvhDSvGUrgm5Nuybu9PCicjSKTACsXX7cln2R19572ORtns399RTE+t20BBOKxSPm2g==}
+    peerDependencies:
+      '@storybook/svelte': ^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+      '@sveltejs/vite-plugin-svelte': ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      storybook: ^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+      svelte: ^5.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/builder-vite@10.4.6':
+    resolution: {integrity: sha512-BHBtD81HiXUiDQz/CaFynLtWmm7AFUQn8VnXuHipZ8KlnUANopa4yqdVuy/Gwz8ub254uFI5NMZsW/KlgWNgNg==}
+    peerDependencies:
+      storybook: ^10.4.6
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/csf-plugin@10.4.6':
+    resolution: {integrity: sha512-NILLxDqpA/JR/AazGWpsz+4fadJwRU4uhHephGtYpVOWnQA/DkJfKT6zpcJVq8+QA8A2zKMLX3GVKsXIrxjuDA==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.4.6
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@storybook/csf@0.1.13':
+    resolution: {integrity: sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q==}
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@2.1.0':
+    resolution: {integrity: sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/react-dom-shim@10.4.6':
+    resolution: {integrity: sha512-iGNmKzrq9vgl2PDrYAnZKI+yvac3Ym+lJXXuQaqlFRS23zA5MNm4EBX+rAG7WulqchoK6NaZ0KQOs2mAgEpTMg==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.6
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@storybook/svelte-vite@10.4.6':
+    resolution: {integrity: sha512-zyFg12tksWb0gLK29ucyZO5oNh4veu4biMeJgAEPEALjHw8HysP7mTA4547JYprk3JzORpwSqQ7Y9TPPB0ZwFA==}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      storybook: ^10.4.6
+      svelte: ^5.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/svelte@10.4.6':
+    resolution: {integrity: sha512-U73tDy/2vgY83Zjjy7Q5Lz0ElpZZjGQHZHZd1rrD0gv1+Zas/7aTnRjRqIUrBNqHBx1S8VA5Tzp5YI0FkM1IOw==}
+    peerDependencies:
+      storybook: ^10.4.6
+      svelte: ^5.0.0
+
+  '@storybook/sveltekit@10.4.6':
+    resolution: {integrity: sha512-DAbNFUr3B/XiUUUZak2TcjxCxB7eRCCgt4P0MSm9LdFTyePBdU13jybuArUfHqp6lgwqNgbFIjv1nazPjHq51g==}
+    peerDependencies:
+      storybook: ^10.4.6
+      svelte: ^5.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
   '@sveltejs/acorn-typescript@1.0.8':
     resolution: {integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==}
     peerDependencies:
@@ -926,8 +1297,17 @@ packages:
       vitest:
         optional: true
 
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -953,11 +1333,17 @@ packages:
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
+  '@types/mdx@2.0.14':
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
@@ -1009,6 +1395,20 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/browser-playwright@4.0.18':
+    resolution: {integrity: sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.0.18
+
+  '@vitest/browser@4.0.18':
+    resolution: {integrity: sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng==}
+    peerDependencies:
+      vitest: 4.0.18
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
@@ -1023,6 +1423,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.0.18':
     resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
 
@@ -1032,11 +1435,20 @@ packages:
   '@vitest/snapshot@4.0.18':
     resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.0.18':
     resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
 
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
@@ -1086,6 +1498,14 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1108,11 +1528,19 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   canvas-confetti@1.9.4:
     resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1126,6 +1554,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -1170,6 +1602,9 @@ packages:
     resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
     engines: {node: '>=20'}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1189,9 +1624,33 @@ packages:
   dedent-js@1.0.1:
     resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
 
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1239,6 +1698,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
+
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
@@ -1251,6 +1713,12 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  esrap@1.2.2:
+    resolution: {integrity: sha512-F2pSJklxx1BlQIQgooczXCPHmcWpn6EsP5oo73LQfonG9fIlIENQ8vMmfGXeojP9MrkzUNAfyU5vdFlR9shHAw==}
+
+  esrap@1.4.9:
+    resolution: {integrity: sha512-3OMlcd0a03UGuZpPeUC1HxR3nA23l+HEyCiZw3b3FumJIN9KphoGzDJKMXI1S72jVS1dsenDyQC0kJlO1U9E1g==}
 
   esrap@2.2.1:
     resolution: {integrity: sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==}
@@ -1364,6 +1832,11 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1371,6 +1844,11 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -1389,6 +1867,10 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1521,6 +2003,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@11.2.5:
     resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
     engines: {node: 20 || >=22}
@@ -1619,8 +2104,19 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  oxc-parser@0.127.0:
+    resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.23.0:
+    resolution: {integrity: sha512-f0+l598CJMOLnYPXsXxttJALH0ljtivdRMKtvHhxRuWa5FYmw5+qODARl8oYjMC/brpzKcrpdORsOBrTqhBZ9A==}
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -1666,6 +2162,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1681,8 +2181,17 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pixelmatch@7.1.0:
+    resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
+    hasBin: true
+
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1690,6 +2199,15 @@ packages:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
     engines: {node: '>=18'}
     hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -1799,8 +2317,17 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -1813,6 +2340,10 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  recast@0.23.12:
+    resolution: {integrity: sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==}
+    engines: {node: '>= 4'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -1844,6 +2375,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1866,6 +2401,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
@@ -1909,6 +2447,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
@@ -1923,6 +2465,21 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  storybook@10.4.6:
+    resolution: {integrity: sha512-6wkA6LxfDSSilloITsrFOJfsnw0mDUP2h8Ls+lRt8oRsudtz2RWFhLv+Toiwg6NW7hUpdTDc2hzR7DztJid6+A==}
+    hasBin: true
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      prettier: ^2 || ^3
+      vite-plus: ^0.1.15
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      prettier:
+        optional: true
+      vite-plus:
+        optional: true
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -1941,6 +2498,12 @@ packages:
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  svelte-ast-print@0.4.2:
+    resolution: {integrity: sha512-hRHHufbJoArFmDYQKCpCvc0xUuIEfwYksvyLYEQyH+1xb5LD5sM/IthfooCdXZQtOIqXz6xm7NmaqdfwG4kh6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      svelte: ^5.0.0
 
   svelte-check@4.3.5:
     resolution: {integrity: sha512-e4VWZETyXaKGhpkxOXP+B/d0Fp/zKViZoJmneZWe/05Y2aqSKj3YN2nLfYPJBQ87WEiY4BQCQ9hWGu9mPT1a1Q==}
@@ -1972,6 +2535,10 @@ packages:
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwind-merge@3.4.0:
     resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
 
@@ -1999,6 +2566,9 @@ packages:
   three@0.183.2:
     resolution: {integrity: sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2010,8 +2580,16 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.21:
@@ -2044,11 +2622,23 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
+    engines: {node: '>=20'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -2096,6 +2686,15 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2199,6 +2798,9 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
@@ -2221,12 +2823,31 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  zimmerframe@1.1.2:
+    resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
@@ -2481,6 +3102,38 @@ snapshots:
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
@@ -2624,6 +3277,26 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@types/mdx': 2.0.14
+      '@types/react': 19.2.17
+      react: 19.2.7
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2654,6 +3327,133 @@ snapshots:
   '@oslojs/jwt@0.2.0':
     dependencies:
       '@oslojs/encoding': 0.4.1
+
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.23.0':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.23.0':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.23.0':
+    optional: true
 
   '@playwright/test@1.58.2':
     dependencies:
@@ -2779,6 +3579,123 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@storybook/addon-a11y@10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      axe-core: 4.12.1
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7)
+
+  '@storybook/addon-docs@10.4.6(@types/react@19.2.17)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@storybook/icons': 2.1.0(react@19.2.7)
+      '@storybook/react-dom-shim': 10.4.6(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7)
+      ts-dedent: 2.3.0
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
+  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1))(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@storybook/csf': 0.1.13
+      '@storybook/svelte': 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1)
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      dedent: 1.7.2
+      es-toolkit: 1.49.0
+      esrap: 1.4.9
+      magic-string: 0.30.21
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7)
+      svelte: 5.46.1
+      svelte-ast-print: 0.4.2(svelte@5.46.1)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - babel-plugin-macros
+
+  '@storybook/builder-vite@10.4.6(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7)
+      ts-dedent: 2.3.0
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/csf-plugin@10.4.6(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.2
+      rollup: 4.55.1
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+
+  '@storybook/csf@0.1.13':
+    dependencies:
+      type-fest: 2.19.0
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@2.1.0(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+
+  '@storybook/react-dom-shim@10.4.6(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))':
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@storybook/svelte-vite@10.4.6(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@storybook/builder-vite': 10.4.6(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@storybook/svelte': 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1)
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      magic-string: 0.30.21
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7)
+      svelte: 5.46.1
+      svelte2tsx: 0.7.52(svelte@5.46.1)(typescript@5.9.3)
+      typescript: 5.9.3
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/svelte@10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1)':
+    dependencies:
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7)
+      svelte: 5.46.1
+      ts-dedent: 2.3.0
+      type-fest: 5.7.0
+
+  '@storybook/sveltekit@10.4.6(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@storybook/builder-vite': 10.4.6(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@storybook/svelte': 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1)
+      '@storybook/svelte-vite': 10.4.6(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7))(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7)
+      svelte: 5.46.1
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - '@sveltejs/vite-plugin-svelte'
+      - esbuild
+      - rollup
+      - webpack
 
   '@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)':
     dependencies:
@@ -2943,16 +3860,25 @@ snapshots:
     dependencies:
       svelte: 5.46.1
 
-  '@testing-library/svelte@5.3.1(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2))':
+  '@testing-library/svelte@5.3.1(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.46.1)
       svelte: 5.46.1
     optionalDependencies:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
-      vitest: 4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
+      vitest: 4.0.18(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tweenjs/tween.js@23.1.3': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/aria-query@5.0.4': {}
 
@@ -2977,11 +3903,17 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.11
 
+  '@types/mdx@2.0.14': {}
+
   '@types/node@12.20.55': {}
 
   '@types/node@25.2.3':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/stats.js@0.17.4': {}
 
@@ -3006,10 +3938,51 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vercel/analytics@2.0.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)':
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(react@19.2.7)(svelte@5.46.1)':
     optionalDependencies:
       '@sveltejs/kit': 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      react: 19.2.7
       svelte: 5.46.1
+
+  '@vitest/browser-playwright@4.0.18(playwright@1.61.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18)':
+    dependencies:
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      playwright: 1.61.1
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18)':
+    dependencies:
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/utils': 4.0.18
+      magic-string: 0.30.21
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -3028,6 +4001,10 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.0.3
@@ -3043,12 +4020,24 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.0.18':
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
+
+  '@webcontainer/env@1.1.1': {}
 
   '@webgpu/types@0.1.69': {}
 
@@ -3084,6 +4073,12 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
+  axe-core@4.12.1: {}
+
   axobject-query@4.1.0: {}
 
   better-path-resolve@1.0.0:
@@ -3111,9 +4106,21 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   canvas-confetti@1.9.4: {}
 
   ccount@2.0.1: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
 
   chai@6.2.2: {}
 
@@ -3122,6 +4129,8 @@ snapshots:
   character-entities-legacy@3.0.0: {}
 
   chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -3164,6 +4173,8 @@ snapshots:
       css-tree: 3.1.0
       lru-cache: 11.2.5
 
+  csstype@3.2.3: {}
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -3179,7 +4190,20 @@ snapshots:
 
   dedent-js@1.0.1: {}
 
+  dedent@1.7.2: {}
+
+  deep-eql@5.0.2: {}
+
   deepmerge@4.3.1: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -3219,6 +4243,8 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
+  es-toolkit@1.49.0: {}
+
   esbuild@0.27.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.2
@@ -3251,6 +4277,15 @@ snapshots:
   esm-env@1.2.2: {}
 
   esprima@4.0.1: {}
+
+  esrap@1.2.2:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@types/estree': 1.0.8
+
+  esrap@1.4.9:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   esrap@2.2.1:
     dependencies:
@@ -3378,11 +4413,17 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-number@7.0.0: {}
 
@@ -3397,6 +4438,10 @@ snapshots:
       better-path-resolve: 1.0.0
 
   is-windows@1.0.2: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 
@@ -3536,6 +4581,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  loupe@3.2.1: {}
+
   lru-cache@11.2.5: {}
 
   lru-cache@11.2.7: {}
@@ -3624,7 +4671,61 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
   outdent@0.5.0: {}
+
+  oxc-parser@0.127.0:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.127.0
+      '@oxc-parser/binding-android-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-x64': 0.127.0
+      '@oxc-parser/binding-freebsd-x64': 0.127.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.127.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.127.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-musl': 0.127.0
+      '@oxc-parser/binding-openharmony-arm64': 0.127.0
+      '@oxc-parser/binding-wasm32-wasi': 0.127.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.127.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.127.0
+
+  oxc-resolver@11.23.0:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.23.0
+      '@oxc-resolver/binding-android-arm64': 11.23.0
+      '@oxc-resolver/binding-darwin-arm64': 11.23.0
+      '@oxc-resolver/binding-darwin-x64': 11.23.0
+      '@oxc-resolver/binding-freebsd-x64': 11.23.0
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.23.0
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.23.0
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.23.0
+      '@oxc-resolver/binding-linux-arm64-musl': 11.23.0
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.23.0
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.23.0
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.23.0
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.23.0
+      '@oxc-resolver/binding-linux-x64-gnu': 11.23.0
+      '@oxc-resolver/binding-linux-x64-musl': 11.23.0
+      '@oxc-resolver/binding-openharmony-arm64': 11.23.0
+      '@oxc-resolver/binding-wasm32-wasi': 11.23.0
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.23.0
+      '@oxc-resolver/binding-win32-x64-msvc': 11.23.0
 
   p-filter@2.1.0:
     dependencies:
@@ -3660,6 +4761,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -3668,13 +4771,31 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pixelmatch@7.1.0:
+    dependencies:
+      pngjs: 7.0.0
+    optional: true
+
   playwright-core@1.58.2: {}
+
+  playwright-core@1.61.1:
+    optional: true
 
   playwright@1.58.2:
     dependencies:
       playwright-core: 1.58.2
     optionalDependencies:
       fsevents: 2.3.2
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    optional: true
+
+  pngjs@7.0.0:
+    optional: true
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -3727,7 +4848,14 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
   react-is@17.0.2: {}
+
+  react@19.2.7: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -3739,6 +4867,14 @@ snapshots:
   readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
+
+  recast@0.23.12:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
 
   redent@3.0.0:
     dependencies:
@@ -3792,6 +4928,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.55.1
       fsevents: 2.3.3
 
+  run-applescript@7.1.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -3814,6 +4952,8 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
 
   scule@1.3.0: {}
 
@@ -3852,6 +4992,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1: {}
+
   space-separated-tokens@2.0.2: {}
 
   spawndamnit@3.0.1:
@@ -3864,6 +5006,32 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.1)(react@19.2.7):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.1.0(react@19.2.7)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.27.2
+      open: 10.2.0
+      oxc-parser: 0.127.0
+      oxc-resolver: 11.23.0
+      recast: 0.23.12
+      semver: 7.7.4
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      ws: 8.21.0
+    optionalDependencies:
+      '@types/react': 19.2.17
+      prettier: 3.8.1
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - react
+      - utf-8-validate
 
   stringify-entities@4.0.4:
     dependencies:
@@ -3883,6 +5051,12 @@ snapshots:
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
+
+  svelte-ast-print@0.4.2(svelte@5.46.1):
+    dependencies:
+      esrap: 1.2.2
+      svelte: 5.46.1
+      zimmerframe: 1.1.2
 
   svelte-check@4.3.5(picomatch@4.0.3)(svelte@5.46.1)(typescript@5.9.3):
     dependencies:
@@ -3934,6 +5108,8 @@ snapshots:
 
   tabbable@6.4.0: {}
 
+  tagged-tag@1.0.0: {}
+
   tailwind-merge@3.4.0: {}
 
   tailwind-variants@3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.1.18):
@@ -3950,6 +5126,8 @@ snapshots:
 
   three@0.183.2: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
@@ -3959,7 +5137,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.0.3: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@7.0.21: {}
 
@@ -3987,9 +5169,17 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  ts-dedent@2.3.0: {}
+
   tslib@2.8.1: {}
 
   tw-animate-css@1.4.0: {}
+
+  type-fest@2.19.0: {}
+
+  type-fest@5.7.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
 
@@ -4041,6 +5231,17 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.15.0
+      picomatch: 4.0.3
+      webpack-virtual-modules: 0.6.2
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   util-deprecate@1.0.2: {}
 
   vfile-message@2.0.4:
@@ -4076,7 +5277,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
 
-  vitest@4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2):
+  vitest@4.0.18(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))
@@ -4100,6 +5301,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.2.3
+      '@vitest/browser-playwright': 4.0.18(playwright@1.61.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.18)
       jsdom: 28.0.0
     transitivePeerDependencies:
       - jiti
@@ -4119,6 +5321,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   webidl-conversions@8.0.1: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   whatwg-mimetype@5.0.0: {}
 
@@ -4147,9 +5351,17 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  ws@8.21.0: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  zimmerframe@1.1.2: {}
 
   zimmerframe@1.1.4: {}
 

--- a/src/stories/Introduction.mdx
+++ b/src/stories/Introduction.mdx
@@ -1,0 +1,58 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Introduction" />
+
+# FancyUI
+
+FancyUI (`fancy-ui-svelte`) is a collection of animated, copy-paste friendly UI components for **Svelte 5** and **Tailwind CSS v4** — buttons, cards, text effects, backgrounds, and visual effects for building polished landing pages and design systems.
+
+## Using a component
+
+Install the package and import any component from the root barrel:
+
+```svelte
+<script>
+	import { ShimmerButton } from "fancy-ui-svelte";
+</script>
+
+<ShimmerButton shimmerColor="#22d3ee">
+	<span class="text-white">Click me</span>
+</ShimmerButton>
+```
+
+Inside this repo, import from `$lib` instead:
+
+```ts
+import { ShimmerButton } from "$lib/fancy-ui/shimmer-button";
+```
+
+## Running Storybook
+
+```bash
+pnpm storybook        # dev server on http://localhost:6006
+pnpm build-storybook  # static build in storybook-static/
+```
+
+## Adding a new story
+
+1. Create `src/stories/<component-slug>.stories.svelte` (kebab-case, matching the component's folder slug in `src/lib/fancy-ui/`).
+2. Use Svelte CSF with `defineMeta`:
+
+```svelte
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { MyComponent } from "$lib/fancy-ui/my-component";
+
+	const { Story } = defineMeta({
+		title: "Category/MyComponent",
+		component: MyComponent,
+		tags: ["autodocs"],
+	});
+</script>
+
+<Story name="Default" />
+```
+
+3. Show the default state plus 2–3 useful variants. Use real component props only — check the `Props` type exported by the component.
+
+Stories live in `src/stories/`, **never** in `src/lib/` — everything under `src/lib` ships to npm via `svelte-package`.

--- a/src/stories/animated-beam.stories.svelte
+++ b/src/stories/animated-beam.stories.svelte
@@ -1,0 +1,104 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { AnimatedBeam } from "$lib/fancy-ui/animated-beam";
+
+	const { Story } = defineMeta({
+		title: "Effects/AnimatedBeam",
+		component: AnimatedBeam,
+		tags: ["autodocs"],
+	});
+</script>
+
+<script lang="ts">
+	// AnimatedBeam needs live element references for its container and endpoints.
+	// Each story keeps its own refs so the two graphs never bind to the same
+	// nodes when autodocs renders every story on one page.
+	let hubContainer = $state<HTMLElement>();
+	let hubA = $state<HTMLElement>();
+	let hubB = $state<HTMLElement>();
+	let hubC = $state<HTMLElement>();
+
+	let curveContainer = $state<HTMLElement>();
+	let curveFrom = $state<HTMLElement>();
+	let curveTo = $state<HTMLElement>();
+</script>
+
+{#snippet hub()}
+	<div
+		bind:this={hubContainer}
+		class="bg-background relative flex h-[320px] w-full items-center justify-center overflow-hidden rounded-lg border p-10"
+	>
+		<div class="flex size-full max-w-lg flex-col items-stretch justify-between">
+			<div class="flex flex-row items-center justify-between">
+				<div
+					bind:this={hubA}
+					class="z-10 flex size-12 items-center justify-center rounded-full border-2 bg-blue-500 p-2 shadow-[0_0_20px_-12px_rgba(0,0,0,0.8)]"
+				>
+					<span class="text-sm font-bold text-white">A</span>
+				</div>
+				<div
+					bind:this={hubC}
+					class="z-10 flex size-12 items-center justify-center rounded-full border-2 bg-pink-500 p-2 shadow-[0_0_20px_-12px_rgba(0,0,0,0.8)]"
+				>
+					<span class="text-sm font-bold text-white">C</span>
+				</div>
+			</div>
+			<div class="flex flex-row items-center justify-center">
+				<div
+					bind:this={hubB}
+					class="z-10 flex size-16 items-center justify-center rounded-full border-2 bg-orange-500 p-2 shadow-[0_0_20px_-12px_rgba(0,0,0,0.8)]"
+				>
+					<span class="text-sm font-bold text-white">HUB</span>
+				</div>
+			</div>
+		</div>
+
+		{#if hubContainer && hubA && hubB}
+			<AnimatedBeam containerRef={hubContainer} fromRef={hubA} toRef={hubB} curvature={40} />
+		{/if}
+		{#if hubContainer && hubC && hubB}
+			<AnimatedBeam
+				containerRef={hubContainer}
+				fromRef={hubC}
+				toRef={hubB}
+				curvature={40}
+				reverse={true}
+			/>
+		{/if}
+	</div>
+{/snippet}
+
+<Story name="Default" template={hub} />
+
+{#snippet curved()}
+	<div
+		bind:this={curveContainer}
+		class="bg-background relative flex h-[280px] w-full items-center justify-between overflow-hidden rounded-lg border px-16"
+	>
+		<div
+			bind:this={curveFrom}
+			class="z-10 flex size-12 items-center justify-center rounded-full border-2 bg-violet-500 p-2 shadow-[0_0_20px_-12px_rgba(0,0,0,0.8)]"
+		>
+			<span class="text-sm font-bold text-white">1</span>
+		</div>
+		<div
+			bind:this={curveTo}
+			class="z-10 flex size-12 items-center justify-center rounded-full border-2 bg-teal-500 p-2 shadow-[0_0_20px_-12px_rgba(0,0,0,0.8)]"
+		>
+			<span class="text-sm font-bold text-white">2</span>
+		</div>
+
+		{#if curveContainer && curveFrom && curveTo}
+			<AnimatedBeam
+				containerRef={curveContainer}
+				fromRef={curveFrom}
+				toRef={curveTo}
+				curvature={-60}
+				gradientStartColor="#22d3ee"
+				gradientStopColor="#a855f7"
+			/>
+		{/if}
+	</div>
+{/snippet}
+
+<Story name="Curved" template={curved} />

--- a/src/stories/animated-testimonials.stories.svelte
+++ b/src/stories/animated-testimonials.stories.svelte
@@ -1,0 +1,58 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { AnimatedTestimonials } from "$lib/fancy-ui/animated-testimonials";
+	import type { Testimonial } from "$lib/fancy-ui/animated-testimonials";
+
+	const testimonials: Testimonial[] = [
+		{
+			quote:
+				"The attention to detail and innovative features have completely transformed our workflow. This is exactly what we've been looking for.",
+			name: "Sarah Chen",
+			designation: "Product Manager at TechFlow",
+			src: "https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?w=500&auto=format&fit=crop&q=60",
+		},
+		{
+			quote:
+				"Implementation was seamless and the results exceeded our expectations. The platform's flexibility is truly impressive.",
+			name: "Michael Rivera",
+			designation: "CTO at InnovateSphere",
+			src: "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=500&auto=format&fit=crop&q=60",
+		},
+		{
+			quote:
+				"This solution has significantly improved our team's productivity. The intuitive interface makes complex tasks simple.",
+			name: "Emily Watson",
+			designation: "Operations Director at CloudScale",
+			src: "https://images.unsplash.com/photo-1623582854588-d60de57fa33f?w=500&auto=format&fit=crop&q=60",
+		},
+	];
+
+	const { Story } = defineMeta({
+		title: "Data Display/AnimatedTestimonials",
+		component: AnimatedTestimonials,
+		tags: ["autodocs"],
+		args: {
+			testimonials,
+			autoplay: false,
+			interval: 5000,
+		},
+		argTypes: {
+			testimonials: { control: "object", description: "Array of testimonials to display" },
+			autoplay: { control: "boolean", description: "Auto-advance testimonials" },
+			interval: {
+				control: "number",
+				description: "Interval between auto-advances in ms",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="flex min-h-[400px] items-center justify-center">
+		<AnimatedTestimonials {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="With Autoplay" {template} args={{ autoplay: true, interval: 3000 }} />

--- a/src/stories/animated-tooltip.stories.svelte
+++ b/src/stories/animated-tooltip.stories.svelte
@@ -1,0 +1,58 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { AnimatedTooltip, type TooltipItem } from "$lib/fancy-ui/animated-tooltip";
+
+	const people: TooltipItem[] = [
+		{
+			id: 1,
+			name: "John Doe",
+			designation: "Software Engineer",
+			image: "https://picsum.photos/seed/john/100/100",
+		},
+		{
+			id: 2,
+			name: "Jane Smith",
+			designation: "Product Manager",
+			image: "https://picsum.photos/seed/jane/100/100",
+		},
+		{
+			id: 3,
+			name: "Robert Johnson",
+			designation: "UX Designer",
+			image: "https://picsum.photos/seed/robert/100/100",
+		},
+		{
+			id: 4,
+			name: "Emily Brown",
+			designation: "Data Scientist",
+			image: "https://picsum.photos/seed/emily/100/100",
+		},
+	];
+
+	const pair: TooltipItem[] = people.slice(0, 2);
+
+	const { Story } = defineMeta({
+		title: "Feedback/AnimatedTooltip",
+		component: AnimatedTooltip,
+		tags: ["autodocs"],
+		args: {
+			items: people,
+		},
+		argTypes: {
+			items: {
+				control: "object",
+				description: "Array of items with id, name, designation, and image URL",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="flex justify-center p-6">
+		<AnimatedTooltip {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Two Members" {template} args={{ items: pair }} />

--- a/src/stories/apple-card-carousel.stories.svelte
+++ b/src/stories/apple-card-carousel.stories.svelte
@@ -1,0 +1,62 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { AppleCardCarousel } from "$lib/fancy-ui/apple-card-carousel";
+	import type { AppleCardData } from "$lib/fancy-ui/apple-card-carousel";
+
+	const cards: AppleCardData[] = [
+		{
+			category: "Nature",
+			title: "Misty Mountains",
+			src: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop&q=60",
+			description:
+				"A breathtaking view of misty mountains at dawn, where layers of fog weave between ancient peaks.",
+		},
+		{
+			category: "Architecture",
+			title: "Brutalist Forms",
+			src: "https://images.unsplash.com/photo-1486325212027-8081e485255e?w=800&auto=format&fit=crop&q=60",
+			description: "Raw concrete and bold geometry define this brutalist landmark.",
+		},
+		{
+			category: "Ocean",
+			title: "Deep Blue",
+			src: "https://images.unsplash.com/photo-1505118380757-91f5f5632de0?w=800&auto=format&fit=crop&q=60",
+			description: "Beneath the surface, an entire world exists in silence.",
+		},
+		{
+			category: "Urban",
+			title: "City Lights",
+			src: "https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?w=800&auto=format&fit=crop&q=60",
+			description: "The city never sleeps. From dusk to dawn, millions of lives intersect.",
+		},
+		{
+			category: "Desert",
+			title: "Sand & Silence",
+			src: "https://images.unsplash.com/photo-1509316785289-025f5b846b35?w=800&auto=format&fit=crop&q=60",
+			description:
+				"The desert teaches patience. Endless dunes shift imperceptibly under a relentless sun.",
+		},
+	];
+
+	const { Story } = defineMeta({
+		title: "Cards/AppleCardCarousel",
+		component: AppleCardCarousel,
+		tags: ["autodocs"],
+		args: {
+			cards,
+		},
+		argTypes: {
+			cards: { control: "object", description: "Cards to display in the carousel" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="overflow-hidden py-8">
+		<AppleCardCarousel {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Two Cards" {template} args={{ cards: cards.slice(0, 2) }} />

--- a/src/stories/bento-grid.stories.svelte
+++ b/src/stories/bento-grid.stories.svelte
@@ -1,0 +1,101 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { BentoGrid, BentoGridItem } from "$lib/fancy-ui/bento-grid";
+
+	const { Story } = defineMeta({
+		title: "Cards/BentoGrid",
+		component: BentoGrid,
+		tags: ["autodocs"],
+	});
+</script>
+
+{#snippet template()}
+	<BentoGrid>
+		<BentoGridItem class="md:col-span-2">
+			{#snippet header()}
+				<div
+					class="flex h-full min-h-[6rem] w-full flex-1 rounded-xl bg-gradient-to-br from-violet-500 to-purple-500"
+				></div>
+			{/snippet}
+			{#snippet title()}Feature One{/snippet}
+			{#snippet description()}A powerful feature that helps you build faster.{/snippet}
+		</BentoGridItem>
+
+		<BentoGridItem>
+			{#snippet header()}
+				<div
+					class="flex h-full min-h-[6rem] w-full flex-1 rounded-xl bg-gradient-to-br from-cyan-500 to-blue-500"
+				></div>
+			{/snippet}
+			{#snippet title()}Feature Two{/snippet}
+			{#snippet description()}Streamline your workflow.{/snippet}
+		</BentoGridItem>
+
+		<BentoGridItem>
+			{#snippet header()}
+				<div
+					class="flex h-full min-h-[6rem] w-full flex-1 rounded-xl bg-gradient-to-br from-orange-500 to-yellow-500"
+				></div>
+			{/snippet}
+			{#snippet title()}Feature Three{/snippet}
+			{#snippet description()}Beautiful by default.{/snippet}
+		</BentoGridItem>
+
+		<BentoGridItem class="md:col-span-2">
+			{#snippet header()}
+				<div
+					class="flex h-full min-h-[6rem] w-full flex-1 rounded-xl bg-gradient-to-br from-pink-500 to-rose-500"
+				></div>
+			{/snippet}
+			{#snippet title()}Feature Four{/snippet}
+			{#snippet description()}Ship with confidence using robust tooling.{/snippet}
+		</BentoGridItem>
+	</BentoGrid>
+{/snippet}
+
+<Story name="Default" {template} />
+
+{#snippet withIcon()}
+	<BentoGrid>
+		<BentoGridItem>
+			{#snippet header()}
+				<div
+					class="flex h-full min-h-[6rem] w-full flex-1 rounded-xl bg-gradient-to-br from-emerald-500 to-teal-500"
+				></div>
+			{/snippet}
+			{#snippet icon()}
+				<div class="text-2xl">⚡</div>
+			{/snippet}
+			{#snippet title()}Fast{/snippet}
+			{#snippet description()}Blazing performance out of the box.{/snippet}
+		</BentoGridItem>
+
+		<BentoGridItem>
+			{#snippet header()}
+				<div
+					class="flex h-full min-h-[6rem] w-full flex-1 rounded-xl bg-gradient-to-br from-fuchsia-500 to-pink-500"
+				></div>
+			{/snippet}
+			{#snippet icon()}
+				<div class="text-2xl">🎨</div>
+			{/snippet}
+			{#snippet title()}Beautiful{/snippet}
+			{#snippet description()}Polished visuals with sensible defaults.{/snippet}
+		</BentoGridItem>
+
+		<BentoGridItem>
+			{#snippet header()}
+				<div
+					class="flex h-full min-h-[6rem] w-full flex-1 rounded-xl bg-gradient-to-br from-sky-500 to-indigo-500"
+				></div>
+			{/snippet}
+			{#snippet icon()}
+				<div class="text-2xl">🔒</div>
+			{/snippet}
+			{#snippet title()}Reliable{/snippet}
+			{#snippet description()}Robust tooling you can trust.{/snippet}
+		</BentoGridItem>
+	</BentoGrid>
+{/snippet}
+
+<Story name="With Icons" template={withIcon} />

--- a/src/stories/bg-falling-stars.stories.svelte
+++ b/src/stories/bg-falling-stars.stories.svelte
@@ -1,0 +1,38 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { FallingStarsBg } from "$lib/fancy-ui/bg-falling-stars";
+
+	const { Story } = defineMeta({
+		title: "Backgrounds/FallingStarsBg",
+		component: FallingStarsBg,
+		tags: ["autodocs"],
+		args: {
+			color: "#FFF",
+			count: 200,
+		},
+		argTypes: {
+			color: { control: "color", description: "Star color as hex string" },
+			count: {
+				control: { type: "range", min: 20, max: 600, step: 20 },
+				description: "Number of stars",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="relative h-72 w-[480px] overflow-hidden rounded-lg border bg-black">
+		<FallingStarsBg {...args} />
+		<div class="relative z-10 flex h-full items-center justify-center">
+			<h2 class="text-4xl font-bold text-white">Falling Stars</h2>
+		</div>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Cyan Stars" {template} args={{ color: "#22d3ee" }} />
+
+<Story name="Dense Field" {template} args={{ count: 500 }} />
+
+<Story name="Sparse Amber" {template} args={{ color: "#fbbf24", count: 80 }} />

--- a/src/stories/bg-stars.stories.svelte
+++ b/src/stories/bg-stars.stories.svelte
@@ -1,0 +1,54 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { StarsBackground } from "$lib/fancy-ui/bg-stars";
+
+	const { Story } = defineMeta({
+		title: "Backgrounds/StarsBackground",
+		component: StarsBackground,
+		tags: ["autodocs"],
+		args: {
+			factor: 0.05,
+			speed: 50,
+			stiffness: 50,
+			damping: 20,
+			starColor: "#fff",
+		},
+		argTypes: {
+			factor: {
+				control: { type: "range", min: 0, max: 0.3, step: 0.01 },
+				description: "Parallax factor for mouse movement",
+			},
+			speed: {
+				control: { type: "range", min: 10, max: 120, step: 5 },
+				description: "Base animation speed in seconds",
+			},
+			stiffness: {
+				control: { type: "range", min: 10, max: 200, step: 10 },
+				description: "Spring stiffness for parallax",
+			},
+			damping: {
+				control: { type: "range", min: 5, max: 60, step: 5 },
+				description: "Spring damping for parallax",
+			},
+			starColor: { control: "color", description: "Color of the stars" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-[480px] overflow-hidden rounded-lg border">
+		<StarsBackground {...args} class="h-72">
+			<div class="relative z-10 flex h-full items-center justify-center">
+				<h2 class="text-4xl font-bold text-white">Move your mouse</h2>
+			</div>
+		</StarsBackground>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Cyan Stars" {template} args={{ starColor: "#67e8f9" }} />
+
+<Story name="Strong Parallax" {template} args={{ factor: 0.15, stiffness: 120 }} />
+
+<Story name="Slow Drift" {template} args={{ speed: 100 }} />

--- a/src/stories/blur-reveal.stories.svelte
+++ b/src/stories/blur-reveal.stories.svelte
@@ -1,0 +1,38 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { BlurReveal } from "$lib/fancy-ui/blur-reveal";
+
+	const { Story } = defineMeta({
+		title: "Text/BlurReveal",
+		component: BlurReveal,
+		tags: ["autodocs"],
+		args: {
+			duration: 1,
+			delay: 0.2,
+			blur: "20px",
+			yOffset: 20,
+		},
+		argTypes: {
+			duration: { control: "number", description: "Animation duration in seconds" },
+			delay: { control: "number", description: "Stagger delay between children in seconds" },
+			blur: { control: "text", description: "Initial blur amount (CSS value)" },
+			yOffset: { control: "number", description: "Initial vertical offset in pixels" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<BlurReveal {...args}>
+		<h3 class="mb-4 text-2xl font-bold">Welcome to the future</h3>
+		<p class="mb-3 text-neutral-500">
+			This paragraph fades in after the heading, with a slight delay.
+		</p>
+		<p class="text-neutral-500">And this one follows with another staggered delay.</p>
+	</BlurReveal>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Fast Reveal" {template} args={{ duration: 0.5, delay: 0.1 }} />
+
+<Story name="Heavy Blur" {template} args={{ blur: "40px", yOffset: 40 }} />

--- a/src/stories/book.stories.svelte
+++ b/src/stories/book.stories.svelte
@@ -1,0 +1,63 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { Book, BookHeader, BookTitle, BookDescription } from "$lib/fancy-ui/book";
+
+	const { Story } = defineMeta({
+		title: "Cards/Book",
+		component: Book,
+		tags: ["autodocs"],
+		args: {
+			duration: 1000,
+			color: "zinc",
+			isStatic: false,
+			size: "md",
+			radius: "md",
+			shadowSize: "lg",
+		},
+		argTypes: {
+			duration: { control: { type: "number" }, description: "Hover animation duration in ms" },
+			color: {
+				control: "select",
+				options: ["zinc", "slate", "red", "orange", "amber", "emerald", "blue", "violet", "rose"],
+				description: "Color theme for the book cover gradient",
+			},
+			isStatic: {
+				control: "boolean",
+				description: "Show book in open position without hover animation",
+			},
+			size: {
+				control: "inline-radio",
+				options: ["sm", "md", "lg", "xl"],
+				description: "Size variant of the book",
+			},
+			radius: {
+				control: "inline-radio",
+				options: ["sm", "md", "lg", "xl"],
+				description: "Border radius variant",
+			},
+			shadowSize: {
+				control: "inline-radio",
+				options: ["sm", "md", "lg", "xl"],
+				description: "Drop shadow size variant",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<Book {...args}>
+		<BookHeader>
+			<span class="rounded bg-white/20 px-2 py-0.5 text-xs">Fiction</span>
+		</BookHeader>
+		<BookTitle>The Great Gatsby</BookTitle>
+		<BookDescription>
+			A story of the mysteriously wealthy Jay Gatsby and his love for Daisy Buchanan.
+		</BookDescription>
+	</Book>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Emerald Large" {template} args={{ color: "emerald", size: "lg" }} />
+
+<Story name="Static Open" {template} args={{ isStatic: true, color: "rose" }} />

--- a/src/stories/border-beam.stories.svelte
+++ b/src/stories/border-beam.stories.svelte
@@ -1,0 +1,55 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { BorderBeam } from "$lib/fancy-ui/border-beam";
+
+	const { Story } = defineMeta({
+		title: "Effects/BorderBeam",
+		component: BorderBeam,
+		tags: ["autodocs"],
+		args: {
+			size: 200,
+			duration: 15,
+			borderWidth: 1.5,
+			anchor: 90,
+			colorFrom: "#ffaa40",
+			colorTo: "#9c40ff",
+			delay: 0,
+		},
+		argTypes: {
+			size: {
+				control: { type: "range", min: 40, max: 400, step: 10 },
+				description: "Size of the beam in pixels",
+			},
+			duration: {
+				control: { type: "range", min: 2, max: 30, step: 1 },
+				description: "Animation duration in seconds",
+			},
+			borderWidth: {
+				control: { type: "range", min: 0.5, max: 6, step: 0.5 },
+				description: "Border width in pixels",
+			},
+			anchor: {
+				control: { type: "range", min: 0, max: 100, step: 5 },
+				description: "Anchor position (0-100)",
+			},
+			colorFrom: { control: "color", description: "Gradient start color" },
+			colorTo: { control: "color", description: "Gradient end color" },
+			delay: { control: "number", description: "Animation delay in seconds" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="relative h-40 w-[420px] overflow-hidden rounded-xl border bg-neutral-950 p-6">
+		<p class="text-center text-neutral-400">Content goes here</p>
+		<BorderBeam {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Cyan Beam" {template} args={{ colorFrom: "#22d3ee", colorTo: "#3b82f6" }} />
+
+<Story name="Fast & Thick" {template} args={{ duration: 5, borderWidth: 3 }} />
+
+<Story name="Small Beam" {template} args={{ size: 80 }} />

--- a/src/stories/box-reveal.stories.svelte
+++ b/src/stories/box-reveal.stories.svelte
@@ -1,0 +1,34 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { BoxReveal } from "$lib/fancy-ui/box-reveal";
+
+	const { Story } = defineMeta({
+		title: "Text/BoxReveal",
+		component: BoxReveal,
+		tags: ["autodocs"],
+		args: {
+			color: "#5046e6",
+			duration: 0.5,
+			delay: 0.25,
+		},
+		argTypes: {
+			color: { control: "color", description: "Color of the reveal box" },
+			duration: { control: "number", description: "Animation duration in seconds" },
+			delay: { control: "number", description: "Delay before animation starts in seconds" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="p-4">
+		<BoxReveal {...args}>
+			<h2 class="text-4xl font-bold">Box Reveal</h2>
+		</BoxReveal>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Custom Color" {template} args={{ color: "#22d3ee" }} />
+
+<Story name="Slow Animation" {template} args={{ duration: 1, delay: 0.5 }} />

--- a/src/stories/card-3d.stories.svelte
+++ b/src/stories/card-3d.stories.svelte
@@ -1,0 +1,76 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { CardContainer, CardBody, CardItem } from "$lib/fancy-ui/card-3d";
+
+	const { Story } = defineMeta({
+		title: "Cards/Card3D",
+		component: CardContainer,
+		tags: ["autodocs"],
+		argTypes: {
+			containerClass: {
+				control: "text",
+				description: "CSS classes for the outer perspective wrapper",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<CardContainer {...args}>
+		<CardBody
+			class="group/card relative h-auto w-auto rounded-xl border border-black/[0.1] bg-gray-50 p-6 sm:w-[30rem] dark:border-white/[0.2] dark:bg-black"
+		>
+			<CardItem translateZ={50} class="text-xl font-bold text-neutral-600 dark:text-white">
+				Make things float in 3D
+			</CardItem>
+			<CardItem
+				as="p"
+				translateZ={60}
+				class="mt-2 max-w-sm text-sm text-neutral-500 dark:text-neutral-300"
+			>
+				Hover over this card to see the 3D depth effect. Each element can have its own translateZ
+				value.
+			</CardItem>
+			<CardItem translateZ={100} class="mt-4 w-full">
+				<img
+					src="https://picsum.photos/seed/forest/600/300"
+					alt="Landscape"
+					class="h-60 w-full rounded-xl object-cover group-hover/card:shadow-xl"
+				/>
+			</CardItem>
+			<div class="mt-6 flex items-center justify-between">
+				<CardItem
+					translateZ={20}
+					as="a"
+					class="rounded-xl px-4 py-2 text-xs font-normal dark:text-white"
+				>
+					Try now &rarr;
+				</CardItem>
+				<CardItem
+					translateZ={20}
+					as="button"
+					class="rounded-xl bg-black px-4 py-2 text-xs font-bold text-white dark:bg-white dark:text-black"
+				>
+					Sign up
+				</CardItem>
+			</div>
+		</CardBody>
+	</CardContainer>
+{/snippet}
+
+<Story name="Default" {template} />
+
+{#snippet highDepth(args: any)}
+	<CardContainer {...args}>
+		<CardBody
+			class="relative h-auto w-auto rounded-xl border border-white/[0.2] bg-black p-6 sm:w-[24rem]"
+		>
+			<CardItem translateZ={120} class="text-2xl font-bold text-white">Deep pop</CardItem>
+			<CardItem as="p" translateZ={80} class="mt-2 max-w-sm text-sm text-neutral-300">
+				A much higher translateZ makes elements leap further off the surface on hover.
+			</CardItem>
+		</CardBody>
+	</CardContainer>
+{/snippet}
+
+<Story name="High Depth" template={highDepth} />

--- a/src/stories/card-spotlight.stories.svelte
+++ b/src/stories/card-spotlight.stories.svelte
@@ -1,0 +1,44 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { CardSpotlight } from "$lib/fancy-ui/card-spotlight";
+
+	const { Story } = defineMeta({
+		title: "Cards/CardSpotlight",
+		component: CardSpotlight,
+		tags: ["autodocs"],
+		args: {
+			gradientSize: 200,
+			gradientColor: "#262626",
+			gradientOpacity: 0.8,
+		},
+		argTypes: {
+			gradientSize: {
+				control: { type: "number" },
+				description: "Size of the spotlight gradient in pixels",
+			},
+			gradientColor: { control: "color", description: "Color of the spotlight gradient" },
+			gradientOpacity: {
+				control: { type: "number", min: 0, max: 1, step: 0.1 },
+				description: "Opacity of the spotlight gradient",
+			},
+			slotClass: { control: "text", description: "CSS classes for the inner content wrapper" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<CardSpotlight class="h-64 w-80" {...args}>
+		<div class="p-6">
+			<h3 class="text-lg font-bold text-white">Spotlight Card</h3>
+			<p class="mt-2 text-sm text-neutral-400">
+				Hover to see the spotlight effect following your cursor.
+			</p>
+		</div>
+	</CardSpotlight>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Blue Spotlight" {template} args={{ gradientColor: "#1d4ed8", gradientSize: 260 }} />
+
+<Story name="Subtle" {template} args={{ gradientOpacity: 0.4 }} />

--- a/src/stories/colourful-text.stories.svelte
+++ b/src/stories/colourful-text.stories.svelte
@@ -1,0 +1,39 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ColourfulText } from "$lib/fancy-ui/colourful-text";
+
+	const { Story } = defineMeta({
+		title: "Text/ColourfulText",
+		component: ColourfulText,
+		tags: ["autodocs"],
+		args: {
+			text: "colourful",
+			startColor: "rgb(0, 0, 0)",
+			duration: 0.5,
+		},
+		argTypes: {
+			text: { control: "text", description: "Text to animate" },
+			startColor: { control: "text", description: "Initial color before animation" },
+			duration: {
+				control: "number",
+				description: "Transition duration in seconds for each character",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<h2 class="text-4xl font-bold">
+		Make things <ColourfulText {...args} />
+	</h2>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story
+	name="Custom Colors"
+	{template}
+	args={{ text: "vibrant", colors: ["#f97316", "#ec4899", "#8b5cf6", "#22d3ee"] }}
+/>
+
+<Story name="Fast Transition" {template} args={{ text: "flicker", duration: 0.15 }} />

--- a/src/stories/compare.stories.svelte
+++ b/src/stories/compare.stories.svelte
@@ -1,0 +1,57 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { Compare } from "$lib/fancy-ui/compare";
+
+	const { Story } = defineMeta({
+		title: "Media/Compare",
+		component: Compare,
+		tags: ["autodocs"],
+		args: {
+			firstImage: "https://picsum.photos/seed/forest/800/600",
+			secondImage: "https://picsum.photos/seed/mountains/800/600",
+			firstImageAlt: "Forest in autumn",
+			secondImageAlt: "Mountains at sunrise",
+			initialSliderPercentage: 50,
+			slideMode: "hover",
+			showHandlebar: true,
+			autoplay: false,
+			autoplayDuration: 5000,
+		},
+		argTypes: {
+			firstImage: { control: "text", description: "URL of the first (left) image" },
+			secondImage: { control: "text", description: "URL of the second (right) image" },
+			firstImageAlt: { control: "text", description: "Alt text for the first image" },
+			secondImageAlt: { control: "text", description: "Alt text for the second image" },
+			initialSliderPercentage: {
+				control: { type: "number", min: 0, max: 100 },
+				description: "Initial slider position (0-100)",
+			},
+			slideMode: {
+				control: "inline-radio",
+				options: ["hover", "drag"],
+				description: "How the slider is controlled",
+			},
+			showHandlebar: { control: "boolean", description: "Show the drag handle bar" },
+			autoplay: {
+				control: "boolean",
+				description: "Automatically animate the slider back and forth",
+			},
+			autoplayDuration: {
+				control: { type: "number" },
+				description: "Duration of one autoplay cycle in ms",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="flex justify-center">
+		<Compare class="h-64 w-96 rounded-lg" {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Drag Mode" {template} args={{ slideMode: "drag" }} />
+
+<Story name="Autoplay" {template} args={{ autoplay: true, autoplayDuration: 4000 }} />

--- a/src/stories/confetti.stories.svelte
+++ b/src/stories/confetti.stories.svelte
@@ -1,0 +1,40 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ConfettiButton } from "$lib/fancy-ui/confetti";
+
+	const { Story } = defineMeta({
+		title: "Effects/ConfettiButton",
+		component: ConfettiButton,
+		tags: ["autodocs"],
+		args: {
+			options: {},
+		},
+		argTypes: {
+			options: { control: "object", description: "canvas-confetti options merged into each burst" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<ConfettiButton {...args}>
+		<span
+			class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-lg px-6 py-3 font-medium transition-colors"
+		>
+			Click for confetti!
+		</span>
+	</ConfettiButton>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story
+	name="Big Burst"
+	{template}
+	args={{ options: { particleCount: 200, spread: 120, startVelocity: 45 } }}
+/>
+
+<Story
+	name="Custom Colors"
+	{template}
+	args={{ options: { colors: ["#22d3ee", "#a855f7", "#f472b6"], particleCount: 120 } }}
+/>

--- a/src/stories/container-scroll.stories.svelte
+++ b/src/stories/container-scroll.stories.svelte
@@ -1,0 +1,58 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ContainerScroll } from "$lib/fancy-ui/container-scroll";
+
+	// ContainerScroll is driven by window scroll, so the story is rendered at its
+	// natural (tall) height and the Storybook canvas iframe is scrolled to reveal
+	// the rotate/scale animation. Wrapping it in an inner overflow container would
+	// prevent the window scroll listener from firing.
+	const { Story } = defineMeta({
+		title: "Layout/ContainerScroll",
+		component: ContainerScroll,
+		tags: ["autodocs"],
+	});
+</script>
+
+{#snippet template()}
+	<ContainerScroll>
+		{#snippet titleContent()}
+			<h2 class="text-foreground text-4xl font-semibold dark:text-white">
+				Unleash the power of <br />
+				<span class="mt-1 text-4xl leading-none font-bold md:text-[6rem]">Scroll Animations</span>
+			</h2>
+		{/snippet}
+		{#snippet cardContent()}
+			<div
+				class="flex size-full flex-col items-center justify-center bg-gradient-to-br from-violet-500 to-purple-700 p-8 text-white"
+			>
+				<h3 class="text-3xl font-bold">Your Content Here</h3>
+				<p class="mt-4 max-w-md text-center text-lg text-white/80">
+					This card rotates from 20 degrees to 0 as you scroll. It also scales smoothly to create a
+					dramatic reveal effect.
+				</p>
+			</div>
+		{/snippet}
+	</ContainerScroll>
+{/snippet}
+
+<Story name="Default" {template} />
+
+{#snippet imageCard()}
+	<ContainerScroll>
+		{#snippet titleContent()}
+			<h2 class="text-foreground text-4xl font-semibold dark:text-white">
+				Show off your <br />
+				<span class="mt-1 text-4xl leading-none font-bold md:text-[6rem]">Product Shots</span>
+			</h2>
+		{/snippet}
+		{#snippet cardContent()}
+			<img
+				src="https://picsum.photos/seed/container-scroll/1200/720"
+				alt="Product preview"
+				class="size-full object-cover"
+			/>
+		{/snippet}
+	</ContainerScroll>
+{/snippet}
+
+<Story name="Image Card" template={imageCard} />

--- a/src/stories/container-text-flip.stories.svelte
+++ b/src/stories/container-text-flip.stories.svelte
@@ -1,0 +1,36 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ContainerTextFlip } from "$lib/fancy-ui/container-text-flip";
+
+	const { Story } = defineMeta({
+		title: "Text/ContainerTextFlip",
+		component: ContainerTextFlip,
+		tags: ["autodocs"],
+		args: {
+			words: ["better", "modern", "beautiful", "awesome"],
+			interval: 3000,
+			animationDuration: 700,
+		},
+		argTypes: {
+			words: { control: "object", description: "Array of words to cycle through" },
+			interval: { control: "number", description: "Time between word changes in ms" },
+			animationDuration: {
+				control: "number",
+				description: "Per-character animation duration in ms",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="flex items-center gap-4">
+		<span class="text-4xl font-bold md:text-7xl">Build</span>
+		<ContainerTextFlip {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Custom Words" {template} args={{ words: ["faster", "smarter", "bolder", "leaner"] }} />
+
+<Story name="Fast Interval" {template} args={{ interval: 1200, animationDuration: 400 }} />

--- a/src/stories/direction-aware-hover.stories.svelte
+++ b/src/stories/direction-aware-hover.stories.svelte
@@ -1,0 +1,44 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { DirectionAwareHover } from "$lib/fancy-ui/direction-aware-hover";
+
+	const { Story } = defineMeta({
+		title: "Cards/DirectionAwareHover",
+		component: DirectionAwareHover,
+		tags: ["autodocs"],
+		args: {
+			imageUrl: "https://picsum.photos/seed/peak/800/600",
+		},
+		argTypes: {
+			imageUrl: { control: "text", description: "URL of the background image" },
+			imageAlt: { control: "text", description: "Alt text for the image" },
+			childrenClass: {
+				control: "text",
+				description: "CSS classes for the overlay content wrapper",
+			},
+			imageClass: { control: "text", description: "CSS classes for the image element" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<DirectionAwareHover {...args}>
+		<p class="text-xl font-bold">Mountain Peak</p>
+		<p class="text-sm font-normal">Swiss Alps, Switzerland</p>
+	</DirectionAwareHover>
+{/snippet}
+
+<Story name="Default" {template} />
+
+{#snippet callToAction(args: any)}
+	<DirectionAwareHover {...args}>
+		<p class="text-xl font-bold">Autumn Trail</p>
+		<p class="mt-1 text-sm font-normal">Discover the season &rarr;</p>
+	</DirectionAwareHover>
+{/snippet}
+
+<Story
+	name="Alternate Image"
+	template={callToAction}
+	args={{ imageUrl: "https://picsum.photos/seed/autumn/800/600" }}
+/>

--- a/src/stories/displacement-text.stories.svelte
+++ b/src/stories/displacement-text.stories.svelte
@@ -1,0 +1,37 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { DisplacementText } from "$lib/fancy-ui/displacement-text";
+
+	const { Story } = defineMeta({
+		title: "Text/DisplacementText",
+		component: DisplacementText,
+		tags: ["autodocs"],
+		args: {
+			text: "Hover Me",
+			fontSize: 160,
+			font: "Inter, sans-serif",
+			lightColor: "#000000",
+			darkColor: "#ffffff",
+		},
+		argTypes: {
+			text: { control: "text", description: "Text to display" },
+			fontSize: { control: "number", description: "Font size in pixels" },
+			font: { control: "text", description: "Font family" },
+			color: { control: "color", description: "Fixed text color (overrides theme colors)" },
+			lightColor: { control: "color", description: "Text color in light mode" },
+			darkColor: { control: "color", description: "Text color in dark mode" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="flex h-64 w-full items-center justify-center">
+		<DisplacementText {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Fixed Color" {template} args={{ text: "Liquid", color: "#8b5cf6" }} />
+
+<Story name="Large" {template} args={{ text: "Warp", fontSize: 220 }} />

--- a/src/stories/dock.stories.svelte
+++ b/src/stories/dock.stories.svelte
@@ -1,0 +1,71 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { Dock, DockIcon, DockSeparator } from "$lib/fancy-ui/dock";
+
+	const { Story } = defineMeta({
+		title: "Navigation/Dock",
+		component: Dock,
+		tags: ["autodocs"],
+		args: {
+			magnification: 60,
+			distance: 140,
+			direction: "middle",
+			orientation: "horizontal",
+		},
+		argTypes: {
+			magnification: {
+				control: { type: "number" },
+				description: "Maximum icon size in pixels when magnified",
+			},
+			distance: {
+				control: { type: "number" },
+				description: "Distance in pixels over which magnification takes effect",
+			},
+			direction: {
+				control: "inline-radio",
+				options: ["top", "middle", "bottom"],
+				description: "Vertical alignment of icons relative to the dock bar",
+			},
+			orientation: {
+				control: "inline-radio",
+				options: ["horizontal", "vertical"],
+				description: "Dock orientation",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="flex justify-center p-8">
+		<Dock {...args}>
+			<DockIcon>
+				<svg class="size-full" viewBox="0 0 24 24" fill="currentColor">
+					<path
+						d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+					/>
+				</svg>
+			</DockIcon>
+			<DockSeparator />
+			<DockIcon>
+				<svg class="size-full" viewBox="0 0 24 24" fill="currentColor">
+					<path
+						d="M22.288 21h-20.576c-.945 0-1.712-.767-1.712-1.712v-13.576c0-.945.767-1.712 1.712-1.712h20.576c.945 0 1.712.767 1.712 1.712v13.576c0 .945-.767 1.712-1.712 1.712zm-10.288-6.086l-9.342-6.483-.02 11.569h18.684v-11.569l-9.322 6.483zm8.869-9.914h-17.789l8.92 6.229 8.869-6.229z"
+					/>
+				</svg>
+			</DockIcon>
+			<DockIcon>
+				<svg class="size-full" viewBox="0 0 24 24" fill="currentColor">
+					<path
+						d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"
+					/>
+				</svg>
+			</DockIcon>
+		</Dock>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Strong Magnification" {template} args={{ magnification: 90, distance: 180 }} />
+
+<Story name="Vertical" {template} args={{ orientation: "vertical" }} />

--- a/src/stories/flickering-grid.stories.svelte
+++ b/src/stories/flickering-grid.stories.svelte
@@ -1,0 +1,58 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { FlickeringGrid } from "$lib/fancy-ui/flickering-grid";
+
+	const { Story } = defineMeta({
+		title: "Backgrounds/FlickeringGrid",
+		component: FlickeringGrid,
+		tags: ["autodocs"],
+		args: {
+			squareSize: 4,
+			gridGap: 6,
+			flickerChance: 0.3,
+			color: "#000000",
+			maxOpacity: 0.3,
+		},
+		argTypes: {
+			squareSize: {
+				control: { type: "range", min: 1, max: 20, step: 1 },
+				description: "Size of each grid square in pixels",
+			},
+			gridGap: {
+				control: { type: "range", min: 0, max: 20, step: 1 },
+				description: "Gap between squares in pixels",
+			},
+			flickerChance: {
+				control: { type: "range", min: 0, max: 1, step: 0.05 },
+				description: "Probability of a square changing opacity each second (0-1)",
+			},
+			color: { control: "color", description: "Color of the squares (hex format)" },
+			maxOpacity: {
+				control: { type: "range", min: 0, max: 1, step: 0.05 },
+				description: "Maximum opacity of squares (0-1)",
+			},
+			width: {
+				control: "number",
+				description: "Fixed width in pixels (defaults to container width)",
+			},
+			height: {
+				control: "number",
+				description: "Fixed height in pixels (defaults to container height)",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="h-72 w-[480px] overflow-hidden rounded-xl border bg-neutral-950">
+		<FlickeringGrid {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Emerald" {template} args={{ color: "#10b981", maxOpacity: 0.5 }} />
+
+<Story name="Large Squares" {template} args={{ squareSize: 10, gridGap: 10, color: "#6366f1" }} />
+
+<Story name="Rapid Flicker" {template} args={{ flickerChance: 0.8, color: "#f43f5e" }} />

--- a/src/stories/flip-card.stories.svelte
+++ b/src/stories/flip-card.stories.svelte
@@ -1,0 +1,40 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { FlipCard } from "$lib/fancy-ui/flip-card";
+
+	const { Story } = defineMeta({
+		title: "Cards/FlipCard",
+		component: FlipCard,
+		tags: ["autodocs"],
+		args: {
+			rotate: "y",
+		},
+		argTypes: {
+			rotate: {
+				control: "inline-radio",
+				options: ["x", "y"],
+				description: "Axis of rotation for the flip effect",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<FlipCard {...args}>
+		<div
+			class="flex size-full items-center justify-center bg-gradient-to-br from-purple-500 to-pink-500"
+		>
+			<p class="text-2xl font-bold text-white">Front</p>
+		</div>
+		{#snippet back()}
+			<div class="flex size-full flex-col items-center justify-center bg-neutral-900">
+				<p class="text-lg font-semibold text-white">Back Side</p>
+				<p class="mt-2 text-sm text-slate-400">Hover to flip</p>
+			</div>
+		{/snippet}
+	</FlipCard>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="X Axis Rotation" {template} args={{ rotate: "x" }} />

--- a/src/stories/flip-words.stories.svelte
+++ b/src/stories/flip-words.stories.svelte
@@ -1,0 +1,36 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { FlipWords } from "$lib/fancy-ui/flip-words";
+
+	const { Story } = defineMeta({
+		title: "Text/FlipWords",
+		component: FlipWords,
+		tags: ["autodocs"],
+		args: {
+			words: ["better", "faster", "stronger", "bolder"],
+			duration: 3000,
+		},
+		argTypes: {
+			words: { control: "object", description: "Array of words to cycle through" },
+			duration: { control: "number", description: "Time each word stays visible in ms" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<h2 class="text-4xl font-bold">
+		Build
+		<FlipWords {...args} />
+		products
+	</h2>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Fast Cycling" {template} args={{ duration: 1200 }} />
+
+<Story
+	name="Multi-Word Phrases"
+	{template}
+	args={{ words: ["ship faster", "scale smarter", "build bolder"] }}
+/>

--- a/src/stories/fluid-cursor.stories.svelte
+++ b/src/stories/fluid-cursor.stories.svelte
@@ -13,6 +13,10 @@
 			curl: 3,
 			colorIntensity: 0.15,
 			densityDissipation: 3.5,
+			// FluidCursor is a singleton by default and destroys any prior instance on
+			// mount. Autodocs renders every story in this file simultaneously, so all
+			// stories opt into `allowMultiple` to coexist on the same docs page.
+			allowMultiple: true,
 		},
 		argTypes: {
 			splatRadius: { control: "number", description: "Radius of fluid splats" },

--- a/src/stories/fluid-cursor.stories.svelte
+++ b/src/stories/fluid-cursor.stories.svelte
@@ -1,0 +1,44 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { FluidCursor } from "$lib/fancy-ui/fluid-cursor";
+
+	// FluidCursor defaults to `contained`, so the WebGL simulation stays inside its
+	// (relative) parent container rather than covering the whole canvas.
+	const { Story } = defineMeta({
+		title: "Effects/FluidCursor",
+		component: FluidCursor,
+		tags: ["autodocs"],
+		args: {
+			splatRadius: 0.2,
+			curl: 3,
+			colorIntensity: 0.15,
+			densityDissipation: 3.5,
+		},
+		argTypes: {
+			splatRadius: { control: "number", description: "Radius of fluid splats" },
+			curl: { control: "number", description: "Amount of curl/vorticity" },
+			colorIntensity: { control: "number", description: "Intensity of color mixing" },
+			densityDissipation: {
+				control: "number",
+				description: "Rate at which density fades",
+			},
+			fluidColor: {
+				control: "color",
+				description: "Override all fluid with a single color",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="relative h-64 w-full overflow-hidden rounded-lg border">
+		<FluidCursor {...args} />
+		<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+			<p class="text-muted-foreground text-sm select-none">Move your cursor here</p>
+		</div>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Custom Color" {template} args={{ fluidColor: "#00ffcc", colorIntensity: 0.4 }} />

--- a/src/stories/focus.stories.svelte
+++ b/src/stories/focus.stories.svelte
@@ -1,0 +1,57 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { Focus } from "$lib/fancy-ui/focus";
+
+	const { Story } = defineMeta({
+		title: "Text/Focus",
+		component: Focus,
+		tags: ["autodocs"],
+		args: {
+			sentence: "Build beautiful interfaces easily",
+			manualMode: false,
+			blurAmount: 5,
+			borderColor: "green",
+			animationDuration: 0.5,
+			pauseBetweenAnimations: 1,
+		},
+		argTypes: {
+			sentence: {
+				control: "text",
+				description: "Space-separated words to cycle focus through",
+			},
+			manualMode: {
+				control: "boolean",
+				description: "Enable manual control via mouse hover instead of auto-cycling",
+			},
+			blurAmount: {
+				control: "number",
+				description: "Blur amount in pixels for unfocused words",
+			},
+			borderColor: { control: "color", description: "Color of the corner frame border" },
+			animationDuration: {
+				control: "number",
+				description: "Transition duration in seconds",
+			},
+			pauseBetweenAnimations: {
+				control: "number",
+				description: "Pause between word cycles in seconds",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="flex min-h-[160px] items-center justify-center text-3xl font-bold">
+		<Focus {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story
+	name="Manual Mode"
+	{template}
+	args={{ manualMode: true, sentence: "Hover each word here" }}
+/>
+
+<Story name="High Blur" {template} args={{ blurAmount: 12, borderColor: "#e11d48" }} />

--- a/src/stories/glare-card.stories.svelte
+++ b/src/stories/glare-card.stories.svelte
@@ -1,0 +1,33 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { GlareCard } from "$lib/fancy-ui/glare-card";
+
+	const { Story } = defineMeta({
+		title: "Cards/GlareCard",
+		component: GlareCard,
+		tags: ["autodocs"],
+	});
+</script>
+
+{#snippet template(args: any)}
+	<GlareCard {...args}>
+		<div class="flex size-full flex-col items-center justify-center bg-neutral-900 p-6 text-white">
+			<h3 class="text-2xl font-bold">Holographic</h3>
+			<p class="mt-2 text-sm text-slate-300">Move your mouse to see the effect</p>
+		</div>
+	</GlareCard>
+{/snippet}
+
+<Story name="Default" {template} />
+
+{#snippet imageCard(args: any)}
+	<GlareCard {...args}>
+		<img
+			src="https://picsum.photos/seed/holo/400/560"
+			alt="Holographic foil"
+			class="size-full object-cover"
+		/>
+	</GlareCard>
+{/snippet}
+
+<Story name="Image Content" template={imageCard} />

--- a/src/stories/glow-border.stories.svelte
+++ b/src/stories/glow-border.stories.svelte
@@ -1,0 +1,46 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { GlowBorder } from "$lib/fancy-ui/glow-border";
+
+	const { Story } = defineMeta({
+		title: "Effects/GlowBorder",
+		component: GlowBorder,
+		tags: ["autodocs"],
+		args: {
+			borderRadius: 10,
+			color: "#FFF",
+			borderWidth: 2,
+			duration: 10,
+		},
+		argTypes: {
+			borderRadius: {
+				control: { type: "range", min: 0, max: 40, step: 1 },
+				description: "Border radius in pixels",
+			},
+			color: { control: "color", description: "Glow color or array of colors for gradient" },
+			borderWidth: {
+				control: { type: "range", min: 1, max: 10, step: 1 },
+				description: "Border width in pixels",
+			},
+			duration: {
+				control: { type: "range", min: 2, max: 20, step: 1 },
+				description: "Animation duration in seconds",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="relative flex h-40 w-64 items-center justify-center rounded-xl bg-neutral-950 p-6">
+		<GlowBorder {...args} />
+		<p class="text-center text-neutral-400">Content goes here</p>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Cyan Glow" {template} args={{ color: "#22d3ee" }} />
+
+<Story name="Multi-Color Gradient" {template} args={{ color: ["#f472b6", "#a855f7", "#22d3ee"] }} />
+
+<Story name="Thick & Fast" {template} args={{ borderWidth: 5, duration: 4, color: "#f59e0b" }} />

--- a/src/stories/glowing-effect.stories.svelte
+++ b/src/stories/glowing-effect.stories.svelte
@@ -1,0 +1,70 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { GlowingEffect } from "$lib/fancy-ui/glowing-effect";
+
+	const { Story } = defineMeta({
+		title: "Effects/GlowingEffect",
+		component: GlowingEffect,
+		tags: ["autodocs"],
+		args: {
+			blur: 0,
+			inactiveZone: 0.7,
+			proximity: 0,
+			spread: 40,
+			variant: "default",
+			glow: true,
+			disabled: false,
+			movementDuration: 2,
+			borderWidth: 1,
+		},
+		argTypes: {
+			blur: {
+				control: { type: "range", min: 0, max: 20, step: 1 },
+				description: "Blur amount applied to the glow layer",
+			},
+			inactiveZone: {
+				control: { type: "range", min: 0, max: 1, step: 0.05 },
+				description: "Fraction of element radius where glow is inactive",
+			},
+			proximity: {
+				control: { type: "range", min: 0, max: 100, step: 5 },
+				description: "Extra pixel range outside element bounds where glow activates",
+			},
+			spread: {
+				control: { type: "range", min: 0, max: 90, step: 5 },
+				description: "Angular spread of the conic gradient in degrees",
+			},
+			variant: {
+				control: "select",
+				options: ["default", "white"],
+				description: "Color variant of the glow",
+			},
+			glow: { control: "boolean", description: "Always show glow regardless of mouse position" },
+			disabled: { control: "boolean", description: "Disable the glow effect" },
+			movementDuration: {
+				control: { type: "range", min: 0.5, max: 5, step: 0.5 },
+				description: "Duration of the glow movement in seconds",
+			},
+			borderWidth: {
+				control: { type: "range", min: 1, max: 6, step: 1 },
+				description: "Width of the glowing border in pixels",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="relative max-w-md rounded-xl border bg-neutral-950 p-8">
+		<GlowingEffect {...args} />
+		<h3 class="mb-2 text-lg font-semibold text-white">Hover near me</h3>
+		<p class="text-neutral-400">Move your cursor near this card to see the glow effect.</p>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="White Variant" {template} args={{ variant: "white" }} />
+
+<Story name="With Blur" {template} args={{ blur: 8, spread: 60 }} />
+
+<Story name="Thick Border" {template} args={{ borderWidth: 3, spread: 60 }} />

--- a/src/stories/gradient-button.stories.svelte
+++ b/src/stories/gradient-button.stories.svelte
@@ -1,0 +1,53 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { GradientButton } from "$lib/fancy-ui/gradient-button";
+
+	const { Story } = defineMeta({
+		title: "Buttons/GradientButton",
+		component: GradientButton,
+		tags: ["autodocs"],
+		args: {
+			duration: 2500,
+			borderWidth: 2,
+			borderRadius: 8,
+			blur: 4,
+			bgColor: "#000",
+		},
+		argTypes: {
+			colors: { control: "object", description: "Gradient colors rotating around the border" },
+			duration: {
+				control: { type: "range", min: 500, max: 10000, step: 100 },
+				description: "Rotation duration in ms",
+			},
+			borderWidth: {
+				control: { type: "range", min: 1, max: 10, step: 1 },
+				description: "Border thickness in px",
+			},
+			borderRadius: {
+				control: { type: "range", min: 0, max: 40, step: 1 },
+				description: "Border radius in px",
+			},
+			blur: {
+				control: { type: "range", min: 0, max: 20, step: 1 },
+				description: "Glow blur in px",
+			},
+			bgColor: { control: "color", description: "Content area background color" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<GradientButton {...args}>
+		<span class="px-2 text-sm font-medium text-white">Gradient Button</span>
+	</GradientButton>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story
+	name="Custom Palette"
+	{template}
+	args={{ colors: ["#06b6d4", "#8b5cf6", "#ec4899", "#06b6d4"], duration: 4000 }}
+/>
+
+<Story name="Thick Border" {template} args={{ borderWidth: 5, blur: 10, borderRadius: 16 }} />

--- a/src/stories/hyper-text.stories.svelte
+++ b/src/stories/hyper-text.stories.svelte
@@ -1,0 +1,30 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { HyperText } from "$lib/fancy-ui/hyper-text";
+
+	const { Story } = defineMeta({
+		title: "Text/HyperText",
+		component: HyperText,
+		tags: ["autodocs"],
+		args: {
+			text: "Hover me!",
+			duration: 800,
+			animateOnLoad: false,
+		},
+		argTypes: {
+			text: { control: "text", description: "Text to display and scramble" },
+			duration: { control: "number", description: "Total animation duration in ms" },
+			animateOnLoad: { control: "boolean", description: "Whether to animate on initial load" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<HyperText class="text-4xl font-bold" {...args} />
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Animate On Load" {template} args={{ text: "SCRAMBLE", animateOnLoad: true }} />
+
+<Story name="Slow Scramble" {template} args={{ text: "Glitch", duration: 2000 }} />

--- a/src/stories/image-trail-cursor.stories.svelte
+++ b/src/stories/image-trail-cursor.stories.svelte
@@ -1,0 +1,50 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ImageTrailCursor } from "$lib/fancy-ui/image-trail-cursor";
+
+	const images = [
+		"https://picsum.photos/seed/trail1/400/440",
+		"https://picsum.photos/seed/trail2/400/440",
+		"https://picsum.photos/seed/trail3/400/440",
+		"https://picsum.photos/seed/trail4/400/440",
+		"https://picsum.photos/seed/trail5/400/440",
+		"https://picsum.photos/seed/trail6/400/440",
+		"https://picsum.photos/seed/trail7/400/440",
+		"https://picsum.photos/seed/trail8/400/440",
+	];
+
+	// The trail is confined to its (relative) parent container, so it stays inside
+	// the sized demo area below rather than hijacking the whole canvas.
+	const { Story } = defineMeta({
+		title: "Effects/ImageTrailCursor",
+		component: ImageTrailCursor,
+		tags: ["autodocs"],
+		args: {
+			images,
+			variant: "type1",
+		},
+		argTypes: {
+			images: { control: "object", description: "Array of image URLs to show in the trail" },
+			variant: {
+				control: "select",
+				options: ["type1", "type2", "type3", "type4", "type5", "type6", "type7", "type8"],
+				description: "Animation variant controlling how images appear and move",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="relative h-[500px] w-full cursor-crosshair overflow-hidden rounded-lg border">
+		<ImageTrailCursor {...args} />
+		<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+			<p class="text-muted-foreground text-lg font-medium select-none">Move your cursor here</p>
+		</div>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Rotation" {template} args={{ variant: "type5" }} />
+
+<Story name="Perspective 3D" {template} args={{ variant: "type8" }} />

--- a/src/stories/interactive-grid-pattern.stories.svelte
+++ b/src/stories/interactive-grid-pattern.stories.svelte
@@ -1,0 +1,50 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { InteractiveGridPattern } from "$lib/fancy-ui/interactive-grid-pattern";
+
+	const { Story } = defineMeta({
+		title: "Effects/InteractiveGridPattern",
+		component: InteractiveGridPattern,
+		tags: ["autodocs"],
+		args: {
+			width: 40,
+			height: 40,
+			squares: [24, 24],
+		},
+		argTypes: {
+			width: {
+				control: { type: "range", min: 10, max: 80, step: 5 },
+				description: "Width of each square in pixels",
+			},
+			height: {
+				control: { type: "range", min: 10, max: 80, step: 5 },
+				description: "Height of each square in pixels",
+			},
+			squares: { control: "object", description: "Grid dimensions as [columns, rows]" },
+			squaresClassName: {
+				control: "text",
+				description: "Additional CSS classes for individual squares",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div
+		class="relative flex h-72 w-[480px] items-center justify-center overflow-hidden rounded-lg border bg-neutral-950"
+	>
+		<InteractiveGridPattern
+			{...args}
+			class="[mask-image:radial-gradient(400px_circle_at_center,white,transparent)]"
+		/>
+		<p class="z-10 text-lg font-medium text-neutral-400">Hover over the grid</p>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Fine Grid" {template} args={{ width: 20, height: 20, squares: [48, 48] }} />
+
+<Story name="Large Cells" {template} args={{ width: 60, height: 60, squares: [16, 12] }} />
+
+<Story name="Indigo Highlight" {template} args={{ squaresClassName: "hover:fill-indigo-400/40" }} />

--- a/src/stories/interactive-hover-button.stories.svelte
+++ b/src/stories/interactive-hover-button.stories.svelte
@@ -1,0 +1,23 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { InteractiveHoverButton } from "$lib/fancy-ui/interactive-hover-button";
+
+	const { Story } = defineMeta({
+		title: "Buttons/InteractiveHoverButton",
+		component: InteractiveHoverButton,
+		tags: ["autodocs"],
+		args: {
+			text: "Button",
+		},
+		argTypes: {
+			text: { control: "text", description: "Button label text" },
+			class: { control: "text", description: "Custom CSS class" },
+		},
+	});
+</script>
+
+<Story name="Default" />
+
+<Story name="Custom Text" args={{ text: "Get Started" }} />
+
+<Story name="Custom Styling" args={{ text: "Wide Button", class: "px-12 text-lg" }} />

--- a/src/stories/letter-pullup.stories.svelte
+++ b/src/stories/letter-pullup.stories.svelte
@@ -1,0 +1,30 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { LetterPullup } from "$lib/fancy-ui/letter-pullup";
+
+	const { Story } = defineMeta({
+		title: "Text/LetterPullup",
+		component: LetterPullup,
+		tags: ["autodocs"],
+		args: {
+			words: "Letter Pullup",
+			delay: 0.05,
+		},
+		argTypes: {
+			words: {
+				control: "text",
+				description: "Text to animate (each character gets its own animation)",
+			},
+			delay: {
+				control: "number",
+				description: "Delay between each letter animation in seconds",
+			},
+		},
+	});
+</script>
+
+<Story name="Default" args={{ words: "Letter Pullup" }} />
+
+<Story name="Slower Stagger" args={{ words: "One by one", delay: 0.15 }} />
+
+<Story name="Single Word" args={{ words: "FancyUI" }} />

--- a/src/stories/line-hover-link.stories.svelte
+++ b/src/stories/line-hover-link.stories.svelte
@@ -1,0 +1,61 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { LineHoverLink } from "$lib/fancy-ui/line-hover-link";
+
+	const { Story } = defineMeta({
+		title: "Navigation/LineHoverLink",
+		component: LineHoverLink,
+		tags: ["autodocs"],
+		args: {
+			variant: "slide",
+			href: "#",
+		},
+		argTypes: {
+			variant: {
+				control: "select",
+				options: [
+					"slide",
+					"double",
+					"grow",
+					"strike",
+					"fade",
+					"pulse",
+					"swap",
+					"sweep",
+					"bounce",
+					"arc",
+					"scribble",
+				],
+				description: "The animation variant",
+			},
+			href: { control: "text", description: "Link href" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="flex min-h-[120px] items-center justify-center text-lg font-medium">
+		<LineHoverLink {...args}>Hover me</LineHoverLink>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Grow" {template} args={{ variant: "grow" }} />
+
+<Story name="Sweep" {template} args={{ variant: "sweep" }} />
+
+<Story name="Scribble" {template} args={{ variant: "scribble" }} />
+
+{#snippet navigation()}
+	<div class="flex min-h-[120px] items-center justify-center">
+		<nav class="flex gap-8">
+			<LineHoverLink variant="slide" href="#" class="text-muted-foreground">Home</LineHoverLink>
+			<LineHoverLink variant="slide" href="#" class="text-muted-foreground">About</LineHoverLink>
+			<LineHoverLink variant="slide" href="#" class="text-muted-foreground">Services</LineHoverLink>
+			<LineHoverLink variant="slide" href="#" class="text-muted-foreground">Contact</LineHoverLink>
+		</nav>
+	</div>
+{/snippet}
+
+<Story name="Navigation" template={navigation} />

--- a/src/stories/line-shadow-text.stories.svelte
+++ b/src/stories/line-shadow-text.stories.svelte
@@ -1,0 +1,36 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { LineShadowText } from "$lib/fancy-ui/line-shadow-text";
+
+	const { Story } = defineMeta({
+		title: "Text/LineShadowText",
+		component: LineShadowText,
+		tags: ["autodocs"],
+		args: {
+			text: "Text",
+			shadowColor: "black",
+			as: "span",
+		},
+		argTypes: {
+			text: { control: "text", description: "Text content to display" },
+			shadowColor: { control: "color", description: "Color of the diagonal line shadow" },
+			as: {
+				control: "select",
+				options: ["span", "h1", "h2", "h3", "h4", "h5", "h6", "p", "div"],
+				description: "HTML element to render as",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<p class="text-6xl leading-none font-bold">
+		Shadow <LineShadowText {...args} class="italic" />
+	</p>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Colored Shadow" {template} args={{ text: "Neon", shadowColor: "#8b5cf6" }} />
+
+<Story name="Heading Element" {template} args={{ text: "Title", as: "h1" }} />

--- a/src/stories/liquid-glass.stories.svelte
+++ b/src/stories/liquid-glass.stories.svelte
@@ -1,0 +1,87 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { LiquidGlass } from "$lib/fancy-ui/liquid-glass";
+
+	const { Story } = defineMeta({
+		title: "Effects/LiquidGlass",
+		component: LiquidGlass,
+		tags: ["autodocs"],
+		args: {
+			radius: 20,
+			frost: 0.05,
+			scale: -180,
+			blur: 11,
+			lightness: 50,
+		},
+		argTypes: {
+			radius: {
+				control: { type: "range", min: 0, max: 60, step: 2 },
+				description: "Border radius in pixels",
+			},
+			frost: {
+				control: { type: "range", min: 0, max: 1, step: 0.05 },
+				description: "Frosted glass opacity",
+			},
+			scale: {
+				control: { type: "range", min: -300, max: 0, step: 10 },
+				description: "Displacement scale (strength of refraction)",
+			},
+			blur: {
+				control: { type: "range", min: 0, max: 30, step: 1 },
+				description: "Blur applied to the displacement map",
+			},
+			lightness: {
+				control: { type: "range", min: 0, max: 100, step: 5 },
+				description: "Background lightness percentage",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div
+		class="relative flex h-80 w-[480px] items-center justify-center overflow-hidden rounded-lg border"
+	>
+		<div
+			class="absolute top-1/4 left-1/4 h-56 w-56 -translate-x-1/2 -translate-y-1/2 rounded-full bg-violet-500/30 blur-3xl"
+		></div>
+		<div class="absolute right-1/4 bottom-1/3 h-48 w-48 rounded-full bg-cyan-500/30 blur-3xl"></div>
+		<div
+			class="absolute bottom-1/4 left-1/2 h-44 w-44 -translate-x-1/2 rounded-full bg-rose-500/25 blur-3xl"
+		></div>
+
+		<div class="absolute inset-0 z-[1] overflow-y-auto" style="scrollbar-width: none;">
+			<div class="space-y-8 px-10 py-16" style="min-height: 220%;">
+				{#each Array(6) as _, i}
+					<div class="flex gap-4">
+						{#each Array(5) as _, j}
+							<div
+								class="h-16 flex-1 rounded-xl"
+								style="background: hsl({(i * 5 + j) * 28}, 65%, 55%); opacity: 0.75;"
+							></div>
+						{/each}
+					</div>
+					<p class="px-1 text-base font-medium text-white/50">Chromatic displacement in action.</p>
+				{/each}
+			</div>
+		</div>
+
+		<div class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
+			<div class="pointer-events-auto">
+				<LiquidGlass {...args}>
+					<div
+						class="flex min-h-16 w-full items-center justify-center px-12 py-4 text-base font-medium text-white"
+					>
+						Liquid Glass. Try scrolling.
+					</div>
+				</LiquidGlass>
+			</div>
+		</div>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Frosted" {template} args={{ frost: 0.3 }} />
+
+<Story name="Strong Refraction" {template} args={{ scale: -260, radius: 32 }} />

--- a/src/stories/logo-cloud.stories.svelte
+++ b/src/stories/logo-cloud.stories.svelte
@@ -1,0 +1,51 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { AnimatedLogoCloud, StaticLogoCloud, IconLogoCloud } from "$lib/fancy-ui/logo-cloud";
+
+	const logos = [
+		{ name: "Vercel", path: "https://svgl.app/library/vercel_wordmark.svg" },
+		{ name: "Svelte", path: "https://svgl.app/library/svelte.svg" },
+		{ name: "Tailwind CSS", path: "https://svgl.app/library/tailwindcss.svg" },
+		{ name: "TypeScript", path: "https://svgl.app/library/typescript.svg" },
+		{ name: "Prisma", path: "https://svgl.app/library/prisma.svg" },
+		{ name: "Stripe", path: "https://svgl.app/library/stripe_wordmark.svg" },
+	];
+
+	const { Story } = defineMeta({
+		title: "Data Display/LogoCloud",
+		component: AnimatedLogoCloud,
+		tags: ["autodocs"],
+		args: {
+			title: "Trusted by the best",
+			logos,
+		},
+		argTypes: {
+			title: { control: "text", description: "Optional title displayed above the logos" },
+			logos: { control: "object", description: "Array of logos with name and image path" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="overflow-hidden rounded-lg border">
+		<AnimatedLogoCloud {...args} />
+	</div>
+{/snippet}
+
+<Story name="Animated" {template} />
+
+{#snippet staticGrid(args: any)}
+	<div class="overflow-hidden rounded-lg border">
+		<StaticLogoCloud {...args} />
+	</div>
+{/snippet}
+
+<Story name="Static Grid" template={staticGrid} args={{ title: "Our partners", logos }} />
+
+{#snippet iconGrid(args: any)}
+	<div class="overflow-hidden rounded-lg border">
+		<IconLogoCloud {...args} />
+	</div>
+{/snippet}
+
+<Story name="Icon Grid" template={iconGrid} args={{ title: "Built with", logos }} />

--- a/src/stories/marquee.stories.svelte
+++ b/src/stories/marquee.stories.svelte
@@ -1,0 +1,71 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { Marquee, ReviewCard } from "$lib/fancy-ui/marquee";
+
+	const reviews = [
+		{
+			name: "Jack",
+			username: "@jack",
+			body: "I've never seen anything like this before. It's amazing.",
+			img: "https://avatar.vercel.sh/jack",
+		},
+		{
+			name: "Jill",
+			username: "@jill",
+			body: "I don't know what to say. I'm speechless. This is amazing.",
+			img: "https://avatar.vercel.sh/jill",
+		},
+		{
+			name: "John",
+			username: "@john",
+			body: "I'm at a loss for words. This is amazing. I love it.",
+			img: "https://avatar.vercel.sh/john",
+		},
+		{
+			name: "Jane",
+			username: "@jane",
+			body: "I'm at a loss for words. This is amazing. I love it.",
+			img: "https://avatar.vercel.sh/jane",
+		},
+	];
+
+	const { Story } = defineMeta({
+		title: "Layout/Marquee",
+		component: Marquee,
+		tags: ["autodocs"],
+		args: {
+			reverse: false,
+			pauseOnHover: true,
+			vertical: false,
+			repeat: 4,
+		},
+		argTypes: {
+			reverse: { control: "boolean", description: "Reverse the scroll direction" },
+			pauseOnHover: { control: "boolean", description: "Pause animation on hover" },
+			vertical: {
+				control: "boolean",
+				description: "Scroll vertically instead of horizontally",
+			},
+			repeat: {
+				control: "number",
+				description: "Number of times to repeat children for seamless loop",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="relative h-72 w-full max-w-3xl overflow-hidden rounded-lg border">
+		<Marquee {...args} class="[--duration:20s]">
+			{#each reviews as review (review.username)}
+				<ReviewCard {...review} />
+			{/each}
+		</Marquee>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Reverse" {template} args={{ reverse: true }} />
+
+<Story name="Vertical" {template} args={{ vertical: true }} />

--- a/src/stories/matrix-rain.stories.svelte
+++ b/src/stories/matrix-rain.stories.svelte
@@ -1,0 +1,39 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { MatrixRain } from "$lib/fancy-ui/matrix-rain";
+
+	const { Story } = defineMeta({
+		title: "Backgrounds/MatrixRain",
+		component: MatrixRain,
+		tags: ["autodocs"],
+		args: {
+			color: "#00ff41",
+			speed: 1.0,
+			density: 1.0,
+			glyphSize: 16,
+			fadeOpacity: 0.05,
+		},
+		argTypes: {
+			color: { control: "color", description: "Glyph color (the classic Matrix green)" },
+			speed: { control: "number", description: "Fall speed multiplier (< 1 slower, > 1 faster)" },
+			density: { control: "number", description: "Column density multiplier" },
+			glyphSize: { control: "number", description: "Font size of each glyph in pixels" },
+			fadeOpacity: {
+				control: "number",
+				description: "Opacity of the black overlay used to create trailing fade effect",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="h-64 w-96 overflow-hidden rounded-lg bg-neutral-950">
+		<MatrixRain class="h-full w-full" {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Amber Fast" {template} args={{ color: "#ffb000", speed: 2 }} />
+
+<Story name="Dense Small Glyphs" {template} args={{ density: 2, glyphSize: 12 }} />

--- a/src/stories/meteors.stories.svelte
+++ b/src/stories/meteors.stories.svelte
@@ -1,0 +1,34 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { Meteors } from "$lib/fancy-ui/meteors";
+
+	const { Story } = defineMeta({
+		title: "Effects/Meteors",
+		component: Meteors,
+		tags: ["autodocs"],
+		args: {
+			count: 20,
+		},
+		argTypes: {
+			count: {
+				control: { type: "range", min: 5, max: 60, step: 5 },
+				description: "Number of meteors to render",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div
+		class="relative flex h-64 w-[480px] items-center justify-center overflow-hidden rounded-xl border bg-neutral-950 p-6"
+	>
+		<p class="z-10 text-center text-white">Meteor shower</p>
+		<Meteors {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Sparse" {template} args={{ count: 8 }} />
+
+<Story name="Dense" {template} args={{ count: 50 }} />

--- a/src/stories/neon-border.stories.svelte
+++ b/src/stories/neon-border.stories.svelte
@@ -1,0 +1,53 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { NeonBorder } from "$lib/fancy-ui/neon-border";
+
+	const { Story } = defineMeta({
+		title: "Effects/NeonBorder",
+		component: NeonBorder,
+		tags: ["autodocs"],
+		args: {
+			color1: "#0496ff",
+			color2: "#ff0a54",
+			animationType: "half",
+			duration: 6,
+		},
+		argTypes: {
+			color1: { control: "color", description: "First neon color" },
+			color2: { control: "color", description: "Second neon color" },
+			animationType: {
+				control: "select",
+				options: ["none", "half", "full"],
+				description: "Animation type: none (static), half (50% coverage), full (100% coverage)",
+			},
+			duration: {
+				control: { type: "range", min: 1, max: 20, step: 1 },
+				description: "Animation duration in seconds",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="flex w-[420px] items-center justify-center bg-neutral-950 p-10">
+		<NeonBorder {...args}>
+			<div
+				class="flex h-full w-full items-center justify-center rounded-lg bg-neutral-950 px-6 py-2"
+			>
+				<span class="text-sm font-medium text-white">Neon Border</span>
+			</div>
+		</NeonBorder>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Full Rotation" {template} args={{ animationType: "full" }} />
+
+<Story name="Static" {template} args={{ animationType: "none" }} />
+
+<Story
+	name="Emerald & Violet"
+	{template}
+	args={{ color1: "#10b981", color2: "#8b5cf6", duration: 3 }}
+/>

--- a/src/stories/number-ticker.stories.svelte
+++ b/src/stories/number-ticker.stories.svelte
@@ -1,0 +1,38 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { NumberTicker } from "$lib/fancy-ui/number-ticker";
+
+	const { Story } = defineMeta({
+		title: "Text/NumberTicker",
+		component: NumberTicker,
+		tags: ["autodocs"],
+		args: {
+			value: 1234,
+			direction: "up",
+			duration: 1000,
+			delay: 0,
+			decimalPlaces: 0,
+		},
+		argTypes: {
+			value: { control: "number", description: "Target number to animate to" },
+			direction: {
+				control: "select",
+				options: ["up", "down"],
+				description: 'Animation direction: "up" counts 0→value, "down" counts value→0',
+			},
+			duration: { control: "number", description: "Animation duration in ms" },
+			delay: { control: "number", description: "Delay before animation starts in ms" },
+			decimalPlaces: { control: "number", description: "Number of decimal places to display" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<NumberTicker class="text-6xl font-bold" {...args} />
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Count Down" {template} args={{ value: 100, direction: "down" }} />
+
+<Story name="Decimal Places" {template} args={{ value: 42.75, decimalPlaces: 2 }} />

--- a/src/stories/rainbow-button.stories.svelte
+++ b/src/stories/rainbow-button.stories.svelte
@@ -1,0 +1,27 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { RainbowButton } from "$lib/fancy-ui/rainbow-button";
+
+	const { Story } = defineMeta({
+		title: "Buttons/RainbowButton",
+		component: RainbowButton,
+		tags: ["autodocs"],
+		args: {
+			speed: 2,
+		},
+		argTypes: {
+			speed: { control: { type: "number" }, description: "Animation speed in seconds" },
+			href: { control: "text", description: "Render as anchor element when provided" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<RainbowButton {...args}>Get Started</RainbowButton>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Fast Animation" {template} args={{ speed: 1 }} />
+
+<Story name="As Link" {template} args={{ href: "https://example.com" }} />

--- a/src/stories/ripple-button.stories.svelte
+++ b/src/stories/ripple-button.stories.svelte
@@ -1,0 +1,28 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { RippleButton } from "$lib/fancy-ui/ripple-button";
+
+	const { Story } = defineMeta({
+		title: "Buttons/RippleButton",
+		component: RippleButton,
+		tags: ["autodocs"],
+		args: {
+			rippleColor: "#ADD8E6",
+			duration: 600,
+		},
+		argTypes: {
+			rippleColor: { control: "color", description: "Color of the ripple effect" },
+			duration: { control: { type: "number" }, description: "Animation duration in milliseconds" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<RippleButton {...args}>Click me</RippleButton>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Custom Color" {template} args={{ rippleColor: "#f472b6" }} />
+
+<Story name="Slow Ripple" {template} args={{ duration: 1200, rippleColor: "#22d3ee" }} />

--- a/src/stories/ripple.stories.svelte
+++ b/src/stories/ripple.stories.svelte
@@ -1,0 +1,62 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { Ripple } from "$lib/fancy-ui/ripple";
+
+	const { Story } = defineMeta({
+		title: "Effects/Ripple",
+		component: Ripple,
+		tags: ["autodocs"],
+		args: {
+			baseCircleSize: 210,
+			baseCircleOpacity: 0.24,
+			spaceBetweenCircle: 70,
+			circleOpacityDowngradeRatio: 0.03,
+			waveSpeed: 80,
+			numberOfCircles: 7,
+		},
+		argTypes: {
+			baseCircleSize: {
+				control: { type: "range", min: 60, max: 320, step: 10 },
+				description: "Diameter of the smallest (innermost) circle in pixels",
+			},
+			baseCircleOpacity: {
+				control: { type: "range", min: 0, max: 1, step: 0.02 },
+				description: "Opacity of the innermost circle",
+			},
+			spaceBetweenCircle: {
+				control: { type: "range", min: 20, max: 140, step: 10 },
+				description: "Extra pixels added to each successive circle",
+			},
+			circleOpacityDowngradeRatio: {
+				control: { type: "range", min: 0, max: 0.1, step: 0.01 },
+				description: "Opacity reduction per circle outward",
+			},
+			waveSpeed: {
+				control: { type: "range", min: 0, max: 200, step: 10 },
+				description: "Animation delay between circles in ms",
+			},
+			numberOfCircles: {
+				control: { type: "range", min: 3, max: 12, step: 1 },
+				description: "Number of circles to render",
+			},
+			circleClass: {
+				control: "text",
+				description: "Additional CSS classes applied to each circle",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="relative h-80 w-[480px] overflow-hidden rounded-lg border bg-neutral-950">
+		<Ripple {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Many Circles" {template} args={{ numberOfCircles: 11, baseCircleSize: 140 }} />
+
+<Story name="Bold & Slow" {template} args={{ baseCircleOpacity: 0.5, waveSpeed: 160 }} />
+
+<Story name="Indigo Rings" {template} args={{ circleClass: "border-indigo-400 bg-indigo-500/5" }} />

--- a/src/stories/shimmer-button.stories.svelte
+++ b/src/stories/shimmer-button.stories.svelte
@@ -1,0 +1,40 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ShimmerButton } from "$lib/fancy-ui/shimmer-button";
+
+	const { Story } = defineMeta({
+		title: "Buttons/ShimmerButton",
+		component: ShimmerButton,
+		tags: ["autodocs"],
+		args: {
+			shimmerColor: "#ffffff",
+			shimmerSize: "0.05em",
+			borderRadius: "100px",
+			shimmerDuration: "3s",
+			background: "rgba(0, 0, 0, 1)",
+		},
+		argTypes: {
+			shimmerColor: { control: "color", description: "Color of the shimmer highlight" },
+			shimmerSize: { control: "text", description: "Thickness of the shimmer border" },
+			borderRadius: { control: "text", description: "Button border radius" },
+			shimmerDuration: { control: "text", description: "Duration of one shimmer cycle" },
+			background: { control: "text", description: "Button background color" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<ShimmerButton {...args}>
+		<span class="text-sm font-medium whitespace-pre-wrap text-white">Shimmer Button</span>
+	</ShimmerButton>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story
+	name="Custom Shimmer"
+	{template}
+	args={{ shimmerColor: "#22d3ee", shimmerDuration: "1.5s" }}
+/>
+
+<Story name="Rounded" {template} args={{ borderRadius: "12px", background: "#1e1b4b" }} />

--- a/src/stories/smooth-cursor.stories.svelte
+++ b/src/stories/smooth-cursor.stories.svelte
@@ -1,0 +1,37 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { SmoothCursor } from "$lib/fancy-ui/smooth-cursor";
+
+	// SmoothCursor attaches to the document and replaces the native cursor. It is
+	// scoped to the Storybook canvas iframe (not the surrounding UI), so it is safe
+	// to render here; move the pointer inside the canvas to see it follow.
+	const { Story } = defineMeta({
+		title: "Effects/SmoothCursor",
+		component: SmoothCursor,
+		tags: ["autodocs"],
+		args: {
+			springConfig: { damping: 45, stiffness: 400, mass: 1 },
+		},
+		argTypes: {
+			springConfig: {
+				control: "object",
+				description: "Spring physics configuration with damping, stiffness, and mass",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<SmoothCursor {...args} />
+	<div class="flex h-48 items-center justify-center rounded-lg border border-dashed">
+		<p class="text-muted-foreground text-sm select-none">Move your cursor around the canvas</p>
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story
+	name="Bouncy"
+	{template}
+	args={{ springConfig: { damping: 20, stiffness: 300, mass: 1.2 } }}
+/>

--- a/src/stories/smooth-cursor.stories.svelte
+++ b/src/stories/smooth-cursor.stories.svelte
@@ -30,8 +30,12 @@
 
 <Story name="Default" {template} />
 
+<!-- SmoothCursor hides the native cursor and attaches document-level listeners.
+     Excluded from autodocs so it doesn't run at the same time as "Default" on
+     the merged docs page; still fully viewable as its own story. -->
 <Story
 	name="Bouncy"
+	tags={["!autodocs"]}
 	{template}
 	args={{ springConfig: { damping: 20, stiffness: 300, mass: 1.2 } }}
 />

--- a/src/stories/sparkles-text.stories.svelte
+++ b/src/stories/sparkles-text.stories.svelte
@@ -1,0 +1,36 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { SparklesText } from "$lib/fancy-ui/sparkles-text";
+
+	const { Story } = defineMeta({
+		title: "Text/SparklesText",
+		component: SparklesText,
+		tags: ["autodocs"],
+		args: {
+			text: "Sparkles",
+			sparklesCount: 10,
+			colors: { first: "#9E7AFF", second: "#FE8BBB" },
+		},
+		argTypes: {
+			text: { control: "text", description: "Text to display" },
+			sparklesCount: { control: "number", description: "Number of sparkle stars" },
+			colors: { control: "object", description: "Two colors for sparkle stars" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="flex items-center justify-center p-8 text-4xl font-bold">
+		<SparklesText {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story
+	name="Custom Colors"
+	{template}
+	args={{ text: "Magic", colors: { first: "#22d3ee", second: "#f97316" } }}
+/>
+
+<Story name="Lots Of Sparkles" {template} args={{ text: "Shine", sparklesCount: 30 }} />

--- a/src/stories/sparkles.stories.svelte
+++ b/src/stories/sparkles.stories.svelte
@@ -1,0 +1,56 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { Sparkles } from "$lib/fancy-ui/sparkles";
+
+	const { Story } = defineMeta({
+		title: "Backgrounds/Sparkles",
+		component: Sparkles,
+		tags: ["autodocs"],
+		args: {
+			background: "#0d47a1",
+			particleColor: "#ffffff",
+			minSize: 1,
+			maxSize: 3,
+			speed: 4,
+			particleDensity: 120,
+		},
+		argTypes: {
+			background: { control: "color", description: "Background color of the canvas container" },
+			particleColor: { control: "color", description: "Color of the particles" },
+			minSize: {
+				control: { type: "range", min: 0.5, max: 5, step: 0.5 },
+				description: "Minimum particle radius in pixels",
+			},
+			maxSize: {
+				control: { type: "range", min: 1, max: 10, step: 0.5 },
+				description: "Maximum particle radius in pixels",
+			},
+			speed: {
+				control: { type: "range", min: 0, max: 12, step: 1 },
+				description: "Particle speed multiplier",
+			},
+			particleDensity: {
+				control: { type: "range", min: 20, max: 400, step: 20 },
+				description: "Number of particles",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="h-64 w-[480px] overflow-hidden rounded-lg border">
+		<Sparkles {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Dark & Gold" {template} args={{ background: "#000000", particleColor: "#fbbf24" }} />
+
+<Story name="Dense & Fast" {template} args={{ particleDensity: 300, speed: 8, maxSize: 2 }} />
+
+<Story
+	name="Large Particles"
+	{template}
+	args={{ minSize: 2, maxSize: 6, particleDensity: 60, particleColor: "#a5f3fc" }}
+/>

--- a/src/stories/terminal-text.stories.svelte
+++ b/src/stories/terminal-text.stories.svelte
@@ -1,0 +1,50 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { TerminalText } from "$lib/fancy-ui/terminal-text";
+
+	const { Story } = defineMeta({
+		title: "Text/TerminalText",
+		component: TerminalText,
+		tags: ["autodocs"],
+		args: {
+			lines: [
+				"[INFO]  boot sequence complete",
+				"[WARN]  memory fragmentation at sector 0x4A2F",
+				"[INFO]  kernel patch applied successfully",
+				"[OK]    all systems nominal",
+			],
+			speed: 25,
+			delay: 0,
+			cursor: true,
+			cursorChar: "█",
+			glitch: false,
+		},
+		argTypes: {
+			lines: { control: "object", description: "Array of lines to stream character by character" },
+			speed: { control: "number", description: "Delay between each character in ms" },
+			delay: { control: "number", description: "Initial delay before streaming starts in ms" },
+			cursor: { control: "boolean", description: "Show blinking cursor" },
+			cursorChar: { control: "text", description: "Character used as the cursor" },
+			glitch: {
+				control: "boolean",
+				description: "Enable random character glitch effect after streaming",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-96 rounded-lg border border-neutral-800 bg-black p-5 text-green-400">
+		<TerminalText {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="No Cursor" {template} args={{ cursor: false }} />
+
+<Story
+	name="With Glitch"
+	{template}
+	args={{ lines: ["initializing neural core...", "> ACCESS GRANTED"], glitch: true }}
+/>

--- a/src/stories/text-generate-effect.stories.svelte
+++ b/src/stories/text-generate-effect.stories.svelte
@@ -1,0 +1,37 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { TextGenerateEffect } from "$lib/fancy-ui/text-generate-effect";
+
+	const { Story } = defineMeta({
+		title: "Text/TextGenerateEffect",
+		component: TextGenerateEffect,
+		tags: ["autodocs"],
+		args: {
+			words:
+				"Svelte is a radical new approach to building user interfaces. It shifts work from the browser to a compile step that happens when you build your app.",
+			filter: true,
+			duration: 0.7,
+			delay: 0,
+			stagger: 200,
+		},
+		argTypes: {
+			words: { control: "text", description: "Text to reveal word by word" },
+			filter: { control: "boolean", description: "Apply blur filter during reveal animation" },
+			duration: { control: "number", description: "Fade-in duration per word in seconds" },
+			delay: { control: "number", description: "Initial delay before animation starts in ms" },
+			stagger: { control: "number", description: "Delay between each word in ms" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="max-w-xl text-xl font-semibold">
+		<TextGenerateEffect {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Fast Reveal" {template} args={{ duration: 0.3, stagger: 80 }} />
+
+<Story name="Without Blur" {template} args={{ filter: false }} />

--- a/src/stories/text-reveal-card.stories.svelte
+++ b/src/stories/text-reveal-card.stories.svelte
@@ -1,0 +1,40 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { TextRevealCard } from "$lib/fancy-ui/text-reveal-card";
+
+	const { Story } = defineMeta({
+		title: "Cards/TextRevealCard",
+		component: TextRevealCard,
+		tags: ["autodocs"],
+		args: {
+			starsCount: 130,
+		},
+		argTypes: {
+			starsCount: {
+				control: { type: "number" },
+				description: "Number of star particles in the background",
+			},
+			starsClass: { control: "text", description: "CSS classes for the stars container" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<TextRevealCard {...args}>
+		<p class="mb-4 text-lg font-bold text-white">Move your mouse to reveal</p>
+		{#snippet text()}
+			<p
+				class="bg-gradient-to-b from-white to-neutral-300 bg-clip-text py-6 text-[2rem] font-bold text-transparent md:text-[3rem]"
+			>
+				I know the secret
+			</p>
+		{/snippet}
+		{#snippet revealText()}
+			<p class="py-6 text-[2rem] font-bold text-white/10 md:text-[3rem]">Hover me to see</p>
+		{/snippet}
+	</TextRevealCard>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Fewer Stars" {template} args={{ starsCount: 40 }} />

--- a/src/stories/timeline.stories.svelte
+++ b/src/stories/timeline.stories.svelte
@@ -1,0 +1,61 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { Timeline } from "$lib/fancy-ui/timeline";
+
+	const items = [
+		{ id: "step-3", label: "Step 3" },
+		{ id: "step-2", label: "Step 2" },
+		{ id: "step-1", label: "Step 1" },
+	];
+
+	// Timeline tracks window scroll to drive its progress line, so the story is
+	// rendered at natural height and the Storybook canvas iframe is scrolled to
+	// reveal the effect (an inner overflow container would not fire the listener).
+	const { Story } = defineMeta({
+		title: "Navigation/Timeline",
+		component: Timeline,
+		tags: ["autodocs"],
+		args: {
+			items,
+			title: "Project Timeline",
+			description: "Key milestones and updates.",
+		},
+		argTypes: {
+			items: { control: "object", description: "Timeline entries with id and label" },
+			title: { control: "text", description: "Heading text" },
+			description: { control: "text", description: "Subheading text" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<Timeline {...args}>
+		{#snippet content(item)}
+			<div class="space-y-4">
+				<h3 class="text-foreground text-lg font-semibold md:hidden">{item.label}</h3>
+				<div class="bg-card rounded-lg border p-4">
+					<h4 class="mb-2 font-semibold">{item.label}</h4>
+					<p class="text-muted-foreground text-sm">
+						Content for {item.label}. The timeline shows scroll-driven progress.
+					</p>
+				</div>
+			</div>
+		{/snippet}
+	</Timeline>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story
+	name="Release History"
+	{template}
+	args={{
+		title: "Release History",
+		description: "How the product evolved over time.",
+		items: [
+			{ id: "v3", label: "v3.0" },
+			{ id: "v2", label: "v2.0" },
+			{ id: "v1", label: "v1.0" },
+		],
+	}}
+/>

--- a/src/stories/tracing-beam.stories.svelte
+++ b/src/stories/tracing-beam.stories.svelte
@@ -1,0 +1,56 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { TracingBeam } from "$lib/fancy-ui/tracing-beam";
+
+	// TracingBeam highlights window-scroll progress alongside its content, so the
+	// story is rendered at natural height and the Storybook canvas iframe is
+	// scrolled to reveal the beam (an inner overflow container would not fire the
+	// window scroll listener the component relies on).
+	const { Story } = defineMeta({
+		title: "Effects/TracingBeam",
+		component: TracingBeam,
+		tags: ["autodocs"],
+	});
+</script>
+
+{#snippet template()}
+	<TracingBeam>
+		<div class="max-w-2xl space-y-16 pl-8">
+			<div>
+				<span class="mb-2 block text-xs font-semibold tracking-wider text-emerald-500 uppercase"
+					>Step 1</span
+				>
+				<h2 class="mb-3 text-xl font-semibold">Getting Started</h2>
+				<p class="text-muted-foreground leading-relaxed">
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt
+					ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+					ullamco laboris.
+				</p>
+			</div>
+
+			<div>
+				<span class="mb-2 block text-xs font-semibold tracking-wider text-purple-500 uppercase"
+					>Step 2</span
+				>
+				<h2 class="mb-3 text-xl font-semibold">Configuration</h2>
+				<p class="text-muted-foreground leading-relaxed">
+					Totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae
+					vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur.
+				</p>
+			</div>
+
+			<div>
+				<span class="mb-2 block text-xs font-semibold tracking-wider text-blue-500 uppercase"
+					>Step 3</span
+				>
+				<h2 class="mb-3 text-xl font-semibold">Advanced Usage</h2>
+				<p class="text-muted-foreground leading-relaxed">
+					Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae
+					consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur.
+				</p>
+			</div>
+		</div>
+	</TracingBeam>
+{/snippet}
+
+<Story name="Default" {template} />


### PR DESCRIPTION
## Summary
- Storybook 10.4 via `@storybook/sveltekit` (Vite builder, reuses the project's vite.config.ts so Tailwind v4 and `$lib` work out of the box), scripts `storybook` / `build-storybook`
- `.storybook/preview.ts` imports `src/routes/layout.css` (single styling source) and adds a light/dark toolbar toggle driving the `.dark` class; addons kept minimal: svelte-csf, a11y, docs
- Full coverage: 56 story files / 164 stories — every component in the registry (buttons, cards, text, backgrounds, effects, layout, navigation, media, feedback), each with Default + 2-3 variants, autodocs, real props only; plus `Introduction.mdx`. Stories live in `src/stories/` so nothing ships to npm
- Storybook conventions documented in CONTRIBUTING.md, pointer in README
- Includes review fixes from the original PR (#131): FluidCursor opts into `allowMultiple` so its two docs canvases don't fight over the singleton WebGL context; SmoothCursor's second story is excluded from autodocs so it doesn't fight the Default story over `document.body` cursor state
- Rebased onto the recreated `develop`

## Technical choices
- Trimmed init defaults: no Chromatic addon, no `@storybook/addon-vitest`/browser-mode test project; `vite.config.ts` untouched
- No `test-storybook` script for now — candidate for a follow-up (play functions / vitest addon)

## Test plan
- [ ] `pnpm storybook` — all stories render with Tailwind styles, controls work, dark toggle flips tokens
- [ ] `pnpm build-storybook` — succeeds
- [ ] `pnpm check` (0 errors) / `pnpm test` (475 green) — app unaffected
- [ ] `pnpm run package` — `dist/` contains no story files, publint passes