### PR TITLE
fix(copilot): correct package name and component count in system prompt

### DIFF
--- a/.changeset/copilot-prompt-package-name.md
+++ b/.changeset/copilot-prompt-package-name.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": patch
+---
+
+Fix the Component Copilot system prompt: it taught the wrong install command (`pnpm add fancy-ui` / `import … from 'fancy-ui'`) instead of the real package `fancy-ui-svelte`, and a hardcoded "60+ components" that had drifted from the registry. The count is now derived from the registry so it never drifts again, and the prompt now documents the required `@import "fancy-ui-svelte/tailwind.css";` stylesheet line without which Tailwind generates none of the component classes. Docs-site only — no change to the published component API.

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -11,11 +11,14 @@ function buildSystemPrompt(): string {
 		.map((cat) => `## ${categoryLabels[cat]}\n${byCategory[cat].join("\n")}`)
 		.join("\n\n");
 
-	return `You are FancyUI Copilot, an expert assistant for the FancyUI Svelte 5 component library.
-FancyUI provides 60+ animated, interactive components built with Svelte 5 runes and Tailwind CSS v4.
+	const count = getAllComponents().length;
 
-INSTALLATION: pnpm add fancy-ui
-USAGE: import { ComponentName } from 'fancy-ui';
+	return `You are FancyUI Copilot, an expert assistant for the FancyUI Svelte 5 component library.
+FancyUI provides ${count} animated, interactive components built with Svelte 5 runes and Tailwind CSS v4.
+
+INSTALLATION: pnpm add fancy-ui-svelte
+STYLESHEET: add \`@import "fancy-ui-svelte/tailwind.css";\` to your Tailwind entry CSS, or component classes won't be generated.
+USAGE: import { ComponentName } from 'fancy-ui-svelte';
 
 AVAILABLE COMPONENTS:
 


### PR DESCRIPTION
## What

The Component Copilot system prompt (`src/lib/ai/system-prompt.ts`) was teaching AI agents to fail:

- **Wrong package name** — `pnpm add fancy-ui` and `import { … } from 'fancy-ui'`. The published package is **`fancy-ui-svelte`** (`fancy-ui` is taken on npm). An agent following this installs the wrong package and every import breaks.
- **Stale count** — hardcoded "60+ animated components" while the registry reported a different number. Now derived from the registry (`getAllComponents().length`), so it can never drift again. (It renders **60** today.)
- **Missing stylesheet step** — added the required `@import "fancy-ui-svelte/tailwind.css";` line. Without it Tailwind v4 generates none of the component classes, so an agent's integration renders unstyled.

## Why

Ledger candidate (c) / architecture weak-point 7: the AI-native surface is a core direction (D3), and the copilot was actively teaching the wrong integration.

## Scope

Docs-site backend only — `src/lib/ai/` is not part of the published npm package. No component API change.

## Verification

- `pnpm check` → 0 errors
- `pnpm check:registry` → Registry parity OK (60 components)
- `pnpm test --run` → 482 passed