### PR TITLE
fix(pkg): ship dist/utils so consumer builds resolve utils/animation.js

### DIFF
--- a/.changeset/fix-publish-dist-utils.md
+++ b/.changeset/fix-publish-dist-utils.md
@@ -1,0 +1,7 @@
+---
+"fancy-ui-svelte": patch
+---
+
+fix(pkg): ship `dist/utils` in the published package
+
+The `files` array listed the file `dist/utils.js` but not the `dist/utils/` directory, so `dist/utils/animation.js` (and `color.js`/`geometry.js`) were never published. Any consumer importing from the barrel pulled in `NoiseReveal`, whose `import ... from "../../utils/animation.js"` then failed to resolve at bundle time, breaking the consumer's build. Adding `dist/utils` to `files` restores the missing directory.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	],
 	"files": [
 		"dist/fancy-ui",
+		"dist/utils",
 		"dist/utils.js",
 		"dist/utils.d.ts",
 		"dist/types.js",


### PR DESCRIPTION
## Problem
`package.json` `files` listed the file `dist/utils.js` but **not** the `dist/utils/` directory. So `dist/utils/animation.js` (+ `color.js`, `geometry.js`) were never published.

Any consumer importing from the package barrel pulls in `NoiseReveal`, whose `import { easeInOutCubic, getProgress, lerp } from "../../utils/animation.js"` then fails to resolve at bundle time:

```
Could not resolve "../../utils/animation.js" from
  node_modules/fancy-ui-svelte/dist/fancy-ui/noise-reveal/NoiseReveal.svelte
```

This breaks `vite build` in any app that imports *anything* from `fancy-ui-svelte` (svelte-check passes because it doesn't bundle). Hit while integrating the package into another app.

## Fix
Add `"dist/utils"` to the `files` array. Verified with `npm pack --dry-run`: the tarball now contains `dist/utils/animation.js`, `color.js`, `geometry.js`, `index.js`.

Changeset included (`patch`). No source changes — packaging only.