### PR TITLE
feat: LiquidText — cursor-driven liquid displacement text with chromatic aberration

### DIFF
--- a/.changeset/liquid-text-component.md
+++ b/.changeset/liquid-text-component.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+Add LiquidText component: big text that liquefies along the cursor's path via a raw-WebGL fluid solver, with chromatic-aberration fringing that relaxes back over time. Falls back to static styled text under reduced-motion, missing WebGL, or narrow viewports.

--- a/src/lib/components/docs/DemoRenderer.svelte
+++ b/src/lib/components/docs/DemoRenderer.svelte
@@ -179,6 +179,7 @@
 		"line-reveal",
 		"editorial-engine",
 		"frosted-glass",
+		"liquid-text",
 	]);
 
 	function getComponent() {

--- a/src/lib/components/docs/examples/liquid-text/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/liquid-text/BasicUsage.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import { LiquidText } from "$lib/fancy-ui/liquid-text";
+</script>
+
+<LiquidText text="Liquid" fontSize={160} />

--- a/src/lib/components/docs/examples/liquid-text/Playground.svelte
+++ b/src/lib/components/docs/examples/liquid-text/Playground.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { LiquidText, type LiquidTextProps } from "$lib/fancy-ui/liquid-text";
+	import PropsPlayground from "$lib/components/PropsPlayground.svelte";
+</script>
+
+<PropsPlayground
+	controls={[
+		{ key: "text", type: "text", label: "Text" },
+		{
+			key: "fontSize",
+			type: "range",
+			label: "Font Size (0 = auto-fit)",
+			min: 0,
+			max: 280,
+			step: 10,
+		},
+		{
+			key: "fontWeight",
+			type: "select",
+			label: "Font Weight",
+			options: [
+				{ value: "400", label: "400" },
+				{ value: "500", label: "500" },
+				{ value: "600", label: "600" },
+				{ value: "700", label: "700" },
+				{ value: "800", label: "800" },
+				{ value: "900", label: "900" },
+			],
+		},
+		{ key: "lightColor", type: "color", label: "Light Color" },
+		{ key: "darkColor", type: "color", label: "Dark Color" },
+		{ key: "strength", type: "range", label: "Warp Strength", min: 0, max: 1, step: 0.05 },
+		{ key: "radius", type: "range", label: "Splat Radius", min: 40, max: 400, step: 10 },
+		{ key: "forceGain", type: "range", label: "Force Gain", min: 1, max: 40, step: 1 },
+		{ key: "dissipation", type: "range", label: "Dissipation", min: 0.8, max: 0.999, step: 0.005 },
+		{ key: "viscosity", type: "range", label: "Viscosity", min: 0, max: 20, step: 1 },
+		{
+			key: "chromaticRatio",
+			type: "range",
+			label: "Chromatic Ratio",
+			min: 0,
+			max: 1,
+			step: 0.05,
+		},
+		{ key: "interactive", type: "boolean", label: "Interactive" },
+	]}
+	initialValues={{
+		text: "Liquid",
+		fontSize: 160,
+		fontWeight: "700",
+		lightColor: "#000000",
+		darkColor: "#ffffff",
+		strength: 0.5,
+		radius: 160,
+		forceGain: 17,
+		dissipation: 0.98,
+		viscosity: 4,
+		chromaticRatio: 0.2,
+		interactive: true,
+	}}
+>
+	{#snippet preview(values)}
+		<div class="bg-background relative h-40 w-full max-w-md overflow-hidden rounded-xl border">
+			<LiquidText {...values as LiquidTextProps} />
+		</div>
+	{/snippet}
+</PropsPlayground>

--- a/src/lib/components/docs/examples/registry.ts
+++ b/src/lib/components/docs/examples/registry.ts
@@ -380,4 +380,12 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 			description: "Drag the orbs, click to pause them, resize the window.",
 		},
 	],
+	"liquid-text": [
+		{
+			name: "BasicUsage",
+			title: "Basic Usage",
+			description: "Move the cursor across the text — it smears, then relaxes back.",
+		},
+		{ name: "Playground", title: "Interactive Playground" },
+	],
 };

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -65,6 +65,7 @@ export * from "./terminal-text/index.js";
 export * from "./noise-reveal/index.js";
 export * from "./line-reveal/index.js";
 export * from "./editorial-engine/index.js";
+export * from "./liquid-text/index.js";
 
 // =============================================================================
 // Registry

--- a/src/lib/fancy-ui/liquid-text/LiquidText.svelte
+++ b/src/lib/fancy-ui/liquid-text/LiquidText.svelte
@@ -1,0 +1,1151 @@
+<script lang="ts" module>
+	export interface LiquidTextProps {
+		/** Text rendered into the fluid texture (or as static fallback text). */
+		text?: string;
+		/** CSS font-family. Empty string resolves to getComputedStyle(host).fontFamily. */
+		font?: string;
+		/** Font size in px. 0 auto-fits the text to the container's width. */
+		fontSize?: number;
+		/** CSS font-weight for the rasterized/fallback text. */
+		fontWeight?: number | string;
+		/** Text color used in light mode. */
+		lightColor?: string;
+		/** Text color used in dark mode. */
+		darkColor?: string;
+		/** Additional CSS classes applied to the root element. */
+		class?: string;
+		/** Geometric UV warp gain — how far the fluid velocity displaces the text's UVs. */
+		strength?: number;
+		/** Splat radius in screen pixels around the pointer. */
+		radius?: number;
+		/** Multiplier from mouse-delta-per-frame to splat force. */
+		forceGain?: number;
+		/** Per-frame velocity decay factor (relax-back rate for the smear). */
+		dissipation?: number;
+		/** Viscous diffusion strength (Jacobi iteration, 8 iters). */
+		viscosity?: number;
+		/** Chromatic offset = warp amount x this ratio. */
+		chromaticRatio?: number;
+		/** If window.innerWidth <= staticBelow at mount, render static DOM text instead. */
+		staticBelow?: number;
+		/** Whether the fluid sim reacts to pointer movement. */
+		interactive?: boolean;
+		/** Pause the render loop via visibilitychange when the tab/page is hidden. */
+		pauseWhenHidden?: boolean;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { onMount } from "svelte";
+
+	// ===========================================================================
+	// Pure WebGL helpers (stateless — take `gl` as a parameter). Structurally
+	// modeled on the FluidCursor pass pipeline (DoubleFBO ping-pong, blit-driven
+	// fullscreen passes, Jacobi iteration), rewritten from scratch for a
+	// text-displacement sim: velocity-only field (no dye buffer), an added
+	// viscous-diffusion pass, and a screen-px splat falloff instead of a
+	// gaussian one. See README.md for the full pass order.
+	// ===========================================================================
+
+	type GL = WebGLRenderingContext | WebGL2RenderingContext;
+
+	interface Fbo {
+		texture: WebGLTexture;
+		framebuffer: WebGLFramebuffer;
+		width: number;
+		height: number;
+		texelSizeX: number;
+		texelSizeY: number;
+		attach: (unit: number) => number;
+	}
+
+	interface DoubleFbo {
+		width: number;
+		height: number;
+		texelSizeX: number;
+		texelSizeY: number;
+		read: Fbo;
+		write: Fbo;
+		swap: () => void;
+	}
+
+	interface TexFormat {
+		internalFormat: number;
+		format: number;
+	}
+
+	interface GlExt {
+		isWebGL2: boolean;
+		halfFloatTexType: number;
+		supportLinearFiltering: boolean;
+		velocityFormat: TexFormat;
+		scalarFormat: TexFormat;
+	}
+
+	function compileShader(gl: GL, type: number, source: string): WebGLShader {
+		const shader = gl.createShader(type);
+		if (!shader) throw new Error("LiquidText: unable to create shader");
+		gl.shaderSource(shader, source);
+		gl.compileShader(shader);
+		if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+			const info = gl.getShaderInfoLog(shader) ?? "unknown error";
+			gl.deleteShader(shader);
+			throw new Error(`LiquidText: shader compile failed: ${info}`);
+		}
+		return shader;
+	}
+
+	function linkProgram(gl: GL, vertexShader: WebGLShader, fragmentShader: WebGLShader): WebGLProgram {
+		const program = gl.createProgram();
+		if (!program) throw new Error("LiquidText: unable to create program");
+		gl.attachShader(program, vertexShader);
+		gl.attachShader(program, fragmentShader);
+		gl.linkProgram(program);
+		if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+			const info = gl.getProgramInfoLog(program) ?? "unknown error";
+			gl.deleteProgram(program);
+			throw new Error(`LiquidText: program link failed: ${info}`);
+		}
+		return program;
+	}
+
+	function uniformLocations(gl: GL, program: WebGLProgram): Map<string, WebGLUniformLocation> {
+		const map = new Map<string, WebGLUniformLocation>();
+		const count = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS) as number;
+		for (let i = 0; i < count; i++) {
+			const info = gl.getActiveUniform(program, i);
+			if (!info) continue;
+			const loc = gl.getUniformLocation(program, info.name);
+			if (loc) map.set(info.name, loc);
+		}
+		return map;
+	}
+
+	class GlProgram {
+		readonly program: WebGLProgram;
+		readonly uniforms: Map<string, WebGLUniformLocation>;
+		private readonly gl: GL;
+
+		constructor(gl: GL, vertexShader: WebGLShader, fragmentSource: string) {
+			this.gl = gl;
+			const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSource);
+			this.program = linkProgram(gl, vertexShader, fragmentShader);
+			gl.deleteShader(fragmentShader);
+			this.uniforms = uniformLocations(gl, this.program);
+		}
+
+		use() {
+			this.gl.useProgram(this.program);
+		}
+
+		set1f(name: string, value: number) {
+			const loc = this.uniforms.get(name);
+			if (loc) this.gl.uniform1f(loc, value);
+		}
+
+		set2f(name: string, x: number, y: number) {
+			const loc = this.uniforms.get(name);
+			if (loc) this.gl.uniform2f(loc, x, y);
+		}
+
+		set1i(name: string, value: number) {
+			const loc = this.uniforms.get(name);
+			if (loc) this.gl.uniform1i(loc, value);
+		}
+
+		dispose() {
+			this.gl.deleteProgram(this.program);
+		}
+	}
+
+	function createFbo(
+		gl: GL,
+		width: number,
+		height: number,
+		fmt: TexFormat,
+		type: number,
+		filter: number
+	): Fbo {
+		gl.activeTexture(gl.TEXTURE0);
+		const texture = gl.createTexture();
+		if (!texture) throw new Error("LiquidText: unable to allocate texture");
+		gl.bindTexture(gl.TEXTURE_2D, texture);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+		gl.texImage2D(gl.TEXTURE_2D, 0, fmt.internalFormat, width, height, 0, fmt.format, type, null);
+
+		const framebuffer = gl.createFramebuffer();
+		if (!framebuffer) throw new Error("LiquidText: unable to allocate framebuffer");
+		gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+		gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+		gl.viewport(0, 0, width, height);
+		gl.clearColor(0, 0, 0, 0);
+		gl.clear(gl.COLOR_BUFFER_BIT);
+
+		return {
+			texture,
+			framebuffer,
+			width,
+			height,
+			texelSizeX: 1 / width,
+			texelSizeY: 1 / height,
+			attach: (unit: number) => {
+				gl.activeTexture(gl.TEXTURE0 + unit);
+				gl.bindTexture(gl.TEXTURE_2D, texture);
+				return unit;
+			},
+		};
+	}
+
+	function deleteFbo(gl: GL, fbo: Fbo | null | undefined) {
+		if (!fbo) return;
+		gl.deleteTexture(fbo.texture);
+		gl.deleteFramebuffer(fbo.framebuffer);
+	}
+
+	function createDoubleFbo(
+		gl: GL,
+		width: number,
+		height: number,
+		fmt: TexFormat,
+		type: number,
+		filter: number
+	): DoubleFbo {
+		let read = createFbo(gl, width, height, fmt, type, filter);
+		let write = createFbo(gl, width, height, fmt, type, filter);
+		return {
+			width,
+			height,
+			texelSizeX: read.texelSizeX,
+			texelSizeY: read.texelSizeY,
+			get read() {
+				return read;
+			},
+			get write() {
+				return write;
+			},
+			swap() {
+				const tmp = read;
+				read = write;
+				write = tmp;
+			},
+		};
+	}
+
+	function deleteDoubleFbo(gl: GL, dfbo: DoubleFbo | null | undefined) {
+		if (!dfbo) return;
+		deleteFbo(gl, dfbo.read);
+		deleteFbo(gl, dfbo.write);
+	}
+
+	function textureRenderable(gl: GL, internalFormat: number, format: number, type: number): boolean {
+		const texture = gl.createTexture();
+		if (!texture) return false;
+		gl.bindTexture(gl.TEXTURE_2D, texture);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+		gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, 4, 4, 0, format, type, null);
+
+		const framebuffer = gl.createFramebuffer();
+		let ok = false;
+		if (framebuffer) {
+			gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+			gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+			ok = gl.checkFramebufferStatus(gl.FRAMEBUFFER) === gl.FRAMEBUFFER_COMPLETE;
+			gl.deleteFramebuffer(framebuffer);
+		}
+		gl.deleteTexture(texture);
+		return ok;
+	}
+
+	function resolveFormat(
+		gl: GL,
+		isWebGL2: boolean,
+		kind: "velocity" | "scalar",
+		type: number
+	): TexFormat | null {
+		if (!isWebGL2) {
+			return textureRenderable(gl, gl.RGBA, gl.RGBA, type)
+				? { internalFormat: gl.RGBA, format: gl.RGBA }
+				: null;
+		}
+		const gl2 = gl as WebGL2RenderingContext;
+		const candidates: TexFormat[] =
+			kind === "velocity"
+				? [
+						{ internalFormat: gl2.RG16F, format: gl2.RG },
+						{ internalFormat: gl2.RGBA16F, format: gl2.RGBA },
+					]
+				: [
+						{ internalFormat: gl2.R16F, format: gl2.RED },
+						{ internalFormat: gl2.RG16F, format: gl2.RG },
+						{ internalFormat: gl2.RGBA16F, format: gl2.RGBA },
+					];
+		for (const candidate of candidates) {
+			if (textureRenderable(gl, candidate.internalFormat, candidate.format, type)) return candidate;
+		}
+		return null;
+	}
+
+	function acquireGL(canvas: HTMLCanvasElement): { gl: GL; ext: GlExt } | null {
+		const attrs: WebGLContextAttributes = {
+			alpha: true,
+			depth: false,
+			stencil: false,
+			antialias: false,
+			preserveDrawingBuffer: false,
+		};
+
+		let gl: GL | null = canvas.getContext("webgl2", attrs) as WebGL2RenderingContext | null;
+		let isWebGL2 = !!gl;
+		if (!gl) {
+			gl = (canvas.getContext("webgl", attrs) ??
+				canvas.getContext("experimental-webgl", attrs)) as WebGLRenderingContext | null;
+			isWebGL2 = false;
+		}
+		if (!gl) return null;
+
+		let halfFloatTexType: number;
+		let supportLinearFiltering: boolean;
+
+		if (isWebGL2) {
+			const gl2 = gl as WebGL2RenderingContext;
+			gl2.getExtension("EXT_color_buffer_float");
+			// This component only ever allocates HALF_FLOAT (RG16F/R16F/RGBA16F)
+			// textures, and 16-bit float textures are always texture-filterable
+			// in core WebGL2 — OES_texture_float_linear only gates 32-bit FLOAT
+			// textures, which never get allocated here. Gating on that
+			// extension made the velocity FBO fall back to NEAREST (and the
+			// 0.25x sim field get upsampled blocky by the display shader) on
+			// the many GPUs/ANGLE backends that expose half-float without
+			// float-linear.
+			supportLinearFiltering = true;
+			halfFloatTexType = gl2.HALF_FLOAT;
+		} else {
+			// Some WebGL1 drivers require this to make a half-float texture
+			// usable as an FBO color attachment; without it, textureRenderable
+			// below fails every candidate and the component drops to the
+			// static fallback even though the sim could have run.
+			gl.getExtension("EXT_color_buffer_half_float");
+			const halfFloat = gl.getExtension("OES_texture_half_float");
+			supportLinearFiltering = !!gl.getExtension("OES_texture_half_float_linear");
+			halfFloatTexType = halfFloat ? halfFloat.HALF_FLOAT_OES : 0;
+		}
+
+		const velocityFormat = resolveFormat(gl, isWebGL2, "velocity", halfFloatTexType);
+		const scalarFormat = resolveFormat(gl, isWebGL2, "scalar", halfFloatTexType);
+		if (!velocityFormat || !scalarFormat) return null;
+
+		return { gl, ext: { isWebGL2, halfFloatTexType, supportLinearFiltering, velocityFormat, scalarFormat } };
+	}
+
+	function createBlit(gl: GL) {
+		const vertexBuffer = gl.createBuffer();
+		const indexBuffer = gl.createBuffer();
+		if (!vertexBuffer || !indexBuffer) throw new Error("LiquidText: unable to allocate geometry buffers");
+
+		gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+		gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, -1, 1, 1, 1, 1, -1]), gl.STATIC_DRAW);
+		gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+		gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array([0, 1, 2, 0, 2, 3]), gl.STATIC_DRAW);
+		gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+		gl.enableVertexAttribArray(0);
+
+		function blit(target: Fbo | null) {
+			if (target) {
+				gl.bindFramebuffer(gl.FRAMEBUFFER, target.framebuffer);
+				gl.viewport(0, 0, target.width, target.height);
+			} else {
+				gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+				gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+			}
+			gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+		}
+
+		function dispose() {
+			gl.deleteBuffer(vertexBuffer);
+			gl.deleteBuffer(indexBuffer);
+		}
+
+		return { blit, dispose };
+	}
+
+	// ===========================================================================
+	// Shader sources
+	// ===========================================================================
+
+	const VERTEX_SHADER = `
+		precision highp float;
+		attribute vec2 aPos;
+		varying vec2 vUv;
+		varying vec2 vL;
+		varying vec2 vR;
+		varying vec2 vT;
+		varying vec2 vB;
+		uniform vec2 texelSize;
+
+		void main () {
+			vUv = aPos * 0.5 + 0.5;
+			vL = vUv - vec2(texelSize.x, 0.0);
+			vR = vUv + vec2(texelSize.x, 0.0);
+			vT = vUv + vec2(0.0, texelSize.y);
+			vB = vUv - vec2(0.0, texelSize.y);
+			gl_Position = vec4(aPos, 0.0, 1.0);
+		}
+	`;
+
+	const COPY_SHADER = `
+		precision mediump float;
+		precision mediump sampler2D;
+		varying vec2 vUv;
+		uniform sampler2D uTexture;
+		void main () {
+			gl_FragColor = texture2D(uTexture, vUv);
+		}
+	`;
+
+	// Self-advects the velocity field along its own flow, then applies the
+	// per-frame dissipation decay (a plain multiplicative decay — not a
+	// dt-scaled rate — so `dissipation` reads directly as "fraction of
+	// velocity kept per frame").
+	const ADVECTION_SHADER = `
+		precision highp float;
+		precision highp sampler2D;
+		varying vec2 vUv;
+		uniform sampler2D uVelocity;
+		uniform float dt;
+		uniform float dissipation;
+
+		void main () {
+			vec2 back = vUv - dt * texture2D(uVelocity, vUv).xy;
+			vec2 advected = texture2D(uVelocity, back).xy;
+			gl_FragColor = vec4(clamp(advected * dissipation, -4.0, 4.0), 0.0, 1.0);
+		}
+	`;
+
+	// Injects pointer force at `point` (UV) with a screen-px radius falloff:
+	// (1 - clamp(dist/radius, 0, 1))^2 * 1.5, dist measured in real screen px
+	// via `resolution` (the container's CSS size), independent of the sim's
+	// own (lower) texel resolution.
+	const SPLAT_SHADER = `
+		precision highp float;
+		precision highp sampler2D;
+		varying vec2 vUv;
+		uniform sampler2D uVelocity;
+		uniform vec2 point;
+		uniform vec2 resolution;
+		uniform float radius;
+		uniform vec2 force;
+
+		void main () {
+			vec2 diffPx = (vUv - point) * resolution;
+			float dist = length(diffPx);
+			float t = clamp(1.0 - dist / max(radius, 1.0), 0.0, 1.0);
+			float falloff = t * t * 1.5;
+			vec2 base = texture2D(uVelocity, vUv).xy;
+			gl_FragColor = vec4(clamp(base + force * falloff, -4.0, 4.0), 0.0, 1.0);
+		}
+	`;
+
+	// One Jacobi iteration of implicit viscous diffusion:
+	// x_new = (x0 + alpha*(xL+xR+xT+xB)) / (1 + 4*alpha), alpha = viscosity*dt.
+	// `uSource` is the fixed pre-diffusion snapshot (x0); `uVelocity` is the
+	// current iterate, ping-ponged across 8 calls.
+	const DIFFUSE_SHADER = `
+		precision highp float;
+		precision highp sampler2D;
+		varying vec2 vUv;
+		varying vec2 vL;
+		varying vec2 vR;
+		varying vec2 vT;
+		varying vec2 vB;
+		uniform sampler2D uVelocity;
+		uniform sampler2D uSource;
+		uniform float alpha;
+
+		void main () {
+			vec2 xL = texture2D(uVelocity, vL).xy;
+			vec2 xR = texture2D(uVelocity, vR).xy;
+			vec2 xT = texture2D(uVelocity, vT).xy;
+			vec2 xB = texture2D(uVelocity, vB).xy;
+			vec2 x0 = texture2D(uSource, vUv).xy;
+			float beta = 1.0 + 4.0 * alpha;
+			vec2 result = (x0 + alpha * (xL + xR + xT + xB)) / beta;
+			gl_FragColor = vec4(clamp(result, -4.0, 4.0), 0.0, 1.0);
+		}
+	`;
+
+	const DIVERGENCE_SHADER = `
+		precision highp float;
+		precision highp sampler2D;
+		varying vec2 vUv;
+		varying vec2 vL;
+		varying vec2 vR;
+		varying vec2 vT;
+		varying vec2 vB;
+		uniform sampler2D uVelocity;
+
+		void main () {
+			float L = texture2D(uVelocity, vL).x;
+			float R = texture2D(uVelocity, vR).x;
+			float T = texture2D(uVelocity, vT).y;
+			float B = texture2D(uVelocity, vB).y;
+			vec2 C = texture2D(uVelocity, vUv).xy;
+			if (vL.x < 0.0) L = -C.x;
+			if (vR.x > 1.0) R = -C.x;
+			if (vT.y > 1.0) T = -C.y;
+			if (vB.y < 0.0) B = -C.y;
+			float div = 0.5 * (R - L + T - B);
+			gl_FragColor = vec4(div, 0.0, 0.0, 1.0);
+		}
+	`;
+
+	const PRESSURE_SHADER = `
+		precision highp float;
+		precision highp sampler2D;
+		varying vec2 vUv;
+		varying vec2 vL;
+		varying vec2 vR;
+		varying vec2 vT;
+		varying vec2 vB;
+		uniform sampler2D uPressure;
+		uniform sampler2D uDivergence;
+
+		void main () {
+			float L = texture2D(uPressure, vL).x;
+			float R = texture2D(uPressure, vR).x;
+			float T = texture2D(uPressure, vT).x;
+			float B = texture2D(uPressure, vB).x;
+			float div = texture2D(uDivergence, vUv).x;
+			float p = (L + R + T + B - div) * 0.25;
+			gl_FragColor = vec4(p, 0.0, 0.0, 1.0);
+		}
+	`;
+
+	const GRADIENT_SUBTRACT_SHADER = `
+		precision highp float;
+		precision highp sampler2D;
+		varying vec2 vUv;
+		varying vec2 vL;
+		varying vec2 vR;
+		varying vec2 vT;
+		varying vec2 vB;
+		uniform sampler2D uPressure;
+		uniform sampler2D uVelocity;
+
+		void main () {
+			float L = texture2D(uPressure, vL).x;
+			float R = texture2D(uPressure, vR).x;
+			float T = texture2D(uPressure, vT).x;
+			float B = texture2D(uPressure, vB).x;
+			vec2 vel = texture2D(uVelocity, vUv).xy;
+			vel -= 0.5 * vec2(R - L, T - B);
+			gl_FragColor = vec4(clamp(vel, -4.0, 4.0), 0.0, 1.0);
+		}
+	`;
+
+	// Final composite: warps the rasterized-text UV by the velocity field and
+	// takes 3 independently-offset taps (R/G/B) for the chromatic-aberration
+	// fringe. Alpha is the max of the 3 taps' alpha so the fringe itself is
+	// visible over the transparent background rather than being clipped to the
+	// unwarped glyph silhouette.
+	const DISPLAY_SHADER = `
+		precision highp float;
+		precision highp sampler2D;
+		varying vec2 vUv;
+		uniform sampler2D uText;
+		uniform sampler2D uVelocity;
+		uniform float strength;
+		uniform float chromaticRatio;
+
+		void main () {
+			vec2 vel = texture2D(uVelocity, vUv).xy;
+			vec2 warp = vel * strength;
+			vec2 chroma = warp * chromaticRatio;
+			vec2 base = vUv - warp;
+			vec4 rTap = texture2D(uText, base - chroma);
+			vec4 gTap = texture2D(uText, base);
+			vec4 bTap = texture2D(uText, base + chroma);
+			vec3 color = vec3(rTap.r, gTap.g, bTap.b);
+			float a = max(rTap.a, max(gTap.a, bTap.a));
+			gl_FragColor = vec4(color, a);
+		}
+	`;
+
+	const FIXED_DT = 0.016;
+	const DIFFUSE_ITERATIONS = 8;
+	const PRESSURE_ITERATIONS = 16;
+	const SIM_SCALE = 0.25;
+
+	// ===========================================================================
+	// Component
+	// ===========================================================================
+
+	let {
+		text = "Liquid",
+		font = "",
+		fontSize = 0,
+		fontWeight = 700,
+		lightColor = "#000000",
+		darkColor = "#ffffff",
+		class: className = "",
+		strength = 0.5,
+		radius = 160,
+		forceGain = 17,
+		dissipation = 0.98,
+		viscosity = 4,
+		chromaticRatio = 0.2,
+		staticBelow = 1024,
+		interactive = true,
+		pauseWhenHidden = true,
+	}: LiquidTextProps = $props();
+
+	let rootEl: HTMLDivElement | undefined = $state();
+	let canvasEl: HTMLCanvasElement | undefined = $state();
+
+	// Always starts "static" so the very first render (SSR or client) never
+	// touches window/document — onMount promotes to "canvas" if eligible.
+	let mode: "static" | "canvas" = $state("static");
+	let themeColor = $state(lightColor);
+	let resolvedFont = $state(font);
+	let displayFontSize = $state(fontSize > 0 ? fontSize : 64);
+
+	// Hoisted so the prop-reactivity effect below can push a re-rasterize
+	// into the live WebGL texture after mount. Assigned by setupCanvasSim
+	// once the sim is running; stays null on the static-fallback path, where
+	// updating the $state above is enough since the fallback is just
+	// reactive DOM markup.
+	let rasterize: (() => void) | null = null;
+
+	const rootHeight = $derived(`${Math.round(displayFontSize * 1.2)}px`);
+
+	function activeThemeColor(): string {
+		return typeof document !== "undefined" && document.documentElement.classList.contains("dark")
+			? darkColor
+			: lightColor;
+	}
+
+	// Recomputes resolvedFont + displayFontSize together (using a local
+	// `family` const rather than re-reading the `resolvedFont` state it just
+	// wrote) so this can safely run inside the reactive $effect below without
+	// the effect both writing and re-reading the same piece of state in one
+	// pass.
+	function fitFontSize() {
+		if (!rootEl) return;
+		const family = font || getComputedStyle(rootEl).fontFamily || "sans-serif";
+		resolvedFont = family;
+		if (fontSize > 0) {
+			displayFontSize = fontSize;
+			return;
+		}
+		const containerWidth = rootEl.clientWidth || 1;
+		const probe = document.createElement("canvas").getContext("2d");
+		if (!probe) return;
+		const reference = 100;
+		probe.font = `${fontWeight} ${reference}px ${family}`;
+		const measured = probe.measureText(text).width || 1;
+		const fitted = reference * (containerWidth / measured);
+		displayFontSize = Math.min(Math.max(fitted, 8), 2000);
+	}
+
+	// Per the "text/font changes re-rasterize" requirement: the WebGL path
+	// otherwise only reads text/font/fontSize/fontWeight/lightColor/
+	// darkColor once, at setup, so updating them in e.g. a Storybook/docs
+	// control would silently do nothing. Reading the props directly here
+	// (rather than only inside the helpers above) registers them as this
+	// effect's dependencies, so any of them changing after mount re-derives
+	// the resolved font/size/color and, on the canvas path, re-rasterizes.
+	$effect(() => {
+		void text;
+		void font;
+		void fontSize;
+		void fontWeight;
+		void lightColor;
+		void darkColor;
+		if (!rootEl) return;
+		themeColor = activeThemeColor();
+		fitFontSize();
+		rasterize?.();
+	});
+
+	onMount(() => {
+		const root = rootEl;
+		const canvas = canvasEl;
+		if (!root || !canvas) return;
+
+		themeColor = activeThemeColor();
+
+		const themeObserver = new MutationObserver(() => {
+			const next = activeThemeColor();
+			if (next !== themeColor) {
+				themeColor = next;
+				rasterize?.();
+			}
+		});
+		themeObserver.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ["class"],
+		});
+
+		fitFontSize();
+
+		const reduceMotionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+		const tooSmall = window.innerWidth <= staticBelow;
+
+		let cleanupCanvasSim: (() => void) | null = null;
+		let fallbackResizeObserver: ResizeObserver | null = null;
+
+		// setupCanvasSim installs its own ResizeObserver; the static fallback
+		// (reduced-motion, staticBelow, no WebGL, a failed GL init, or a
+		// mid-session GPU context loss — see onContextLost inside
+		// setupCanvasSim) has no such observer of its own, so without this the
+		// auto-fit (fontSize=0) fallback text would stay frozen at its
+		// mount-time size across any later container/viewport resize (e.g.
+		// mobile rotation). Guarded against re-entry so it's safe to call
+		// again (e.g. if a restored context is lost a second time) without
+		// leaking a duplicate observer.
+		function startFallbackResize() {
+			if (!root || fallbackResizeObserver) return;
+			fallbackResizeObserver = new ResizeObserver(() => fitFontSize());
+			fallbackResizeObserver.observe(root);
+		}
+
+		if (!reduceMotionQuery.matches && !tooSmall) {
+			cleanupCanvasSim = setupCanvasSim(canvas, root, startFallbackResize);
+		}
+		if (!cleanupCanvasSim) {
+			startFallbackResize();
+		}
+
+		// Honor a live toggle of the OS reduced-motion setting, not just its
+		// value at mount: if it flips to "reduce" while the sim is running,
+		// tear the sim down and drop to the static fallback.
+		function onReduceMotionChange(e: MediaQueryListEvent) {
+			if (e.matches && cleanupCanvasSim) {
+				cleanupCanvasSim();
+				cleanupCanvasSim = null;
+				mode = "static";
+				startFallbackResize();
+			}
+		}
+		reduceMotionQuery.addEventListener("change", onReduceMotionChange);
+
+		return () => {
+			themeObserver.disconnect();
+			reduceMotionQuery.removeEventListener("change", onReduceMotionChange);
+			fallbackResizeObserver?.disconnect();
+			cleanupCanvasSim?.();
+		};
+	});
+
+	/**
+	 * Attempts to acquire a WebGL context and, if successful, boots the fluid
+	 * sim + render loop and switches `mode` to "canvas". Returns a cleanup
+	 * function on success, or `null` if WebGL is unavailable (caller should
+	 * keep the static DOM fallback).
+	 *
+	 * `startFallbackResize` is onMount's fallback-resize starter, threaded
+	 * through so the context-loss handler below can re-arm it when it drops
+	 * the sim to the static fallback mid-session — it closes over onMount's
+	 * `root`/`fallbackResizeObserver`, so calling it here keeps that observer
+	 * reachable from onMount's own cleanup return, and it's a no-op if the
+	 * observer is already attached.
+	 */
+	function setupCanvasSim(
+		canvas: HTMLCanvasElement,
+		root: HTMLDivElement,
+		startFallbackResize: () => void
+	): (() => void) | null {
+		const acquired = acquireGL(canvas);
+		if (!acquired) return null;
+
+		const { gl, ext } = acquired;
+
+		// Declared here (outside the try below) so both the success path and
+		// the failure-recovery catch block can safely reference them — `let`/
+		// `function` declared inside a `try { … }` are not visible from its
+		// `catch { … }`, since try/catch are separate block scopes.
+		let velocity: DoubleFbo | null = null;
+		let divergenceFbo: Fbo | null = null;
+		let pressure: DoubleFbo | null = null;
+		let diffuseSource: Fbo | null = null;
+		let textTexture: WebGLTexture | null = null;
+		let textCanvas: HTMLCanvasElement | null = null;
+
+		function destroySimBuffers() {
+			deleteDoubleFbo(gl, velocity);
+			deleteFbo(gl, divergenceFbo);
+			deleteDoubleFbo(gl, pressure);
+			deleteFbo(gl, diffuseSource);
+			velocity = null;
+			divergenceFbo = null;
+			pressure = null;
+			diffuseSource = null;
+		}
+
+		// Tracks GL resources as they're successfully allocated during this
+		// synchronous setup pass, so a later failure (a program that fails to
+		// compile/link, exhausted buffers, …) can free everything created
+		// before it instead of stranding those objects on the canvas's
+		// still-live GL context. Cleared once setup fully succeeds.
+		const disposeOnFailure: Array<() => void> = [];
+
+		try {
+			const { blit, dispose: disposeGeometry } = createBlit(gl);
+			disposeOnFailure.push(disposeGeometry);
+
+			const vertexShader = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
+			disposeOnFailure.push(() => gl.deleteShader(vertexShader));
+
+			function makeProgram(fragmentSource: string): GlProgram {
+				const program = new GlProgram(gl, vertexShader, fragmentSource);
+				disposeOnFailure.push(() => program.dispose());
+				return program;
+			}
+
+			const advectionProgram = makeProgram(ADVECTION_SHADER);
+			const splatProgram = makeProgram(SPLAT_SHADER);
+			const diffuseProgram = makeProgram(DIFFUSE_SHADER);
+			const divergenceProgram = makeProgram(DIVERGENCE_SHADER);
+			const pressureProgram = makeProgram(PRESSURE_SHADER);
+			const gradientSubtractProgram = makeProgram(GRADIENT_SUBTRACT_SHADER);
+			const copyProgram = makeProgram(COPY_SHADER);
+			const displayProgram = makeProgram(DISPLAY_SHADER);
+			gl.deleteShader(vertexShader);
+
+			const filter = ext.supportLinearFiltering ? gl.LINEAR : gl.NEAREST;
+
+			let cssWidth = 0;
+			let cssHeight = 0;
+
+			function createSimBuffers(simW: number, simH: number) {
+				velocity = createDoubleFbo(gl, simW, simH, ext.velocityFormat, ext.halfFloatTexType, filter);
+				divergenceFbo = createFbo(gl, simW, simH, ext.scalarFormat, ext.halfFloatTexType, gl.NEAREST);
+				pressure = createDoubleFbo(gl, simW, simH, ext.scalarFormat, ext.halfFloatTexType, gl.NEAREST);
+				diffuseSource = createFbo(gl, simW, simH, ext.velocityFormat, ext.halfFloatTexType, filter);
+			}
+
+			function rasterizeText() {
+				const dpr = window.devicePixelRatio || 1;
+				const w = Math.max(1, Math.round(cssWidth * dpr));
+				const h = Math.max(1, Math.round(cssHeight * dpr));
+				if (!textCanvas) textCanvas = document.createElement("canvas");
+				textCanvas.width = w;
+				textCanvas.height = h;
+				const ctx = textCanvas.getContext("2d");
+				if (!ctx) return;
+				ctx.clearRect(0, 0, w, h);
+				ctx.font = `${fontWeight} ${displayFontSize * dpr}px ${resolvedFont}`;
+				ctx.fillStyle = themeColor;
+				ctx.textAlign = "left";
+				ctx.textBaseline = "middle";
+				ctx.fillText(text, 0, h / 2);
+
+				if (!textTexture) textTexture = gl.createTexture();
+				gl.bindTexture(gl.TEXTURE_2D, textTexture);
+				gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+				gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, textCanvas);
+				gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+			}
+
+			function resizeAll() {
+				fitFontSize();
+				const dpr = window.devicePixelRatio || 1;
+				cssWidth = root.clientWidth || 1;
+				cssHeight = Math.round(displayFontSize * 1.2) || 1;
+				const pxW = Math.max(1, Math.round(cssWidth * dpr));
+				const pxH = Math.max(1, Math.round(cssHeight * dpr));
+				if (canvas.width !== pxW || canvas.height !== pxH) {
+					canvas.width = pxW;
+					canvas.height = pxH;
+				}
+				const simW = Math.max(1, Math.round(pxW * SIM_SCALE));
+				const simH = Math.max(1, Math.round(pxH * SIM_SCALE));
+				if (!velocity || velocity.width !== simW || velocity.height !== simH) {
+					destroySimBuffers();
+					createSimBuffers(simW, simH);
+				}
+				rasterizeText();
+			}
+
+			resizeAll();
+			mode = "canvas";
+			rasterize = rasterizeText;
+
+			const resizeObserver = new ResizeObserver(() => resizeAll());
+			resizeObserver.observe(root);
+
+			// --- pointer tracking (UV space, y=1 at top to match vUv) ---
+			const pointerUV = { x: 0.5, y: 0.5 };
+			const pointerPrevUV = { x: 0.5, y: 0.5 };
+			const pointerForce = { x: 0, y: 0 };
+			let pointerHasPrev = false;
+			let pointerMoved = false;
+
+			function onPointerMove(e: PointerEvent) {
+				if (!interactive) return;
+				const rect = root.getBoundingClientRect();
+				if (rect.width <= 0 || rect.height <= 0) return;
+				const x = (e.clientX - rect.left) / rect.width;
+				const y = 1 - (e.clientY - rect.top) / rect.height;
+				if (pointerHasPrev) {
+					pointerForce.x = (x - pointerPrevUV.x) * forceGain;
+					pointerForce.y = (y - pointerPrevUV.y) * forceGain;
+					pointerMoved = true;
+				}
+				pointerPrevUV.x = x;
+				pointerPrevUV.y = y;
+				pointerUV.x = x;
+				pointerUV.y = y;
+				pointerHasPrev = true;
+			}
+
+			// Always registered — `interactive` is read live inside
+			// onPointerMove above, so toggling the prop after mount (e.g. a
+			// Storybook/docs control) takes effect immediately instead of
+			// only reflecting its value at initial setup.
+			window.addEventListener("pointermove", onPointerMove, { passive: true });
+
+			// --- visibility pause ---
+			let hidden = document.hidden;
+			function onVisibilityChange() {
+				hidden = document.hidden;
+			}
+			// Always registered — `pauseWhenHidden` is read live in frame()
+			// below, so toggling the prop after mount takes effect immediately
+			// instead of only reflecting its value at initial setup.
+			document.addEventListener("visibilitychange", onVisibilityChange);
+
+			// --- sim passes ---
+			function applySplat() {
+				if (!pointerMoved || !velocity) return;
+				pointerMoved = false;
+				splatProgram.use();
+				splatProgram.set2f("point", pointerUV.x, pointerUV.y);
+				splatProgram.set2f("resolution", cssWidth, cssHeight);
+				splatProgram.set1f("radius", radius);
+				splatProgram.set2f("force", pointerForce.x, pointerForce.y);
+				splatProgram.set1i("uVelocity", velocity.read.attach(0));
+				blit(velocity.write);
+				velocity.swap();
+			}
+
+			function diffuseVelocity(dt: number) {
+				if (!velocity || !diffuseSource) return;
+				copyProgram.use();
+				copyProgram.set1i("uTexture", velocity.read.attach(0));
+				blit(diffuseSource);
+
+				const alpha = viscosity * dt;
+				for (let i = 0; i < DIFFUSE_ITERATIONS; i++) {
+					diffuseProgram.use();
+					diffuseProgram.set2f("texelSize", velocity.texelSizeX, velocity.texelSizeY);
+					diffuseProgram.set1i("uVelocity", velocity.read.attach(0));
+					diffuseProgram.set1i("uSource", diffuseSource.attach(1));
+					diffuseProgram.set1f("alpha", alpha);
+					blit(velocity.write);
+					velocity.swap();
+				}
+			}
+
+			function clearFbo(fbo: Fbo) {
+				gl.bindFramebuffer(gl.FRAMEBUFFER, fbo.framebuffer);
+				gl.viewport(0, 0, fbo.width, fbo.height);
+				gl.clearColor(0, 0, 0, 0);
+				gl.clear(gl.COLOR_BUFFER_BIT);
+			}
+
+			function step(dt: number) {
+				if (!velocity || !divergenceFbo || !pressure) return;
+				gl.disable(gl.BLEND);
+
+				advectionProgram.use();
+				advectionProgram.set2f("texelSize", velocity.texelSizeX, velocity.texelSizeY);
+				advectionProgram.set1i("uVelocity", velocity.read.attach(0));
+				advectionProgram.set1f("dt", dt);
+				advectionProgram.set1f("dissipation", dissipation);
+				blit(velocity.write);
+				velocity.swap();
+
+				applySplat();
+				diffuseVelocity(dt);
+
+				divergenceProgram.use();
+				divergenceProgram.set2f("texelSize", velocity.texelSizeX, velocity.texelSizeY);
+				divergenceProgram.set1i("uVelocity", velocity.read.attach(0));
+				blit(divergenceFbo);
+
+				clearFbo(pressure.write);
+				pressure.swap();
+				for (let i = 0; i < PRESSURE_ITERATIONS; i++) {
+					pressureProgram.use();
+					pressureProgram.set2f("texelSize", velocity.texelSizeX, velocity.texelSizeY);
+					pressureProgram.set1i("uPressure", pressure.read.attach(0));
+					pressureProgram.set1i("uDivergence", divergenceFbo.attach(1));
+					blit(pressure.write);
+					pressure.swap();
+				}
+
+				gradientSubtractProgram.use();
+				gradientSubtractProgram.set2f("texelSize", velocity.texelSizeX, velocity.texelSizeY);
+				gradientSubtractProgram.set1i("uPressure", pressure.read.attach(0));
+				gradientSubtractProgram.set1i("uVelocity", velocity.read.attach(1));
+				blit(velocity.write);
+				velocity.swap();
+			}
+
+			function draw() {
+				if (!velocity || !textTexture) return;
+				gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+				gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+				gl.clearColor(0, 0, 0, 0);
+				gl.clear(gl.COLOR_BUFFER_BIT);
+				gl.enable(gl.BLEND);
+				gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+				displayProgram.use();
+				gl.activeTexture(gl.TEXTURE0);
+				gl.bindTexture(gl.TEXTURE_2D, textTexture);
+				displayProgram.set1i("uText", 0);
+				displayProgram.set1i("uVelocity", velocity.read.attach(1));
+				displayProgram.set1f("strength", strength);
+				displayProgram.set1f("chromaticRatio", chromaticRatio);
+				blit(null);
+			}
+
+			let rafId: number | null = requestAnimationFrame(frame);
+			function frame() {
+				rafId = requestAnimationFrame(frame);
+				if (pauseWhenHidden && hidden) return;
+				step(FIXED_DT);
+				draw();
+			}
+
+			// Tears down the running sim's listeners/GL resources. Shared by
+			// the context-loss handler below (which must stop issuing calls
+			// against a dead context) and the normal unmount cleanup.
+			function teardownSim() {
+				if (rafId !== null) {
+					cancelAnimationFrame(rafId);
+					rafId = null;
+				}
+				document.removeEventListener("visibilitychange", onVisibilityChange);
+				window.removeEventListener("pointermove", onPointerMove);
+				resizeObserver.disconnect();
+				destroySimBuffers();
+				if (textTexture) {
+					gl.deleteTexture(textTexture);
+					textTexture = null;
+				}
+				for (const p of [
+					advectionProgram,
+					splatProgram,
+					diffuseProgram,
+					divergenceProgram,
+					pressureProgram,
+					gradientSubtractProgram,
+					copyProgram,
+					displayProgram,
+				]) {
+					p.dispose();
+				}
+				disposeGeometry();
+				rasterize = null;
+			}
+
+			// A real GPU context loss (driver reset, GPU switch, too many live
+			// contexts, …) must not leave the rAF loop silently issuing calls
+			// against a dead context, and — without preventDefault() — the
+			// context would never become eligible for restoration. Recovery
+			// here is deliberately conservative: every GL object created
+			// above is invalidated by the loss, so rather than rebuilding the
+			// whole sim in place this drops to the stable static DOM fallback
+			// for the remainder of this mount.
+			function onContextLost(event: Event) {
+				event.preventDefault();
+				teardownSim();
+				mode = "static";
+				startFallbackResize();
+			}
+			function onContextRestored() {
+				// Intentionally inert — see onContextLost above. The static
+				// fallback stays in place rather than attempting a risky
+				// partial rebuild of programs/geometry/FBOs in place.
+			}
+			canvas.addEventListener("webglcontextlost", onContextLost, false);
+			canvas.addEventListener("webglcontextrestored", onContextRestored, false);
+
+			disposeOnFailure.length = 0;
+
+			return () => {
+				canvas.removeEventListener("webglcontextlost", onContextLost);
+				canvas.removeEventListener("webglcontextrestored", onContextRestored);
+				teardownSim();
+				const loseContext = gl.getExtension("WEBGL_lose_context");
+				loseContext?.loseContext();
+			};
+		} catch {
+			// Best-effort cleanup of whatever GL resources were already
+			// allocated before the failure (a program compile/link error,
+			// exhausted geometry buffers, a texture allocation failure inside
+			// the initial resizeAll(), …), so a failed init doesn't strand
+			// them on the canvas's still-live context. The disposeOnFailure
+			// entries are each individually guarded since how far setup got
+			// before throwing determines which of them actually ran; the sim
+			// buffers/texture are unconditionally declared above (outside
+			// this try), so they're always safe to tear down here.
+			for (const dispose of disposeOnFailure) {
+				try {
+					dispose();
+				} catch {
+					/* already gone, or the context is no longer usable */
+				}
+			}
+			destroySimBuffers();
+			if (textTexture) gl.deleteTexture(textTexture);
+			gl.getExtension("WEBGL_lose_context")?.loseContext();
+			// Falls back to the static DOM text path rather than throwing.
+			mode = "static";
+			return null;
+		}
+	}
+</script>
+
+<div bind:this={rootEl} class={cn("liquid-text relative block w-full", className)} style:height={rootHeight}>
+	<canvas
+		bind:this={canvasEl}
+		aria-hidden="true"
+		class={cn("pointer-events-none absolute inset-0 block h-full w-full", mode === "canvas" ? "" : "invisible")}
+	></canvas>
+	{#if mode === "canvas"}
+		<span class="sr-only">{text}</span>
+	{:else}
+		<span
+			class="liquid-text-fallback block"
+			style:color={themeColor}
+			style:font-family={resolvedFont}
+			style:font-size={`${displayFontSize}px`}
+			style:font-weight={fontWeight}
+		>{text}</span>
+	{/if}
+</div>
+
+<style>
+	.liquid-text {
+		line-height: 1;
+	}
+
+	.liquid-text-fallback {
+		margin: 0;
+		white-space: nowrap;
+	}
+</style>

--- a/src/lib/fancy-ui/liquid-text/LiquidText.test.ts
+++ b/src/lib/fancy-ui/liquid-text/LiquidText.test.ts
@@ -1,0 +1,251 @@
+import { render, screen, cleanup } from "@testing-library/svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import LiquidText from "./LiquidText.svelte";
+
+/**
+ * Ambient test environment (see src/test-setup.ts) already stubs:
+ *   - HTMLCanvasElement.prototype.getContext -> null   (WebGL "unavailable")
+ *   - window.matchMedia                       -> { matches: false, ... }
+ *   - ResizeObserver / IntersectionObserver    -> no-op classes
+ *
+ * Per the frozen LiquidText contract, "no WebGL" and "no reduced-motion
+ * preference" both drive the component into its DOM-fallback path. Tests
+ * below that specifically target the fallback/no-WebGL/reduced-motion
+ * behavior re-assert these overrides explicitly (mirroring the ambient
+ * default) so intent is self-documenting and independent of test-setup.ts.
+ */
+
+describe("LiquidText", () => {
+	afterEach(cleanup);
+
+	describe("accessible text node", () => {
+		it("renders the text prop as a real text node in the DOM", () => {
+			render(LiquidText, { props: { text: "Hello Liquid" } });
+			const textNode = screen.getByText("Hello Liquid");
+			expect(textNode).toBeInTheDocument();
+			// The contract only requires the *canvas* to be aria-hidden; the
+			// real text node itself must stay in the accessibility tree,
+			// whether it is the sr-only span (canvas active) or the visible
+			// fallback text.
+			expect(textNode.getAttribute("aria-hidden")).not.toBe("true");
+		});
+
+		it('falls back to the default text "Liquid" when no text prop is passed', () => {
+			render(LiquidText);
+			expect(screen.getByText("Liquid")).toBeInTheDocument();
+		});
+
+		it("marks the canvas aria-hidden when a canvas is rendered", () => {
+			const { container } = render(LiquidText, { props: { text: "Canvas Check" } });
+			const canvas = container.querySelector("canvas");
+			// The contract does not pin down whether <canvas> is always present
+			// in the markup or only mounted on the interactive/WebGL path, so
+			// this only asserts when one is actually found.
+			if (canvas) {
+				expect(canvas.getAttribute("aria-hidden")).toBe("true");
+			}
+		});
+	});
+
+	describe("WebGL unavailable fallback", () => {
+		it("renders visible styled fallback text, starts no rAF render loop, and logs no console errors", () => {
+			const originalGetContext = HTMLCanvasElement.prototype.getContext;
+			HTMLCanvasElement.prototype.getContext = (() =>
+				null) as typeof HTMLCanvasElement.prototype.getContext;
+
+			const rafSpy = vi.spyOn(window, "requestAnimationFrame");
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			render(LiquidText, {
+				props: {
+					text: "No WebGL",
+					font: "Georgia, serif",
+					fontSize: 48,
+					fontWeight: 600,
+					lightColor: "#123456",
+				},
+			});
+
+			const textNode = screen.getByText("No WebGL");
+			expect(textNode).toBeInTheDocument();
+			// Per contract: "visible styled text in fallback modes", as opposed
+			// to the sr-only span used when the canvas is actively driven. It
+			// must actually carry the prop-driven font/size/color styling, not
+			// just be present and unstyled.
+			expect(textNode.className).not.toContain("sr-only");
+			expect(textNode.style.fontFamily).toBe("Georgia, serif");
+			expect(textNode.style.fontSize).toBe("48px");
+			expect(textNode.style.fontWeight).toBe("600");
+			expect(textNode.style.color).toBe("rgb(18, 52, 86)");
+			expect(rafSpy).not.toHaveBeenCalled();
+			expect(errorSpy).not.toHaveBeenCalled();
+
+			rafSpy.mockRestore();
+			errorSpy.mockRestore();
+			HTMLCanvasElement.prototype.getContext = originalGetContext;
+		});
+	});
+
+	describe("prefers-reduced-motion fallback", () => {
+		it("renders static fallback text and starts no rAF render loop when reduced motion is preferred", () => {
+			const originalMatchMedia = window.matchMedia;
+			Object.defineProperty(window, "matchMedia", {
+				writable: true,
+				configurable: true,
+				value: (query: string) => ({
+					matches: query.includes("prefers-reduced-motion"),
+					media: query,
+					onchange: null,
+					addEventListener: () => {},
+					removeEventListener: () => {},
+					dispatchEvent: () => false,
+					addListener: () => {},
+					removeListener: () => {},
+				}),
+			});
+
+			const rafSpy = vi.spyOn(window, "requestAnimationFrame");
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			render(LiquidText, {
+				props: {
+					text: "Reduced Motion",
+					font: "Georgia, serif",
+					fontSize: 32,
+					fontWeight: 500,
+					lightColor: "#654321",
+				},
+			});
+
+			const textNode = screen.getByText("Reduced Motion");
+			expect(textNode).toBeInTheDocument();
+			expect(textNode.className).not.toContain("sr-only");
+			// Same requirement as the no-WebGL fallback: styled per the props,
+			// not just present.
+			expect(textNode.style.fontFamily).toBe("Georgia, serif");
+			expect(textNode.style.fontSize).toBe("32px");
+			expect(textNode.style.fontWeight).toBe("500");
+			expect(textNode.style.color).toBe("rgb(101, 67, 33)");
+			expect(rafSpy).not.toHaveBeenCalled();
+			expect(errorSpy).not.toHaveBeenCalled();
+
+			rafSpy.mockRestore();
+			errorSpy.mockRestore();
+			Object.defineProperty(window, "matchMedia", {
+				writable: true,
+				configurable: true,
+				value: originalMatchMedia,
+			});
+		});
+	});
+
+	describe("cleanup on repeated mount/unmount", () => {
+		it("leaves window/document/body listener counts balanced and no dangling rAF after 5 mount/unmount cycles", () => {
+			const targets = [window, document, document.body] as const;
+			const addSpies = targets.map((t) => vi.spyOn(t, "addEventListener"));
+			const removeSpies = targets.map((t) => vi.spyOn(t, "removeEventListener"));
+
+			let nextRafId = 1;
+			const pendingRafIds = new Set<number>();
+			const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => {
+				const id = nextRafId++;
+				pendingRafIds.add(id);
+				return id;
+			});
+			const cafSpy = vi
+				.spyOn(window, "cancelAnimationFrame")
+				.mockImplementation((id: number) => {
+					pendingRafIds.delete(id);
+				});
+
+			for (let i = 0; i < 5; i++) {
+				const { unmount } = render(LiquidText, { props: { text: `pass-${i}` } });
+				unmount();
+			}
+
+			// Per-event-name balance on each target: every addEventListener("x", …)
+			// must be matched by a removeEventListener("x", …) across the 5
+			// mount/unmount cycles. Checking per event name (not just raw totals)
+			// catches leaks that would otherwise cancel out coincidentally.
+			targets.forEach((_, i) => {
+				const counts = new Map<string, number>();
+				for (const call of addSpies[i].mock.calls) {
+					const name = call[0] as string;
+					counts.set(name, (counts.get(name) ?? 0) + 1);
+				}
+				for (const call of removeSpies[i].mock.calls) {
+					const name = call[0] as string;
+					counts.set(name, (counts.get(name) ?? 0) - 1);
+				}
+				for (const [eventName, balance] of counts) {
+					expect(balance, `"${eventName}" listener leak on target #${i}`).toBe(0);
+				}
+			});
+
+			expect(pendingRafIds.size).toBe(0);
+
+			addSpies.forEach((s) => s.mockRestore());
+			removeSpies.forEach((s) => s.mockRestore());
+			rafSpy.mockRestore();
+			cafSpy.mockRestore();
+		});
+	});
+
+	describe("class prop", () => {
+		it("applies the class prop to the root element", () => {
+			const { container } = render(LiquidText, { props: { class: "my-liquid-class" } });
+			const root = container.firstElementChild as HTMLElement;
+			expect(root.className).toContain("my-liquid-class");
+		});
+
+		it("still renders a root element with the default empty class", () => {
+			const { container } = render(LiquidText);
+			expect(container.firstElementChild).toBeInTheDocument();
+		});
+	});
+
+	describe("prop defaults and full prop surface (smoke)", () => {
+		it("mounts without error using only defaults", () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			const { container } = render(LiquidText);
+
+			expect(container.firstElementChild).toBeInTheDocument();
+			expect(screen.getByText("Liquid")).toBeInTheDocument();
+			expect(errorSpy).not.toHaveBeenCalled();
+
+			errorSpy.mockRestore();
+		});
+
+		it("mounts without error with every documented prop explicitly set", () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			const { container } = render(LiquidText, {
+				props: {
+					text: "Smoke Test",
+					font: "Arial, sans-serif",
+					fontSize: 96,
+					fontWeight: 800,
+					lightColor: "#111111",
+					darkColor: "#eeeeee",
+					class: "smoke-root",
+					strength: 0.75,
+					radius: 220,
+					forceGain: 24,
+					dissipation: 0.95,
+					viscosity: 6,
+					chromaticRatio: 0.35,
+					staticBelow: 768,
+					interactive: false,
+					pauseWhenHidden: false,
+				},
+			});
+
+			expect(container.firstElementChild).toBeInTheDocument();
+			expect(screen.getByText("Smoke Test")).toBeInTheDocument();
+			expect(errorSpy).not.toHaveBeenCalled();
+
+			errorSpy.mockRestore();
+		});
+	});
+});

--- a/src/lib/fancy-ui/liquid-text/README.md
+++ b/src/lib/fancy-ui/liquid-text/README.md
@@ -1,0 +1,139 @@
+# LiquidText
+
+Large display text that liquefies under the cursor: a raw-WebGL fluid velocity
+field displaces the text's UVs along the pointer's trail, with RGB chromatic
+fringing on the warped edges, then relaxes back to rest as the fluid decays.
+
+## Features
+
+- Raw WebGL2 (WebGL1 fallback) fluid simulation — no Three.js dependency
+- Any string rendered through the sim: text is rasterized to a texture via
+  Canvas2D (`fillText`), not a pre-baked image
+- Mouse-velocity-driven splats: faster cursor movement = stronger smear
+- Chromatic aberration on displaced edges (3-tap R/G/B sampling)
+- Self-relaxing: velocity field decays every frame, so the smear resolves on
+  its own roughly a second after the cursor moves away
+- Auto-fit font size to the container width when `fontSize` is unset
+- Graceful fallbacks: `prefers-reduced-motion`, no WebGL, and small viewports
+  (`staticBelow`) all render plain styled static text instead of the sim
+- Accessible by construction: a real text node is always present in the DOM;
+  only the `<canvas>` is `aria-hidden`
+- Single `requestAnimationFrame` loop, paused via `visibilitychange` when the
+  tab is hidden (`pauseWhenHidden`)
+- Exhaustive cleanup on unmount: cancels the rAF loop, removes every
+  listener, disconnects the `ResizeObserver`, and calls `WEBGL_lose_context`
+
+## Usage
+
+```svelte
+<script>
+	import { LiquidText } from "fancy-ui-svelte";
+</script>
+
+<LiquidText text="Liquid" class="text-7xl font-bold" />
+```
+
+```svelte
+<!-- Tuned for a subtler, slower-decaying smear -->
+<LiquidText
+	text="Rama Herbin"
+	font="Bricolage Grotesque, sans-serif"
+	fontWeight={700}
+	strength={0.35}
+	radius={120}
+	dissipation={0.985}
+	lightColor="#0a0a0a"
+	darkColor="#fafafa"
+/>
+```
+
+```svelte
+<!-- Force the static DOM fallback (e.g. inside a `prefers-reduced-motion`
+     conscious layout, or below a custom breakpoint) -->
+<LiquidText text="Liquid" interactive={false} staticBelow={1280} />
+```
+
+## Props
+
+| Prop             | Type                 | Default     | Description                                                                          |
+| ---------------- | -------------------- | ----------- | -------------------------------------------------------------------------------------- |
+| `text`           | `string`             | `"Liquid"`  | The text rendered into the fluid texture (or as static fallback text).                 |
+| `font`           | `string`             | `""`        | CSS font-family for the text. Empty string resolves to `getComputedStyle(host).fontFamily`. |
+| `fontSize`       | `number`             | `0`         | Font size in px. `0` auto-fits the text to the container's width.                     |
+| `fontWeight`     | `number \| string`   | `700`       | CSS font-weight for the rasterized/fallback text.                                     |
+| `lightColor`     | `string`             | `"#000000"` | Text color used in light mode.                                                        |
+| `darkColor`      | `string`             | `"#ffffff"` | Text color used in dark mode.                                                          |
+| `class`          | `string`             | `""`        | Additional class names applied to the root element.                                  |
+| `strength`       | `number`             | `0.5`       | Geometric UV warp gain — how far the fluid velocity displaces the text's UVs.         |
+| `radius`         | `number`             | `160`       | Splat radius in screen pixels around the pointer.                                    |
+| `forceGain`      | `number`             | `17`        | Multiplier from mouse-delta-per-frame to splat force.                                 |
+| `dissipation`    | `number`             | `0.98`      | Per-frame velocity decay factor (relax-back rate for the smear).                      |
+| `viscosity`      | `number`             | `4`         | Viscous diffusion strength (Jacobi iteration, 8 iters).                               |
+| `chromaticRatio` | `number`             | `0.2`       | Chromatic offset = warp amount × this ratio.                                         |
+| `staticBelow`    | `number`             | `1024`      | If `window.innerWidth <= staticBelow` at mount, render static DOM text instead.       |
+| `interactive`    | `boolean`            | `true`      | Whether the fluid sim reacts to pointer movement.                                     |
+| `pauseWhenHidden`| `boolean`            | `true`      | Pause the render loop via `visibilitychange` when the tab/page is hidden.             |
+
+## Behavior contract
+
+- A real text node is **always** in the DOM: a `sr-only` span while the
+  canvas is actively driven, or visible styled text in any fallback mode.
+- The `<canvas>` is always `aria-hidden="true"` — it is a visual effect
+  layer, not content.
+- The component falls back to plain styled DOM text (no WebGL sim, no rAF
+  loop) when any of these are true at mount: `prefers-reduced-motion` is
+  preferred, WebGL is unavailable, or `window.innerWidth <= staticBelow`.
+- Root markup shape: `<div class={...}>` wrapping the canvas and the text
+  node.
+
+## Implementation notes
+
+### Fluid simulation
+
+- Runs the velocity solve at **0.25× the canvas resolution** to keep the
+  per-frame cost low for a text-sized effect (this doesn't need dye-buffer
+  resolution the way a full-screen cursor effect does).
+- Pipeline per frame: self-advection with `dissipation` decay → pointer-velocity
+  splat (screen-px falloff `(1 - dist/radius)² × 1.5`, force ∝ mouse delta ×
+  `forceGain`) → viscous diffusion (Jacobi, `viscosity`, 8 iterations) →
+  divergence → pressure solve (Jacobi, 16 iterations) → gradient
+  subtraction/projection. Vorticity confinement is intentionally left out —
+  it isn't part of the reference behavior being reproduced and would add
+  cost without visible benefit at this scale. `dt` is fixed rather than
+  measured from real frame time, so the decay rate stays predictable
+  regardless of frame rate.
+- Text is rasterized once per (text, font, fontSize, fontWeight) combination
+  via Canvas2D `fillText` into a texture, and re-rasterized on `ResizeObserver`
+  changes that affect layout (e.g. auto-fit font size).
+
+### Chromatic sampling
+
+- The fragment shader reads the velocity field at the screen UV, derives a
+  geometric warp (`velocity * strength`) and a chromatic offset
+  (`warp * chromaticRatio`), then does 3 independent texture taps: red at
+  `uv - offset`, green at `uv`, blue at `uv + offset`. The result is a
+  visible RGB fringe exactly where the text is being smeared, which
+  disappears as the velocity field dissipates.
+
+### Fallbacks
+
+- `prefers-reduced-motion: reduce` and "no WebGL context available" both
+  short-circuit straight to the static DOM text path — no canvas sim is
+  initialized, no rAF loop starts.
+- `staticBelow` is checked once against `window.innerWidth` at mount (not
+  reactively re-checked on resize) — crossing the breakpoint after mount
+  does not retroactively swap modes.
+- All three fallback conditions render the same static markup: visible,
+  normally-styled text using `lightColor`/`darkColor` per color scheme.
+
+### Cleanup
+
+- A single `requestAnimationFrame` loop drives the sim; it is paused (not
+  cancelled) on `document.visibilitychange` when `pauseWhenHidden` is true,
+  and resumed when the tab becomes visible again.
+- On unmount: cancels the pending rAF, removes every `window`/`document`
+  listener the component registered, disconnects the `ResizeObserver`, and
+  explicitly calls the `WEBGL_lose_context` extension's `loseContext()` to
+  release GPU resources deterministically rather than waiting on GC.
+- Verified safe under repeated mount/unmount (no leaked listeners, no
+  dangling animation frames) — see `LiquidText.test.ts`.

--- a/src/lib/fancy-ui/liquid-text/index.ts
+++ b/src/lib/fancy-ui/liquid-text/index.ts
@@ -1,0 +1,2 @@
+export { default as LiquidText } from "./LiquidText.svelte";
+export type { LiquidTextProps } from "./LiquidText.svelte";

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -2303,6 +2303,110 @@ export const registry: Record<string, ComponentMeta> = {
 			},
 		],
 	},
+
+	"liquid-text": {
+		name: "LiquidText",
+		slug: "liquid-text",
+		description:
+			"Big text that liquefies along the cursor's path via a raw-WebGL fluid solver, with chromatic-aberration fringing that relaxes back over time",
+		category: "text",
+		status: "done",
+		credits: [
+			{ source: "Inspired by ryanritzenthaler.com (behavioral study)" },
+			{ source: "Fluid solver after Pavel Dobryakov's WebGL fluid simulation" },
+		],
+		tags: ["text", "webgl", "fluid", "displacement", "cursor", "shader", "chromatic-aberration"],
+		props: [
+			{ name: "text", type: "string", default: '"Liquid"', description: "Text to display" },
+			{
+				name: "font",
+				type: "string",
+				default: '""',
+				description:
+					"Font family; empty string resolves via getComputedStyle(host).fontFamily",
+			},
+			{
+				name: "fontSize",
+				type: "number",
+				default: "0",
+				description: "Font size in pixels; 0 auto-fits to the container width",
+			},
+			{
+				name: "fontWeight",
+				type: "number | string",
+				default: "700",
+				description: "Font weight",
+			},
+			{
+				name: "lightColor",
+				type: "string",
+				default: '"#000000"',
+				description: "Text color in light mode",
+			},
+			{
+				name: "darkColor",
+				type: "string",
+				default: '"#ffffff"',
+				description: "Text color in dark mode",
+			},
+			{ name: "class", type: "string", description: "Additional CSS classes" },
+			{
+				name: "strength",
+				type: "number",
+				default: "0.5",
+				description: "Geometric UV warp gain",
+			},
+			{
+				name: "radius",
+				type: "number",
+				default: "160",
+				description: "Splat radius in screen pixels",
+			},
+			{
+				name: "forceGain",
+				type: "number",
+				default: "17",
+				description: "Mouse-delta to force multiplier",
+			},
+			{
+				name: "dissipation",
+				type: "number",
+				default: "0.98",
+				description: "Per-frame velocity decay factor",
+			},
+			{
+				name: "viscosity",
+				type: "number",
+				default: "4",
+				description: "Jacobi viscous diffusion strength (8 iterations)",
+			},
+			{
+				name: "chromaticRatio",
+				type: "number",
+				default: "0.2",
+				description: "Chromatic offset as a ratio of the warp",
+			},
+			{
+				name: "staticBelow",
+				type: "number",
+				default: "1024",
+				description:
+					"innerWidth at/below which the component renders as static DOM text (also used at mount)",
+			},
+			{
+				name: "interactive",
+				type: "boolean",
+				default: "true",
+				description: "Whether pointer movement drives the fluid simulation",
+			},
+			{
+				name: "pauseWhenHidden",
+				type: "boolean",
+				default: "true",
+				description: "Pause the render loop while the document is hidden",
+			},
+		],
+	},
 };
 
 // =============================================================================

--- a/src/stories/liquid-text.stories.svelte
+++ b/src/stories/liquid-text.stories.svelte
@@ -1,0 +1,77 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { LiquidText } from "$lib/fancy-ui/liquid-text";
+
+	const { Story } = defineMeta({
+		title: "Text/LiquidText",
+		component: LiquidText,
+		tags: ["autodocs"],
+		args: {
+			text: "Liquid",
+			font: "",
+			fontSize: 160,
+			fontWeight: 700,
+			lightColor: "#000000",
+			darkColor: "#ffffff",
+			strength: 0.5,
+			radius: 160,
+			forceGain: 17,
+			dissipation: 0.98,
+			viscosity: 4,
+			chromaticRatio: 0.2,
+			staticBelow: 1024,
+			interactive: true,
+			pauseWhenHidden: true,
+		},
+		argTypes: {
+			text: { control: "text", description: "Text to display" },
+			font: {
+				control: "text",
+				description: "Font family; empty string resolves via getComputedStyle(host).fontFamily",
+			},
+			fontSize: {
+				control: "number",
+				description: "Font size in pixels; 0 auto-fits to the container width",
+			},
+			fontWeight: { control: "text", description: "Font weight" },
+			lightColor: { control: "color", description: "Text color in light mode" },
+			darkColor: { control: "color", description: "Text color in dark mode" },
+			strength: { control: "number", description: "Geometric UV warp gain" },
+			radius: { control: "number", description: "Splat radius in screen pixels" },
+			forceGain: { control: "number", description: "Mouse-delta to force multiplier" },
+			dissipation: { control: "number", description: "Per-frame velocity decay factor" },
+			viscosity: {
+				control: "number",
+				description: "Jacobi viscous diffusion strength (8 iterations)",
+			},
+			chromaticRatio: {
+				control: "number",
+				description: "Chromatic offset as a ratio of the warp",
+			},
+			staticBelow: {
+				control: "number",
+				description: "innerWidth at/below which the component renders as static DOM text",
+			},
+			interactive: {
+				control: "boolean",
+				description: "Whether pointer movement drives the fluid simulation",
+			},
+			pauseWhenHidden: {
+				control: "boolean",
+				description: "Pause the render loop while the document is hidden",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="flex h-64 w-full items-center justify-center">
+		<LiquidText {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Strong Warp" {template} args={{ text: "Warp", strength: 0.9, chromaticRatio: 0.4 }} />
+
+<Story name="Large" {template} args={{ text: "Flow", fontSize: 220 }} />


### PR DESCRIPTION
## Summary
New `LiquidText` component: big text that the cursor liquefies locally — the smear follows the pointer trajectory with RGB chromatic-aberration fringes on the distorted edges, then relaxes back over ~1s.

Clean-room implementation from a behavioral study of ryanritzenthaler.com's hero effect (timings/parameters only — original code, no third-party source). Fluid solver structure after Pavel Dobryakov's WebGL fluid simulation approach, adapted from this repo's own `FluidCursor` machinery (`fluid-cursor/` itself untouched).

## How it works
- **Text → texture**: DPR-aware Canvas2D rasterization (`text`/`font`/`fontSize` props, auto-fit to container when `fontSize=0`), re-rasterized on text/font/theme/resize changes
- **Velocity sim** at 0.25× canvas resolution, raw WebGL (WebGL2 + WebGL1 fallback): advection with configurable `dissipation` (0.98) → pointer splat (force ∝ per-frame pointer delta × `forceGain`, `(1-r)²·1.5` falloff over `radius` px) → viscous Jacobi ×8 → divergence → pressure Jacobi ×16 → projection
- **Display pass**: `warped_uv = uv − vel×strength`; 3-tap chromatic sampling — R at `−chroma`, G center, B at `+chroma` (`chroma = warp × chromaticRatio`)

## A11y & fallbacks
- Real text node always in the DOM (sr-only under canvas); canvas `aria-hidden`
- Plain styled DOM text when: `prefers-reduced-motion`, no WebGL, or `innerWidth ≤ staticBelow` (default 1024)
- Context-loss handling → graceful static fallback (with auto-fit resize re-armed)
- Full teardown: rAF, listeners, ResizeObserver/MutationObserver, GL resources, `WEBGL_lose_context`

## Process
Implemented by a parallel agent team against a frozen prop contract, then 4-lens review (WebGL/shader, lifecycle/memory, a11y/fallbacks, behavioral fidelity) — 9 findings, all fixed and adversarially re-verified.

## Tests
- `pnpm check` — 0 errors
- `pnpm test` — 492/492 (10 new LiquidText tests: accessible text, no-WebGL fallback, reduced-motion, mount/unmount leak balance, props)
- `pnpm run package` — publint clean, `dist/fancy-ui/liquid-text/` + barrel re-export verified
- Changeset included (minor)

## Manual QA to do before merge
- [ ] Storybook: `pnpm storybook` → LiquidText story — smear follows cursor, fringes visible, relax-back feel
- [ ] Emulated reduced-motion + narrow viewport → static text