### PR TITLE
fix(liquid-glass): Safari fallback + navbar landing previews for glass components

### DIFF
--- a/.changeset/liquid-glass-safari-fallback.md
+++ b/.changeset/liquid-glass-safari-fallback.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+LiquidGlass: add an automatic Safari fallback — WebKit cannot resolve SVG url() filter references inside backdrop-filter, so the chromatic displacement silently disappeared there. On Safari the component now renders a plain frosted blur instead, tunable via the new optional props `fallbackBlur` (default 20) and `fallbackSaturation` (default 180), mirroring FrostedGlass. Docs: both glass components' preview now showcases the landing-page navbar example.

--- a/src/lib/components/docs/DemoRenderer.svelte
+++ b/src/lib/components/docs/DemoRenderer.svelte
@@ -11,7 +11,13 @@
 	let error = $state("");
 
 	const modules = import.meta.glob("$lib/fancy-ui/*/index.ts");
-	const exampleModules = import.meta.glob("$lib/components/docs/examples/**/BasicUsage.svelte");
+	const exampleModules = import.meta.glob("$lib/components/docs/examples/**/*.svelte");
+
+	// Per-slug override of which example is used as the Preview
+	const PREVIEW_EXAMPLE: Record<string, string> = {
+		"frosted-glass": "Navbar",
+		"liquid-glass": "Navbar",
+	};
 
 	$effect(() => {
 		const currentSlug = slug;
@@ -21,8 +27,9 @@
 		error = "";
 
 		if (skipDirectRender.has(currentSlug)) {
-			// Load first example (BasicUsage) as preview
-			const exPath = `/src/lib/components/docs/examples/${currentSlug}/BasicUsage.svelte`;
+			// Load the preview example (BasicUsage, unless overridden per-slug)
+			const previewExample = PREVIEW_EXAMPLE[currentSlug] ?? "BasicUsage";
+			const exPath = `/src/lib/components/docs/examples/${currentSlug}/${previewExample}.svelte`;
 			const exLoader = exampleModules[exPath];
 			if (exLoader) {
 				exLoader()

--- a/src/lib/components/docs/DemoRenderer.svelte
+++ b/src/lib/components/docs/DemoRenderer.svelte
@@ -1,3 +1,12 @@
+<script module lang="ts">
+	// Per-slug override of which example is rendered as the Preview. Exported so the
+	// component page can source the Code tab from the same example (keeps the two in sync).
+	export const PREVIEW_EXAMPLE: Record<string, string> = {
+		"frosted-glass": "Navbar",
+		"liquid-glass": "Navbar",
+	};
+</script>
+
 <script lang="ts">
 	interface Props {
 		slug: string;
@@ -12,12 +21,6 @@
 
 	const modules = import.meta.glob("$lib/fancy-ui/*/index.ts");
 	const exampleModules = import.meta.glob("$lib/components/docs/examples/**/*.svelte");
-
-	// Per-slug override of which example is used as the Preview
-	const PREVIEW_EXAMPLE: Record<string, string> = {
-		"frosted-glass": "Navbar",
-		"liquid-glass": "Navbar",
-	};
 
 	$effect(() => {
 		const currentSlug = slug;

--- a/src/lib/components/docs/examples/liquid-glass/Navbar.svelte
+++ b/src/lib/components/docs/examples/liquid-glass/Navbar.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { LiquidGlass } from "$lib/fancy-ui/liquid-glass";
+</script>
+
+<div class="relative h-[440px] w-full overflow-hidden rounded-lg border bg-[#fafafa]">
+	<div class="absolute inset-0 overflow-y-auto" style="scrollbar-width: none;">
+		<!-- Hero -->
+		<div class="flex min-h-[420px] flex-col items-center justify-center px-8 pt-24 text-center">
+			<span
+				class="rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-500"
+			>
+				Now available for macOS
+			</span>
+			<h1 class="mt-5 max-w-md text-4xl leading-tight font-semibold tracking-tight text-gray-900">
+				Your UI, at the speed of thought.
+			</h1>
+			<p class="mt-4 max-w-sm text-sm text-gray-500">
+				FancyOS turns your voice into polished interfaces. Speak naturally, ship beautifully.
+			</p>
+			<div class="mt-6 flex items-center gap-3">
+				<span class="rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white">
+					Download
+				</span>
+				<span class="px-3 py-2.5 text-sm font-medium text-gray-600">Watch demo</span>
+			</div>
+		</div>
+
+		<!-- Colorful sections to scroll behind the nav -->
+		<div class="space-y-6 px-8 pb-12">
+			{#each Array(6) as _, i}
+				<div
+					class="flex h-32 items-end rounded-3xl p-5"
+					style="background: linear-gradient(120deg, hsl({210 + i * 40}, 75%, 62%), hsl({250 +
+						i * 40}, 70%, 55%));"
+				>
+					<p class="text-sm font-semibold text-white/90">Feature {i + 1}</p>
+				</div>
+			{/each}
+		</div>
+	</div>
+
+	<!-- Fixed pill nav -->
+	<div class="pointer-events-none absolute inset-x-0 top-4 z-10 flex justify-center px-6">
+		<div class="pointer-events-auto w-full max-w-lg">
+			<LiquidGlass radius={9999} containerClass="w-full">
+				<nav class="flex w-full items-center justify-between px-6 py-3">
+					<span class="flex items-center gap-1.5 text-sm font-bold tracking-tight text-gray-900">
+						<span class="inline-block size-4 rounded-full bg-gray-900"></span>
+						FancyOS
+					</span>
+					<div class="flex items-center gap-5 text-[13px] font-medium text-gray-800">
+						<span class="hidden sm:inline">Manifesto</span>
+						<span class="hidden sm:inline">Pricing</span>
+						<span class="hidden sm:inline">Blog</span>
+						<span class="rounded-full bg-gray-900 px-3.5 py-1.5 text-xs font-semibold text-white">
+							Download
+						</span>
+					</div>
+				</nav>
+			</LiquidGlass>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/docs/examples/registry.ts
+++ b/src/lib/components/docs/examples/registry.ts
@@ -319,7 +319,14 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 		{ name: "CustomColors", title: "Custom Colors", description: "Fixed teal fluid color." },
 	],
 	"smooth-cursor": [{ name: "BasicUsage", title: "Basic Usage" }],
-	"liquid-glass": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"liquid-glass": [
+		{ name: "BasicUsage", title: "Basic Usage" },
+		{
+			name: "Navbar",
+			title: "Landing Page Navbar",
+			description: "Landing page with a liquid glass pill navigation.",
+		},
+	],
 	"frosted-glass": [
 		{ name: "BasicUsage", title: "Basic Usage" },
 		{

--- a/src/lib/fancy-ui/frosted-glass/FrostedGlass.svelte
+++ b/src/lib/fancy-ui/frosted-glass/FrostedGlass.svelte
@@ -155,11 +155,13 @@
 		}
 	}
 
-	/* Safari can't combine filter:url() with backdrop-filter — fall back to
-	   plain frosted blur */
-	@supports (-webkit-hyphens: none) {
+	/* Safari can't combine filter:url() with backdrop-filter, so it needs a plain-blur
+	   fallback. -webkit-named-image is a WebKit-only feature query (Chromium and Firefox
+	   return false). Ship the -webkit- prefixed backdrop-filter too for Safari and iOS 17 and older. */
+	@supports (background: -webkit-named-image(i)) {
 		.frosted-glass-filter {
 			filter: none !important;
+			-webkit-backdrop-filter: blur(var(--fg-fallback-blur)) saturate(var(--fg-fallback-saturation));
 			backdrop-filter: blur(var(--fg-fallback-blur)) saturate(var(--fg-fallback-saturation));
 		}
 

--- a/src/lib/fancy-ui/frosted-glass/README.md
+++ b/src/lib/fancy-ui/frosted-glass/README.md
@@ -58,4 +58,4 @@ An optional conic-gradient border (`border` prop) frames the container.
 
 ## Browser support
 
-Safari (WebKit) cannot combine an SVG `filter: url(#…)` with `backdrop-filter`, so the turbulence displacement silently disappears there. To keep the component usable, FrostedGlass automatically detects Safari (via an `@supports (-webkit-hyphens: none)` feature query) and falls back to a plain frosted `blur()` + `saturate()`, tunable via the `fallbackBlur` and `fallbackSaturation` props. Chromium and Firefox get the full turbulence refraction.
+Safari (WebKit) cannot combine an SVG `filter: url(#…)` with `backdrop-filter`, so the turbulence displacement silently disappears there. To keep the component usable, FrostedGlass automatically detects Safari (via a WebKit-only `@supports` feature query) and falls back to a plain frosted `blur()` + `saturate()` (both `-webkit-` prefixed and unprefixed), tunable via the `fallbackBlur` and `fallbackSaturation` props. Chromium and Firefox get the full turbulence refraction.

--- a/src/lib/fancy-ui/frosted-glass/README.md
+++ b/src/lib/fancy-ui/frosted-glass/README.md
@@ -13,8 +13,6 @@ The effect stacks four layers inside a rounded container:
 
 An optional conic-gradient border (`border` prop) frames the container.
 
-Safari cannot combine `filter: url()` with `backdrop-filter`, so it falls back to a plain `blur() saturate()` frosted look (tunable via `fallbackBlur` / `fallbackSaturation`).
-
 ## Usage
 
 ```svelte
@@ -57,3 +55,7 @@ Safari cannot combine `filter: url()` with `backdrop-filter`, so it falls back t
 ## Notes
 
 - The displacement only shows over content that scrolls or moves behind the glass; over a flat background the effect reads as a subtle frost.
+
+## Browser support
+
+Safari (WebKit) cannot combine an SVG `filter: url(#…)` with `backdrop-filter`, so the turbulence displacement silently disappears there. To keep the component usable, FrostedGlass automatically detects Safari (via an `@supports (-webkit-hyphens: none)` feature query) and falls back to a plain frosted `blur()` + `saturate()`, tunable via the `fallbackBlur` and `fallbackSaturation` props. Chromium and Firefox get the full turbulence refraction.

--- a/src/lib/fancy-ui/liquid-glass/LiquidGlass.svelte
+++ b/src/lib/fancy-ui/liquid-glass/LiquidGlass.svelte
@@ -18,6 +18,10 @@
 		bOffset?: number;
 		scale?: number;
 		frost?: number;
+		/** Backdrop blur in pixels for the Safari fallback */
+		fallbackBlur?: number;
+		/** Backdrop saturation percentage for the Safari fallback */
+		fallbackSaturation?: number;
 		class?: string;
 		containerClass?: string;
 		children?: Snippet;
@@ -38,6 +42,8 @@
 		bOffset = 20,
 		scale = -180,
 		frost = 0.05,
+		fallbackBlur = 20,
+		fallbackSaturation = 180,
 		class: className = "",
 		containerClass = "",
 		children,
@@ -57,8 +63,8 @@
 
 	let backdropStyle = $derived(
 		filterId
-			? `--frost:${frost};border-radius:${radius}px;backdrop-filter:url(#displacementFilter-${filterId});`
-			: `--frost:${frost};border-radius:${radius}px;`
+			? `--frost:${frost};border-radius:${radius}px;backdrop-filter:url(#displacementFilter-${filterId});--lg-fallback-blur:${fallbackBlur}px;--lg-fallback-saturation:${fallbackSaturation}%;`
+			: `--frost:${frost};border-radius:${radius}px;--lg-fallback-blur:${fallbackBlur}px;--lg-fallback-saturation:${fallbackSaturation}%;`
 	);
 
 	onMount(() => {
@@ -185,6 +191,13 @@
 			0px 4px 16px rgba(17, 17, 26, 0.05) inset,
 			0px 8px 24px rgba(17, 17, 26, 0.05) inset,
 			0px 16px 56px rgba(17, 17, 26, 0.05) inset;
+	}
+
+	/* Safari cannot resolve SVG url() references inside backdrop-filter - fall back to a plain frosted blur */
+	@supports (-webkit-hyphens: none) {
+		.liquid-glass-effect {
+			backdrop-filter: blur(var(--lg-fallback-blur)) saturate(var(--lg-fallback-saturation)) !important;
+		}
 	}
 
 	.liquid-glass-slot {

--- a/src/lib/fancy-ui/liquid-glass/LiquidGlass.svelte
+++ b/src/lib/fancy-ui/liquid-glass/LiquidGlass.svelte
@@ -193,9 +193,13 @@
 			0px 16px 56px rgba(17, 17, 26, 0.05) inset;
 	}
 
-	/* Safari cannot resolve SVG url() references inside backdrop-filter - fall back to a plain frosted blur */
-	@supports (-webkit-hyphens: none) {
+	/* Safari cannot resolve SVG url() references inside backdrop-filter, so it needs a
+	   plain-blur fallback. -webkit-named-image is a WebKit-only feature query (Chromium
+	   and Firefox return false), so this never overrides Chromium's working SVG filter.
+	   Ship the -webkit- prefixed backdrop-filter too for Safari and iOS 17 and older. */
+	@supports (background: -webkit-named-image(i)) {
 		.liquid-glass-effect {
+			-webkit-backdrop-filter: blur(var(--lg-fallback-blur)) saturate(var(--lg-fallback-saturation)) !important;
 			backdrop-filter: blur(var(--lg-fallback-blur)) saturate(var(--lg-fallback-saturation)) !important;
 		}
 	}

--- a/src/lib/fancy-ui/liquid-glass/LiquidGlass.test.ts
+++ b/src/lib/fancy-ui/liquid-glass/LiquidGlass.test.ts
@@ -56,4 +56,24 @@ describe("LiquidGlass", () => {
 		expect(wrapper.getAttribute("style")).toContain("border-radius");
 		expect(wrapper.getAttribute("style")).toContain("24px");
 	});
+
+	it("exposes Safari fallback CSS variables from props", () => {
+		const { container: defaultContainer } = render(LiquidGlass);
+		const defaultWrapper = defaultContainer.querySelector(
+			".liquid-glass-effect"
+		) as HTMLElement;
+		const defaultStyle = defaultWrapper.getAttribute("style") ?? "";
+		expect(defaultStyle).toMatch(/--lg-fallback-blur:\s*20px/);
+		expect(defaultStyle).toMatch(/--lg-fallback-saturation:\s*180%/);
+
+		const { container: customContainer } = render(LiquidGlass, {
+			props: { fallbackBlur: 8, fallbackSaturation: 120 },
+		});
+		const customWrapper = customContainer.querySelector(
+			".liquid-glass-effect"
+		) as HTMLElement;
+		const customStyle = customWrapper.getAttribute("style") ?? "";
+		expect(customStyle).toMatch(/--lg-fallback-blur:\s*8px/);
+		expect(customStyle).toMatch(/--lg-fallback-saturation:\s*120%/);
+	});
 });

--- a/src/lib/fancy-ui/liquid-glass/README.md
+++ b/src/lib/fancy-ui/liquid-glass/README.md
@@ -20,6 +20,8 @@ A glass-like visual effect using SVG filters for chromatic displacement, creatin
 | `bOffset`        | `number`      | `20`           | Blue channel offset                  |
 | `scale`          | `number`      | `-180`         | Displacement scale                   |
 | `frost`          | `number`      | `0.05`         | Frosted overlay opacity              |
+| `fallbackBlur`   | `number`      | `20`           | Backdrop blur in pixels for the Safari fallback |
+| `fallbackSaturation` | `number`  | `180`          | Backdrop saturation percentage for the Safari fallback |
 | `class`          | `string`      | `""`           | CSS classes for inner container      |
 | `containerClass` | `string`      | `""`           | CSS classes for outer container      |
 
@@ -31,4 +33,8 @@ A glass-like visual effect using SVG filters for chromatic displacement, creatin
 </LiquidGlass>
 ```
 
-**Note**: This component uses `position: fixed` and `backdrop-filter` with SVG filters. Place it over content to see the refraction effect.
+**Note**: This component uses `position: relative` and `backdrop-filter` with SVG filters. Place it over content to see the refraction effect.
+
+## Browser support
+
+On Safari, the SVG displacement filter cannot run inside `backdrop-filter`, so the chromatic refraction effect silently disappears. To keep the component usable there, LiquidGlass automatically detects Safari and falls back to a plain frosted blur, tunable via `fallbackBlur` / `fallbackSaturation`.

--- a/src/lib/fancy-ui/liquid-glass/README.md
+++ b/src/lib/fancy-ui/liquid-glass/README.md
@@ -37,4 +37,4 @@ A glass-like visual effect using SVG filters for chromatic displacement, creatin
 
 ## Browser support
 
-Safari (WebKit) cannot resolve an SVG `url(#…)` filter reference inside `backdrop-filter`, so the chromatic displacement silently disappears there. To keep the component usable, LiquidGlass automatically detects Safari (via an `@supports (-webkit-hyphens: none)` feature query) and falls back to a plain frosted `blur()` + `saturate()`, tunable via the `fallbackBlur` and `fallbackSaturation` props. Chromium and Firefox get the full chromatic refraction.
+Safari (WebKit) cannot resolve an SVG `url(#…)` filter reference inside `backdrop-filter`, so the chromatic displacement silently disappears there. To keep the component usable, LiquidGlass automatically detects Safari (via a WebKit-only `@supports` feature query) and falls back to a plain frosted `blur()` + `saturate()` (both `-webkit-` prefixed and unprefixed), tunable via the `fallbackBlur` and `fallbackSaturation` props. Chromium and Firefox get the full chromatic refraction.

--- a/src/lib/fancy-ui/liquid-glass/README.md
+++ b/src/lib/fancy-ui/liquid-glass/README.md
@@ -37,4 +37,4 @@ A glass-like visual effect using SVG filters for chromatic displacement, creatin
 
 ## Browser support
 
-On Safari, the SVG displacement filter cannot run inside `backdrop-filter`, so the chromatic refraction effect silently disappears. To keep the component usable there, LiquidGlass automatically detects Safari and falls back to a plain frosted blur, tunable via `fallbackBlur` / `fallbackSaturation`.
+Safari (WebKit) cannot resolve an SVG `url(#…)` filter reference inside `backdrop-filter`, so the chromatic displacement silently disappears there. To keep the component usable, LiquidGlass automatically detects Safari (via an `@supports (-webkit-hyphens: none)` feature query) and falls back to a plain frosted `blur()` + `saturate()`, tunable via the `fallbackBlur` and `fallbackSaturation` props. Chromium and Firefox get the full chromatic refraction.

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -1842,6 +1842,18 @@ export const registry: Record<string, ComponentMeta> = {
 			{ name: "scale", type: "number", default: "-180", description: "Displacement scale" },
 			{ name: "frost", type: "number", default: "0.05", description: "Frosted glass opacity" },
 			{
+				name: "fallbackBlur",
+				type: "number",
+				default: "20",
+				description: "Backdrop blur in pixels for the Safari fallback",
+			},
+			{
+				name: "fallbackSaturation",
+				type: "number",
+				default: "180",
+				description: "Backdrop saturation percentage for the Safari fallback",
+			},
+			{
 				name: "containerClass",
 				type: "string",
 				default: '""',

--- a/src/routes/docs/components/[slug]/+page.svelte
+++ b/src/routes/docs/components/[slug]/+page.svelte
@@ -4,7 +4,7 @@
 	import PropsTable from "$lib/components/docs/PropsTable.svelte";
 	import InstallBlock from "$lib/components/docs/InstallBlock.svelte";
 	import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
-	import DemoRenderer from "$lib/components/docs/DemoRenderer.svelte";
+	import DemoRenderer, { PREVIEW_EXAMPLE } from "$lib/components/docs/DemoRenderer.svelte";
 	import ExamplesSection from "$lib/components/docs/ExamplesSection.svelte";
 	import type { PageData } from "./$types";
 
@@ -19,6 +19,24 @@
 <\/script>
 
 <${component.name} />`);
+
+	// Raw source of every docs example, so slugs whose Preview is overridden to a specific
+	// example (PREVIEW_EXAMPLE) show that example's source in the Code tab instead of the
+	// generic single-tag usage — keeping the Preview and its Code tab in sync.
+	const rawExamples = import.meta.glob("$lib/components/docs/examples/**/*.svelte", {
+		query: "?raw",
+		import: "default",
+		eager: true,
+	}) as Record<string, string>;
+
+	let previewCode = $derived.by(() => {
+		const example = PREVIEW_EXAMPLE[component.slug];
+		if (example) {
+			const src = rawExamples[`/src/lib/components/docs/examples/${component.slug}/${example}.svelte`];
+			if (src) return src.trim();
+		}
+		return basicUsageCode;
+	});
 
 	let previewTab = $state<"preview" | "code">("preview");
 </script>
@@ -81,7 +99,7 @@
 				</div>
 			{:else}
 				<div class="max-h-[500px] overflow-auto">
-					<CodeBlock code={basicUsageCode} lang="svelte" />
+					<CodeBlock code={previewCode} lang="svelte" />
 				</div>
 			{/if}
 		</div>


### PR DESCRIPTION
## Summary
- **Safari fix**: WebKit cannot resolve SVG `url()` filter references inside `backdrop-filter`, so LiquidGlass's chromatic displacement silently disappeared on Safari (frost shell, zero refraction). The component now mirrors FrostedGlass's proven fallback: an `@supports (-webkit-hyphens: none)` block (Safari-only feature query) replaces the `url()` filter with a plain `backdrop-filter: blur() saturate()`, tunable via the new optional props `fallbackBlur` (default 20) and `fallbackSaturation` (default 180). `!important` is required because the `url()` backdrop-filter is an inline style on the same element.
- **Previews**: both glass components' docs Preview now showcases the "Landing Page Navbar" scene (hero + gradient cards + fixed glass pill nav). New `examples/liquid-glass/Navbar.svelte`, examples-registry entry, and a per-slug `PREVIEW_EXAMPLE` override in `DemoRenderer` (`BasicUsage` remains the first Examples entry for both).
- Registry props + README (props table, new Browser support note, fixes the stale `position: fixed` claim) + 1 new jsdom test + minor changeset.

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm test --run` — 493/493 (58 files, incl. the new fallback test)
- [x] `pnpm check:registry` — parity OK (61 components)
- [x] Headless (Chromium): FancyOS scene renders in both components' Preview; Examples sections show Basic Usage + Landing Page Navbar; fallback CSS vars present inline; Chromium keeps the `url()` displacement path; the `@supports` Safari rule exists in the compiled stylesheet with `!important`; 0 console errors
- [ ] **Manual Safari check (macOS)**: open `/docs/components/liquid-glass` — the pill nav should show a clean frosted blur (no missing effect); tweak `fallbackBlur`/`fallbackSaturation` if the default looks off