### PR TITLE
fix(docs Sidebar): keep sidebar docked on desktop under RTL locales

### DIFF
--- a/.changeset/rtl-docs-sidebar-desktop.md
+++ b/.changeset/rtl-docs-sidebar-desktop.md
@@ -1,0 +1,7 @@
+---
+"fancy-ui-svelte": patch
+---
+
+fix(docs Sidebar): keep the sidebar docked on desktop under RTL locales
+
+Under RTL locales (`ar`, `fa`) the docs sidebar was pushed off-screen on desktop (`lg`+), leaving an empty `ps-64` gutter and no navigation. The desktop docking utility `lg:translate-x-0` and the mobile-drawer RTL transform `rtl:translate-x-full` compile to equal-specificity rules, so source order decides — and `rtl:translate-x-full` is emitted later, winning on RTL desktop. Adding an RTL-aware desktop override (`rtl:lg:translate-x-0`) restores the docked sidebar (mirrored to the right) while leaving the mobile drawer behaviour unchanged. Docs-site only — no change to the published component API.

--- a/src/lib/components/docs/Sidebar.svelte
+++ b/src/lib/components/docs/Sidebar.svelte
@@ -45,7 +45,7 @@
 {/if}
 
 <aside
-	class="border-sidebar-border bg-sidebar text-sidebar-foreground fixed start-0 top-0 z-50 flex h-full w-64 flex-col border-e transition-transform duration-300 lg:translate-x-0 {open
+	class="border-sidebar-border bg-sidebar text-sidebar-foreground fixed start-0 top-0 z-50 flex h-full w-64 flex-col border-e transition-transform duration-300 lg:translate-x-0 rtl:lg:translate-x-0 {open
 		? 'translate-x-0'
 		: '-translate-x-full rtl:translate-x-full'}"
 >

--- a/src/lib/components/docs/Sidebar.test.ts
+++ b/src/lib/components/docs/Sidebar.test.ts
@@ -1,0 +1,51 @@
+import { render, cleanup } from "@testing-library/svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { readable } from "svelte/store";
+
+// Sidebar reads `$page.url.pathname` to highlight the active link; provide a
+// minimal page store so the component can render outside of a SvelteKit route.
+vi.mock("$app/stores", () => ({
+	page: readable({ url: new URL("http://localhost/docs/getting-started/introduction") }),
+}));
+
+import Sidebar from "./Sidebar.svelte";
+
+describe("Sidebar", () => {
+	afterEach(cleanup);
+
+	function getAside(container: HTMLElement): HTMLElement {
+		return container.querySelector("aside") as HTMLElement;
+	}
+
+	it("renders the sidebar landmark", () => {
+		const { container } = render(Sidebar);
+		expect(getAside(container)).toBeInTheDocument();
+	});
+
+	it("stays docked on desktop in both LTR and RTL (regression: issue #149)", () => {
+		// The desktop docking utility (`lg:translate-x-0`) and the RTL drawer
+		// transform (`rtl:translate-x-full`) compile to equal-specificity rules,
+		// so source order decides the winner. Without an RTL-aware desktop
+		// override, `rtl:translate-x-full` (emitted later) wins on RTL desktop
+		// and pushes the sidebar off-screen. `rtl:lg:translate-x-0` restores it.
+		const { container } = render(Sidebar);
+		const cls = getAside(container).className;
+		expect(cls).toContain("lg:translate-x-0");
+		expect(cls).toContain("rtl:lg:translate-x-0");
+	});
+
+	it("is off-screen as a closed drawer by default (LTR and RTL)", () => {
+		const { container } = render(Sidebar);
+		const cls = getAside(container).className;
+		expect(cls).toContain("-translate-x-full");
+		expect(cls).toContain("rtl:translate-x-full");
+		expect(cls).not.toContain(" translate-x-0");
+	});
+
+	it("slides into view when the drawer is open", () => {
+		const { container } = render(Sidebar, { props: { open: true } });
+		const cls = getAside(container).className;
+		expect(cls).toContain("translate-x-0");
+		expect(cls).not.toContain("-translate-x-full");
+	});
+});


### PR DESCRIPTION
Fixes #149

## Cause

On the docs site, selecting an RTL locale (`?lang=ar` / `?lang=fa`) hid the desktop sidebar (`lg`+), leaving an empty `ps-64` gutter and no navigation. Mobile drawer behaviour was fine.

`src/lib/components/docs/Sidebar.svelte` builds the `<aside>` transform from three utilities:

```
lg:translate-x-0                 // desktop docking
translate-x-0                    // open (drawer)
-translate-x-full rtl:translate-x-full   // closed (drawer)
```

On desktop the drawer defaults to closed, so `lg:translate-x-0` is meant to override the closed transform. In the installed Tailwind v4, the `rtl:` variant compiles with `:where(...)` (zero specificity), so `lg:translate-x-0` and `rtl:translate-x-full` have **equal** specificity — the winner is decided by **source order**. Tailwind emits `rtl:translate-x-full` *after* `lg:translate-x-0`, so under RTL on desktop it wins and applies `translateX(100%)`, pushing the sidebar off-screen to the right.

(The issue analysed this as a specificity difference; in the pinned Tailwind version the exact mechanism is the equal-specificity source-order tie-break, but the symptom and fix are the same.)

## Fix

Add an RTL-aware desktop docking override so it beats the RTL drawer transform on desktop:

```diff
- ... lg:translate-x-0 {open
+ ... lg:translate-x-0 rtl:lg:translate-x-0 {open
```

`rtl:lg:translate-x-0` is emitted *after* `rtl:translate-x-full` (equal specificity), so it wins on RTL desktop and re-docks the sidebar (mirrored to the right via the existing `start-0` / `border-e` / `lg:ps-64` logical properties). It never matches below `lg`, so the mobile drawer slide-in/out is untouched. One-token change; no other files needed.

## Verification

Reproduced by compiling the exact utility set through the project's Tailwind and computing the winning `translateX` for each context (closed-drawer state):

| Context | Before | After |
|---|---|---|
| LTR desktop (>=1024) | `0` — docked | `0` — docked |
| **RTL desktop (>=1024)** | **`100%` — off-screen** | **`0` — docked** |
| LTR mobile (<1024) | `-100%` — closed | `-100%` — closed |
| RTL mobile (<1024) | `100%` — closed | `100%` — closed |

Added `src/lib/components/docs/Sidebar.test.ts` (vitest) as a regression guard — it fails on the pre-fix class string and passes after.

Checks run from repo root (base `develop`):

- `pnpm install --frozen-lockfile` — pass
- `pnpm check:registry` — pass (`Registry parity OK (61 components).`)
- `pnpm check` — pass (`svelte-check found 0 errors`; pre-existing warnings only, none in touched files)
- `pnpm test` — pass (`60 passed (60)` / `501 passed (501)`)

Changeset: `.changeset/rtl-docs-sidebar-desktop.md` (`patch`).

---
Draft — for human review; please don't merge automatically.