### PR TITLE
feat(fluid-cursor): HDR mode via WebGPU engine with WebGL fallback

### DIFF
--- a/.changeset/fluid-cursor-hdr.md
+++ b/.changeset/fluid-cursor-hdr.md
@@ -3,3 +3,5 @@
 ---
 
 FluidCursor HDR mode: new `hdr` and `hdrBoost` props. When enabled, the simulation renders through a new WebGPU engine (WGSL port of the fluid solver) into an `rgba16float` / `display-p3` canvas with extended tone mapping — colors glow brighter than SDR white on HDR displays. Falls back automatically to the existing WebGL renderer (with a wide-gamut P3 backbuffer where supported), and rendering with `hdr` disabled is unchanged.
+
+Also: in `contained` mode the splat radius now auto-scales to viewport-equivalent size (capped at ~30% of the container height), so the effect no longer looks tiny inside small containers such as docs demos. Fullscreen and viewport-sized containers are unaffected.

--- a/.changeset/fluid-cursor-hdr.md
+++ b/.changeset/fluid-cursor-hdr.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+FluidCursor HDR mode: new `hdr` and `hdrBoost` props. When enabled, the simulation renders through a new WebGPU engine (WGSL port of the fluid solver) into an `rgba16float` / `display-p3` canvas with extended tone mapping — colors glow brighter than SDR white on HDR displays. Falls back automatically to the existing WebGL renderer (with a wide-gamut P3 backbuffer where supported), and rendering with `hdr` disabled is unchanged.

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.30.0",
-		"@vercel/analytics": "^2.0.1",
 		"@internationalized/date": "^3.10.1",
 		"@lucide/svelte": "^0.562.0",
 		"@playwright/test": "^1.58.2",
@@ -100,6 +99,8 @@
 		"@types/canvas-confetti": "^1.9.0",
 		"@types/node": "^25.2.3",
 		"@types/three": "^0.183.1",
+		"@vercel/analytics": "^2.0.1",
+		"@webgpu/types": "^0.1.71",
 		"arctic": "^3.7.0",
 		"bits-ui": "^2.15.4",
 		"isomorphic-dompurify": "^3.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.1)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)))(react@19.2.7)(svelte@5.46.1)
+      '@webgpu/types':
+        specifier: ^0.1.71
+        version: 0.1.71
       arctic:
         specifier: ^3.7.0
         version: 3.7.0
@@ -1452,6 +1455,9 @@ packages:
 
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
+
+  '@webgpu/types@0.1.71':
+    resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -4040,6 +4046,8 @@ snapshots:
   '@webcontainer/env@1.1.1': {}
 
   '@webgpu/types@0.1.69': {}
+
+  '@webgpu/types@0.1.71': {}
 
   acorn@8.15.0: {}
 

--- a/src/lib/components/docs/examples/fluid-cursor/HdrDemo.svelte
+++ b/src/lib/components/docs/examples/fluid-cursor/HdrDemo.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { FluidCursor } from "$lib/fancy-ui/fluid-cursor";
+</script>
+
+<div class="relative h-64 w-full overflow-hidden rounded-lg border bg-black">
+	<FluidCursor
+		hdr
+		hdrBoost={2}
+		fluidColors={["#a142ff", "#42cfff", "#ff2fd6"]}
+		colorIntensity={0.5}
+		splatOnMount
+		allowMultiple
+	/>
+	<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+		<p class="text-sm text-white/60 select-none">
+			HDR glow — brightest on an HDR display in a WebGPU browser
+		</p>
+	</div>
+</div>

--- a/src/lib/components/docs/examples/registry.ts
+++ b/src/lib/components/docs/examples/registry.ts
@@ -321,7 +321,7 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 			name: "HdrDemo",
 			title: "HDR Mode",
 			description:
-				"WebGPU engine with extended tone mapping — glows brighter than white on HDR displays.",
+				"WebGPU engine with extended tone mapping — glows brighter than white on HDR displays. Requires a WebGPU browser (Chrome/Edge 129+, Safari 26+) plus an HDR screen for the full glow; otherwise falls back to wide-gamut WebGL (Chrome 104+, Safari 16.4+, Firefox 132+), then to standard rendering.",
 		},
 	],
 	"smooth-cursor": [{ name: "BasicUsage", title: "Basic Usage" }],

--- a/src/lib/components/docs/examples/registry.ts
+++ b/src/lib/components/docs/examples/registry.ts
@@ -317,6 +317,12 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 	"fluid-cursor": [
 		{ name: "BasicUsage", title: "Basic Usage" },
 		{ name: "CustomColors", title: "Custom Colors", description: "Fixed teal fluid color." },
+		{
+			name: "HdrDemo",
+			title: "HDR Mode",
+			description:
+				"WebGPU engine with extended tone mapping — glows brighter than white on HDR displays.",
+		},
 	],
 	"smooth-cursor": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"liquid-glass": [

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -7,6 +7,7 @@
 		pointerPrototype,
 		hexToRgb,
 		HSVtoRGB,
+		scaleRadiusForContainer,
 		wrap,
 	} from "./fluid-shared.js";
 	import { startWebGpuFluid } from "./webgpu-engine.js";
@@ -1359,7 +1360,15 @@
 					gl.uniform3f(splatProgram.uniforms.color, dx, dy, 0);
 				}
 				if (splatProgram.uniforms.radius) {
-					gl.uniform1f(splatProgram.uniforms.radius, correctRadius(config.SPLAT_RADIUS / 100)!);
+					let baseRadius = config.SPLAT_RADIUS / 100;
+					if (contained) {
+						baseRadius = scaleRadiusForContainer(
+							baseRadius,
+							canvas.clientHeight,
+							window.innerHeight
+						);
+					}
+					gl.uniform1f(splatProgram.uniforms.radius, correctRadius(baseRadius)!);
 				}
 				blit(velocity.write);
 				velocity.swap();

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -14,6 +14,9 @@
 
 	// Module-level singleton registry
 	let activeInstance: (() => void) | null = null;
+	// Monotonic mount counter so async (WebGPU) startups that finish out of
+	// order cannot let an older instance destroy a newer one.
+	let mountCounter = 0;
 
 	interface Props {
 		simResolution?: number;
@@ -158,6 +161,7 @@
 		const canvas = canvasRef;
 		if (!canvas) return;
 
+		const mountToken = ++mountCounter;
 		const pointers = [pointerPrototype()];
 
 		const config = {
@@ -207,6 +211,13 @@
 			})
 				.then((cleanup) => {
 					if (disposed) {
+						cleanup?.();
+						return;
+					}
+					// A newer singleton instance mounted while we were starting up:
+					// registering now would destroy it (newest-mount-wins would
+					// invert). Discard this stale completion instead.
+					if (!allowMultiple && mountToken !== mountCounter) {
 						cleanup?.();
 						return;
 					}

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -1360,15 +1360,11 @@
 					gl.uniform3f(splatProgram.uniforms.color, dx, dy, 0);
 				}
 				if (splatProgram.uniforms.radius) {
-					let baseRadius = config.SPLAT_RADIUS / 100;
+					let radius = correctRadius(config.SPLAT_RADIUS / 100)!;
 					if (contained) {
-						baseRadius = scaleRadiusForContainer(
-							baseRadius,
-							canvas.clientHeight,
-							window.innerHeight
-						);
+						radius = scaleRadiusForContainer(radius, canvas.clientHeight, window.innerHeight);
 					}
-					gl.uniform1f(splatProgram.uniforms.radius, correctRadius(baseRadius)!);
+					gl.uniform1f(splatProgram.uniforms.radius, radius);
 				}
 				blit(velocity.write);
 				velocity.swap();

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
 	import { cn } from "$lib/utils.js";
 	import { onMount } from "svelte";
+	import {
+		type ColorRGB,
+		type Pointer,
+		pointerPrototype,
+		hexToRgb,
+		HSVtoRGB,
+		wrap,
+	} from "./fluid-shared.js";
+	import { startWebGpuFluid } from "./webgpu-engine.js";
 
 	// Module-level singleton registry
 	let activeInstance: (() => void) | null = null;
-
-	interface ColorRGB {
-		r: number;
-		g: number;
-		b: number;
-	}
 
 	interface Props {
 		simResolution?: number;
@@ -37,6 +40,8 @@
 		splatOnMount?: boolean;
 		allowMultiple?: boolean;
 		contained?: boolean;
+		hdr?: boolean;
+		hdrBoost?: number;
 	}
 
 	let {
@@ -65,63 +70,94 @@
 		splatOnMount = false,
 		allowMultiple = false,
 		contained = true,
+		hdr = false,
+		hdrBoost = 1.5,
 	}: Props = $props();
 
-	function hexToRgb(hex: string): ColorRGB {
-		const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-		if (!result) {
-			console.warn(
-				`[FluidCursor] Invalid hex color: "${hex}". Expected format: "#rrggbb". Falling back to white.`
-			);
-			return { r: 1, g: 1, b: 1 };
-		}
-		return {
-			r: parseInt(result[1], 16) / 255,
-			g: parseInt(result[2], 16) / 255,
-			b: parseInt(result[3], 16) / 255,
-		};
-	}
-
 	const clampedColorIntensity = Math.max(0, Math.min(1, colorIntensity));
+	const clampedHdrBoost = Math.max(1, Math.min(4, hdrBoost));
 
 	const resolvedBackColor: ColorRGB =
 		typeof backColor === "string" ? hexToRgb(backColor) : backColor;
 
 	let canvasRef: HTMLCanvasElement;
 
+	// Cached pre-scaled colors to avoid re-parsing hex on every splat
+	let colorIndex = 0;
+	let cachedFluidColorHex: string | undefined;
+	let cachedFluidColor: ColorRGB | null = null;
+	let cachedFluidColorsRef: string[] | undefined;
+	let cachedFluidColorsScaled: ColorRGB[] = [];
+
+	function getScaledColor(hex: string): ColorRGB {
+		const { r, g, b } = hexToRgb(hex);
+		return {
+			r: r * clampedColorIntensity,
+			g: g * clampedColorIntensity,
+			b: b * clampedColorIntensity,
+		};
+	}
+
+	function getCachedFluidColor(hex: string): ColorRGB {
+		if (cachedFluidColor === null || cachedFluidColorHex !== hex) {
+			cachedFluidColorHex = hex;
+			cachedFluidColor = getScaledColor(hex);
+		}
+		return cachedFluidColor;
+	}
+
+	function getCachedFluidColors(colors: string[]): ColorRGB[] {
+		if (cachedFluidColorsRef !== colors) {
+			cachedFluidColorsRef = colors;
+			cachedFluidColorsScaled = colors.map(getScaledColor);
+		}
+		return cachedFluidColorsScaled;
+	}
+
+	function generateColor(): ColorRGB {
+		if (fluidColor) {
+			return getCachedFluidColor(fluidColor);
+		}
+		if (fluidColors && fluidColors.length > 0) {
+			const colors = getCachedFluidColors(fluidColors);
+			const idx = colorIndex % colors.length;
+			colorIndex++;
+			return colors[idx];
+		}
+		const c = HSVtoRGB(Math.random(), 1.0, 1.0);
+		c.r *= clampedColorIntensity;
+		c.g *= clampedColorIntensity;
+		c.b *= clampedColorIntensity;
+		return c;
+	}
+
+	// Singleton wiring shared by the WebGL and WebGPU paths.
+	function registerInstance(cleanup: () => void): () => void {
+		if (!allowMultiple) {
+			if (activeInstance) {
+				if (import.meta.env.DEV) {
+					console.warn(
+						"[FluidCursor] Destroying previous instance. Only one instance is allowed by default. Use `allowMultiple={true}` to opt out of singleton behavior."
+					);
+				}
+				activeInstance();
+			}
+			activeInstance = cleanup;
+			return () => {
+				cleanup();
+				if (activeInstance === cleanup) {
+					activeInstance = null;
+				}
+			};
+		}
+		return cleanup;
+	}
+
 	onMount(() => {
 		const canvas = canvasRef;
 		if (!canvas) return;
 
-		interface Pointer {
-			id: number;
-			texcoordX: number;
-			texcoordY: number;
-			prevTexcoordX: number;
-			prevTexcoordY: number;
-			deltaX: number;
-			deltaY: number;
-			down: boolean;
-			moved: boolean;
-			color: ColorRGB;
-		}
-
-		function pointerPrototype(): Pointer {
-			return {
-				id: -1,
-				texcoordX: 0,
-				texcoordY: 0,
-				prevTexcoordX: 0,
-				prevTexcoordY: 0,
-				deltaX: 0,
-				deltaY: 0,
-				down: false,
-				moved: false,
-				color: { r: 0, g: 0, b: 0 },
-			};
-		}
-
-		const pointers: Pointer[] = [pointerPrototype()];
+		const pointers = [pointerPrototype()];
 
 		const config = {
 			SIM_RESOLUTION: simResolution,
@@ -141,270 +177,339 @@
 			TRANSPARENT: transparent,
 		};
 
-		// Get WebGL context
-		const context = getWebGLContext(canvas);
-		if (!context.gl || !context.ext) return;
-
-		// These are guaranteed non-null after the check above
-		const gl = context.gl;
-		const ext = context.ext;
-
-		// If no linear filtering, reduce resolution
-		if (!ext.supportLinearFiltering) {
-			config.DYE_RESOLUTION = 256;
-			config.SHADING = false;
-		}
-
-		function getWebGLContext(canvas: HTMLCanvasElement) {
-			const params = {
-				alpha: true,
-				depth: false,
-				stencil: false,
-				antialias: false,
-				preserveDrawingBuffer: false,
-			};
-
-			let gl = canvas.getContext("webgl2", params) as WebGL2RenderingContext | null;
-
-			if (!gl) {
-				gl = (canvas.getContext("webgl", params) ||
-					canvas.getContext("experimental-webgl", params)) as WebGL2RenderingContext | null;
-			}
-
-			if (!gl) {
-				console.error("Unable to initialize WebGL.");
-				return { gl: null, ext: null };
-			}
-
-			const isWebGL2 = "drawBuffers" in gl;
-
-			let supportLinearFiltering = false;
-			let halfFloat = null;
-
-			if (isWebGL2) {
-				(gl as WebGL2RenderingContext).getExtension("EXT_color_buffer_float");
-				supportLinearFiltering = !!(gl as WebGL2RenderingContext).getExtension(
-					"OES_texture_float_linear"
-				);
-			} else {
-				halfFloat = gl.getExtension("OES_texture_half_float");
-				supportLinearFiltering = !!gl.getExtension("OES_texture_half_float_linear");
-			}
-
-			gl.clearColor(0, 0, 0, 1);
-
-			const halfFloatTexType = isWebGL2
-				? (gl as WebGL2RenderingContext).HALF_FLOAT
-				: (halfFloat && halfFloat.HALF_FLOAT_OES) || 0;
-
-			let formatRGBA: { internalFormat: number; format: number } | null;
-			let formatRG: { internalFormat: number; format: number } | null;
-			let formatR: { internalFormat: number; format: number } | null;
-
-			if (isWebGL2) {
-				formatRGBA = getSupportedFormat(
-					gl,
-					(gl as WebGL2RenderingContext).RGBA16F,
-					gl.RGBA,
-					halfFloatTexType
-				);
-				formatRG = getSupportedFormat(
-					gl,
-					(gl as WebGL2RenderingContext).RG16F,
-					(gl as WebGL2RenderingContext).RG,
-					halfFloatTexType
-				);
-				formatR = getSupportedFormat(
-					gl,
-					(gl as WebGL2RenderingContext).R16F,
-					(gl as WebGL2RenderingContext).RED,
-					halfFloatTexType
-				);
-			} else {
-				formatRGBA = getSupportedFormat(gl, gl.RGBA, gl.RGBA, halfFloatTexType);
-				formatRG = getSupportedFormat(gl, gl.RGBA, gl.RGBA, halfFloatTexType);
-				formatR = getSupportedFormat(gl, gl.RGBA, gl.RGBA, halfFloatTexType);
-			}
-
-			return {
-				gl,
-				ext: {
-					formatRGBA,
-					formatRG,
-					formatR,
-					halfFloatTexType,
-					supportLinearFiltering,
-				},
+		// HDR path: WebGPU engine (rgba16float backbuffer, display-p3,
+		// extended tone mapping). Falls back to the WebGL path below when
+		// WebGPU is unavailable or initialization fails.
+		if (hdr && typeof navigator !== "undefined" && "gpu" in navigator) {
+			let disposed = false;
+			let activeCleanup: (() => void) | null = null;
+			startWebGpuFluid(canvas, {
+				simResolution: config.SIM_RESOLUTION,
+				dyeResolution: config.DYE_RESOLUTION,
+				densityDissipation: config.DENSITY_DISSIPATION,
+				velocityDissipation: config.VELOCITY_DISSIPATION,
+				pressure: config.PRESSURE,
+				pressureIterations: config.PRESSURE_ITERATIONS,
+				curl: config.CURL,
+				splatRadius: config.SPLAT_RADIUS,
+				splatForce: config.SPLAT_FORCE,
+				shading: config.SHADING,
+				colorUpdateSpeed: config.COLOR_UPDATE_SPEED,
+				exposure: clampedHdrBoost,
+				contained,
+				interactive,
+				autoSplat,
+				autoSplatInterval,
+				pauseWhenHidden,
+				splatOnMount,
+				generateColor,
+			})
+				.then((cleanup) => {
+					if (disposed) {
+						cleanup?.();
+						return;
+					}
+					if (!cleanup) {
+						activeCleanup = startWebGl() ?? null;
+						return;
+					}
+					activeCleanup = registerInstance(cleanup);
+				})
+				.catch((error) => {
+					// Unexpected failure while wiring the WebGPU path: fall back
+					// to WebGL instead of leaving a permanently blank canvas.
+					if (import.meta.env.DEV) {
+						console.warn("[FluidCursor] WebGPU setup failed, falling back to WebGL:", error);
+					}
+					if (!disposed) activeCleanup = startWebGl() ?? null;
+				});
+			return () => {
+				disposed = true;
+				activeCleanup?.();
 			};
 		}
 
-		function getSupportedFormat(
-			gl: WebGLRenderingContext | WebGL2RenderingContext,
-			internalFormat: number,
-			format: number,
-			type: number
-		): { internalFormat: number; format: number } | null {
-			if (!supportRenderTextureFormat(gl, internalFormat, format, type)) {
-				if ("drawBuffers" in gl) {
-					const gl2 = gl as WebGL2RenderingContext;
-					switch (internalFormat) {
-						case gl2.R16F:
-							return getSupportedFormat(gl2, gl2.RG16F, gl2.RG, type);
-						case gl2.RG16F:
-							return getSupportedFormat(gl2, gl2.RGBA16F, gl2.RGBA, type);
-						default:
-							return null;
+		return startWebGl();
+
+		// WebGL engine path (default, and fallback when WebGPU is missing).
+		function startWebGl(): (() => void) | undefined {
+			// Get WebGL context
+			const context = getWebGLContext(canvas);
+			if (!context.gl || !context.ext) return;
+
+			// These are guaranteed non-null after the check above
+			const gl = context.gl;
+			const ext = context.ext;
+
+			// If no linear filtering, reduce resolution
+			if (!ext.supportLinearFiltering) {
+				config.DYE_RESOLUTION = 256;
+				config.SHADING = false;
+			}
+
+			function getWebGLContext(canvas: HTMLCanvasElement) {
+				const params = {
+					alpha: true,
+					depth: false,
+					stencil: false,
+					antialias: false,
+					preserveDrawingBuffer: false,
+				};
+
+				let gl = canvas.getContext("webgl2", params) as WebGL2RenderingContext | null;
+
+				if (!gl) {
+					gl = (canvas.getContext("webgl", params) ||
+						canvas.getContext("experimental-webgl", params)) as WebGL2RenderingContext | null;
+				}
+
+				if (!gl) {
+					console.error("Unable to initialize WebGL.");
+					return { gl: null, ext: null };
+				}
+
+				// HDR fallback: wide-gamut backbuffer when the WebGPU engine is
+				// unavailable. Colors are reinterpreted in P3 (more saturated).
+				if (hdr && "drawingBufferColorSpace" in gl) {
+					try {
+						gl.drawingBufferColorSpace = "display-p3";
+						if (import.meta.env.DEV) {
+							console.info("[FluidCursor] HDR level: webgl-p3 (wide gamut fallback)");
+						}
+					} catch {
+						// Unsupported color space: buffer stays sRGB.
 					}
 				}
-				return null;
-			}
-			return { internalFormat, format };
-		}
 
-		function supportRenderTextureFormat(
-			gl: WebGLRenderingContext | WebGL2RenderingContext,
-			internalFormat: number,
-			format: number,
-			type: number
-		) {
-			const texture = gl.createTexture();
-			if (!texture) return false;
+				const isWebGL2 = "drawBuffers" in gl;
 
-			gl.bindTexture(gl.TEXTURE_2D, texture);
-			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-			gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, 4, 4, 0, format, type, null);
+				let supportLinearFiltering = false;
+				let halfFloat = null;
 
-			const fbo = gl.createFramebuffer();
-			if (!fbo) return false;
-
-			gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-			gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
-			const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-			return status === gl.FRAMEBUFFER_COMPLETE;
-		}
-
-		function hashCode(s: string) {
-			if (!s.length) return 0;
-			let hash = 0;
-			for (let i = 0; i < s.length; i++) {
-				hash = (hash << 5) - hash + s.charCodeAt(i);
-				hash |= 0;
-			}
-			return hash;
-		}
-
-		function addKeywords(source: string, keywords: string[] | null) {
-			if (!keywords) return source;
-			let keywordsString = "";
-			for (const keyword of keywords) {
-				keywordsString += `#define ${keyword}\n`;
-			}
-			return keywordsString + source;
-		}
-
-		function compileShader(
-			type: number,
-			source: string,
-			keywords: string[] | null = null
-		): WebGLShader | null {
-			const shaderSource = addKeywords(source, keywords);
-			const shader = gl.createShader(type);
-			if (!shader) return null;
-			gl.shaderSource(shader, shaderSource);
-			gl.compileShader(shader);
-			return shader;
-		}
-
-		function createProgram(
-			vertexShader: WebGLShader | null,
-			fragmentShader: WebGLShader | null
-		): WebGLProgram | null {
-			if (!vertexShader || !fragmentShader) return null;
-			const program = gl.createProgram();
-			if (!program) return null;
-			gl.attachShader(program, vertexShader);
-			gl.attachShader(program, fragmentShader);
-			gl.linkProgram(program);
-			return program;
-		}
-
-		function getUniforms(program: WebGLProgram) {
-			const uniforms: Record<string, WebGLUniformLocation | null> = {};
-			const uniformCount = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
-			for (let i = 0; i < uniformCount; i++) {
-				const uniformInfo = gl.getActiveUniform(program, i);
-				if (uniformInfo) {
-					uniforms[uniformInfo.name] = gl.getUniformLocation(program, uniformInfo.name);
-				}
-			}
-			return uniforms;
-		}
-
-		class Program {
-			program: WebGLProgram | null;
-			uniforms: Record<string, WebGLUniformLocation | null>;
-
-			constructor(vertexShader: WebGLShader | null, fragmentShader: WebGLShader | null) {
-				this.program = createProgram(vertexShader, fragmentShader);
-				this.uniforms = this.program ? getUniforms(this.program) : {};
-			}
-
-			bind() {
-				if (this.program) gl.useProgram(this.program);
-			}
-		}
-
-		class Material {
-			vertexShader: WebGLShader | null;
-			fragmentShaderSource: string;
-			programs: Record<number, WebGLProgram | null>;
-			activeProgram: WebGLProgram | null;
-			uniforms: Record<string, WebGLUniformLocation | null>;
-
-			constructor(vertexShader: WebGLShader | null, fragmentShaderSource: string) {
-				this.vertexShader = vertexShader;
-				this.fragmentShaderSource = fragmentShaderSource;
-				this.programs = {};
-				this.activeProgram = null;
-				this.uniforms = {};
-			}
-
-			setKeywords(keywords: string[]) {
-				let hash = 0;
-				for (const kw of keywords) {
-					hash += hashCode(kw);
-				}
-				let program = this.programs[hash];
-				if (program == null) {
-					const fragmentShader = compileShader(
-						gl.FRAGMENT_SHADER,
-						this.fragmentShaderSource,
-						keywords
+				if (isWebGL2) {
+					(gl as WebGL2RenderingContext).getExtension("EXT_color_buffer_float");
+					supportLinearFiltering = !!(gl as WebGL2RenderingContext).getExtension(
+						"OES_texture_float_linear"
 					);
-					program = createProgram(this.vertexShader, fragmentShader);
-					this.programs[hash] = program;
+				} else {
+					halfFloat = gl.getExtension("OES_texture_half_float");
+					supportLinearFiltering = !!gl.getExtension("OES_texture_half_float_linear");
 				}
-				if (program === this.activeProgram) return;
-				if (program) {
-					this.uniforms = getUniforms(program);
+
+				gl.clearColor(0, 0, 0, 1);
+
+				const halfFloatTexType = isWebGL2
+					? (gl as WebGL2RenderingContext).HALF_FLOAT
+					: (halfFloat && halfFloat.HALF_FLOAT_OES) || 0;
+
+				let formatRGBA: { internalFormat: number; format: number } | null;
+				let formatRG: { internalFormat: number; format: number } | null;
+				let formatR: { internalFormat: number; format: number } | null;
+
+				if (isWebGL2) {
+					formatRGBA = getSupportedFormat(
+						gl,
+						(gl as WebGL2RenderingContext).RGBA16F,
+						gl.RGBA,
+						halfFloatTexType
+					);
+					formatRG = getSupportedFormat(
+						gl,
+						(gl as WebGL2RenderingContext).RG16F,
+						(gl as WebGL2RenderingContext).RG,
+						halfFloatTexType
+					);
+					formatR = getSupportedFormat(
+						gl,
+						(gl as WebGL2RenderingContext).R16F,
+						(gl as WebGL2RenderingContext).RED,
+						halfFloatTexType
+					);
+				} else {
+					formatRGBA = getSupportedFormat(gl, gl.RGBA, gl.RGBA, halfFloatTexType);
+					formatRG = getSupportedFormat(gl, gl.RGBA, gl.RGBA, halfFloatTexType);
+					formatR = getSupportedFormat(gl, gl.RGBA, gl.RGBA, halfFloatTexType);
 				}
-				this.activeProgram = program;
+
+				return {
+					gl,
+					ext: {
+						formatRGBA,
+						formatRG,
+						formatR,
+						halfFloatTexType,
+						supportLinearFiltering,
+					},
+				};
 			}
 
-			bind() {
-				if (this.activeProgram) {
-					gl.useProgram(this.activeProgram);
+			function getSupportedFormat(
+				gl: WebGLRenderingContext | WebGL2RenderingContext,
+				internalFormat: number,
+				format: number,
+				type: number
+			): { internalFormat: number; format: number } | null {
+				if (!supportRenderTextureFormat(gl, internalFormat, format, type)) {
+					if ("drawBuffers" in gl) {
+						const gl2 = gl as WebGL2RenderingContext;
+						switch (internalFormat) {
+							case gl2.R16F:
+								return getSupportedFormat(gl2, gl2.RG16F, gl2.RG, type);
+							case gl2.RG16F:
+								return getSupportedFormat(gl2, gl2.RGBA16F, gl2.RGBA, type);
+							default:
+								return null;
+						}
+					}
+					return null;
+				}
+				return { internalFormat, format };
+			}
+
+			function supportRenderTextureFormat(
+				gl: WebGLRenderingContext | WebGL2RenderingContext,
+				internalFormat: number,
+				format: number,
+				type: number
+			) {
+				const texture = gl.createTexture();
+				if (!texture) return false;
+
+				gl.bindTexture(gl.TEXTURE_2D, texture);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+				gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, 4, 4, 0, format, type, null);
+
+				const fbo = gl.createFramebuffer();
+				if (!fbo) return false;
+
+				gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+				gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+				const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+				return status === gl.FRAMEBUFFER_COMPLETE;
+			}
+
+			function hashCode(s: string) {
+				if (!s.length) return 0;
+				let hash = 0;
+				for (let i = 0; i < s.length; i++) {
+					hash = (hash << 5) - hash + s.charCodeAt(i);
+					hash |= 0;
+				}
+				return hash;
+			}
+
+			function addKeywords(source: string, keywords: string[] | null) {
+				if (!keywords) return source;
+				let keywordsString = "";
+				for (const keyword of keywords) {
+					keywordsString += `#define ${keyword}\n`;
+				}
+				return keywordsString + source;
+			}
+
+			function compileShader(
+				type: number,
+				source: string,
+				keywords: string[] | null = null
+			): WebGLShader | null {
+				const shaderSource = addKeywords(source, keywords);
+				const shader = gl.createShader(type);
+				if (!shader) return null;
+				gl.shaderSource(shader, shaderSource);
+				gl.compileShader(shader);
+				return shader;
+			}
+
+			function createProgram(
+				vertexShader: WebGLShader | null,
+				fragmentShader: WebGLShader | null
+			): WebGLProgram | null {
+				if (!vertexShader || !fragmentShader) return null;
+				const program = gl.createProgram();
+				if (!program) return null;
+				gl.attachShader(program, vertexShader);
+				gl.attachShader(program, fragmentShader);
+				gl.linkProgram(program);
+				return program;
+			}
+
+			function getUniforms(program: WebGLProgram) {
+				const uniforms: Record<string, WebGLUniformLocation | null> = {};
+				const uniformCount = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
+				for (let i = 0; i < uniformCount; i++) {
+					const uniformInfo = gl.getActiveUniform(program, i);
+					if (uniformInfo) {
+						uniforms[uniformInfo.name] = gl.getUniformLocation(program, uniformInfo.name);
+					}
+				}
+				return uniforms;
+			}
+
+			class Program {
+				program: WebGLProgram | null;
+				uniforms: Record<string, WebGLUniformLocation | null>;
+
+				constructor(vertexShader: WebGLShader | null, fragmentShader: WebGLShader | null) {
+					this.program = createProgram(vertexShader, fragmentShader);
+					this.uniforms = this.program ? getUniforms(this.program) : {};
+				}
+
+				bind() {
+					if (this.program) gl.useProgram(this.program);
 				}
 			}
-		}
 
-		// Shaders
-		const baseVertexShader = compileShader(
-			gl.VERTEX_SHADER,
-			`
+			class Material {
+				vertexShader: WebGLShader | null;
+				fragmentShaderSource: string;
+				programs: Record<number, WebGLProgram | null>;
+				activeProgram: WebGLProgram | null;
+				uniforms: Record<string, WebGLUniformLocation | null>;
+
+				constructor(vertexShader: WebGLShader | null, fragmentShaderSource: string) {
+					this.vertexShader = vertexShader;
+					this.fragmentShaderSource = fragmentShaderSource;
+					this.programs = {};
+					this.activeProgram = null;
+					this.uniforms = {};
+				}
+
+				setKeywords(keywords: string[]) {
+					let hash = 0;
+					for (const kw of keywords) {
+						hash += hashCode(kw);
+					}
+					let program = this.programs[hash];
+					if (program == null) {
+						const fragmentShader = compileShader(
+							gl.FRAGMENT_SHADER,
+							this.fragmentShaderSource,
+							keywords
+						);
+						program = createProgram(this.vertexShader, fragmentShader);
+						this.programs[hash] = program;
+					}
+					if (program === this.activeProgram) return;
+					if (program) {
+						this.uniforms = getUniforms(program);
+					}
+					this.activeProgram = program;
+				}
+
+				bind() {
+					if (this.activeProgram) {
+						gl.useProgram(this.activeProgram);
+					}
+				}
+			}
+
+			// Shaders
+			const baseVertexShader = compileShader(
+				gl.VERTEX_SHADER,
+				`
 			precision highp float;
 			attribute vec2 aPosition;
 			varying vec2 vUv;
@@ -423,11 +528,11 @@
 				gl_Position = vec4(aPosition, 0.0, 1.0);
 			}
 		`
-		);
+			);
 
-		const copyShader = compileShader(
-			gl.FRAGMENT_SHADER,
-			`
+			const copyShader = compileShader(
+				gl.FRAGMENT_SHADER,
+				`
 			precision mediump float;
 			precision mediump sampler2D;
 			varying highp vec2 vUv;
@@ -437,11 +542,11 @@
 				gl_FragColor = texture2D(uTexture, vUv);
 			}
 		`
-		);
+			);
 
-		const clearShader = compileShader(
-			gl.FRAGMENT_SHADER,
-			`
+			const clearShader = compileShader(
+				gl.FRAGMENT_SHADER,
+				`
 			precision mediump float;
 			precision mediump sampler2D;
 			varying highp vec2 vUv;
@@ -452,9 +557,9 @@
 				gl_FragColor = value * texture2D(uTexture, vUv);
 			}
 		`
-		);
+			);
 
-		const displayShaderSource = `
+			const displayShaderSource = `
 			precision highp float;
 			precision highp sampler2D;
 			varying vec2 vUv;
@@ -495,9 +600,9 @@
 			}
 		`;
 
-		const splatShader = compileShader(
-			gl.FRAGMENT_SHADER,
-			`
+			const splatShader = compileShader(
+				gl.FRAGMENT_SHADER,
+				`
 			precision highp float;
 			precision highp sampler2D;
 			varying vec2 vUv;
@@ -515,11 +620,11 @@
 				gl_FragColor = vec4(base + splat, 1.0);
 			}
 		`
-		);
+			);
 
-		const advectionShader = compileShader(
-			gl.FRAGMENT_SHADER,
-			`
+			const advectionShader = compileShader(
+				gl.FRAGMENT_SHADER,
+				`
 			precision highp float;
 			precision highp sampler2D;
 			varying vec2 vUv;
@@ -555,12 +660,12 @@
 				gl_FragColor = result / decay;
 			}
 		`,
-			ext.supportLinearFiltering ? null : ["MANUAL_FILTERING"]
-		);
+				ext.supportLinearFiltering ? null : ["MANUAL_FILTERING"]
+			);
 
-		const divergenceShader = compileShader(
-			gl.FRAGMENT_SHADER,
-			`
+			const divergenceShader = compileShader(
+				gl.FRAGMENT_SHADER,
+				`
 			precision mediump float;
 			precision mediump sampler2D;
 			varying highp vec2 vUv;
@@ -586,11 +691,11 @@
 				gl_FragColor = vec4(div, 0.0, 0.0, 1.0);
 			}
 		`
-		);
+			);
 
-		const curlShader = compileShader(
-			gl.FRAGMENT_SHADER,
-			`
+			const curlShader = compileShader(
+				gl.FRAGMENT_SHADER,
+				`
 			precision mediump float;
 			precision mediump sampler2D;
 			varying highp vec2 vUv;
@@ -609,11 +714,11 @@
 				gl_FragColor = vec4(0.5 * vorticity, 0.0, 0.0, 1.0);
 			}
 		`
-		);
+			);
 
-		const vorticityShader = compileShader(
-			gl.FRAGMENT_SHADER,
-			`
+			const vorticityShader = compileShader(
+				gl.FRAGMENT_SHADER,
+				`
 			precision highp float;
 			precision highp sampler2D;
 			varying vec2 vUv;
@@ -644,11 +749,11 @@
 				gl_FragColor = vec4(velocity, 0.0, 1.0);
 			}
 		`
-		);
+			);
 
-		const pressureShader = compileShader(
-			gl.FRAGMENT_SHADER,
-			`
+			const pressureShader = compileShader(
+				gl.FRAGMENT_SHADER,
+				`
 			precision mediump float;
 			precision mediump sampler2D;
 			varying highp vec2 vUv;
@@ -670,11 +775,11 @@
 				gl_FragColor = vec4(pressure, 0.0, 0.0, 1.0);
 			}
 		`
-		);
+			);
 
-		const gradientSubtractShader = compileShader(
-			gl.FRAGMENT_SHADER,
-			`
+			const gradientSubtractShader = compileShader(
+				gl.FRAGMENT_SHADER,
+				`
 			precision mediump float;
 			precision mediump sampler2D;
 			varying highp vec2 vUv;
@@ -695,874 +800,774 @@
 				gl_FragColor = vec4(velocity, 0.0, 1.0);
 			}
 		`
-		);
-
-		// Fullscreen Triangles
-		interface FBO {
-			texture: WebGLTexture;
-			fbo: WebGLFramebuffer;
-			width: number;
-			height: number;
-			texelSizeX: number;
-			texelSizeY: number;
-			attach: (id: number) => number;
-		}
-
-		interface DoubleFBO {
-			width: number;
-			height: number;
-			texelSizeX: number;
-			texelSizeY: number;
-			read: FBO;
-			write: FBO;
-			swap: () => void;
-		}
-
-		const blit = (() => {
-			const buffer = gl.createBuffer()!;
-			gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-			gl.bufferData(
-				gl.ARRAY_BUFFER,
-				new Float32Array([-1, -1, -1, 1, 1, 1, 1, -1]),
-				gl.STATIC_DRAW
 			);
-			const elemBuffer = gl.createBuffer()!;
-			gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, elemBuffer);
-			gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array([0, 1, 2, 0, 2, 3]), gl.STATIC_DRAW);
-			gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
-			gl.enableVertexAttribArray(0);
 
-			return (target: FBO | null, doClear = false) => {
-				if (!gl) return;
-				if (!target) {
-					gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-					gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-				} else {
-					gl.viewport(0, 0, target.width, target.height);
-					gl.bindFramebuffer(gl.FRAMEBUFFER, target.fbo);
-				}
-				if (doClear) {
-					gl.clearColor(0, 0, 0, 1);
-					gl.clear(gl.COLOR_BUFFER_BIT);
-				}
-				gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
-			};
-		})();
-
-		// FBO variables
-		let dye: DoubleFBO;
-		let velocity: DoubleFBO;
-		let divergenceFBO: FBO;
-		let curlFBO: FBO;
-		let pressureFBO: DoubleFBO;
-
-		// WebGL Programs
-		const copyProgram = new Program(baseVertexShader, copyShader);
-		const clearProgram = new Program(baseVertexShader, clearShader);
-		const splatProgram = new Program(baseVertexShader, splatShader);
-		const advectionProgram = new Program(baseVertexShader, advectionShader);
-		const divergenceProgram = new Program(baseVertexShader, divergenceShader);
-		const curlProgram = new Program(baseVertexShader, curlShader);
-		const vorticityProgram = new Program(baseVertexShader, vorticityShader);
-		const pressureProgram = new Program(baseVertexShader, pressureShader);
-		const gradienSubtractProgram = new Program(baseVertexShader, gradientSubtractShader);
-		const displayMaterial = new Material(baseVertexShader, displayShaderSource);
-
-		// FBO creation
-		function createFBO(
-			w: number,
-			h: number,
-			internalFormat: number,
-			format: number,
-			type: number,
-			param: number
-		): FBO {
-			gl.activeTexture(gl.TEXTURE0);
-			const texture = gl.createTexture()!;
-			gl.bindTexture(gl.TEXTURE_2D, texture);
-			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, param);
-			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, param);
-			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-			gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, w, h, 0, format, type, null);
-			const fbo = gl.createFramebuffer()!;
-			gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-			gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
-			gl.viewport(0, 0, w, h);
-			gl.clear(gl.COLOR_BUFFER_BIT);
-
-			const texelSizeX = 1 / w;
-			const texelSizeY = 1 / h;
-
-			return {
-				texture,
-				fbo,
-				width: w,
-				height: h,
-				texelSizeX,
-				texelSizeY,
-				attach(id: number) {
-					gl.activeTexture(gl.TEXTURE0 + id);
-					gl.bindTexture(gl.TEXTURE_2D, texture);
-					return id;
-				},
-			};
-		}
-
-		function createDoubleFBO(
-			w: number,
-			h: number,
-			internalFormat: number,
-			format: number,
-			type: number,
-			param: number
-		): DoubleFBO {
-			const fbo1 = createFBO(w, h, internalFormat, format, type, param);
-			const fbo2 = createFBO(w, h, internalFormat, format, type, param);
-			return {
-				width: w,
-				height: h,
-				texelSizeX: fbo1.texelSizeX,
-				texelSizeY: fbo1.texelSizeY,
-				read: fbo1,
-				write: fbo2,
-				swap() {
-					const tmp = this.read;
-					this.read = this.write;
-					this.write = tmp;
-				},
-			};
-		}
-
-		function resizeFBO(
-			target: FBO,
-			w: number,
-			h: number,
-			internalFormat: number,
-			format: number,
-			type: number,
-			param: number
-		) {
-			const newFBO = createFBO(w, h, internalFormat, format, type, param);
-			copyProgram.bind();
-			if (copyProgram.uniforms.uTexture)
-				gl.uniform1i(copyProgram.uniforms.uTexture, target.attach(0));
-			blit(newFBO, false);
-			return newFBO;
-		}
-
-		function resizeDoubleFBO(
-			target: DoubleFBO,
-			w: number,
-			h: number,
-			internalFormat: number,
-			format: number,
-			type: number,
-			param: number
-		) {
-			if (target.width === w && target.height === h) return target;
-			target.read = resizeFBO(target.read, w, h, internalFormat, format, type, param);
-			target.write = createFBO(w, h, internalFormat, format, type, param);
-			target.width = w;
-			target.height = h;
-			target.texelSizeX = 1 / w;
-			target.texelSizeY = 1 / h;
-			return target;
-		}
-
-		function initFramebuffers() {
-			const simRes = getResolution(config.SIM_RESOLUTION!);
-			const dyeRes = getResolution(config.DYE_RESOLUTION!);
-
-			const texType = ext.halfFloatTexType;
-			const rgba = ext.formatRGBA!;
-			const rg = ext.formatRG!;
-			const r = ext.formatR!;
-			const filtering = ext.supportLinearFiltering ? gl.LINEAR : gl.NEAREST;
-			gl.disable(gl.BLEND);
-
-			if (!dye) {
-				dye = createDoubleFBO(
-					dyeRes.width,
-					dyeRes.height,
-					rgba.internalFormat,
-					rgba.format,
-					texType,
-					filtering
-				);
-			} else {
-				dye = resizeDoubleFBO(
-					dye,
-					dyeRes.width,
-					dyeRes.height,
-					rgba.internalFormat,
-					rgba.format,
-					texType,
-					filtering
-				);
+			// Fullscreen Triangles
+			interface FBO {
+				texture: WebGLTexture;
+				fbo: WebGLFramebuffer;
+				width: number;
+				height: number;
+				texelSizeX: number;
+				texelSizeY: number;
+				attach: (id: number) => number;
 			}
 
-			if (!velocity) {
-				velocity = createDoubleFBO(
-					simRes.width,
-					simRes.height,
-					rg.internalFormat,
-					rg.format,
-					texType,
-					filtering
-				);
-			} else {
-				velocity = resizeDoubleFBO(
-					velocity,
-					simRes.width,
-					simRes.height,
-					rg.internalFormat,
-					rg.format,
-					texType,
-					filtering
-				);
+			interface DoubleFBO {
+				width: number;
+				height: number;
+				texelSizeX: number;
+				texelSizeY: number;
+				read: FBO;
+				write: FBO;
+				swap: () => void;
 			}
 
-			divergenceFBO = createFBO(
-				simRes.width,
-				simRes.height,
-				r.internalFormat,
-				r.format,
-				texType,
-				gl.NEAREST
-			);
-			curlFBO = createFBO(
-				simRes.width,
-				simRes.height,
-				r.internalFormat,
-				r.format,
-				texType,
-				gl.NEAREST
-			);
-			pressureFBO = createDoubleFBO(
-				simRes.width,
-				simRes.height,
-				r.internalFormat,
-				r.format,
-				texType,
-				gl.NEAREST
-			);
-		}
+			const blit = (() => {
+				const buffer = gl.createBuffer()!;
+				gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+				gl.bufferData(
+					gl.ARRAY_BUFFER,
+					new Float32Array([-1, -1, -1, 1, 1, 1, 1, -1]),
+					gl.STATIC_DRAW
+				);
+				const elemBuffer = gl.createBuffer()!;
+				gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, elemBuffer);
+				gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array([0, 1, 2, 0, 2, 3]), gl.STATIC_DRAW);
+				gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+				gl.enableVertexAttribArray(0);
 
-		function updateKeywords() {
-			const displayKeywords: string[] = [];
-			if (config.SHADING) displayKeywords.push("SHADING");
-			displayMaterial.setKeywords(displayKeywords);
-		}
+				return (target: FBO | null, doClear = false) => {
+					if (!gl) return;
+					if (!target) {
+						gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+						gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+					} else {
+						gl.viewport(0, 0, target.width, target.height);
+						gl.bindFramebuffer(gl.FRAMEBUFFER, target.fbo);
+					}
+					if (doClear) {
+						gl.clearColor(0, 0, 0, 1);
+						gl.clear(gl.COLOR_BUFFER_BIT);
+					}
+					gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+				};
+			})();
 
-		function getResolution(resolution: number) {
-			const w = gl.drawingBufferWidth;
-			const h = gl.drawingBufferHeight;
-			const aspectRatio = w / h;
-			const aspect = aspectRatio < 1 ? 1 / aspectRatio : aspectRatio;
-			const min = Math.round(resolution);
-			const max = Math.round(resolution * aspect);
-			if (w > h) {
-				return { width: max, height: min };
-			}
-			return { width: min, height: max };
-		}
+			// FBO variables
+			let dye: DoubleFBO;
+			let velocity: DoubleFBO;
+			let divergenceFBO: FBO;
+			let curlFBO: FBO;
+			let pressureFBO: DoubleFBO;
 
-		function scaleByPixelRatio(input: number) {
-			const pixelRatio = window.devicePixelRatio || 1;
-			return Math.floor(input * pixelRatio);
-		}
+			// WebGL Programs
+			const copyProgram = new Program(baseVertexShader, copyShader);
+			const clearProgram = new Program(baseVertexShader, clearShader);
+			const splatProgram = new Program(baseVertexShader, splatShader);
+			const advectionProgram = new Program(baseVertexShader, advectionShader);
+			const divergenceProgram = new Program(baseVertexShader, divergenceShader);
+			const curlProgram = new Program(baseVertexShader, curlShader);
+			const vorticityProgram = new Program(baseVertexShader, vorticityShader);
+			const pressureProgram = new Program(baseVertexShader, pressureShader);
+			const gradienSubtractProgram = new Program(baseVertexShader, gradientSubtractShader);
+			const displayMaterial = new Material(baseVertexShader, displayShaderSource);
 
-		let canvasRectCache: DOMRect | null = null;
-		function updateCanvasRectCache() {
-			if (contained && canvas) canvasRectCache = canvas.getBoundingClientRect();
-		}
-		if (contained) {
-			window.addEventListener("resize", updateCanvasRectCache, { passive: true });
-			window.addEventListener("scroll", updateCanvasRectCache, { passive: true });
-			updateCanvasRectCache();
-		}
+			// FBO creation
+			function createFBO(
+				w: number,
+				h: number,
+				internalFormat: number,
+				format: number,
+				type: number,
+				param: number
+			): FBO {
+				gl.activeTexture(gl.TEXTURE0);
+				const texture = gl.createTexture()!;
+				gl.bindTexture(gl.TEXTURE_2D, texture);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, param);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, param);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+				gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, w, h, 0, format, type, null);
+				const fbo = gl.createFramebuffer()!;
+				gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+				gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+				gl.viewport(0, 0, w, h);
+				gl.clear(gl.COLOR_BUFFER_BIT);
 
-		function getCanvasPos(clientX: number, clientY: number): { x: number; y: number } {
-			if (contained) {
-				if (!canvasRectCache) updateCanvasRectCache();
-				const rect = canvasRectCache!;
+				const texelSizeX = 1 / w;
+				const texelSizeY = 1 / h;
+
 				return {
-					x: scaleByPixelRatio(clientX - rect.left),
-					y: scaleByPixelRatio(clientY - rect.top),
+					texture,
+					fbo,
+					width: w,
+					height: h,
+					texelSizeX,
+					texelSizeY,
+					attach(id: number) {
+						gl.activeTexture(gl.TEXTURE0 + id);
+						gl.bindTexture(gl.TEXTURE_2D, texture);
+						return id;
+					},
 				};
 			}
-			return { x: scaleByPixelRatio(clientX), y: scaleByPixelRatio(clientY) };
-		}
 
-		// Simulation Setup
-		updateKeywords();
-		initFramebuffers();
-
-		let lastUpdateTime = Date.now();
-		let colorUpdateTimer = 0.0;
-		let colorIndex = 0;
-		let animationFrameId: number;
-
-		// Cached pre-scaled colors to avoid re-parsing hex on every splat
-		let cachedFluidColorHex: string | undefined;
-		let cachedFluidColor: ColorRGB | null = null;
-		let cachedFluidColorsRef: string[] | undefined;
-		let cachedFluidColorsScaled: ColorRGB[] = [];
-
-		function getScaledColor(hex: string): ColorRGB {
-			const { r, g, b } = hexToRgb(hex);
-			return {
-				r: r * clampedColorIntensity,
-				g: g * clampedColorIntensity,
-				b: b * clampedColorIntensity,
-			};
-		}
-
-		function getCachedFluidColor(hex: string): ColorRGB {
-			if (cachedFluidColor === null || cachedFluidColorHex !== hex) {
-				cachedFluidColorHex = hex;
-				cachedFluidColor = getScaledColor(hex);
+			function createDoubleFBO(
+				w: number,
+				h: number,
+				internalFormat: number,
+				format: number,
+				type: number,
+				param: number
+			): DoubleFBO {
+				const fbo1 = createFBO(w, h, internalFormat, format, type, param);
+				const fbo2 = createFBO(w, h, internalFormat, format, type, param);
+				return {
+					width: w,
+					height: h,
+					texelSizeX: fbo1.texelSizeX,
+					texelSizeY: fbo1.texelSizeY,
+					read: fbo1,
+					write: fbo2,
+					swap() {
+						const tmp = this.read;
+						this.read = this.write;
+						this.write = tmp;
+					},
+				};
 			}
-			return cachedFluidColor;
-		}
 
-		function getCachedFluidColors(colors: string[]): ColorRGB[] {
-			if (cachedFluidColorsRef !== colors) {
-				cachedFluidColorsRef = colors;
-				cachedFluidColorsScaled = colors.map(getScaledColor);
+			function resizeFBO(
+				target: FBO,
+				w: number,
+				h: number,
+				internalFormat: number,
+				format: number,
+				type: number,
+				param: number
+			) {
+				const newFBO = createFBO(w, h, internalFormat, format, type, param);
+				copyProgram.bind();
+				if (copyProgram.uniforms.uTexture)
+					gl.uniform1i(copyProgram.uniforms.uTexture, target.attach(0));
+				blit(newFBO, false);
+				return newFBO;
 			}
-			return cachedFluidColorsScaled;
-		}
 
-		let isVisible = true;
-
-		function updateFrame() {
-			if (!isVisible) return;
-			const dt = calcDeltaTime();
-			if (resizeCanvas()) initFramebuffers();
-			updateColors(dt);
-			applyInputs();
-			step(dt);
-			render(null);
-			animationFrameId = requestAnimationFrame(updateFrame);
-		}
-
-		function calcDeltaTime() {
-			const now = Date.now();
-			let dt = (now - lastUpdateTime) / 1000;
-			dt = Math.min(dt, 0.016666);
-			lastUpdateTime = now;
-			return dt;
-		}
-
-		function resizeCanvas() {
-			const width = scaleByPixelRatio(canvas.clientWidth);
-			const height = scaleByPixelRatio(canvas.clientHeight);
-			if (canvas.width !== width || canvas.height !== height) {
-				canvas.width = width;
-				canvas.height = height;
-				return true;
+			function resizeDoubleFBO(
+				target: DoubleFBO,
+				w: number,
+				h: number,
+				internalFormat: number,
+				format: number,
+				type: number,
+				param: number
+			) {
+				if (target.width === w && target.height === h) return target;
+				target.read = resizeFBO(target.read, w, h, internalFormat, format, type, param);
+				target.write = createFBO(w, h, internalFormat, format, type, param);
+				target.width = w;
+				target.height = h;
+				target.texelSizeX = 1 / w;
+				target.texelSizeY = 1 / h;
+				return target;
 			}
-			return false;
-		}
 
-		function updateColors(dt: number) {
-			colorUpdateTimer += dt * config.COLOR_UPDATE_SPEED;
-			if (colorUpdateTimer >= 1) {
-				colorUpdateTimer = wrap(colorUpdateTimer, 0, 1);
-				pointers.forEach((p) => {
-					p.color = generateColor();
-				});
-			}
-		}
+			function initFramebuffers() {
+				const simRes = getResolution(config.SIM_RESOLUTION!);
+				const dyeRes = getResolution(config.DYE_RESOLUTION!);
 
-		function applyInputs() {
-			for (const p of pointers) {
-				if (p.moved) {
-					p.moved = false;
-					splatPointer(p);
+				const texType = ext.halfFloatTexType;
+				const rgba = ext.formatRGBA!;
+				const rg = ext.formatRG!;
+				const r = ext.formatR!;
+				const filtering = ext.supportLinearFiltering ? gl.LINEAR : gl.NEAREST;
+				gl.disable(gl.BLEND);
+
+				if (!dye) {
+					dye = createDoubleFBO(
+						dyeRes.width,
+						dyeRes.height,
+						rgba.internalFormat,
+						rgba.format,
+						texType,
+						filtering
+					);
+				} else {
+					dye = resizeDoubleFBO(
+						dye,
+						dyeRes.width,
+						dyeRes.height,
+						rgba.internalFormat,
+						rgba.format,
+						texType,
+						filtering
+					);
 				}
-			}
-		}
 
-		function step(dt: number) {
-			gl.disable(gl.BLEND);
+				if (!velocity) {
+					velocity = createDoubleFBO(
+						simRes.width,
+						simRes.height,
+						rg.internalFormat,
+						rg.format,
+						texType,
+						filtering
+					);
+				} else {
+					velocity = resizeDoubleFBO(
+						velocity,
+						simRes.width,
+						simRes.height,
+						rg.internalFormat,
+						rg.format,
+						texType,
+						filtering
+					);
+				}
 
-			// Curl
-			curlProgram.bind();
-			if (curlProgram.uniforms.texelSize) {
-				gl.uniform2f(curlProgram.uniforms.texelSize, velocity.texelSizeX, velocity.texelSizeY);
-			}
-			if (curlProgram.uniforms.uVelocity) {
-				gl.uniform1i(curlProgram.uniforms.uVelocity, velocity.read.attach(0));
-			}
-			blit(curlFBO);
-
-			// Vorticity
-			vorticityProgram.bind();
-			if (vorticityProgram.uniforms.texelSize) {
-				gl.uniform2f(vorticityProgram.uniforms.texelSize, velocity.texelSizeX, velocity.texelSizeY);
-			}
-			if (vorticityProgram.uniforms.uVelocity) {
-				gl.uniform1i(vorticityProgram.uniforms.uVelocity, velocity.read.attach(0));
-			}
-			if (vorticityProgram.uniforms.uCurl) {
-				gl.uniform1i(vorticityProgram.uniforms.uCurl, curlFBO.attach(1));
-			}
-			if (vorticityProgram.uniforms.curl) {
-				gl.uniform1f(vorticityProgram.uniforms.curl, config.CURL);
-			}
-			if (vorticityProgram.uniforms.dt) {
-				gl.uniform1f(vorticityProgram.uniforms.dt, dt);
-			}
-			blit(velocity.write);
-			velocity.swap();
-
-			// Divergence
-			divergenceProgram.bind();
-			if (divergenceProgram.uniforms.texelSize) {
-				gl.uniform2f(
-					divergenceProgram.uniforms.texelSize,
-					velocity.texelSizeX,
-					velocity.texelSizeY
+				divergenceFBO = createFBO(
+					simRes.width,
+					simRes.height,
+					r.internalFormat,
+					r.format,
+					texType,
+					gl.NEAREST
+				);
+				curlFBO = createFBO(
+					simRes.width,
+					simRes.height,
+					r.internalFormat,
+					r.format,
+					texType,
+					gl.NEAREST
+				);
+				pressureFBO = createDoubleFBO(
+					simRes.width,
+					simRes.height,
+					r.internalFormat,
+					r.format,
+					texType,
+					gl.NEAREST
 				);
 			}
-			if (divergenceProgram.uniforms.uVelocity) {
-				gl.uniform1i(divergenceProgram.uniforms.uVelocity, velocity.read.attach(0));
-			}
-			blit(divergenceFBO);
 
-			// Clear pressure
-			clearProgram.bind();
-			if (clearProgram.uniforms.uTexture) {
-				gl.uniform1i(clearProgram.uniforms.uTexture, pressureFBO.read.attach(0));
+			function updateKeywords() {
+				const displayKeywords: string[] = [];
+				if (config.SHADING) displayKeywords.push("SHADING");
+				displayMaterial.setKeywords(displayKeywords);
 			}
-			if (clearProgram.uniforms.value) {
-				gl.uniform1f(clearProgram.uniforms.value, config.PRESSURE);
-			}
-			blit(pressureFBO.write);
-			pressureFBO.swap();
 
-			// Pressure
-			pressureProgram.bind();
-			if (pressureProgram.uniforms.texelSize) {
-				gl.uniform2f(pressureProgram.uniforms.texelSize, velocity.texelSizeX, velocity.texelSizeY);
+			function getResolution(resolution: number) {
+				const w = gl.drawingBufferWidth;
+				const h = gl.drawingBufferHeight;
+				const aspectRatio = w / h;
+				const aspect = aspectRatio < 1 ? 1 / aspectRatio : aspectRatio;
+				const min = Math.round(resolution);
+				const max = Math.round(resolution * aspect);
+				if (w > h) {
+					return { width: max, height: min };
+				}
+				return { width: min, height: max };
 			}
-			if (pressureProgram.uniforms.uDivergence) {
-				gl.uniform1i(pressureProgram.uniforms.uDivergence, divergenceFBO.attach(0));
+
+			function scaleByPixelRatio(input: number) {
+				const pixelRatio = window.devicePixelRatio || 1;
+				return Math.floor(input * pixelRatio);
 			}
-			for (let i = 0; i < config.PRESSURE_ITERATIONS; i++) {
-				if (pressureProgram.uniforms.uPressure) {
-					gl.uniform1i(pressureProgram.uniforms.uPressure, pressureFBO.read.attach(1));
+
+			let canvasRectCache: DOMRect | null = null;
+			function updateCanvasRectCache() {
+				if (contained && canvas) canvasRectCache = canvas.getBoundingClientRect();
+			}
+			if (contained) {
+				window.addEventListener("resize", updateCanvasRectCache, { passive: true });
+				window.addEventListener("scroll", updateCanvasRectCache, { passive: true });
+				updateCanvasRectCache();
+			}
+
+			function getCanvasPos(clientX: number, clientY: number): { x: number; y: number } {
+				if (contained) {
+					if (!canvasRectCache) updateCanvasRectCache();
+					const rect = canvasRectCache!;
+					return {
+						x: scaleByPixelRatio(clientX - rect.left),
+						y: scaleByPixelRatio(clientY - rect.top),
+					};
+				}
+				return { x: scaleByPixelRatio(clientX), y: scaleByPixelRatio(clientY) };
+			}
+
+			// Simulation Setup
+			updateKeywords();
+			initFramebuffers();
+
+			let lastUpdateTime = Date.now();
+			let colorUpdateTimer = 0.0;
+			let animationFrameId: number;
+
+			let isVisible = true;
+
+			function updateFrame() {
+				if (!isVisible) return;
+				const dt = calcDeltaTime();
+				if (resizeCanvas()) initFramebuffers();
+				updateColors(dt);
+				applyInputs();
+				step(dt);
+				render(null);
+				animationFrameId = requestAnimationFrame(updateFrame);
+			}
+
+			function calcDeltaTime() {
+				const now = Date.now();
+				let dt = (now - lastUpdateTime) / 1000;
+				dt = Math.min(dt, 0.016666);
+				lastUpdateTime = now;
+				return dt;
+			}
+
+			function resizeCanvas() {
+				const width = scaleByPixelRatio(canvas.clientWidth);
+				const height = scaleByPixelRatio(canvas.clientHeight);
+				if (canvas.width !== width || canvas.height !== height) {
+					canvas.width = width;
+					canvas.height = height;
+					return true;
+				}
+				return false;
+			}
+
+			function updateColors(dt: number) {
+				colorUpdateTimer += dt * config.COLOR_UPDATE_SPEED;
+				if (colorUpdateTimer >= 1) {
+					colorUpdateTimer = wrap(colorUpdateTimer, 0, 1);
+					pointers.forEach((p) => {
+						p.color = generateColor();
+					});
+				}
+			}
+
+			function applyInputs() {
+				for (const p of pointers) {
+					if (p.moved) {
+						p.moved = false;
+						splatPointer(p);
+					}
+				}
+			}
+
+			function step(dt: number) {
+				gl.disable(gl.BLEND);
+
+				// Curl
+				curlProgram.bind();
+				if (curlProgram.uniforms.texelSize) {
+					gl.uniform2f(curlProgram.uniforms.texelSize, velocity.texelSizeX, velocity.texelSizeY);
+				}
+				if (curlProgram.uniforms.uVelocity) {
+					gl.uniform1i(curlProgram.uniforms.uVelocity, velocity.read.attach(0));
+				}
+				blit(curlFBO);
+
+				// Vorticity
+				vorticityProgram.bind();
+				if (vorticityProgram.uniforms.texelSize) {
+					gl.uniform2f(
+						vorticityProgram.uniforms.texelSize,
+						velocity.texelSizeX,
+						velocity.texelSizeY
+					);
+				}
+				if (vorticityProgram.uniforms.uVelocity) {
+					gl.uniform1i(vorticityProgram.uniforms.uVelocity, velocity.read.attach(0));
+				}
+				if (vorticityProgram.uniforms.uCurl) {
+					gl.uniform1i(vorticityProgram.uniforms.uCurl, curlFBO.attach(1));
+				}
+				if (vorticityProgram.uniforms.curl) {
+					gl.uniform1f(vorticityProgram.uniforms.curl, config.CURL);
+				}
+				if (vorticityProgram.uniforms.dt) {
+					gl.uniform1f(vorticityProgram.uniforms.dt, dt);
+				}
+				blit(velocity.write);
+				velocity.swap();
+
+				// Divergence
+				divergenceProgram.bind();
+				if (divergenceProgram.uniforms.texelSize) {
+					gl.uniform2f(
+						divergenceProgram.uniforms.texelSize,
+						velocity.texelSizeX,
+						velocity.texelSizeY
+					);
+				}
+				if (divergenceProgram.uniforms.uVelocity) {
+					gl.uniform1i(divergenceProgram.uniforms.uVelocity, velocity.read.attach(0));
+				}
+				blit(divergenceFBO);
+
+				// Clear pressure
+				clearProgram.bind();
+				if (clearProgram.uniforms.uTexture) {
+					gl.uniform1i(clearProgram.uniforms.uTexture, pressureFBO.read.attach(0));
+				}
+				if (clearProgram.uniforms.value) {
+					gl.uniform1f(clearProgram.uniforms.value, config.PRESSURE);
 				}
 				blit(pressureFBO.write);
 				pressureFBO.swap();
-			}
 
-			// Gradient Subtract
-			gradienSubtractProgram.bind();
-			if (gradienSubtractProgram.uniforms.texelSize) {
-				gl.uniform2f(
-					gradienSubtractProgram.uniforms.texelSize,
-					velocity.texelSizeX,
-					velocity.texelSizeY
-				);
-			}
-			if (gradienSubtractProgram.uniforms.uPressure) {
-				gl.uniform1i(gradienSubtractProgram.uniforms.uPressure, pressureFBO.read.attach(0));
-			}
-			if (gradienSubtractProgram.uniforms.uVelocity) {
-				gl.uniform1i(gradienSubtractProgram.uniforms.uVelocity, velocity.read.attach(1));
-			}
-			blit(velocity.write);
-			velocity.swap();
-
-			// Advection - velocity
-			advectionProgram.bind();
-			if (advectionProgram.uniforms.texelSize) {
-				gl.uniform2f(advectionProgram.uniforms.texelSize, velocity.texelSizeX, velocity.texelSizeY);
-			}
-			if (!ext.supportLinearFiltering && advectionProgram.uniforms.dyeTexelSize) {
-				gl.uniform2f(
-					advectionProgram.uniforms.dyeTexelSize,
-					velocity.texelSizeX,
-					velocity.texelSizeY
-				);
-			}
-			const velocityId = velocity.read.attach(0);
-			if (advectionProgram.uniforms.uVelocity) {
-				gl.uniform1i(advectionProgram.uniforms.uVelocity, velocityId);
-			}
-			if (advectionProgram.uniforms.uSource) {
-				gl.uniform1i(advectionProgram.uniforms.uSource, velocityId);
-			}
-			if (advectionProgram.uniforms.dt) {
-				gl.uniform1f(advectionProgram.uniforms.dt, dt);
-			}
-			if (advectionProgram.uniforms.dissipation) {
-				gl.uniform1f(advectionProgram.uniforms.dissipation, config.VELOCITY_DISSIPATION);
-			}
-			blit(velocity.write);
-			velocity.swap();
-
-			// Advection - dye
-			if (!ext.supportLinearFiltering && advectionProgram.uniforms.dyeTexelSize) {
-				gl.uniform2f(advectionProgram.uniforms.dyeTexelSize, dye.texelSizeX, dye.texelSizeY);
-			}
-			if (advectionProgram.uniforms.uVelocity) {
-				gl.uniform1i(advectionProgram.uniforms.uVelocity, velocity.read.attach(0));
-			}
-			if (advectionProgram.uniforms.uSource) {
-				gl.uniform1i(advectionProgram.uniforms.uSource, dye.read.attach(1));
-			}
-			if (advectionProgram.uniforms.dissipation) {
-				gl.uniform1f(advectionProgram.uniforms.dissipation, config.DENSITY_DISSIPATION);
-			}
-			blit(dye.write);
-			dye.swap();
-		}
-
-		function render(target: FBO | null) {
-			gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-			gl.enable(gl.BLEND);
-			drawDisplay(target);
-		}
-
-		function drawDisplay(target: FBO | null) {
-			const width = target ? target.width : gl.drawingBufferWidth;
-			const height = target ? target.height : gl.drawingBufferHeight;
-			displayMaterial.bind();
-			if (config.SHADING && displayMaterial.uniforms.texelSize) {
-				gl.uniform2f(displayMaterial.uniforms.texelSize, 1 / width, 1 / height);
-			}
-			if (displayMaterial.uniforms.uTexture) {
-				gl.uniform1i(displayMaterial.uniforms.uTexture, dye.read.attach(0));
-			}
-			blit(target, false);
-		}
-
-		// Interaction
-		function splatPointer(pointer: Pointer) {
-			const dx = pointer.deltaX * config.SPLAT_FORCE;
-			const dy = pointer.deltaY * config.SPLAT_FORCE;
-			splat(pointer.texcoordX, pointer.texcoordY, dx, dy, pointer.color);
-		}
-
-		function clickSplat(pointer: Pointer) {
-			const color = generateColor();
-			color.r *= 10;
-			color.g *= 10;
-			color.b *= 10;
-			const dx = 10 * (Math.random() - 0.5);
-			const dy = 30 * (Math.random() - 0.5);
-			splat(pointer.texcoordX, pointer.texcoordY, dx, dy, color);
-		}
-
-		function splat(x: number, y: number, dx: number, dy: number, color: ColorRGB) {
-			splatProgram.bind();
-			if (splatProgram.uniforms.uTarget) {
-				gl.uniform1i(splatProgram.uniforms.uTarget, velocity.read.attach(0));
-			}
-			if (splatProgram.uniforms.aspectRatio) {
-				gl.uniform1f(splatProgram.uniforms.aspectRatio, canvas.width / canvas.height);
-			}
-			if (splatProgram.uniforms.point) {
-				gl.uniform2f(splatProgram.uniforms.point, x, y);
-			}
-			if (splatProgram.uniforms.color) {
-				gl.uniform3f(splatProgram.uniforms.color, dx, dy, 0);
-			}
-			if (splatProgram.uniforms.radius) {
-				gl.uniform1f(splatProgram.uniforms.radius, correctRadius(config.SPLAT_RADIUS / 100)!);
-			}
-			blit(velocity.write);
-			velocity.swap();
-
-			if (splatProgram.uniforms.uTarget) {
-				gl.uniform1i(splatProgram.uniforms.uTarget, dye.read.attach(0));
-			}
-			if (splatProgram.uniforms.color) {
-				gl.uniform3f(splatProgram.uniforms.color, color.r, color.g, color.b);
-			}
-			blit(dye.write);
-			dye.swap();
-		}
-
-		function multipleSplats(steps: number) {
-			// Simulate a cursor sweep along a random arc — each step on its own frame
-			// so the velocity field has time to evolve between injections.
-			const angle = Math.random() * Math.PI * 2;
-			const cx = 0.25 + Math.random() * 0.5;
-			const cy = 0.25 + Math.random() * 0.5;
-			const arcSpan = Math.PI * (0.8 + Math.random() * 0.8);
-			let i = 0;
-
-			function step() {
-				if (i >= steps) return;
-				const t = i / Math.max(1, steps - 1);
-				const a = angle + t * arcSpan;
-				const r = 0.15 + 0.05 * Math.sin(t * Math.PI);
-				const x = cx + Math.cos(a) * r;
-				const y = cy + Math.sin(a) * r;
-				const color = generateColor();
-				splat(
-					x,
-					y,
-					-Math.sin(a) * config.SPLAT_FORCE * 0.5,
-					Math.cos(a) * config.SPLAT_FORCE * 0.5,
-					color
-				);
-				i++;
-				if (i < steps) requestAnimationFrame(step);
-			}
-			requestAnimationFrame(step);
-		}
-
-		function correctRadius(radius: number) {
-			const aspectRatio = canvas.width / canvas.height;
-			if (aspectRatio > 1) radius *= aspectRatio;
-			return radius;
-		}
-
-		function updatePointerDownData(pointer: Pointer, id: number, posX: number, posY: number) {
-			pointer.id = id;
-			pointer.down = true;
-			pointer.moved = false;
-			pointer.texcoordX = posX / canvas.width;
-			pointer.texcoordY = 1 - posY / canvas.height;
-			pointer.prevTexcoordX = pointer.texcoordX;
-			pointer.prevTexcoordY = pointer.texcoordY;
-			pointer.deltaX = 0;
-			pointer.deltaY = 0;
-			pointer.color = generateColor();
-		}
-
-		function updatePointerMoveData(pointer: Pointer, posX: number, posY: number, color: ColorRGB) {
-			pointer.prevTexcoordX = pointer.texcoordX;
-			pointer.prevTexcoordY = pointer.texcoordY;
-			pointer.texcoordX = posX / canvas.width;
-			pointer.texcoordY = 1 - posY / canvas.height;
-			pointer.deltaX = correctDeltaX(pointer.texcoordX - pointer.prevTexcoordX)!;
-			pointer.deltaY = correctDeltaY(pointer.texcoordY - pointer.prevTexcoordY)!;
-			pointer.moved = Math.abs(pointer.deltaX) > 0 || Math.abs(pointer.deltaY) > 0;
-			pointer.color = color;
-		}
-
-		function correctDeltaX(delta: number) {
-			const aspectRatio = canvas.width / canvas.height;
-			if (aspectRatio < 1) delta *= aspectRatio;
-			return delta;
-		}
-
-		function correctDeltaY(delta: number) {
-			const aspectRatio = canvas.width / canvas.height;
-			if (aspectRatio > 1) delta /= aspectRatio;
-			return delta;
-		}
-
-		function generateColor(): ColorRGB {
-			if (fluidColor) {
-				return getCachedFluidColor(fluidColor);
-			}
-			if (fluidColors && fluidColors.length > 0) {
-				const colors = getCachedFluidColors(fluidColors);
-				const idx = colorIndex % colors.length;
-				colorIndex++;
-				return colors[idx];
-			}
-			const c = HSVtoRGB(Math.random(), 1.0, 1.0);
-			c.r *= clampedColorIntensity;
-			c.g *= clampedColorIntensity;
-			c.b *= clampedColorIntensity;
-			return c;
-		}
-
-		function HSVtoRGB(h: number, s: number, v: number): ColorRGB {
-			let r = 0;
-			let g = 0;
-			let b = 0;
-			const i = Math.floor(h * 6);
-			const f = h * 6 - i;
-			const p = v * (1 - s);
-			const q = v * (1 - f * s);
-			const t = v * (1 - (1 - f) * s);
-
-			switch (i % 6) {
-				case 0:
-					r = v;
-					g = t;
-					b = p;
-					break;
-				case 1:
-					r = q;
-					g = v;
-					b = p;
-					break;
-				case 2:
-					r = p;
-					g = v;
-					b = t;
-					break;
-				case 3:
-					r = p;
-					g = q;
-					b = v;
-					break;
-				case 4:
-					r = t;
-					g = p;
-					b = v;
-					break;
-				case 5:
-					r = v;
-					g = p;
-					b = q;
-					break;
-			}
-			return { r, g, b };
-		}
-
-		function wrap(value: number, min: number, max: number) {
-			const range = max - min;
-			if (range === 0) return min;
-			return ((value - min) % range) + min;
-		}
-
-		// Event Listeners
-		function handleMouseDown(e: MouseEvent) {
-			const pointer = pointers[0];
-			const { x: posX, y: posY } = getCanvasPos(e.clientX, e.clientY);
-			updatePointerDownData(pointer, -1, posX, posY);
-			clickSplat(pointer);
-		}
-
-		function handleFirstMouseMove(e: MouseEvent) {
-			const pointer = pointers[0];
-			const { x: posX, y: posY } = getCanvasPos(e.clientX, e.clientY);
-			const color = generateColor();
-			updatePointerMoveData(pointer, posX, posY, color);
-			document.body.removeEventListener("mousemove", handleFirstMouseMove);
-		}
-
-		function handleMouseMove(e: MouseEvent) {
-			const pointer = pointers[0];
-			const { x: posX, y: posY } = getCanvasPos(e.clientX, e.clientY);
-			updatePointerMoveData(pointer, posX, posY, pointer.color);
-		}
-
-		function handleFirstTouchStart(e: TouchEvent) {
-			const touches = e.targetTouches;
-			const pointer = pointers[0];
-			for (let i = 0; i < touches.length; i++) {
-				const { x: posX, y: posY } = getCanvasPos(touches[i].clientX, touches[i].clientY);
-				updatePointerDownData(pointer, touches[i].identifier, posX, posY);
-			}
-			document.body.removeEventListener("touchstart", handleFirstTouchStart);
-		}
-
-		function handleTouchStart(e: TouchEvent) {
-			const touches = e.targetTouches;
-			const pointer = pointers[0];
-			for (let i = 0; i < touches.length; i++) {
-				const { x: posX, y: posY } = getCanvasPos(touches[i].clientX, touches[i].clientY);
-				updatePointerDownData(pointer, touches[i].identifier, posX, posY);
-			}
-		}
-
-		function handleTouchMove(e: TouchEvent) {
-			const touches = e.targetTouches;
-			const pointer = pointers[0];
-			for (let i = 0; i < touches.length; i++) {
-				const { x: posX, y: posY } = getCanvasPos(touches[i].clientX, touches[i].clientY);
-				updatePointerMoveData(pointer, posX, posY, pointer.color);
-			}
-		}
-
-		// Add event listeners
-		if (interactive) {
-			window.addEventListener("mousedown", handleMouseDown);
-			document.body.addEventListener("mousemove", handleFirstMouseMove);
-			window.addEventListener("mousemove", handleMouseMove);
-			document.body.addEventListener("touchstart", handleFirstTouchStart);
-			window.addEventListener("touchstart", handleTouchStart, false);
-			window.addEventListener("touchmove", handleTouchMove, false);
-		}
-
-		// Pause animation when scrolled out of view
-		let observer: IntersectionObserver | null = null;
-		if (pauseWhenHidden) {
-			observer = new IntersectionObserver(
-				([entry]) => {
-					const wasVisible = isVisible;
-					isVisible = entry.isIntersecting;
-					if (isVisible && !wasVisible) {
-						lastUpdateTime = Date.now();
-						animationFrameId = requestAnimationFrame(updateFrame);
-					}
-				},
-				{ threshold: 0 }
-			);
-			observer.observe(canvas);
-		}
-
-		// Start animation
-		updateFrame();
-		if (splatOnMount) multipleSplats(Math.floor(Math.random() * 6) + 10);
-
-		// Auto-splat timer
-		let autoSplatTimer: ReturnType<typeof setInterval> | null = null;
-		if (autoSplat) {
-			autoSplatTimer = setInterval(() => {
-				const color = generateColor();
-				splat(
-					Math.random(),
-					Math.random(),
-					(Math.random() - 0.5) * 200,
-					(Math.random() - 0.5) * 200,
-					color
-				);
-			}, autoSplatInterval);
-		}
-
-		// Cleanup
-		function cleanup() {
-			cancelAnimationFrame(animationFrameId);
-			if (observer) observer.disconnect();
-			if (autoSplatTimer) clearInterval(autoSplatTimer);
-			if (interactive) {
-				window.removeEventListener("mousedown", handleMouseDown);
-				document.body.removeEventListener("mousemove", handleFirstMouseMove);
-				window.removeEventListener("mousemove", handleMouseMove);
-				document.body.removeEventListener("touchstart", handleFirstTouchStart);
-				window.removeEventListener("touchstart", handleTouchStart);
-				window.removeEventListener("touchmove", handleTouchMove);
-			}
-			if (contained) {
-				window.removeEventListener("resize", updateCanvasRectCache);
-				window.removeEventListener("scroll", updateCanvasRectCache);
-			}
-		}
-
-		if (!allowMultiple) {
-			if (activeInstance) {
-				if (import.meta.env.DEV) {
-					console.warn(
-						"[FluidCursor] Destroying previous instance. Only one instance is allowed by default. Use `allowMultiple={true}` to opt out of singleton behavior."
+				// Pressure
+				pressureProgram.bind();
+				if (pressureProgram.uniforms.texelSize) {
+					gl.uniform2f(
+						pressureProgram.uniforms.texelSize,
+						velocity.texelSizeX,
+						velocity.texelSizeY
 					);
 				}
-				activeInstance();
-			}
-			activeInstance = cleanup;
-			return () => {
-				cleanup();
-				if (activeInstance === cleanup) {
-					activeInstance = null;
+				if (pressureProgram.uniforms.uDivergence) {
+					gl.uniform1i(pressureProgram.uniforms.uDivergence, divergenceFBO.attach(0));
 				}
-			};
-		}
+				for (let i = 0; i < config.PRESSURE_ITERATIONS; i++) {
+					if (pressureProgram.uniforms.uPressure) {
+						gl.uniform1i(pressureProgram.uniforms.uPressure, pressureFBO.read.attach(1));
+					}
+					blit(pressureFBO.write);
+					pressureFBO.swap();
+				}
 
-		return cleanup;
+				// Gradient Subtract
+				gradienSubtractProgram.bind();
+				if (gradienSubtractProgram.uniforms.texelSize) {
+					gl.uniform2f(
+						gradienSubtractProgram.uniforms.texelSize,
+						velocity.texelSizeX,
+						velocity.texelSizeY
+					);
+				}
+				if (gradienSubtractProgram.uniforms.uPressure) {
+					gl.uniform1i(gradienSubtractProgram.uniforms.uPressure, pressureFBO.read.attach(0));
+				}
+				if (gradienSubtractProgram.uniforms.uVelocity) {
+					gl.uniform1i(gradienSubtractProgram.uniforms.uVelocity, velocity.read.attach(1));
+				}
+				blit(velocity.write);
+				velocity.swap();
+
+				// Advection - velocity
+				advectionProgram.bind();
+				if (advectionProgram.uniforms.texelSize) {
+					gl.uniform2f(
+						advectionProgram.uniforms.texelSize,
+						velocity.texelSizeX,
+						velocity.texelSizeY
+					);
+				}
+				if (!ext.supportLinearFiltering && advectionProgram.uniforms.dyeTexelSize) {
+					gl.uniform2f(
+						advectionProgram.uniforms.dyeTexelSize,
+						velocity.texelSizeX,
+						velocity.texelSizeY
+					);
+				}
+				const velocityId = velocity.read.attach(0);
+				if (advectionProgram.uniforms.uVelocity) {
+					gl.uniform1i(advectionProgram.uniforms.uVelocity, velocityId);
+				}
+				if (advectionProgram.uniforms.uSource) {
+					gl.uniform1i(advectionProgram.uniforms.uSource, velocityId);
+				}
+				if (advectionProgram.uniforms.dt) {
+					gl.uniform1f(advectionProgram.uniforms.dt, dt);
+				}
+				if (advectionProgram.uniforms.dissipation) {
+					gl.uniform1f(advectionProgram.uniforms.dissipation, config.VELOCITY_DISSIPATION);
+				}
+				blit(velocity.write);
+				velocity.swap();
+
+				// Advection - dye
+				if (!ext.supportLinearFiltering && advectionProgram.uniforms.dyeTexelSize) {
+					gl.uniform2f(advectionProgram.uniforms.dyeTexelSize, dye.texelSizeX, dye.texelSizeY);
+				}
+				if (advectionProgram.uniforms.uVelocity) {
+					gl.uniform1i(advectionProgram.uniforms.uVelocity, velocity.read.attach(0));
+				}
+				if (advectionProgram.uniforms.uSource) {
+					gl.uniform1i(advectionProgram.uniforms.uSource, dye.read.attach(1));
+				}
+				if (advectionProgram.uniforms.dissipation) {
+					gl.uniform1f(advectionProgram.uniforms.dissipation, config.DENSITY_DISSIPATION);
+				}
+				blit(dye.write);
+				dye.swap();
+			}
+
+			function render(target: FBO | null) {
+				gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+				gl.enable(gl.BLEND);
+				drawDisplay(target);
+			}
+
+			function drawDisplay(target: FBO | null) {
+				const width = target ? target.width : gl.drawingBufferWidth;
+				const height = target ? target.height : gl.drawingBufferHeight;
+				displayMaterial.bind();
+				if (config.SHADING && displayMaterial.uniforms.texelSize) {
+					gl.uniform2f(displayMaterial.uniforms.texelSize, 1 / width, 1 / height);
+				}
+				if (displayMaterial.uniforms.uTexture) {
+					gl.uniform1i(displayMaterial.uniforms.uTexture, dye.read.attach(0));
+				}
+				blit(target, false);
+			}
+
+			// Interaction
+			function splatPointer(pointer: Pointer) {
+				const dx = pointer.deltaX * config.SPLAT_FORCE;
+				const dy = pointer.deltaY * config.SPLAT_FORCE;
+				splat(pointer.texcoordX, pointer.texcoordY, dx, dy, pointer.color);
+			}
+
+			function clickSplat(pointer: Pointer) {
+				const color = generateColor();
+				color.r *= 10;
+				color.g *= 10;
+				color.b *= 10;
+				const dx = 10 * (Math.random() - 0.5);
+				const dy = 30 * (Math.random() - 0.5);
+				splat(pointer.texcoordX, pointer.texcoordY, dx, dy, color);
+			}
+
+			function splat(x: number, y: number, dx: number, dy: number, color: ColorRGB) {
+				splatProgram.bind();
+				if (splatProgram.uniforms.uTarget) {
+					gl.uniform1i(splatProgram.uniforms.uTarget, velocity.read.attach(0));
+				}
+				if (splatProgram.uniforms.aspectRatio) {
+					gl.uniform1f(splatProgram.uniforms.aspectRatio, canvas.width / canvas.height);
+				}
+				if (splatProgram.uniforms.point) {
+					gl.uniform2f(splatProgram.uniforms.point, x, y);
+				}
+				if (splatProgram.uniforms.color) {
+					gl.uniform3f(splatProgram.uniforms.color, dx, dy, 0);
+				}
+				if (splatProgram.uniforms.radius) {
+					gl.uniform1f(splatProgram.uniforms.radius, correctRadius(config.SPLAT_RADIUS / 100)!);
+				}
+				blit(velocity.write);
+				velocity.swap();
+
+				if (splatProgram.uniforms.uTarget) {
+					gl.uniform1i(splatProgram.uniforms.uTarget, dye.read.attach(0));
+				}
+				if (splatProgram.uniforms.color) {
+					gl.uniform3f(splatProgram.uniforms.color, color.r, color.g, color.b);
+				}
+				blit(dye.write);
+				dye.swap();
+			}
+
+			function multipleSplats(steps: number) {
+				// Simulate a cursor sweep along a random arc — each step on its own frame
+				// so the velocity field has time to evolve between injections.
+				const angle = Math.random() * Math.PI * 2;
+				const cx = 0.25 + Math.random() * 0.5;
+				const cy = 0.25 + Math.random() * 0.5;
+				const arcSpan = Math.PI * (0.8 + Math.random() * 0.8);
+				let i = 0;
+
+				function step() {
+					if (i >= steps) return;
+					const t = i / Math.max(1, steps - 1);
+					const a = angle + t * arcSpan;
+					const r = 0.15 + 0.05 * Math.sin(t * Math.PI);
+					const x = cx + Math.cos(a) * r;
+					const y = cy + Math.sin(a) * r;
+					const color = generateColor();
+					splat(
+						x,
+						y,
+						-Math.sin(a) * config.SPLAT_FORCE * 0.5,
+						Math.cos(a) * config.SPLAT_FORCE * 0.5,
+						color
+					);
+					i++;
+					if (i < steps) requestAnimationFrame(step);
+				}
+				requestAnimationFrame(step);
+			}
+
+			function correctRadius(radius: number) {
+				const aspectRatio = canvas.width / canvas.height;
+				if (aspectRatio > 1) radius *= aspectRatio;
+				return radius;
+			}
+
+			function updatePointerDownData(pointer: Pointer, id: number, posX: number, posY: number) {
+				pointer.id = id;
+				pointer.down = true;
+				pointer.moved = false;
+				pointer.texcoordX = posX / canvas.width;
+				pointer.texcoordY = 1 - posY / canvas.height;
+				pointer.prevTexcoordX = pointer.texcoordX;
+				pointer.prevTexcoordY = pointer.texcoordY;
+				pointer.deltaX = 0;
+				pointer.deltaY = 0;
+				pointer.color = generateColor();
+			}
+
+			function updatePointerMoveData(
+				pointer: Pointer,
+				posX: number,
+				posY: number,
+				color: ColorRGB
+			) {
+				pointer.prevTexcoordX = pointer.texcoordX;
+				pointer.prevTexcoordY = pointer.texcoordY;
+				pointer.texcoordX = posX / canvas.width;
+				pointer.texcoordY = 1 - posY / canvas.height;
+				pointer.deltaX = correctDeltaX(pointer.texcoordX - pointer.prevTexcoordX)!;
+				pointer.deltaY = correctDeltaY(pointer.texcoordY - pointer.prevTexcoordY)!;
+				pointer.moved = Math.abs(pointer.deltaX) > 0 || Math.abs(pointer.deltaY) > 0;
+				pointer.color = color;
+			}
+
+			function correctDeltaX(delta: number) {
+				const aspectRatio = canvas.width / canvas.height;
+				if (aspectRatio < 1) delta *= aspectRatio;
+				return delta;
+			}
+
+			function correctDeltaY(delta: number) {
+				const aspectRatio = canvas.width / canvas.height;
+				if (aspectRatio > 1) delta /= aspectRatio;
+				return delta;
+			}
+
+			// Event Listeners
+			function handleMouseDown(e: MouseEvent) {
+				const pointer = pointers[0];
+				const { x: posX, y: posY } = getCanvasPos(e.clientX, e.clientY);
+				updatePointerDownData(pointer, -1, posX, posY);
+				clickSplat(pointer);
+			}
+
+			function handleFirstMouseMove(e: MouseEvent) {
+				const pointer = pointers[0];
+				const { x: posX, y: posY } = getCanvasPos(e.clientX, e.clientY);
+				const color = generateColor();
+				updatePointerMoveData(pointer, posX, posY, color);
+				document.body.removeEventListener("mousemove", handleFirstMouseMove);
+			}
+
+			function handleMouseMove(e: MouseEvent) {
+				const pointer = pointers[0];
+				const { x: posX, y: posY } = getCanvasPos(e.clientX, e.clientY);
+				updatePointerMoveData(pointer, posX, posY, pointer.color);
+			}
+
+			function handleFirstTouchStart(e: TouchEvent) {
+				const touches = e.targetTouches;
+				const pointer = pointers[0];
+				for (let i = 0; i < touches.length; i++) {
+					const { x: posX, y: posY } = getCanvasPos(touches[i].clientX, touches[i].clientY);
+					updatePointerDownData(pointer, touches[i].identifier, posX, posY);
+				}
+				document.body.removeEventListener("touchstart", handleFirstTouchStart);
+			}
+
+			function handleTouchStart(e: TouchEvent) {
+				const touches = e.targetTouches;
+				const pointer = pointers[0];
+				for (let i = 0; i < touches.length; i++) {
+					const { x: posX, y: posY } = getCanvasPos(touches[i].clientX, touches[i].clientY);
+					updatePointerDownData(pointer, touches[i].identifier, posX, posY);
+				}
+			}
+
+			function handleTouchMove(e: TouchEvent) {
+				const touches = e.targetTouches;
+				const pointer = pointers[0];
+				for (let i = 0; i < touches.length; i++) {
+					const { x: posX, y: posY } = getCanvasPos(touches[i].clientX, touches[i].clientY);
+					updatePointerMoveData(pointer, posX, posY, pointer.color);
+				}
+			}
+
+			// Add event listeners
+			if (interactive) {
+				window.addEventListener("mousedown", handleMouseDown);
+				document.body.addEventListener("mousemove", handleFirstMouseMove);
+				window.addEventListener("mousemove", handleMouseMove);
+				document.body.addEventListener("touchstart", handleFirstTouchStart);
+				window.addEventListener("touchstart", handleTouchStart, false);
+				window.addEventListener("touchmove", handleTouchMove, false);
+			}
+
+			// Pause animation when scrolled out of view
+			let observer: IntersectionObserver | null = null;
+			if (pauseWhenHidden) {
+				observer = new IntersectionObserver(
+					([entry]) => {
+						const wasVisible = isVisible;
+						isVisible = entry.isIntersecting;
+						if (isVisible && !wasVisible) {
+							lastUpdateTime = Date.now();
+							animationFrameId = requestAnimationFrame(updateFrame);
+						}
+					},
+					{ threshold: 0 }
+				);
+				observer.observe(canvas);
+			}
+
+			// Start animation
+			updateFrame();
+			if (splatOnMount) multipleSplats(Math.floor(Math.random() * 6) + 10);
+
+			// Auto-splat timer
+			let autoSplatTimer: ReturnType<typeof setInterval> | null = null;
+			if (autoSplat) {
+				autoSplatTimer = setInterval(() => {
+					const color = generateColor();
+					splat(
+						Math.random(),
+						Math.random(),
+						(Math.random() - 0.5) * 200,
+						(Math.random() - 0.5) * 200,
+						color
+					);
+				}, autoSplatInterval);
+			}
+
+			// Cleanup
+			function cleanup() {
+				cancelAnimationFrame(animationFrameId);
+				if (observer) observer.disconnect();
+				if (autoSplatTimer) clearInterval(autoSplatTimer);
+				if (interactive) {
+					window.removeEventListener("mousedown", handleMouseDown);
+					document.body.removeEventListener("mousemove", handleFirstMouseMove);
+					window.removeEventListener("mousemove", handleMouseMove);
+					document.body.removeEventListener("touchstart", handleFirstTouchStart);
+					window.removeEventListener("touchstart", handleTouchStart);
+					window.removeEventListener("touchmove", handleTouchMove);
+				}
+				if (contained) {
+					window.removeEventListener("resize", updateCanvasRectCache);
+					window.removeEventListener("scroll", updateCanvasRectCache);
+				}
+			}
+
+			return registerInstance(cleanup);
+		}
 	});
 </script>
 

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
@@ -78,6 +78,37 @@ describe("FluidCursor", () => {
 		});
 	});
 
+	describe("hdr props", () => {
+		it("renders without error with hdr={true} when WebGPU is unavailable", () => {
+			const { container } = render(FluidCursor, { props: { hdr: true } });
+			expect(container.querySelector("canvas")).toBeInTheDocument();
+		});
+
+		it("renders without error when hdrBoost is out of [1,4] range (clamped internally)", () => {
+			const { container } = render(FluidCursor, { props: { hdr: true, hdrBoost: 100 } });
+			expect(container.querySelector("canvas")).toBeInTheDocument();
+		});
+
+		it("falls back cleanly when WebGPU is present but no adapter is returned", async () => {
+			const requestAdapter = vi.fn(async () => null);
+			// Define `gpu` on the real navigator instead of replacing it, so the
+			// Navigator prototype (userAgent, etc.) stays intact.
+			Object.defineProperty(navigator, "gpu", {
+				value: { requestAdapter },
+				configurable: true,
+			});
+			try {
+				const { container } = render(FluidCursor, { props: { hdr: true } });
+				// Let the async WebGPU attempt resolve and fall back.
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				expect(requestAdapter).toHaveBeenCalled();
+				expect(container.querySelector("canvas")).toBeInTheDocument();
+			} finally {
+				delete (navigator as unknown as Record<string, unknown>).gpu;
+			}
+		});
+	});
+
 	describe("color props", () => {
 		it("renders without error when fluidColor is provided", () => {
 			const { container } = render(FluidCursor, { props: { fluidColor: "#00ffcc" } });

--- a/src/lib/fancy-ui/fluid-cursor/README.md
+++ b/src/lib/fancy-ui/fluid-cursor/README.md
@@ -58,8 +58,9 @@ The component implements a full Navier-Stokes fluid simulation with:
 
 `splatRadius` is defined as a fraction of the canvas, which would make the
 effect look tiny inside small containers (e.g. docs demos). In `contained`
-mode both engines automatically scale the radius so the apparent splat size
-matches what the same settings produce at viewport size, capped at ~30% of
+mode both engines grow the aspect-corrected radius with the
+viewport/container height ratio — sub-linearly in apparent size (×√k), so a
+small demo reads bigger without mimicking fullscreen 1:1 — capped at ~30% of
 the container height (`scaleRadiusForContainer` in `fluid-shared.ts`).
 Fullscreen and viewport-sized containers are unaffected.
 

--- a/src/lib/fancy-ui/fluid-cursor/README.md
+++ b/src/lib/fancy-ui/fluid-cursor/README.md
@@ -54,6 +54,15 @@ The component implements a full Navier-Stokes fluid simulation with:
 <FluidCursor backColor="#1a1a2e" />
 ```
 
+### Contained-mode splat scaling
+
+`splatRadius` is defined as a fraction of the canvas, which would make the
+effect look tiny inside small containers (e.g. docs demos). In `contained`
+mode both engines automatically scale the radius so the apparent splat size
+matches what the same settings produce at viewport size, capped at ~30% of
+the container height (`scaleRadiusForContainer` in `fluid-shared.ts`).
+Fullscreen and viewport-sized containers are unaffected.
+
 ### Event Handling
 
 - Window-level mouse/touch events for full-screen tracking

--- a/src/lib/fancy-ui/fluid-cursor/README.md
+++ b/src/lib/fancy-ui/fluid-cursor/README.md
@@ -5,6 +5,7 @@ A WebGL-based fluid simulation that follows the cursor, creating beautiful flowi
 ## Features
 
 - WebGL2 fluid simulation with WebGL1 fallback
+- Optional HDR mode rendered by a WebGPU engine (wide gamut + extended tone mapping)
 - Mouse and touch support
 - Configurable simulation parameters
 - Transparent background support
@@ -23,6 +24,7 @@ A WebGL-based fluid simulation that follows the cursor, creating beautiful flowi
 ### WebGL Implementation
 
 The component implements a full Navier-Stokes fluid simulation with:
+
 - Curl/vorticity computation
 - Pressure solving with iterative Jacobi method
 - Advection for both velocity and dye
@@ -30,12 +32,12 @@ The component implements a full Navier-Stokes fluid simulation with:
 
 ## Color Props
 
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `fluidColor` | `string` (hex) | — | Fixed fluid color. Disables random cycling. |
-| `fluidColors` | `string[]` (hex) | — | Palette to cycle through on each splat. |
-| `colorIntensity` | `number` | `0.15` | Intensity multiplier applied to fluid colors (0–1). |
-| `backColor` | `{ r, g, b }` or `string` (hex) | `{ r: 0.5, g: 0, b: 0 }` | Background color — accepts RGB object or hex string. |
+| Prop             | Type                            | Default                  | Description                                          |
+| ---------------- | ------------------------------- | ------------------------ | ---------------------------------------------------- |
+| `fluidColor`     | `string` (hex)                  | —                        | Fixed fluid color. Disables random cycling.          |
+| `fluidColors`    | `string[]` (hex)                | —                        | Palette to cycle through on each splat.              |
+| `colorIntensity` | `number`                        | `0.15`                   | Intensity multiplier applied to fluid colors (0–1).  |
+| `backColor`      | `{ r, g, b }` or `string` (hex) | `{ r: 0.5, g: 0, b: 0 }` | Background color — accepts RGB object or hex string. |
 
 **Priority**: `fluidColor` > `fluidColors` > random HSV
 
@@ -57,3 +59,42 @@ The component implements a full Navier-Stokes fluid simulation with:
 - Window-level mouse/touch events for full-screen tracking
 - First-move handlers to start animation only when user interacts
 - Proper cleanup of all event listeners on component unmount
+
+## HDR Mode
+
+```svelte
+<FluidCursor hdr hdrBoost={2} fluidColors={["#a142ff", "#42cfff"]} />
+```
+
+With `hdr` enabled the component tries a WebGPU engine (`webgpu-engine.ts`, a
+WGSL port of the same simulation) that renders into an `rgba16float` canvas
+configured with `colorSpace: "display-p3"` and `toneMapping: { mode: "extended" }`.
+On an HDR display, dye values pushed above `1.0` by `hdrBoost` render brighter
+than SDR white; on a wide-gamut (P3) display colors are noticeably more
+saturated even without HDR headroom.
+
+| Prop       | Type      | Default | Description                                                                          |
+| ---------- | --------- | ------- | ------------------------------------------------------------------------------------ |
+| `hdr`      | `boolean` | `false` | Opt into the WebGPU HDR engine with automatic fallback.                              |
+| `hdrBoost` | `number`  | `1.5`   | Display exposure multiplier, clamped to `[1, 4]`. Only applied by the WebGPU engine. |
+
+### Support cascade
+
+The component degrades silently (the level is logged to the console in dev):
+
+1. **`webgpu-hdr`** — WebGPU available: float16 backbuffer, P3, extended tone
+   mapping (Chrome/Edge 129+, Safari 26+; browsers that ignore `toneMapping`
+   still get the float16 + P3 rendering, clamped to SDR).
+2. **`webgl-p3`** — no WebGPU: the regular WebGL engine with
+   `drawingBufferColorSpace = "display-p3"` (Chrome/Edge 104+, Safari 16.4+,
+   Firefox 132+). Wide gamut only, no extra brightness; `hdrBoost` is ignored.
+3. **`sdr`** — everything else: the unchanged default rendering.
+
+Notes:
+
+- Colors are intentionally reinterpreted in P3 space rather than converted
+  from sRGB — the resulting saturation push is the point of the effect.
+- The glow requires an HDR-capable display (`matchMedia("(dynamic-range: high)")`).
+  On SDR displays HDR mode is still safe, just clamped.
+- With `hdr={false}` (the default) the WebGPU code path is never taken and
+  rendering is identical to previous versions.

--- a/src/lib/fancy-ui/fluid-cursor/fluid-shared.test.ts
+++ b/src/lib/fancy-ui/fluid-cursor/fluid-shared.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { scaleRadiusForContainer, correctRadius, getSimResolution } from "./fluid-shared.js";
+
+describe("scaleRadiusForContainer", () => {
+	it("keeps the radius unchanged at viewport size (fullscreen)", () => {
+		expect(scaleRadiusForContainer(0.002, 900, 900)).toBe(0.002);
+	});
+
+	it("keeps the radius unchanged when the container is larger than the viewport", () => {
+		expect(scaleRadiusForContainer(0.002, 1800, 900)).toBe(0.002);
+	});
+
+	it("scales quadratically so the apparent size matches viewport size", () => {
+		// Container 4x smaller than viewport: characteristic length must be
+		// 4x larger in container fractions, i.e. radius x16.
+		expect(scaleRadiusForContainer(0.002, 250, 1000)).toBeCloseTo(0.032, 10);
+	});
+
+	it("caps the radius so a splat stays under ~30% of a tiny container", () => {
+		expect(scaleRadiusForContainer(0.002, 50, 1000)).toBe(0.09);
+	});
+
+	it("is defensive about degenerate dimensions", () => {
+		expect(scaleRadiusForContainer(0.002, 0, 1000)).toBe(0.002);
+		expect(scaleRadiusForContainer(0.002, 250, 0)).toBe(0.002);
+	});
+});
+
+describe("correctRadius", () => {
+	it("stretches the radius by aspect ratio on landscape canvases", () => {
+		expect(correctRadius(0.01, 200, 100)).toBe(0.02);
+	});
+
+	it("leaves portrait canvases unchanged", () => {
+		expect(correctRadius(0.01, 100, 200)).toBe(0.01);
+	});
+});
+
+describe("getSimResolution", () => {
+	it("puts the larger grid dimension along the larger canvas axis", () => {
+		expect(getSimResolution(128, 1000, 500)).toEqual({ width: 256, height: 128 });
+		expect(getSimResolution(128, 500, 1000)).toEqual({ width: 128, height: 256 });
+	});
+});

--- a/src/lib/fancy-ui/fluid-cursor/fluid-shared.test.ts
+++ b/src/lib/fancy-ui/fluid-cursor/fluid-shared.test.ts
@@ -10,14 +10,14 @@ describe("scaleRadiusForContainer", () => {
 		expect(scaleRadiusForContainer(0.002, 1800, 900)).toBe(0.002);
 	});
 
-	it("scales quadratically so the apparent size matches viewport size", () => {
-		// Container 4x smaller than viewport: characteristic length must be
-		// 4x larger in container fractions, i.e. radius x16.
-		expect(scaleRadiusForContainer(0.002, 250, 1000)).toBeCloseTo(0.032, 10);
+	it("grows the radius linearly with the viewport/container ratio (sqrt(k) in apparent size)", () => {
+		// Container 4x smaller than viewport: radius x4, characteristic
+		// length x2 in container fractions.
+		expect(scaleRadiusForContainer(0.002, 250, 1000)).toBeCloseTo(0.008, 10);
 	});
 
 	it("caps the radius so a splat stays under ~30% of a tiny container", () => {
-		expect(scaleRadiusForContainer(0.002, 50, 1000)).toBe(0.09);
+		expect(scaleRadiusForContainer(0.01, 50, 1000)).toBe(0.09);
 	});
 
 	it("is defensive about degenerate dimensions", () => {

--- a/src/lib/fancy-ui/fluid-cursor/fluid-shared.test.ts
+++ b/src/lib/fancy-ui/fluid-cursor/fluid-shared.test.ts
@@ -20,6 +20,10 @@ describe("scaleRadiusForContainer", () => {
 		expect(scaleRadiusForContainer(0.01, 50, 1000)).toBe(0.09);
 	});
 
+	it("never shrinks a caller-provided radius already above the cap", () => {
+		expect(scaleRadiusForContainer(0.2, 250, 1000)).toBe(0.2);
+	});
+
 	it("is defensive about degenerate dimensions", () => {
 		expect(scaleRadiusForContainer(0.002, 0, 1000)).toBe(0.002);
 		expect(scaleRadiusForContainer(0.002, 250, 0)).toBe(0.002);

--- a/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
+++ b/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
@@ -118,6 +118,25 @@ export function correctRadius(radius: number, width: number, height: number) {
 	return radius;
 }
 
+/**
+ * In contained mode the splat radius is a fraction of the canvas, so the same
+ * settings that look right fullscreen produce a tiny effect inside a small
+ * demo container. Scale the radius so the apparent splat size matches what it
+ * would be at viewport size, capped so a single splat cannot swallow a very
+ * small container (the gaussian's characteristic length is sqrt(radius), so
+ * the cap of 0.09 keeps it under ~30% of the container height).
+ */
+export function scaleRadiusForContainer(
+	radius: number,
+	containerHeight: number,
+	viewportHeight: number
+): number {
+	if (containerHeight <= 0 || viewportHeight <= 0) return radius;
+	const k = viewportHeight / containerHeight;
+	if (k <= 1) return radius;
+	return Math.min(radius * k * k, 0.09);
+}
+
 export function correctDeltaX(delta: number, width: number, height: number) {
 	const aspectRatio = width / height;
 	if (aspectRatio < 1) return delta * aspectRatio;

--- a/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
+++ b/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
@@ -121,10 +121,12 @@ export function correctRadius(radius: number, width: number, height: number) {
 /**
  * In contained mode the splat radius is a fraction of the canvas, so the same
  * settings that look right fullscreen produce a tiny effect inside a small
- * demo container. Scale the radius so the apparent splat size matches what it
- * would be at viewport size, capped so a single splat cannot swallow a very
- * small container (the gaussian's characteristic length is sqrt(radius), so
- * the cap of 0.09 keeps it under ~30% of the container height).
+ * demo container. Grow the radius with the viewport/container ratio —
+ * sub-linearly in apparent size (the gaussian's characteristic length is
+ * sqrt(radius), so `radius * k` scales the length by sqrt(k)): a small demo
+ * reads bigger without mimicking fullscreen 1:1. Must be applied to the
+ * final, aspect-corrected radius; the 0.09 cap keeps the characteristic
+ * length under ~30% of the container height.
  */
 export function scaleRadiusForContainer(
 	radius: number,
@@ -134,7 +136,7 @@ export function scaleRadiusForContainer(
 	if (containerHeight <= 0 || viewportHeight <= 0) return radius;
 	const k = viewportHeight / containerHeight;
 	if (k <= 1) return radius;
-	return Math.min(radius * k * k, 0.09);
+	return Math.min(radius * k, 0.09);
 }
 
 export function correctDeltaX(delta: number, width: number, height: number) {

--- a/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
+++ b/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
@@ -1,0 +1,131 @@
+// Pure helpers shared by the WebGL and WebGPU fluid engines.
+
+export interface ColorRGB {
+	r: number;
+	g: number;
+	b: number;
+}
+
+export interface Pointer {
+	id: number;
+	texcoordX: number;
+	texcoordY: number;
+	prevTexcoordX: number;
+	prevTexcoordY: number;
+	deltaX: number;
+	deltaY: number;
+	down: boolean;
+	moved: boolean;
+	color: ColorRGB;
+}
+
+export function pointerPrototype(): Pointer {
+	return {
+		id: -1,
+		texcoordX: 0,
+		texcoordY: 0,
+		prevTexcoordX: 0,
+		prevTexcoordY: 0,
+		deltaX: 0,
+		deltaY: 0,
+		down: false,
+		moved: false,
+		color: { r: 0, g: 0, b: 0 },
+	};
+}
+
+export function hexToRgb(hex: string): ColorRGB {
+	const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+	if (!result) {
+		console.warn(
+			`[FluidCursor] Invalid hex color: "${hex}". Expected format: "#rrggbb". Falling back to white.`
+		);
+		return { r: 1, g: 1, b: 1 };
+	}
+	return {
+		r: parseInt(result[1], 16) / 255,
+		g: parseInt(result[2], 16) / 255,
+		b: parseInt(result[3], 16) / 255,
+	};
+}
+
+export function HSVtoRGB(h: number, s: number, v: number): ColorRGB {
+	let r = 0;
+	let g = 0;
+	let b = 0;
+	const i = Math.floor(h * 6);
+	const f = h * 6 - i;
+	const p = v * (1 - s);
+	const q = v * (1 - f * s);
+	const t = v * (1 - (1 - f) * s);
+
+	switch (i % 6) {
+		case 0:
+			r = v;
+			g = t;
+			b = p;
+			break;
+		case 1:
+			r = q;
+			g = v;
+			b = p;
+			break;
+		case 2:
+			r = p;
+			g = v;
+			b = t;
+			break;
+		case 3:
+			r = p;
+			g = q;
+			b = v;
+			break;
+		case 4:
+			r = t;
+			g = p;
+			b = v;
+			break;
+		case 5:
+			r = v;
+			g = p;
+			b = q;
+			break;
+	}
+	return { r, g, b };
+}
+
+export function wrap(value: number, min: number, max: number) {
+	const range = max - min;
+	if (range === 0) return min;
+	return ((value - min) % range) + min;
+}
+
+/** Sim/dye grid size for a given base resolution and drawing buffer dimensions. */
+export function getSimResolution(resolution: number, bufferWidth: number, bufferHeight: number) {
+	const aspectRatio = bufferWidth / bufferHeight;
+	const aspect = aspectRatio < 1 ? 1 / aspectRatio : aspectRatio;
+	const min = Math.round(resolution);
+	const max = Math.round(resolution * aspect);
+	if (bufferWidth > bufferHeight) {
+		return { width: max, height: min };
+	}
+	return { width: min, height: max };
+}
+
+export function correctRadius(radius: number, width: number, height: number) {
+	const aspectRatio = width / height;
+	if (aspectRatio > 1) return radius * aspectRatio;
+	return radius;
+}
+
+export function correctDeltaX(delta: number, width: number, height: number) {
+	const aspectRatio = width / height;
+	if (aspectRatio < 1) return delta * aspectRatio;
+	return delta;
+}
+
+export function correctDeltaY(delta: number, width: number, height: number) {
+	const aspectRatio = width / height;
+	if (aspectRatio > 1) return delta / aspectRatio;
+	return delta;
+}

--- a/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
+++ b/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
@@ -136,7 +136,9 @@ export function scaleRadiusForContainer(
 	if (containerHeight <= 0 || viewportHeight <= 0) return radius;
 	const k = viewportHeight / containerHeight;
 	if (k <= 1) return radius;
-	return Math.min(radius * k, 0.09);
+	// The cap only limits the auto-scaling — a caller-provided radius that is
+	// already larger must never be shrunk by entering a small container.
+	return Math.max(radius, Math.min(radius * k, 0.09));
 }
 
 export function correctDeltaX(delta: number, width: number, height: number) {

--- a/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
+++ b/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
@@ -1,0 +1,1040 @@
+/// <reference types="@webgpu/types" />
+// WebGPU HDR engine for FluidCursor.
+//
+// Port of the WebGL fluid simulation to WGSL, rendering into an
+// `rgba16float` canvas configured with `colorSpace: "display-p3"` and
+// `toneMapping: { mode: "extended" }`. On HDR displays, dye values pushed
+// above 1.0 by the exposure boost render brighter than SDR white; on wide
+// gamut (P3) displays colors are noticeably more saturated. Browsers that
+// ignore the `toneMapping` member simply clamp to SDR — the sim still runs.
+//
+// The math mirrors the GLSL shaders in FluidCursor.svelte pass for pass
+// (splat, curl, vorticity, divergence, clear, pressure Jacobi iterations,
+// gradient subtract, advection, display). Any behavioral change here must be
+// mirrored in the WebGL path and vice versa.
+
+import {
+	type ColorRGB,
+	type Pointer,
+	pointerPrototype,
+	correctDeltaX,
+	correctDeltaY,
+	correctRadius,
+	getSimResolution,
+} from "./fluid-shared.js";
+
+export interface WebGpuFluidOptions {
+	simResolution: number;
+	dyeResolution: number;
+	densityDissipation: number;
+	velocityDissipation: number;
+	pressure: number;
+	pressureIterations: number;
+	curl: number;
+	splatRadius: number;
+	splatForce: number;
+	shading: boolean;
+	colorUpdateSpeed: number;
+	/** Display exposure multiplier — values above 1 create the HDR glow. */
+	exposure: number;
+	contained: boolean;
+	interactive: boolean;
+	autoSplat: boolean;
+	autoSplatInterval: number;
+	pauseWhenHidden: boolean;
+	splatOnMount: boolean;
+	generateColor: () => ColorRGB;
+}
+
+const WGSL = /* wgsl */ `
+struct Uniforms {
+	texelSize: vec2f,
+	point: vec2f,
+	color: vec4f,
+	dt: f32,
+	dissipation: f32,
+	curlStrength: f32,
+	clearValue: f32,
+	aspect: f32,
+	radius: f32,
+	exposure: f32,
+	shading: f32,
+}
+
+@group(0) @binding(0) var<uniform> u: Uniforms;
+@group(0) @binding(1) var smpLinear: sampler;
+@group(0) @binding(2) var smpNearest: sampler;
+@group(0) @binding(3) var tex0: texture_2d<f32>;
+@group(0) @binding(4) var tex1: texture_2d<f32>;
+
+struct VSOut {
+	@builtin(position) pos: vec4f,
+	@location(0) uv: vec2f,
+}
+
+@vertex
+fn vs(@builtin(vertex_index) i: u32) -> VSOut {
+	// Fullscreen triangle.
+	var p = array<vec2f, 3>(vec2f(-1.0, -3.0), vec2f(-1.0, 1.0), vec2f(3.0, 1.0));
+	var out: VSOut;
+	out.pos = vec4f(p[i], 0.0, 1.0);
+	// Negated y so uv row order matches texture row order (WebGPU NDC +Y is
+	// up but texture v=0 is the top row) — without it every pass mirrors its
+	// input vertically. Pointer texcoords use the same top-origin convention.
+	out.uv = vec2f(p[i].x, -p[i].y) * 0.5 + 0.5;
+	return out;
+}
+
+@fragment
+fn fs_copy(in: VSOut) -> @location(0) vec4f {
+	return textureSample(tex0, smpLinear, in.uv);
+}
+
+@fragment
+fn fs_splat(in: VSOut) -> @location(0) vec4f {
+	var p = in.uv - u.point;
+	p.x = p.x * u.aspect;
+	let splat = exp(-dot(p, p) / u.radius) * u.color.rgb;
+	let base = textureSample(tex0, smpLinear, in.uv).rgb;
+	return vec4f(base + splat, 1.0);
+}
+
+@fragment
+fn fs_curl(in: VSOut) -> @location(0) vec4f {
+	let vL = in.uv - vec2f(u.texelSize.x, 0.0);
+	let vR = in.uv + vec2f(u.texelSize.x, 0.0);
+	let vT = in.uv + vec2f(0.0, u.texelSize.y);
+	let vB = in.uv - vec2f(0.0, u.texelSize.y);
+	let L = textureSample(tex0, smpLinear, vL).y;
+	let R = textureSample(tex0, smpLinear, vR).y;
+	let T = textureSample(tex0, smpLinear, vT).x;
+	let B = textureSample(tex0, smpLinear, vB).x;
+	let vorticity = R - L - T + B;
+	return vec4f(0.5 * vorticity, 0.0, 0.0, 1.0);
+}
+
+@fragment
+fn fs_vorticity(in: VSOut) -> @location(0) vec4f {
+	let vL = in.uv - vec2f(u.texelSize.x, 0.0);
+	let vR = in.uv + vec2f(u.texelSize.x, 0.0);
+	let vT = in.uv + vec2f(0.0, u.texelSize.y);
+	let vB = in.uv - vec2f(0.0, u.texelSize.y);
+	let L = textureSample(tex1, smpNearest, vL).x;
+	let R = textureSample(tex1, smpNearest, vR).x;
+	let T = textureSample(tex1, smpNearest, vT).x;
+	let B = textureSample(tex1, smpNearest, vB).x;
+	let C = textureSample(tex1, smpNearest, in.uv).x;
+
+	var force = 0.5 * vec2f(abs(T) - abs(B), abs(R) - abs(L));
+	force = force / (length(force) + 0.0001);
+	force = force * u.curlStrength * C;
+	force.y = force.y * -1.0;
+
+	var velocity = textureSample(tex0, smpLinear, in.uv).xy;
+	velocity = velocity + force * u.dt;
+	velocity = clamp(velocity, vec2f(-1000.0), vec2f(1000.0));
+	return vec4f(velocity, 0.0, 1.0);
+}
+
+@fragment
+fn fs_divergence(in: VSOut) -> @location(0) vec4f {
+	let vL = in.uv - vec2f(u.texelSize.x, 0.0);
+	let vR = in.uv + vec2f(u.texelSize.x, 0.0);
+	let vT = in.uv + vec2f(0.0, u.texelSize.y);
+	let vB = in.uv - vec2f(0.0, u.texelSize.y);
+	var L = textureSample(tex0, smpLinear, vL).x;
+	var R = textureSample(tex0, smpLinear, vR).x;
+	var T = textureSample(tex0, smpLinear, vT).y;
+	var B = textureSample(tex0, smpLinear, vB).y;
+
+	let C = textureSample(tex0, smpLinear, in.uv).xy;
+	if (vL.x < 0.0) { L = -C.x; }
+	if (vR.x > 1.0) { R = -C.x; }
+	if (vT.y > 1.0) { T = -C.y; }
+	if (vB.y < 0.0) { B = -C.y; }
+
+	let div = 0.5 * (R - L + T - B);
+	return vec4f(div, 0.0, 0.0, 1.0);
+}
+
+@fragment
+fn fs_clear(in: VSOut) -> @location(0) vec4f {
+	return u.clearValue * textureSample(tex0, smpNearest, in.uv);
+}
+
+@fragment
+fn fs_pressure(in: VSOut) -> @location(0) vec4f {
+	let vL = in.uv - vec2f(u.texelSize.x, 0.0);
+	let vR = in.uv + vec2f(u.texelSize.x, 0.0);
+	let vT = in.uv + vec2f(0.0, u.texelSize.y);
+	let vB = in.uv - vec2f(0.0, u.texelSize.y);
+	let L = textureSample(tex0, smpNearest, vL).x;
+	let R = textureSample(tex0, smpNearest, vR).x;
+	let T = textureSample(tex0, smpNearest, vT).x;
+	let B = textureSample(tex0, smpNearest, vB).x;
+	let divergence = textureSample(tex1, smpNearest, in.uv).x;
+	let pressure = (L + R + B + T - divergence) * 0.25;
+	return vec4f(pressure, 0.0, 0.0, 1.0);
+}
+
+@fragment
+fn fs_gradient(in: VSOut) -> @location(0) vec4f {
+	let vL = in.uv - vec2f(u.texelSize.x, 0.0);
+	let vR = in.uv + vec2f(u.texelSize.x, 0.0);
+	let vT = in.uv + vec2f(0.0, u.texelSize.y);
+	let vB = in.uv - vec2f(0.0, u.texelSize.y);
+	let L = textureSample(tex0, smpNearest, vL).x;
+	let R = textureSample(tex0, smpNearest, vR).x;
+	let T = textureSample(tex0, smpNearest, vT).x;
+	let B = textureSample(tex0, smpNearest, vB).x;
+	var velocity = textureSample(tex1, smpLinear, in.uv).xy;
+	velocity = velocity - vec2f(R - L, T - B);
+	return vec4f(velocity, 0.0, 1.0);
+}
+
+@fragment
+fn fs_advection(in: VSOut) -> @location(0) vec4f {
+	let coord = in.uv - u.dt * textureSample(tex0, smpLinear, in.uv).xy * u.texelSize;
+	let result = textureSample(tex1, smpLinear, coord);
+	let decay = 1.0 + u.dissipation * u.dt;
+	return result / decay;
+}
+
+@fragment
+fn fs_display(in: VSOut) -> @location(0) vec4f {
+	var c = textureSample(tex0, smpLinear, in.uv).rgb;
+
+	// Neighbor samples are taken unconditionally and mixed by the shading
+	// flag so texture sampling stays in uniform control flow.
+	let vL = in.uv - vec2f(u.texelSize.x, 0.0);
+	let vR = in.uv + vec2f(u.texelSize.x, 0.0);
+	let vT = in.uv + vec2f(0.0, u.texelSize.y);
+	let vB = in.uv - vec2f(0.0, u.texelSize.y);
+	let lc = textureSample(tex0, smpLinear, vL).rgb;
+	let rc = textureSample(tex0, smpLinear, vR).rgb;
+	let tc = textureSample(tex0, smpLinear, vT).rgb;
+	let bc = textureSample(tex0, smpLinear, vB).rgb;
+	let dx = length(rc) - length(lc);
+	let dy = length(tc) - length(bc);
+	let n = normalize(vec3f(dx, dy, length(u.texelSize)));
+	let l = vec3f(0.0, 0.0, 1.0);
+	let diffuse = clamp(dot(n, l) + 0.7, 0.7, 1.0);
+	c = c * mix(1.0, diffuse, u.shading);
+
+	// The canvas color space keeps the sRGB transfer function even with a
+	// float16 format (it only adds range/precision), so values are written
+	// as-is like the WebGL path — no gamma conversion. The exposure boost
+	// pushes encoded values above 1.0, which extended tone mapping renders
+	// brighter than SDR white. Alpha stays clamped for premultiplied
+	// compositing; color intentionally exceeds it for the HDR glow.
+	let a = min(max(c.r, max(c.g, c.b)), 1.0);
+	let boosted = max(c, vec3f(0.0)) * u.exposure;
+	return vec4f(boosted, a);
+}
+`;
+
+// Float offsets inside the 64-byte Uniforms struct.
+const U_FLOATS = 16;
+const OFF_TEXEL = 0;
+const OFF_POINT = 2;
+const OFF_COLOR = 4;
+const OFF_DT = 8;
+const OFF_DISSIPATION = 9;
+const OFF_CURL = 10;
+const OFF_CLEAR = 11;
+const OFF_ASPECT = 12;
+const OFF_RADIUS = 13;
+const OFF_EXPOSURE = 14;
+const OFF_SHADING = 15;
+
+interface UniformValues {
+	texelSize?: [number, number];
+	point?: [number, number];
+	color?: [number, number, number];
+	dt?: number;
+	dissipation?: number;
+	curlStrength?: number;
+	clearValue?: number;
+	aspect?: number;
+	radius?: number;
+	exposure?: number;
+	shading?: number;
+}
+
+interface DoubleTex {
+	read: GPUTexture;
+	write: GPUTexture;
+	readView: GPUTextureView;
+	writeView: GPUTextureView;
+	width: number;
+	height: number;
+	texelSizeX: number;
+	texelSizeY: number;
+	swap: () => void;
+}
+
+interface FluidEngine {
+	splat: (x: number, y: number, dx: number, dy: number, color: ColorRGB) => void;
+	resizeIfNeeded: () => void;
+	frame: (dt: number) => void;
+	readonly lost: boolean;
+	destroy: () => void;
+}
+
+function scaleByPixelRatio(input: number) {
+	const pixelRatio = window.devicePixelRatio || 1;
+	return Math.floor(input * pixelRatio);
+}
+
+async function createWebGpuFluid(
+	canvas: HTMLCanvasElement,
+	opts: WebGpuFluidOptions
+): Promise<FluidEngine | null> {
+	try {
+		const gpu = navigator.gpu;
+		if (!gpu) return null;
+		const adapter = await gpu.requestAdapter();
+		if (!adapter) return null;
+		const device = await adapter.requestDevice();
+		const maybeContext = canvas.getContext("webgpu");
+		if (!maybeContext) {
+			device.destroy();
+			return null;
+		}
+		const context: GPUCanvasContext = maybeContext;
+
+		const format: GPUTextureFormat = "rgba16float";
+		// `toneMapping` and `colorSpace` are ignored by browsers that do not
+		// support them yet (WebIDL drops unknown dictionary members), in which
+		// case output is clamped to SDR.
+		context.configure({
+			device,
+			format,
+			alphaMode: "premultiplied",
+			colorSpace: "display-p3",
+			toneMapping: { mode: "extended" },
+		} as GPUCanvasConfiguration);
+
+		if (import.meta.env.DEV) {
+			// Browsers that do not support toneMapping drop the member, which
+			// getConfiguration() makes observable — log the real level.
+			let extended = false;
+			try {
+				const applied = context.getConfiguration?.() as
+					| (GPUCanvasConfiguration & { toneMapping?: { mode?: string } })
+					| null;
+				extended = applied?.toneMapping?.mode === "extended";
+			} catch {
+				// getConfiguration unsupported: assume clamped output.
+			}
+			console.info(
+				extended
+					? "[FluidCursor] HDR level: webgpu-hdr (extended tone mapping active)"
+					: "[FluidCursor] HDR level: webgpu-sdr (float16 + P3, tone mapping clamped by browser)"
+			);
+		}
+
+		let destroyed = false;
+		let lost = false;
+		device.lost.then((info) => {
+			lost = true;
+			if (!destroyed && import.meta.env.DEV) {
+				console.warn(`[FluidCursor] WebGPU device lost (${info.reason}): ${info.message}`);
+			}
+		});
+		if (import.meta.env.DEV) {
+			device.addEventListener("uncapturederror", (event) => {
+				console.error(
+					"[FluidCursor] WebGPU uncaptured error:",
+					(event as GPUUncapturedErrorEvent).error.message
+				);
+			});
+		}
+
+		const module = device.createShaderModule({ code: WGSL });
+
+		const bindGroupLayout = device.createBindGroupLayout({
+			entries: [
+				{ binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: "uniform" } },
+				{ binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: "filtering" } },
+				{ binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: "filtering" } },
+				{ binding: 3, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: "float" } },
+				{ binding: 4, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: "float" } },
+			],
+		});
+		const pipelineLayout = device.createPipelineLayout({ bindGroupLayouts: [bindGroupLayout] });
+
+		function makePipeline(entryPoint: string, targetFormat: GPUTextureFormat) {
+			return device.createRenderPipeline({
+				layout: pipelineLayout,
+				vertex: { module, entryPoint: "vs" },
+				fragment: { module, entryPoint, targets: [{ format: targetFormat }] },
+				primitive: { topology: "triangle-list" },
+			});
+		}
+
+		const VEL_FORMAT: GPUTextureFormat = "rg16float";
+		const SCALAR_FORMAT: GPUTextureFormat = "r16float";
+		const DYE_FORMAT: GPUTextureFormat = "rgba16float";
+
+		const pipelines = {
+			splatVel: makePipeline("fs_splat", VEL_FORMAT),
+			splatDye: makePipeline("fs_splat", DYE_FORMAT),
+			curl: makePipeline("fs_curl", SCALAR_FORMAT),
+			vorticity: makePipeline("fs_vorticity", VEL_FORMAT),
+			divergence: makePipeline("fs_divergence", SCALAR_FORMAT),
+			clear: makePipeline("fs_clear", SCALAR_FORMAT),
+			pressure: makePipeline("fs_pressure", SCALAR_FORMAT),
+			gradient: makePipeline("fs_gradient", VEL_FORMAT),
+			advectVel: makePipeline("fs_advection", VEL_FORMAT),
+			advectDye: makePipeline("fs_advection", DYE_FORMAT),
+			display: makePipeline("fs_display", format),
+			copyVel: makePipeline("fs_copy", VEL_FORMAT),
+			copyDye: makePipeline("fs_copy", DYE_FORMAT),
+		};
+
+		const smpLinear = device.createSampler({
+			magFilter: "linear",
+			minFilter: "linear",
+			addressModeU: "clamp-to-edge",
+			addressModeV: "clamp-to-edge",
+		});
+		const smpNearest = device.createSampler({
+			magFilter: "nearest",
+			minFilter: "nearest",
+			addressModeU: "clamp-to-edge",
+			addressModeV: "clamp-to-edge",
+		});
+
+		function makeUniformBuffer() {
+			return device.createBuffer({
+				size: U_FLOATS * 4,
+				usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+			});
+		}
+
+		const uSplatVel = makeUniformBuffer();
+		const uSplatDye = makeUniformBuffer();
+		const uCurl = makeUniformBuffer();
+		const uVorticity = makeUniformBuffer();
+		const uDivergence = makeUniformBuffer();
+		const uClear = makeUniformBuffer();
+		const uPressure = makeUniformBuffer();
+		const uGradient = makeUniformBuffer();
+		const uAdvectVel = makeUniformBuffer();
+		const uAdvectDye = makeUniformBuffer();
+		const uDisplay = makeUniformBuffer();
+		const uCopy = makeUniformBuffer();
+
+		const scratch = new Float32Array(U_FLOATS);
+		function writeUniforms(buffer: GPUBuffer, v: UniformValues) {
+			scratch.fill(0);
+			if (v.texelSize) {
+				scratch[OFF_TEXEL] = v.texelSize[0];
+				scratch[OFF_TEXEL + 1] = v.texelSize[1];
+			}
+			if (v.point) {
+				scratch[OFF_POINT] = v.point[0];
+				scratch[OFF_POINT + 1] = v.point[1];
+			}
+			if (v.color) {
+				scratch[OFF_COLOR] = v.color[0];
+				scratch[OFF_COLOR + 1] = v.color[1];
+				scratch[OFF_COLOR + 2] = v.color[2];
+				scratch[OFF_COLOR + 3] = 1;
+			}
+			scratch[OFF_DT] = v.dt ?? 0;
+			scratch[OFF_DISSIPATION] = v.dissipation ?? 0;
+			scratch[OFF_CURL] = v.curlStrength ?? 0;
+			scratch[OFF_CLEAR] = v.clearValue ?? 0;
+			scratch[OFF_ASPECT] = v.aspect ?? 1;
+			scratch[OFF_RADIUS] = v.radius ?? 1;
+			scratch[OFF_EXPOSURE] = v.exposure ?? 1;
+			scratch[OFF_SHADING] = v.shading ?? 0;
+			device.queue.writeBuffer(buffer, 0, scratch);
+		}
+
+		function makeTexture(w: number, h: number, texFormat: GPUTextureFormat) {
+			return device.createTexture({
+				size: { width: w, height: h },
+				format: texFormat,
+				usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+			});
+		}
+
+		function makeDoubleTex(w: number, h: number, texFormat: GPUTextureFormat): DoubleTex {
+			const a = makeTexture(w, h, texFormat);
+			const b = makeTexture(w, h, texFormat);
+			const target: DoubleTex = {
+				read: a,
+				write: b,
+				readView: a.createView(),
+				writeView: b.createView(),
+				width: w,
+				height: h,
+				texelSizeX: 1 / w,
+				texelSizeY: 1 / h,
+				swap() {
+					const t = this.read;
+					const tv = this.readView;
+					this.read = this.write;
+					this.readView = this.writeView;
+					this.write = t;
+					this.writeView = tv;
+				},
+			};
+			return target;
+		}
+
+		function runPass(
+			encoder: GPUCommandEncoder,
+			pipeline: GPURenderPipeline,
+			uniforms: GPUBuffer,
+			tex0: GPUTextureView,
+			tex1: GPUTextureView,
+			target: GPUTextureView
+		) {
+			const bindGroup = device.createBindGroup({
+				layout: bindGroupLayout,
+				entries: [
+					{ binding: 0, resource: { buffer: uniforms } },
+					{ binding: 1, resource: smpLinear },
+					{ binding: 2, resource: smpNearest },
+					{ binding: 3, resource: tex0 },
+					{ binding: 4, resource: tex1 },
+				],
+			});
+			const pass = encoder.beginRenderPass({
+				colorAttachments: [
+					{
+						view: target,
+						loadOp: "clear",
+						storeOp: "store",
+						clearValue: { r: 0, g: 0, b: 0, a: 0 },
+					},
+				],
+			});
+			pass.setPipeline(pipeline);
+			pass.setBindGroup(0, bindGroup);
+			pass.draw(3);
+			pass.end();
+		}
+
+		// --- Simulation state ---
+		let dye: DoubleTex | null = null;
+		let velocity: DoubleTex | null = null;
+		let pressureTex: DoubleTex | null = null;
+		let divergenceTex: GPUTexture | null = null;
+		let divergenceView: GPUTextureView | null = null;
+		let curlTex: GPUTexture | null = null;
+		let curlView: GPUTextureView | null = null;
+
+		function initTextures() {
+			const simRes = getSimResolution(opts.simResolution, canvas.width, canvas.height);
+			const dyeRes = getSimResolution(opts.dyeResolution, canvas.width, canvas.height);
+
+			const oldDye = dye;
+			const oldVelocity = velocity;
+
+			// Canvas resize that leaves grid sizes unchanged (aspect-preserving):
+			// keep the existing textures (mirrors resizeDoubleFBO's early-out).
+			if (
+				oldDye &&
+				oldVelocity &&
+				oldDye.width === dyeRes.width &&
+				oldDye.height === dyeRes.height &&
+				oldVelocity.width === simRes.width &&
+				oldVelocity.height === simRes.height
+			) {
+				return;
+			}
+
+			const newDye = makeDoubleTex(dyeRes.width, dyeRes.height, DYE_FORMAT);
+			const newVelocity = makeDoubleTex(simRes.width, simRes.height, VEL_FORMAT);
+
+			// Preserve existing fluid across resizes by resampling the old
+			// read textures into the new ones (mirrors resizeDoubleFBO).
+			if (oldDye && oldVelocity) {
+				writeUniforms(uCopy, {});
+				const encoder = device.createCommandEncoder();
+				runPass(
+					encoder,
+					pipelines.copyDye,
+					uCopy,
+					oldDye.readView,
+					oldDye.readView,
+					newDye.readView
+				);
+				runPass(
+					encoder,
+					pipelines.copyVel,
+					uCopy,
+					oldVelocity.readView,
+					oldVelocity.readView,
+					newVelocity.readView
+				);
+				device.queue.submit([encoder.finish()]);
+				oldDye.read.destroy();
+				oldDye.write.destroy();
+				oldVelocity.read.destroy();
+				oldVelocity.write.destroy();
+			}
+
+			dye = newDye;
+			velocity = newVelocity;
+
+			pressureTex?.read.destroy();
+			pressureTex?.write.destroy();
+			divergenceTex?.destroy();
+			curlTex?.destroy();
+			pressureTex = makeDoubleTex(simRes.width, simRes.height, SCALAR_FORMAT);
+			divergenceTex = makeTexture(simRes.width, simRes.height, SCALAR_FORMAT);
+			divergenceView = divergenceTex.createView();
+			curlTex = makeTexture(simRes.width, simRes.height, SCALAR_FORMAT);
+			curlView = curlTex.createView();
+		}
+
+		function resizeIfNeeded() {
+			if (destroyed || lost) return;
+			const width = scaleByPixelRatio(canvas.clientWidth);
+			const height = scaleByPixelRatio(canvas.clientHeight);
+			if (width > 0 && height > 0 && (canvas.width !== width || canvas.height !== height)) {
+				canvas.width = width;
+				canvas.height = height;
+				initTextures();
+			}
+		}
+
+		function splat(x: number, y: number, dx: number, dy: number, color: ColorRGB) {
+			if (destroyed || lost || !velocity || !dye) return;
+			const radius = correctRadius(opts.splatRadius / 100, canvas.width, canvas.height);
+			const aspect = canvas.width / canvas.height;
+
+			writeUniforms(uSplatVel, {
+				point: [x, y],
+				color: [dx, dy, 0],
+				aspect,
+				radius,
+			});
+			writeUniforms(uSplatDye, {
+				point: [x, y],
+				color: [color.r, color.g, color.b],
+				aspect,
+				radius,
+			});
+
+			const encoder = device.createCommandEncoder();
+			runPass(
+				encoder,
+				pipelines.splatVel,
+				uSplatVel,
+				velocity.readView,
+				velocity.readView,
+				velocity.writeView
+			);
+			velocity.swap();
+			runPass(encoder, pipelines.splatDye, uSplatDye, dye.readView, dye.readView, dye.writeView);
+			dye.swap();
+			device.queue.submit([encoder.finish()]);
+		}
+
+		function frame(dt: number) {
+			if (destroyed || lost || !velocity || !dye || !pressureTex || !divergenceView || !curlView) {
+				return;
+			}
+
+			const velTexel: [number, number] = [velocity.texelSizeX, velocity.texelSizeY];
+			writeUniforms(uCurl, { texelSize: velTexel });
+			writeUniforms(uVorticity, { texelSize: velTexel, curlStrength: opts.curl, dt });
+			writeUniforms(uDivergence, { texelSize: velTexel });
+			writeUniforms(uClear, { clearValue: opts.pressure });
+			writeUniforms(uPressure, { texelSize: velTexel });
+			writeUniforms(uGradient, { texelSize: velTexel });
+			writeUniforms(uAdvectVel, {
+				texelSize: velTexel,
+				dt,
+				dissipation: opts.velocityDissipation,
+			});
+			writeUniforms(uAdvectDye, {
+				texelSize: velTexel,
+				dt,
+				dissipation: opts.densityDissipation,
+			});
+			writeUniforms(uDisplay, {
+				texelSize: [1 / canvas.width, 1 / canvas.height],
+				exposure: opts.exposure,
+				shading: opts.shading ? 1 : 0,
+			});
+
+			const encoder = device.createCommandEncoder();
+
+			runPass(encoder, pipelines.curl, uCurl, velocity.readView, velocity.readView, curlView);
+
+			runPass(
+				encoder,
+				pipelines.vorticity,
+				uVorticity,
+				velocity.readView,
+				curlView,
+				velocity.writeView
+			);
+			velocity.swap();
+
+			runPass(
+				encoder,
+				pipelines.divergence,
+				uDivergence,
+				velocity.readView,
+				velocity.readView,
+				divergenceView
+			);
+
+			runPass(
+				encoder,
+				pipelines.clear,
+				uClear,
+				pressureTex.readView,
+				pressureTex.readView,
+				pressureTex.writeView
+			);
+			pressureTex.swap();
+
+			for (let i = 0; i < opts.pressureIterations; i++) {
+				runPass(
+					encoder,
+					pipelines.pressure,
+					uPressure,
+					pressureTex.readView,
+					divergenceView,
+					pressureTex.writeView
+				);
+				pressureTex.swap();
+			}
+
+			runPass(
+				encoder,
+				pipelines.gradient,
+				uGradient,
+				pressureTex.readView,
+				velocity.readView,
+				velocity.writeView
+			);
+			velocity.swap();
+
+			runPass(
+				encoder,
+				pipelines.advectVel,
+				uAdvectVel,
+				velocity.readView,
+				velocity.readView,
+				velocity.writeView
+			);
+			velocity.swap();
+
+			runPass(
+				encoder,
+				pipelines.advectDye,
+				uAdvectDye,
+				velocity.readView,
+				dye.readView,
+				dye.writeView
+			);
+			dye.swap();
+
+			runPass(
+				encoder,
+				pipelines.display,
+				uDisplay,
+				dye.readView,
+				dye.readView,
+				context.getCurrentTexture().createView()
+			);
+
+			device.queue.submit([encoder.finish()]);
+		}
+
+		initTextures();
+
+		return {
+			splat,
+			resizeIfNeeded,
+			frame,
+			get lost() {
+				return lost;
+			},
+			destroy() {
+				destroyed = true;
+				device.destroy();
+			},
+		};
+	} catch (error) {
+		if (import.meta.env.DEV) {
+			console.warn("[FluidCursor] WebGPU init failed, falling back to WebGL:", error);
+		}
+		return null;
+	}
+}
+
+/**
+ * Full WebGPU setup for FluidCursor: engine + pointer wiring + rAF loop +
+ * visibility pause + auto splats. Resolves with a cleanup function, or with
+ * `null` when WebGPU is unavailable (caller falls back to the WebGL path).
+ */
+export async function startWebGpuFluid(
+	canvas: HTMLCanvasElement,
+	opts: WebGpuFluidOptions
+): Promise<(() => void) | null> {
+	const maybeEngine = await createWebGpuFluid(canvas, opts);
+	if (!maybeEngine) return null;
+	const engine: FluidEngine = maybeEngine;
+
+	const pointers: Pointer[] = [pointerPrototype()];
+	let animationFrameId = 0;
+	let lastUpdateTime = Date.now();
+	let colorUpdateTimer = 0;
+	let isVisible = true;
+	let stopped = false;
+
+	// --- Pointer position mapping (mirrors the WebGL path) ---
+	let canvasRectCache: DOMRect | null = null;
+	function updateCanvasRectCache() {
+		if (opts.contained) canvasRectCache = canvas.getBoundingClientRect();
+	}
+	function getCanvasPos(clientX: number, clientY: number): { x: number; y: number } {
+		if (opts.contained) {
+			if (!canvasRectCache) updateCanvasRectCache();
+			const rect = canvasRectCache!;
+			return {
+				x: scaleByPixelRatio(clientX - rect.left),
+				y: scaleByPixelRatio(clientY - rect.top),
+			};
+		}
+		return { x: scaleByPixelRatio(clientX), y: scaleByPixelRatio(clientY) };
+	}
+
+	function updatePointerDownData(pointer: Pointer, id: number, posX: number, posY: number) {
+		pointer.id = id;
+		pointer.down = true;
+		pointer.moved = false;
+		pointer.texcoordX = posX / canvas.width;
+		pointer.texcoordY = posY / canvas.height;
+		pointer.prevTexcoordX = pointer.texcoordX;
+		pointer.prevTexcoordY = pointer.texcoordY;
+		pointer.deltaX = 0;
+		pointer.deltaY = 0;
+		pointer.color = opts.generateColor();
+	}
+
+	function updatePointerMoveData(pointer: Pointer, posX: number, posY: number, color: ColorRGB) {
+		pointer.prevTexcoordX = pointer.texcoordX;
+		pointer.prevTexcoordY = pointer.texcoordY;
+		pointer.texcoordX = posX / canvas.width;
+		pointer.texcoordY = posY / canvas.height;
+		pointer.deltaX = correctDeltaX(
+			pointer.texcoordX - pointer.prevTexcoordX,
+			canvas.width,
+			canvas.height
+		);
+		pointer.deltaY = correctDeltaY(
+			pointer.texcoordY - pointer.prevTexcoordY,
+			canvas.width,
+			canvas.height
+		);
+		pointer.moved = Math.abs(pointer.deltaX) > 0 || Math.abs(pointer.deltaY) > 0;
+		pointer.color = color;
+	}
+
+	function splatPointer(pointer: Pointer) {
+		const dx = pointer.deltaX * opts.splatForce;
+		const dy = pointer.deltaY * opts.splatForce;
+		engine.splat(pointer.texcoordX, pointer.texcoordY, dx, dy, pointer.color);
+	}
+
+	function clickSplat(pointer: Pointer) {
+		const color = opts.generateColor();
+		color.r *= 10;
+		color.g *= 10;
+		color.b *= 10;
+		const dx = 10 * (Math.random() - 0.5);
+		const dy = 30 * (Math.random() - 0.5);
+		engine.splat(pointer.texcoordX, pointer.texcoordY, dx, dy, color);
+	}
+
+	function multipleSplats(steps: number) {
+		// Simulate a cursor sweep along a random arc — each step on its own
+		// frame so the velocity field has time to evolve between injections.
+		const angle = Math.random() * Math.PI * 2;
+		const cx = 0.25 + Math.random() * 0.5;
+		const cy = 0.25 + Math.random() * 0.5;
+		const arcSpan = Math.PI * (0.8 + Math.random() * 0.8);
+		let i = 0;
+
+		function step() {
+			if (stopped || i >= steps) return;
+			const t = i / Math.max(1, steps - 1);
+			const a = angle + t * arcSpan;
+			const r = 0.15 + 0.05 * Math.sin(t * Math.PI);
+			const x = cx + Math.cos(a) * r;
+			const y = cy + Math.sin(a) * r;
+			const color = opts.generateColor();
+			engine.splat(
+				x,
+				y,
+				-Math.sin(a) * opts.splatForce * 0.5,
+				Math.cos(a) * opts.splatForce * 0.5,
+				color
+			);
+			i++;
+			if (i < steps) requestAnimationFrame(step);
+		}
+		requestAnimationFrame(step);
+	}
+
+	// --- Frame loop (same ordering as the WebGL path: resize, colors,
+	// inputs, then simulation step + render) ---
+	function updateFrame() {
+		if (stopped || !isVisible) return;
+		// Device loss (GPU reset, driver update): stop the loop instead of
+		// spinning on a dead device. The effect simply disappears.
+		if (engine.lost) return;
+		const now = Date.now();
+		const dt = Math.min((now - lastUpdateTime) / 1000, 0.016666);
+		lastUpdateTime = now;
+
+		engine.resizeIfNeeded();
+
+		colorUpdateTimer += dt * opts.colorUpdateSpeed;
+		if (colorUpdateTimer >= 1) {
+			colorUpdateTimer = colorUpdateTimer % 1;
+			pointers.forEach((p) => {
+				p.color = opts.generateColor();
+			});
+		}
+
+		for (const p of pointers) {
+			if (p.moved) {
+				p.moved = false;
+				splatPointer(p);
+			}
+		}
+
+		engine.frame(dt);
+		animationFrameId = requestAnimationFrame(updateFrame);
+	}
+
+	// --- Event listeners ---
+	function handleMouseDown(e: MouseEvent) {
+		const pointer = pointers[0];
+		const { x: posX, y: posY } = getCanvasPos(e.clientX, e.clientY);
+		updatePointerDownData(pointer, -1, posX, posY);
+		clickSplat(pointer);
+	}
+
+	function handleFirstMouseMove(e: MouseEvent) {
+		const pointer = pointers[0];
+		const { x: posX, y: posY } = getCanvasPos(e.clientX, e.clientY);
+		updatePointerMoveData(pointer, posX, posY, opts.generateColor());
+		document.body.removeEventListener("mousemove", handleFirstMouseMove);
+	}
+
+	function handleMouseMove(e: MouseEvent) {
+		const pointer = pointers[0];
+		const { x: posX, y: posY } = getCanvasPos(e.clientX, e.clientY);
+		updatePointerMoveData(pointer, posX, posY, pointer.color);
+	}
+
+	function handleFirstTouchStart(e: TouchEvent) {
+		const touches = e.targetTouches;
+		const pointer = pointers[0];
+		for (let i = 0; i < touches.length; i++) {
+			const { x: posX, y: posY } = getCanvasPos(touches[i].clientX, touches[i].clientY);
+			updatePointerDownData(pointer, touches[i].identifier, posX, posY);
+		}
+		document.body.removeEventListener("touchstart", handleFirstTouchStart);
+	}
+
+	function handleTouchStart(e: TouchEvent) {
+		const touches = e.targetTouches;
+		const pointer = pointers[0];
+		for (let i = 0; i < touches.length; i++) {
+			const { x: posX, y: posY } = getCanvasPos(touches[i].clientX, touches[i].clientY);
+			updatePointerDownData(pointer, touches[i].identifier, posX, posY);
+		}
+	}
+
+	function handleTouchMove(e: TouchEvent) {
+		const touches = e.targetTouches;
+		const pointer = pointers[0];
+		for (let i = 0; i < touches.length; i++) {
+			const { x: posX, y: posY } = getCanvasPos(touches[i].clientX, touches[i].clientY);
+			updatePointerMoveData(pointer, posX, posY, pointer.color);
+		}
+	}
+
+	if (opts.contained) {
+		window.addEventListener("resize", updateCanvasRectCache, { passive: true });
+		window.addEventListener("scroll", updateCanvasRectCache, { passive: true });
+		updateCanvasRectCache();
+	}
+
+	if (opts.interactive) {
+		window.addEventListener("mousedown", handleMouseDown);
+		document.body.addEventListener("mousemove", handleFirstMouseMove);
+		window.addEventListener("mousemove", handleMouseMove);
+		document.body.addEventListener("touchstart", handleFirstTouchStart);
+		window.addEventListener("touchstart", handleTouchStart, false);
+		window.addEventListener("touchmove", handleTouchMove, false);
+	}
+
+	let observer: IntersectionObserver | null = null;
+	if (opts.pauseWhenHidden) {
+		observer = new IntersectionObserver(
+			([entry]) => {
+				const wasVisible = isVisible;
+				isVisible = entry.isIntersecting;
+				if (isVisible && !wasVisible && !stopped) {
+					lastUpdateTime = Date.now();
+					animationFrameId = requestAnimationFrame(updateFrame);
+				}
+			},
+			{ threshold: 0 }
+		);
+		observer.observe(canvas);
+	}
+
+	updateFrame();
+	if (opts.splatOnMount) multipleSplats(Math.floor(Math.random() * 6) + 10);
+
+	let autoSplatTimer: ReturnType<typeof setInterval> | null = null;
+	if (opts.autoSplat) {
+		autoSplatTimer = setInterval(() => {
+			engine.splat(
+				Math.random(),
+				Math.random(),
+				(Math.random() - 0.5) * 200,
+				(Math.random() - 0.5) * 200,
+				opts.generateColor()
+			);
+		}, opts.autoSplatInterval);
+	}
+
+	return () => {
+		stopped = true;
+		cancelAnimationFrame(animationFrameId);
+		if (observer) observer.disconnect();
+		if (autoSplatTimer) clearInterval(autoSplatTimer);
+		if (opts.interactive) {
+			window.removeEventListener("mousedown", handleMouseDown);
+			document.body.removeEventListener("mousemove", handleFirstMouseMove);
+			window.removeEventListener("mousemove", handleMouseMove);
+			document.body.removeEventListener("touchstart", handleFirstTouchStart);
+			window.removeEventListener("touchstart", handleTouchStart);
+			window.removeEventListener("touchmove", handleTouchMove);
+		}
+		if (opts.contained) {
+			window.removeEventListener("resize", updateCanvasRectCache);
+			window.removeEventListener("scroll", updateCanvasRectCache);
+		}
+		engine.destroy();
+	};
+}

--- a/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
+++ b/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
@@ -297,24 +297,46 @@ async function createWebGpuFluid(
 		const adapter = await gpu.requestAdapter();
 		if (!adapter) return null;
 		const device = await adapter.requestDevice();
+
+		const format: GPUTextureFormat = "rgba16float";
+		// `toneMapping` and `colorSpace` are ignored by browsers that do not
+		// support them yet (WebIDL drops unknown dictionary members), in which
+		// case output is clamped to SDR.
+		const configuration = {
+			device,
+			format,
+			alphaMode: "premultiplied",
+			colorSpace: "display-p3",
+			toneMapping: { mode: "extended" },
+		} as GPUCanvasConfiguration;
+
+		// Probe the configuration on a detached canvas first. Once a canvas
+		// has vended a "webgpu" context it can never provide a WebGL one, so
+		// claiming the visible canvas before knowing configure() succeeds
+		// would break the advertised WebGL fallback.
+		try {
+			const probe = document.createElement("canvas").getContext("webgpu");
+			if (!probe) {
+				device.destroy();
+				return null;
+			}
+			probe.configure(configuration);
+			probe.unconfigure();
+		} catch (error) {
+			device.destroy();
+			if (import.meta.env.DEV) {
+				console.warn("[FluidCursor] WebGPU canvas configuration rejected:", error);
+			}
+			return null;
+		}
+
 		const maybeContext = canvas.getContext("webgpu");
 		if (!maybeContext) {
 			device.destroy();
 			return null;
 		}
 		const context: GPUCanvasContext = maybeContext;
-
-		const format: GPUTextureFormat = "rgba16float";
-		// `toneMapping` and `colorSpace` are ignored by browsers that do not
-		// support them yet (WebIDL drops unknown dictionary members), in which
-		// case output is clamped to SDR.
-		context.configure({
-			device,
-			format,
-			alphaMode: "premultiplied",
-			colorSpace: "display-p3",
-			toneMapping: { mode: "extended" },
-		} as GPUCanvasConfiguration);
+		context.configure(configuration);
 
 		if (import.meta.env.DEV) {
 			// Browsers that do not support toneMapping drop the member, which
@@ -487,6 +509,41 @@ async function createWebGpuFluid(
 			return target;
 		}
 
+		// Bind groups are cached per (uniform buffer, texture views) combination
+		// — the ping-pong swaps only cycle through a small finite set, and
+		// recreating ~30 bind groups per frame (20 of them for the pressure
+		// iterations) is measurable allocation/validation overhead. The cache
+		// is cleared whenever textures are recreated (resize).
+		const bindGroupCache = new Map<string, GPUBindGroup>();
+		const resourceIds = new WeakMap<object, number>();
+		let nextResourceId = 0;
+		function idOf(resource: object): number {
+			let id = resourceIds.get(resource);
+			if (id === undefined) {
+				id = nextResourceId++;
+				resourceIds.set(resource, id);
+			}
+			return id;
+		}
+		function getBindGroup(uniforms: GPUBuffer, tex0: GPUTextureView, tex1: GPUTextureView) {
+			const key = `${idOf(uniforms)}:${idOf(tex0)}:${idOf(tex1)}`;
+			let bindGroup = bindGroupCache.get(key);
+			if (!bindGroup) {
+				bindGroup = device.createBindGroup({
+					layout: bindGroupLayout,
+					entries: [
+						{ binding: 0, resource: { buffer: uniforms } },
+						{ binding: 1, resource: smpLinear },
+						{ binding: 2, resource: smpNearest },
+						{ binding: 3, resource: tex0 },
+						{ binding: 4, resource: tex1 },
+					],
+				});
+				bindGroupCache.set(key, bindGroup);
+			}
+			return bindGroup;
+		}
+
 		function runPass(
 			encoder: GPUCommandEncoder,
 			pipeline: GPURenderPipeline,
@@ -495,16 +552,7 @@ async function createWebGpuFluid(
 			tex1: GPUTextureView,
 			target: GPUTextureView
 		) {
-			const bindGroup = device.createBindGroup({
-				layout: bindGroupLayout,
-				entries: [
-					{ binding: 0, resource: { buffer: uniforms } },
-					{ binding: 1, resource: smpLinear },
-					{ binding: 2, resource: smpNearest },
-					{ binding: 3, resource: tex0 },
-					{ binding: 4, resource: tex1 },
-				],
-			});
+			const bindGroup = getBindGroup(uniforms, tex0, tex1);
 			const pass = encoder.beginRenderPass({
 				colorAttachments: [
 					{
@@ -583,6 +631,9 @@ async function createWebGpuFluid(
 
 			dye = newDye;
 			velocity = newVelocity;
+
+			// Cached bind groups reference the destroyed texture views.
+			bindGroupCache.clear();
 
 			pressureTex?.read.destroy();
 			pressureTex?.write.destroy();

--- a/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
+++ b/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
@@ -608,11 +608,10 @@ async function createWebGpuFluid(
 
 		function splat(x: number, y: number, dx: number, dy: number, color: ColorRGB) {
 			if (destroyed || lost || !velocity || !dye) return;
-			let baseRadius = opts.splatRadius / 100;
+			let radius = correctRadius(opts.splatRadius / 100, canvas.width, canvas.height);
 			if (opts.contained) {
-				baseRadius = scaleRadiusForContainer(baseRadius, canvas.clientHeight, window.innerHeight);
+				radius = scaleRadiusForContainer(radius, canvas.clientHeight, window.innerHeight);
 			}
-			const radius = correctRadius(baseRadius, canvas.width, canvas.height);
 			const aspect = canvas.width / canvas.height;
 
 			writeUniforms(uSplatVel, {

--- a/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
+++ b/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
@@ -21,6 +21,7 @@ import {
 	correctDeltaY,
 	correctRadius,
 	getSimResolution,
+	scaleRadiusForContainer,
 } from "./fluid-shared.js";
 
 export interface WebGpuFluidOptions {
@@ -607,7 +608,11 @@ async function createWebGpuFluid(
 
 		function splat(x: number, y: number, dx: number, dy: number, color: ColorRGB) {
 			if (destroyed || lost || !velocity || !dye) return;
-			const radius = correctRadius(opts.splatRadius / 100, canvas.width, canvas.height);
+			let baseRadius = opts.splatRadius / 100;
+			if (opts.contained) {
+				baseRadius = scaleRadiusForContainer(baseRadius, canvas.clientHeight, window.innerHeight);
+			}
+			const radius = correctRadius(baseRadius, canvas.width, canvas.height);
 			const aspect = canvas.width / canvas.height;
 
 			writeUniforms(uSplatVel, {

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -969,6 +969,19 @@ export const registry: Record<string, ComponentMeta> = {
 				default: "true",
 				description: "Confine simulation to parent container",
 			},
+			{
+				name: "hdr",
+				type: "boolean",
+				default: "false",
+				description:
+					"Render via the WebGPU HDR engine (wide gamut + brighter-than-white glow on HDR displays), with automatic WebGL fallback",
+			},
+			{
+				name: "hdrBoost",
+				type: "number",
+				default: "1.5",
+				description: "Display exposure multiplier in HDR mode, clamped to [1, 4]",
+			},
 		],
 	},
 

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -974,7 +974,7 @@ export const registry: Record<string, ComponentMeta> = {
 				type: "boolean",
 				default: "false",
 				description:
-					"Render via the WebGPU HDR engine (wide gamut + brighter-than-white glow on HDR displays), with automatic WebGL fallback",
+					"Render via the WebGPU HDR engine — wide gamut + brighter-than-white glow on HDR displays. Needs Chrome/Edge 129+ or Safari 26+; falls back to wide-gamut WebGL (Chrome 104+, Safari 16.4+, Firefox 132+), then to standard rendering",
 			},
 			{
 				name: "hdrBoost",
@@ -2347,8 +2347,7 @@ export const registry: Record<string, ComponentMeta> = {
 				name: "font",
 				type: "string",
 				default: '""',
-				description:
-					"Font family; empty string resolves via getComputedStyle(host).fontFamily",
+				description: "Font family; empty string resolves via getComputedStyle(host).fontFamily",
 			},
 			{
 				name: "fontSize",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -149,7 +149,7 @@
 >
 	<!-- Fluid Cursor + Interactive Grid (lazy) -->
 	{#if showInteractiveElements}
-		<FluidCursor simResolution={128} />
+		<FluidCursor simResolution={128} hdr hdrBoost={2} splatOnMount />
 		<InteractiveGridPattern
 			width={80}
 			height={80}


### PR DESCRIPTION
## Summary

New `hdr` + `hdrBoost` props on **FluidCursor**. With `hdr` enabled, the simulation renders through a new WebGPU engine — a WGSL port of the fluid solver — into an `rgba16float` / `display-p3` canvas configured with `toneMapping: { mode: "extended" }`. Dye values pushed above 1.0 by the exposure boost render **brighter than SDR white** on HDR displays; on wide-gamut screens colors are markedly more saturated.

```svelte
<FluidCursor hdr hdrBoost={2} fluidColors={["#a142ff", "#42cfff"]} />
```

## Support cascade (silent, logged in dev)

1. `webgpu-hdr` — Chrome/Edge 129+, Safari 26+ (real HDR glow). Detected honestly via `context.getConfiguration()`: browsers that drop `toneMapping` are reported as clamped.
2. `webgl-p3` — no WebGPU: existing WebGL renderer with a `display-p3` backbuffer (Chrome 104+/Safari 16.4+/Firefox 132+), wide gamut only.
3. `sdr` — unchanged default rendering. **`hdr={false}` is behavior-identical to develop** (verified by whitespace-insensitive diff during review).

## Implementation

- `webgpu-engine.ts` — WGSL port of all passes (splat, curl, vorticity, divergence, clear, pressure Jacobi, gradient subtract, advection, display) + pointer/loop wiring; resize preserves fluid via copy passes; device-loss stops the loop; `.catch` falls back to WebGL if wiring fails post-init.
- `fluid-shared.ts` — pure helpers extracted from the component, shared by both engines.
- Adversarial review (2 rounds) caught and fixed: per-pass vertical mirroring from WebGPU texture-coordinate conventions (uv y-flip + top-origin pointer texcoords), an incorrect gamma conversion in the display shader, missing promise rejection fallback, dead rAF loop on device loss, needless texture realloc on aspect-preserving resizes.
- Verified live in Chrome on a P3/HDR display: engine active, correct splat orientation, resize preservation, WebGL demos on the same page unaffected.

## Dependencies

Zero runtime deps added. One **devDependency**: `@webgpu/types` (WebGPU TS types were previously only reachable through a transitive typings package — now explicit).

## Gates

- `pnpm check:registry` — parity OK (61)
- `pnpm check` — 0 errors
- `pnpm test` — 504 passing (3 new HDR cases)
- `pnpm build` — OK
- Prettier — clean

Changeset: minor.