### PR TITLE
feat(site): GitHub star count on the landing hero and docs header

### DIFF
--- a/.changeset/github-stars-badge.md
+++ b/.changeset/github-stars-badge.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": patch
+---
+
+Docs & landing: live GitHub star count next to the GitHub links (fetched client-side, cached for 1h, hidden when the API is unreachable).

--- a/src/lib/components/docs/DocHeader.svelte
+++ b/src/lib/components/docs/DocHeader.svelte
@@ -3,6 +3,7 @@
 	import { t } from "$lib/stores";
 	import ThemeSwitcher from "$lib/components/docs/ThemeSwitcher.svelte";
 	import LanguageSwitcher from "$lib/components/docs/LanguageSwitcher.svelte";
+	import GitHubStars from "$lib/components/docs/GitHubStars.svelte";
 
 	interface Props {
 		onMenuClick?: () => void;
@@ -95,7 +96,7 @@
 			href="https://github.com/ramaherbin/fancy-ui"
 			target="_blank"
 			rel="noopener noreferrer"
-			class="text-muted-foreground hover:text-foreground flex h-9 w-9 items-center justify-center rounded-md transition-colors"
+			class="text-muted-foreground hover:text-foreground flex h-9 items-center gap-1.5 rounded-md px-2 transition-colors"
 			aria-label={t("a11y.github")}
 		>
 			<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
@@ -103,6 +104,7 @@
 					d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"
 				/>
 			</svg>
+			<GitHubStars class="text-xs" />
 		</a>
 
 		<LanguageSwitcher />

--- a/src/lib/components/docs/GitHubStars.svelte
+++ b/src/lib/components/docs/GitHubStars.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { cn } from "$lib/utils.js";
+
+	interface Props {
+		repo?: string;
+		class?: string;
+	}
+
+	let { repo = "ramaherbin/fancy-ui", class: className = "" }: Props = $props();
+
+	const CACHE_KEY = "fancyui:github-stars";
+	const CACHE_TTL = 60 * 60 * 1000; // 1h — avoids hammering the unauthenticated API (60 req/h/IP)
+
+	let stars = $state<number | null>(null);
+
+	const formatted = $derived(
+		stars === null
+			? null
+			: new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(stars)
+	);
+
+	onMount(async () => {
+		try {
+			const cached = localStorage.getItem(CACHE_KEY);
+			if (cached) {
+				const { value, at } = JSON.parse(cached) as { value: number; at: number };
+				if (typeof value === "number" && Date.now() - at < CACHE_TTL) {
+					stars = value;
+					return;
+				}
+			}
+		} catch {
+			// Corrupt cache: ignore and refetch.
+		}
+
+		try {
+			const res = await fetch(`https://api.github.com/repos/${repo}`);
+			if (!res.ok) return;
+			const data = (await res.json()) as { stargazers_count?: unknown };
+			if (typeof data.stargazers_count === "number") {
+				stars = data.stargazers_count;
+				localStorage.setItem(CACHE_KEY, JSON.stringify({ value: stars, at: Date.now() }));
+			}
+		} catch {
+			// Offline or rate-limited: render nothing.
+		}
+	});
+</script>
+
+{#if formatted}
+	<span class={cn("inline-flex items-center gap-1 tabular-nums", className)}>
+		<svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+			<path
+				d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+			/>
+		</svg>
+		{formatted}
+	</span>
+{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,6 +20,7 @@
 	} from "$lib/fancy-ui";
 	import type { TimelineItem, TooltipItem } from "$lib/fancy-ui";
 	import SynthwaveGrid from "$lib/components/SynthwaveGrid.svelte";
+	import GitHubStars from "$lib/components/docs/GitHubStars.svelte";
 
 	let showInteractiveElements = $state(false);
 
@@ -198,6 +199,7 @@
 					/>
 				</svg>
 				GitHub
+				<GitHubStars class="border-l border-white/15 pl-2 text-white/60" />
 			</a>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

Live GitHub star count displayed in two places:

- **Landing hero** — inside the existing GitHub button, after a subtle separator: `GitHub | ★ 21`
- **Docs header** — next to the GitHub icon: `⌂ ★ 21`

## Implementation

New site component `src/lib/components/docs/GitHubStars.svelte` (not part of the published library):

- Client-side fetch of `api.github.com/repos/ramaherbin/fancy-ui` on mount
- Compact formatting via `Intl.NumberFormat` (1.2k style)
- 1h `localStorage` cache — stays far under the unauthenticated API rate limit (60 req/h/IP)
- Renders nothing when offline/rate-limited/failed: no layout breakage, links keep working as before

## Gates

`pnpm check` 0 errors, Prettier clean. Verified live in Chrome on both pages (real count rendered). Changeset: patch.