### PR TITLE
chore(docs): i18n parity gate, compile-time catalog typing, category-label dedup

### DIFF
--- a/.changeset/docs-i18n-parity-tooling.md
+++ b/.changeset/docs-i18n-parity-tooling.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": patch
+---
+
+Docs: lock the localization system down — a CI parity gate (`pnpm check:i18n`) plus compile-time key checking (`satisfies Catalog`) across all 16 catalogs, typed `tCategory()`/`docTitle()` helpers replacing five unchecked casts and six hand-built title strings, and translated category/status badges in the component gallery (they were stuck in English next to translated headings).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm check:registry
+      - run: pnpm check:i18n
       - run: pnpm check
       - run: pnpm test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,19 @@ pnpm check         # svelte-check type checking
 
 `pnpm test` and `pnpm test:e2e` must pass. `pnpm check` must pass for any files you touched — pre-existing errors in unrelated files are acceptable.
 
+## Docs translations (i18n)
+
+The docs site is localized through a single mechanism: **message catalogs** in `src/lib/i18n/messages/`. `en.ts` is the source of truth; every other `<code>.ts` file translates the exact same keys and is looked up at runtime by `t()` (from `$lib/stores`), which falls back to English per key.
+
+**Adding a UI string:** add the key to `en.ts` first, then add its translation to all other catalogs. Two gates keep the catalogs honest:
+
+- `satisfies Catalog` on every translated catalog makes a missing, extra, or typo'd key a compile error (`pnpm check`).
+- `pnpm check:i18n` verifies locale registry ↔ catalog files ↔ key parity ↔ the RTL map in `src/app.html`, and runs in CI.
+
+**Adding a locale:** add an entry to `src/lib/i18n/locales.ts`, drop a full `src/lib/i18n/messages/<code>.ts` catalog (`export default { … } satisfies Catalog;`), and if the language is RTL, mirror it in the pre-paint `RTL` map in `src/app.html`.
+
+**What stays English:** component names, and the registry descriptions in `src/lib/fancy-ui/registry.ts` (including `categoryLabels`/`categoryDescriptions`) — they are the machine-facing source feeding `/llms.txt` and the Component Copilot. Docs UI must not render them as display text; use the translated `category.*` keys (via `tCategory()`) instead.
+
 ## Storybook
 
 Storybook documents and develops components in isolation, with live prop controls and autodocs.
@@ -159,10 +172,10 @@ and a complete CHANGELOG exists.
 
 fancy-ui uses a two-branch model:
 
-| Branch | Role |
-|---|---|
-| `develop` | Integration branch — all feature/fix PRs target here |
-| `main` | Release branch — only merged from `develop`, triggers publishing |
+| Branch    | Role                                                             |
+| --------- | ---------------------------------------------------------------- |
+| `develop` | Integration branch — all feature/fix PRs target here             |
+| `main`    | Release branch — only merged from `develop`, triggers publishing |
 
 ### Full cycle
 
@@ -184,11 +197,11 @@ fancy-ui uses a two-branch model:
 
 ### CI pipelines at a glance
 
-| Trigger | Pipeline | Blocking? | What it checks |
-|---|---|---|---|
-| PR → `develop` | CI | ✅ Yes | type-check, tests, changeset present |
-| PR → `main` | CI | ✅ Yes | type-check, tests |
-| Push to `main` | Release | — | builds + publish or opens "Version Packages" PR |
+| Trigger        | Pipeline | Blocking? | What it checks                                  |
+| -------------- | -------- | --------- | ----------------------------------------------- |
+| PR → `develop` | CI       | ✅ Yes    | type-check, tests, changeset present            |
+| PR → `main`    | CI       | ✅ Yes    | type-check, tests                               |
+| Push to `main` | Release  | —         | builds + publish or opens "Version Packages" PR |
 
 ### Secrets required
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"check:registry": "node scripts/check-registry.mjs",
+		"check:i18n": "node scripts/check-i18n.mjs",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:e2e": "playwright test",

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * i18n parity check.
+ *
+ * Verifies that four sources of truth agree:
+ *   1. Locale entries in `src/lib/i18n/locales.ts` (the `locales` array)
+ *   2. Message catalogs in `src/lib/i18n/messages/<code>.ts`
+ *   3. The key set of every catalog vs `en.ts` (the source of truth)
+ *   4. The pre-paint RTL map in `src/app.html` vs `dir: "rtl"` locales
+ *
+ * Also requires every non-en catalog to carry `satisfies Catalog`, which is
+ * what gives svelte-check compile-time key checking — this script guards the
+ * guard. Exits non-zero on any drift.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const localesPath = join(repoRoot, "src", "lib", "i18n", "locales.ts");
+const messagesDir = join(repoRoot, "src", "lib", "i18n", "messages");
+const appHtmlPath = join(repoRoot, "src", "app.html");
+
+function parseLocales() {
+	const src = readFileSync(localesPath, "utf8");
+	const bodyMatch = src.match(/export\s+const\s+locales[^=]*=\s*\[([\s\S]*?)^\];/m);
+	if (!bodyMatch) throw new Error("Could not locate `export const locales` in locales.ts");
+	const entries = [];
+	const re = /\{\s*code:\s*"([^"]+)"[^}]*?dir:\s*"(ltr|rtl)"[^}]*\}/g;
+	let m;
+	while ((m = re.exec(bodyMatch[1])) !== null) {
+		entries.push({ code: m[1], dir: m[2] });
+	}
+	if (entries.length === 0) throw new Error("Parsed zero locale entries from locales.ts");
+	return entries;
+}
+
+function listCatalogFiles() {
+	return readdirSync(messagesDir)
+		.filter((name) => name.endsWith(".ts") && name !== "index.ts")
+		.map((name) => name.replace(/\.ts$/, ""))
+		.sort();
+}
+
+function parseCatalogKeys(code) {
+	const src = readFileSync(join(messagesDir, `${code}.ts`), "utf8");
+	const keys = [];
+	const re = /^[\t ]*"([^"]+)"\s*:/gm;
+	let m;
+	while ((m = re.exec(src)) !== null) keys.push(m[1]);
+	return { keys, src };
+}
+
+function parseAppHtmlRtl() {
+	const src = readFileSync(appHtmlPath, "utf8");
+	const mapMatch = src.match(/var\s+RTL\s*=\s*\{([^}]*)\}/);
+	if (!mapMatch) throw new Error("Could not locate `var RTL = {...}` in src/app.html");
+	return [...mapMatch[1].matchAll(/([a-zA-Z-]+)\s*:/g)].map((m) => m[1]).sort();
+}
+
+function diff(expected, actual) {
+	const expSet = new Set(expected);
+	const actSet = new Set(actual);
+	const missing = expected.filter((x) => !actSet.has(x));
+	const extra = actual.filter((x) => !expSet.has(x));
+	return missing.length || extra.length ? { missing, extra } : null;
+}
+
+function main() {
+	const locales = parseLocales();
+	const codes = locales.map((l) => l.code).sort();
+	const catalogFiles = listCatalogFiles();
+	const issues = [];
+
+	// 1. locales.ts <-> catalog files
+	const fileDiff = diff(codes, catalogFiles);
+	if (fileDiff) {
+		issues.push(
+			`[locales.ts vs messages/*.ts]\n    missing catalog: ${fileDiff.missing.join(", ") || "-"}\n    orphan catalog:  ${fileDiff.extra.join(", ") || "-"}`
+		);
+	}
+
+	// 2. Key parity + duplicates + `satisfies Catalog`
+	const { keys: enKeys } = parseCatalogKeys("en");
+	for (const code of catalogFiles) {
+		const { keys, src } = parseCatalogKeys(code);
+		const dupes = [...new Set(keys.filter((k, i) => keys.indexOf(k) !== i))];
+		if (dupes.length) issues.push(`[${code}.ts] duplicate keys: ${dupes.join(", ")}`);
+		if (code === "en") continue;
+		const keyDiff = diff(enKeys, keys);
+		if (keyDiff) {
+			issues.push(
+				`[${code}.ts vs en.ts]\n    missing: ${keyDiff.missing.join(", ") || "-"}\n    extra:   ${keyDiff.extra.join(", ") || "-"}`
+			);
+		}
+		if (!src.includes("satisfies Catalog")) {
+			issues.push(`[${code}.ts] catalog does not end with \`satisfies Catalog\``);
+		}
+	}
+
+	// 3. app.html pre-paint RTL map <-> locales.ts dir fields
+	const rtlFromLocales = locales
+		.filter((l) => l.dir === "rtl")
+		.map((l) => l.code)
+		.sort();
+	const rtlFromHtml = parseAppHtmlRtl();
+	const rtlDiff = diff(rtlFromLocales, rtlFromHtml);
+	if (rtlDiff) {
+		issues.push(
+			`[app.html RTL map vs locales.ts]\n    missing in app.html: ${rtlDiff.missing.join(", ") || "-"}\n    extra in app.html:   ${rtlDiff.extra.join(", ") || "-"}`
+		);
+	}
+
+	if (issues.length === 0) {
+		console.log(`i18n parity OK (${catalogFiles.length} locales x ${enKeys.length} keys).`);
+		process.exit(0);
+	}
+
+	console.error("i18n parity check FAILED.\n");
+	for (const issue of issues) console.error(`  ${issue}\n`);
+	process.exit(1);
+}
+
+main();

--- a/src/app.html
+++ b/src/app.html
@@ -25,6 +25,8 @@
 					// Locale (docs routes only): set lang + dir before paint.
 					// Precedence: ?lang= → saved → navigator.language. RTL for ar/fa.
 					if (location.pathname.indexOf("/docs") === 0) {
+						// Must mirror the `dir: "rtl"` entries in src/lib/i18n/locales.ts —
+						// enforced by scripts/check-i18n.mjs.
 						var RTL = { ar: 1, fa: 1 };
 						var loc =
 							new URLSearchParams(location.search).get("lang") ||

--- a/src/lib/components/docs/CommandSearch.svelte
+++ b/src/lib/components/docs/CommandSearch.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
 	import { searchComponents, getAllComponents } from "$lib/fancy-ui/registry.js";
-	import { t } from "$lib/stores";
-	import type { MessageKey } from "$lib/i18n/messages/en.js";
+	import { t, tCategory } from "$lib/stores";
 
 	interface Props {
 		open?: boolean;
@@ -54,7 +53,7 @@
 						name: c.name,
 						slug: c.slug,
 						href: `/docs/components/${c.slug}`,
-						category: t(`category.${c.category}` as MessageKey),
+						category: tCategory(c.category),
 						type: "component" as const,
 					})),
 			];
@@ -70,7 +69,7 @@
 				name: c.name,
 				slug: c.slug,
 				href: `/docs/components/${c.slug}`,
-				category: t(`category.${c.category}` as MessageKey),
+				category: tCategory(c.category),
 				type: "component" as const,
 			}));
 

--- a/src/lib/components/docs/ComponentCard.svelte
+++ b/src/lib/components/docs/ComponentCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { ComponentMeta } from "$lib/types.js";
-	import { categoryLabels } from "$lib/fancy-ui/registry.js";
+	import { t, tCategory } from "$lib/stores";
 
 	interface Props {
 		component: ComponentMeta;
@@ -36,13 +36,13 @@
 		<p class="text-muted-foreground line-clamp-2 text-xs">{component.description}</p>
 		<div class="mt-auto flex items-center gap-2 pt-2">
 			<span class="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-[10px] font-medium">
-				{categoryLabels[component.category]}
+				{tCategory(component.category)}
 			</span>
 			{#if component.status === "done"}
 				<span
 					class="rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400"
 				>
-					Stable
+					{t("status.stable")}
 				</span>
 			{/if}
 		</div>

--- a/src/lib/components/docs/ComponentCard.test.ts
+++ b/src/lib/components/docs/ComponentCard.test.ts
@@ -1,0 +1,40 @@
+import { render, cleanup } from "@testing-library/svelte";
+import { afterEach, describe, it, expect } from "vitest";
+import ComponentCard from "./ComponentCard.svelte";
+import { setLocale } from "$lib/stores";
+import type { ComponentMeta } from "$lib/types.js";
+
+const component: ComponentMeta = {
+	slug: "rainbow-button",
+	name: "RainbowButton",
+	description: "Animated rainbow gradient border effect",
+	category: "buttons",
+	status: "done",
+};
+
+describe("ComponentCard", () => {
+	afterEach(() => {
+		cleanup();
+		setLocale("en");
+	});
+
+	it("renders the translated category and status badges (regression: gallery showed English badges)", () => {
+		const { container } = render(ComponentCard, { component });
+		const badges = Array.from(container.querySelectorAll("span.rounded-full")).map((b) =>
+			b.textContent?.trim()
+		);
+		expect(badges).toContain("Buttons");
+		expect(badges).toContain("Stable");
+	});
+
+	it("re-renders badges in the active locale", () => {
+		setLocale("ja");
+		const { container } = render(ComponentCard, { component });
+		const badges = Array.from(container.querySelectorAll("span.rounded-full")).map((b) =>
+			b.textContent?.trim()
+		);
+		expect(badges).toContain("ボタン");
+		expect(badges).toContain("安定版");
+		expect(badges).not.toContain("Buttons");
+	});
+});

--- a/src/lib/components/docs/Sidebar.svelte
+++ b/src/lib/components/docs/Sidebar.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { page } from "$app/stores";
 	import { categories, getComponentsGroupedByCategory } from "$lib/fancy-ui/registry.js";
-	import { t } from "$lib/stores";
-	import type { MessageKey } from "$lib/i18n/messages/en.js";
+	import { t, tCategory } from "$lib/stores";
 
 	interface Props {
 		open?: boolean;
@@ -107,7 +106,7 @@
 						onclick={() => toggleCategory(category)}
 						class="text-sidebar-foreground/50 hover:text-sidebar-foreground/70 flex w-full items-center justify-between px-2 py-1 text-xs font-semibold tracking-wider uppercase"
 					>
-						{t(`category.${category}` as MessageKey)}
+						{tCategory(category)}
 						<svg
 							class="h-3 w-3 transition-transform {collapsed ? '' : 'rotate-90'}"
 							fill="none"

--- a/src/lib/i18n/messages/ar.ts
+++ b/src/lib/i18n/messages/ar.ts
@@ -1,4 +1,6 @@
 // Arabic (ar) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "بدء الاستخدام",
@@ -271,4 +273,4 @@ export default {
 	"changelog.major": "تغييرات كبرى",
 	"changelog.minor": "تغييرات صغرى",
 	"changelog.patch": "تغييرات الإصلاح",
-};
+} satisfies Catalog;

--- a/src/lib/i18n/messages/cs.ts
+++ b/src/lib/i18n/messages/cs.ts
@@ -1,4 +1,6 @@
 // Czech (cs) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "Začínáme",
@@ -277,4 +279,4 @@ export default {
 	"changelog.major": "Velké změny",
 	"changelog.minor": "Menší změny",
 	"changelog.patch": "Opravy",
-};
+} satisfies Catalog;

--- a/src/lib/i18n/messages/de.ts
+++ b/src/lib/i18n/messages/de.ts
@@ -1,4 +1,6 @@
 // German (de) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "Erste Schritte",
@@ -281,4 +283,4 @@ export default {
 	"changelog.major": "Größere Änderungen",
 	"changelog.minor": "Kleinere Änderungen",
 	"changelog.patch": "Patch-Änderungen",
-};
+} satisfies Catalog;

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -287,4 +287,11 @@ export const en = {
 export type Messages = typeof en;
 export type MessageKey = keyof Messages;
 
+/**
+ * Shape every translated catalog must satisfy: all of en's keys, string
+ * values. `satisfies Catalog` on a catalog literal turns a missing, extra,
+ * or typo'd key into a compile error (enforced by scripts/check-i18n.mjs).
+ */
+export type Catalog = Record<MessageKey, string>;
+
 export default en;

--- a/src/lib/i18n/messages/es.ts
+++ b/src/lib/i18n/messages/es.ts
@@ -1,4 +1,6 @@
 // Spanish (es) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "Primeros pasos",
@@ -281,4 +283,4 @@ export default {
 	"changelog.major": "Cambios mayores",
 	"changelog.minor": "Cambios menores",
 	"changelog.patch": "Cambios de parche",
-} as const;
+} satisfies Catalog;

--- a/src/lib/i18n/messages/fa.ts
+++ b/src/lib/i18n/messages/fa.ts
@@ -1,4 +1,6 @@
 // Persian (fa) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "شروع به کار",
@@ -279,4 +281,4 @@ export default {
 	"changelog.major": "تغییرات عمده",
 	"changelog.minor": "تغییرات فرعی",
 	"changelog.patch": "تغییرات وصله‌ای",
-};
+} satisfies Catalog;

--- a/src/lib/i18n/messages/fr.ts
+++ b/src/lib/i18n/messages/fr.ts
@@ -1,4 +1,6 @@
 // French (fr) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "Prise en main",
@@ -285,4 +287,4 @@ export default {
 	"changelog.major": "Changements majeurs",
 	"changelog.minor": "Changements mineurs",
 	"changelog.patch": "Correctifs",
-};
+} satisfies Catalog;

--- a/src/lib/i18n/messages/hi.ts
+++ b/src/lib/i18n/messages/hi.ts
@@ -1,4 +1,6 @@
 // Hindi (hi) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "शुरू करें",
@@ -277,4 +279,4 @@ export default {
 	"changelog.major": "बड़े बदलाव",
 	"changelog.minor": "छोटे बदलाव",
 	"changelog.patch": "पैच बदलाव",
-};
+} satisfies Catalog;

--- a/src/lib/i18n/messages/id.ts
+++ b/src/lib/i18n/messages/id.ts
@@ -1,4 +1,6 @@
 // Indonesian (id) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "Memulai",
@@ -278,4 +280,4 @@ export default {
 	"changelog.major": "Perubahan besar",
 	"changelog.minor": "Perubahan kecil",
 	"changelog.patch": "Perubahan patch",
-};
+} satisfies Catalog;

--- a/src/lib/i18n/messages/index.ts
+++ b/src/lib/i18n/messages/index.ts
@@ -5,14 +5,14 @@
  * so adding a locale is just dropping a file (its default export is the catalog).
  */
 
-import type { Messages } from "./en.js";
+import type { Catalog } from "./en.js";
 
 const modules = import.meta.glob("./*.ts", { eager: true }) as Record<
 	string,
-	{ default?: Partial<Messages> }
+	{ default?: Catalog }
 >;
 
-export const catalogs: Record<string, Partial<Messages>> = {};
+export const catalogs: Record<string, Catalog> = {};
 
 for (const [path, mod] of Object.entries(modules)) {
 	const code = path.match(/\.\/(.+)\.ts$/)?.[1];

--- a/src/lib/i18n/messages/it.ts
+++ b/src/lib/i18n/messages/it.ts
@@ -1,4 +1,6 @@
 // Italian (it) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "Per iniziare",
@@ -280,4 +282,4 @@ export default {
 	"changelog.major": "Modifiche principali",
 	"changelog.minor": "Modifiche minori",
 	"changelog.patch": "Modifiche patch",
-};
+} satisfies Catalog;

--- a/src/lib/i18n/messages/ja.ts
+++ b/src/lib/i18n/messages/ja.ts
@@ -1,4 +1,6 @@
 // Japanese (ja) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "スタートガイド",
@@ -283,4 +285,4 @@ export default {
 	"changelog.major": "メジャー変更",
 	"changelog.minor": "マイナー変更",
 	"changelog.patch": "パッチ変更",
-};
+} satisfies Catalog;

--- a/src/lib/i18n/messages/ko.ts
+++ b/src/lib/i18n/messages/ko.ts
@@ -1,4 +1,6 @@
 // Korean (ko) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "시작하기",
@@ -275,4 +277,4 @@ export default {
 	"changelog.major": "메이저 변경",
 	"changelog.minor": "마이너 변경",
 	"changelog.patch": "패치 변경",
-};
+} satisfies Catalog;

--- a/src/lib/i18n/messages/pl.ts
+++ b/src/lib/i18n/messages/pl.ts
@@ -1,4 +1,6 @@
 // Polish (pl) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "Pierwsze kroki",
@@ -280,4 +282,4 @@ export default {
 	"changelog.major": "Zmiany główne",
 	"changelog.minor": "Zmiany pomniejsze",
 	"changelog.patch": "Poprawki",
-} as const;
+} satisfies Catalog;

--- a/src/lib/i18n/messages/pt.ts
+++ b/src/lib/i18n/messages/pt.ts
@@ -1,4 +1,6 @@
 // Portuguese (pt) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "Primeiros passos",
@@ -279,4 +281,4 @@ export default {
 	"changelog.major": "Alterações principais",
 	"changelog.minor": "Alterações secundárias",
 	"changelog.patch": "Correções",
-} as const;
+} satisfies Catalog;

--- a/src/lib/i18n/messages/tr.ts
+++ b/src/lib/i18n/messages/tr.ts
@@ -1,4 +1,6 @@
 // Turkish (tr) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	// Sidebar / nav
 	"nav.gettingStarted": "Başlarken",
@@ -282,4 +284,4 @@ export default {
 	"changelog.major": "Büyük değişiklikler",
 	"changelog.minor": "Küçük değişiklikler",
 	"changelog.patch": "Yama değişiklikleri",
-};
+} satisfies Catalog;

--- a/src/lib/i18n/messages/zh-Hans.ts
+++ b/src/lib/i18n/messages/zh-Hans.ts
@@ -1,4 +1,6 @@
 // Simplified Chinese (zh-Hans) — machine-translated draft. TODO: native review.
+import type { Catalog } from "./en.js";
+
 export default {
 	"nav.gettingStarted": "快速开始",
 	"nav.components": "组件",
@@ -244,4 +246,4 @@ export default {
 	"changelog.major": "重大变更",
 	"changelog.minor": "次要变更",
 	"changelog.patch": "补丁变更",
-} as const;
+} satisfies Catalog;

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -20,4 +20,13 @@ export {
 	createThemeState,
 } from "./theme.svelte.js";
 
-export { setLocale, getLocale, getDir, t, createI18n, applyForRoute } from "./locale.svelte.js";
+export {
+	setLocale,
+	getLocale,
+	getDir,
+	t,
+	tCategory,
+	docTitle,
+	createI18n,
+	applyForRoute,
+} from "./locale.svelte.js";

--- a/src/lib/stores/locale.svelte.ts
+++ b/src/lib/stores/locale.svelte.ts
@@ -10,6 +10,7 @@ import { browser } from "$app/environment";
 import { locales, defaultLocale, getLocaleDef, type Dir } from "$lib/i18n/locales.js";
 import { en, type MessageKey } from "$lib/i18n/messages/en.js";
 import { catalogs } from "$lib/i18n/messages/index.js";
+import type { ComponentCategory } from "$lib/types.js";
 
 const STORAGE_KEY = "fancy-ui-locale";
 
@@ -115,6 +116,20 @@ export function getDir(): Dir {
 export function t(key: MessageKey): string {
 	const code = current;
 	return catalogs[code]?.[key] ?? en[key];
+}
+
+/**
+ * Translate a component category label. The template-literal key is checked
+ * against the catalog at compile time, so adding a category without its
+ * `category.*` message key is a type error here instead of a runtime miss.
+ */
+export function tCategory(category: ComponentCategory): string {
+	return t(`category.${category}`);
+}
+
+/** Compose a docs <title> — the "FancyUI Docs" suffix is brand, never translated. */
+export function docTitle(pageTitle: string): string {
+	return `${pageTitle} - FancyUI Docs`;
 }
 
 /** Reactive accessor for components (locale + dir + translator + list). */

--- a/src/routes/docs/components/+page.svelte
+++ b/src/routes/docs/components/+page.svelte
@@ -6,8 +6,7 @@
 		getStats,
 	} from "$lib/fancy-ui/registry.js";
 	import ComponentCard from "$lib/components/docs/ComponentCard.svelte";
-	import { t } from "$lib/stores";
-	import type { MessageKey } from "$lib/i18n/messages/en.js";
+	import { t, tCategory, docTitle } from "$lib/stores";
 
 	const grouped = getComponentsGroupedByCategory();
 	const allComponents = getAllComponents();
@@ -32,7 +31,7 @@
 </script>
 
 <svelte:head>
-	<title>Components - FancyUI Docs</title>
+	<title>{docTitle(t("gallery.title"))}</title>
 </svelte:head>
 
 <div class="max-w-5xl">
@@ -107,7 +106,7 @@
 							? 'bg-foreground text-background'
 							: 'bg-muted text-muted-foreground hover:text-foreground'}"
 					>
-						{t(`category.${cat}` as MessageKey)}
+						{tCategory(cat)}
 						<span class="ml-1 opacity-60">{count}</span>
 					</button>
 				{/if}

--- a/src/routes/docs/components/[slug]/+page.svelte
+++ b/src/routes/docs/components/[slug]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import { t } from "$lib/stores";
-	import type { MessageKey } from "$lib/i18n/messages/en.js";
+	import { t, tCategory, docTitle } from "$lib/stores";
 	import PropsTable from "$lib/components/docs/PropsTable.svelte";
 	import InstallBlock from "$lib/components/docs/InstallBlock.svelte";
 	import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
@@ -32,7 +31,8 @@
 	let previewCode = $derived.by(() => {
 		const example = PREVIEW_EXAMPLE[component.slug];
 		if (example) {
-			const src = rawExamples[`/src/lib/components/docs/examples/${component.slug}/${example}.svelte`];
+			const src =
+				rawExamples[`/src/lib/components/docs/examples/${component.slug}/${example}.svelte`];
 			if (src) return src.trim();
 		}
 		return basicUsageCode;
@@ -42,7 +42,7 @@
 </script>
 
 <svelte:head>
-	<title>{component.name} - FancyUI Docs</title>
+	<title>{docTitle(component.name)}</title>
 	<meta name="description" content={component.description} />
 </svelte:head>
 
@@ -50,7 +50,7 @@
 	<!-- Header -->
 	<div class="mb-3 flex flex-wrap items-center gap-2">
 		<span class="bg-muted text-muted-foreground rounded-full px-2.5 py-0.5 text-xs font-medium">
-			{t(`category.${component.category}` as MessageKey)}
+			{tCategory(component.category)}
 		</span>
 		{#if component.status === "done"}
 			<span

--- a/src/routes/docs/getting-started/changelog/+page.svelte
+++ b/src/routes/docs/getting-started/changelog/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import ChangelogPage from "$lib/components/docs/ChangelogPage.svelte";
-	import { t } from "$lib/stores";
+	import { t, docTitle } from "$lib/stores";
 
 	let { data } = $props();
 </script>
 
 <svelte:head>
-	<title>{t("changelog.metaTitle")} - FancyUI Docs</title>
+	<title>{docTitle(t("changelog.metaTitle"))}</title>
 </svelte:head>
 
 <ChangelogPage raw={data.changelogRaw} />

--- a/src/routes/docs/getting-started/installation/+page.svelte
+++ b/src/routes/docs/getting-started/installation/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import InstallationPage from "$lib/components/docs/InstallationPage.svelte";
-	import { t } from "$lib/stores";
+	import { t, docTitle } from "$lib/stores";
 </script>
 
 <svelte:head>
-	<title>{t("install.metaTitle")} - FancyUI Docs</title>
+	<title>{docTitle(t("install.metaTitle"))}</title>
 </svelte:head>
 
 <InstallationPage />

--- a/src/routes/docs/getting-started/introduction/+page.svelte
+++ b/src/routes/docs/getting-started/introduction/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import IntroductionPage from "$lib/components/docs/IntroductionPage.svelte";
-	import { t } from "$lib/stores";
+	import { t, docTitle } from "$lib/stores";
 </script>
 
 <svelte:head>
-	<title>{t("intro.metaTitle")} - FancyUI Docs</title>
+	<title>{docTitle(t("intro.metaTitle"))}</title>
 </svelte:head>
 
 <IntroductionPage />

--- a/src/routes/docs/getting-started/theme-generator/+page.svelte
+++ b/src/routes/docs/getting-started/theme-generator/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { GradientButton, ShimmerButton, BorderBeam } from "$lib/fancy-ui";
-	import { t } from "$lib/stores";
+	import { t, docTitle } from "$lib/stores";
 
 	// ─── Base light/dark token sets (mirror src/routes/layout.css) ──────────────
 	const bases = {
@@ -169,7 +169,7 @@ ${selector} {
 </script>
 
 <svelte:head>
-	<title>{t("page.themeGenerator")} - FancyUI Docs</title>
+	<title>{docTitle(t("page.themeGenerator"))}</title>
 	<meta name="description" content={t("tg.metaDescription")} />
 </svelte:head>
 

--- a/src/routes/docs/getting-started/theming/+page.svelte
+++ b/src/routes/docs/getting-started/theming/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import ThemingPage from "$lib/components/docs/ThemingPage.svelte";
-	import { t } from "$lib/stores";
+	import { t, docTitle } from "$lib/stores";
 </script>
 
 <svelte:head>
-	<title>{t("theming.metaTitle")} - FancyUI Docs</title>
+	<title>{docTitle(t("theming.metaTitle"))}</title>
 </svelte:head>
 
 <ThemingPage />


### PR DESCRIPTION
## Summary

Locks down the message-catalog system that is now (after #156/#157) the docs' **single** localization mechanism.

### CI parity gate
`scripts/check-i18n.mjs` (`pnpm check:i18n`, added to CI next to `check:registry`) verifies:
1. locale registry (`locales.ts`) ↔ catalog files — no missing/orphan catalogs
2. key parity of every catalog vs `en.ts` (missing / extra / duplicate keys)
3. every translated catalog keeps its `satisfies Catalog` clause (guards the compile gate itself)
4. the pre-paint `var RTL = {…}` map in `app.html` ↔ `dir: "rtl"` entries in `locales.ts` (they were silently duplicated)

Output mirrors the registry gate: `i18n parity OK (16 locales x 216 keys).`

### Compile-time typing
- `export type Catalog = Record<MessageKey, string>` in `en.ts`; all 15 translated catalogs end with `satisfies Catalog` → a missing, extra, or typo'd key is now a `pnpm check` error (before: silent English fallback, zero detection)
- `tCategory()` replaces the five unchecked `as MessageKey` casts (CommandSearch ×2, Sidebar, gallery, component page) — adding a category without its `category.*` key becomes a type error
- `docTitle()` replaces six hand-concatenated `- FancyUI Docs` title suffixes

### Bug fix — mixed-language gallery
`ComponentCard` badges were hardcoded English (registry `categoryLabels` + a `Stable` literal) next to translated headings on the same page. Now `tCategory()` / `t("status.stable")`, with a regression test (verified in French: « Cartes », « Effets », « Affichage de données »). The gallery `<title>` was also hardcoded `Components` — now `gallery.title`.

### Docs
`CONTRIBUTING.md` gains a **Docs translations (i18n)** section: how to add a string / a locale, the two gates, and the rule that registry descriptions and `categoryLabels`/`categoryDescriptions` stay English (published API + machine-facing source for `/llms.txt` and the copilot — deliberately untouched here).

Known out-of-scope drift, for the record: `intro.leadHighlight` still says "60 animated" while the registry has 61.

## Stacked on #157

Based on `feat/docs-changelog-generated` — the gate locks the final 216-key set that lands there. GitHub will retarget when #157 merges.

## Gates

Registry parity 61 · **i18n parity 16 × 216** · svelte-check 0 errors · **539 tests** (+2) · build OK · Prettier clean. Visually verified in Chrome (French gallery). Changeset: patch.