### PR TITLE
feat(fluid-cursor): imperative handle + render-level readback

### DIFF
--- a/.changeset/fluid-cursor-imperative-handle.md
+++ b/.changeset/fluid-cursor-imperative-handle.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+FluidCursor: new optional `onReady` callback handing the parent an imperative handle to drive the simulation programmatically — `moveTo(x, y, color?)` traces a path with a synthetic pointer, `penUp()` ends a stroke without a connecting streak, `burst(x, y, dx, dy, color)` fires a one-off impulse — plus a `renderLevel` readback (`"webgpu-hdr" | "webgpu-sdr" | "webgl-p3" | "webgl-sdr" | "none"`) so callers can tell true HDR output from a clamped fallback. `webgpu-hdr` requires both extended tone mapping and a display reporting `(dynamic-range: high)`; when no renderer comes up at all the callback receives an inert handle reporting `"none"`. The new `FluidCursorHandle` and `FluidRenderLevel` types are exported from the package root. Behavior is unchanged when `onReady` is omitted.

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -168,6 +168,31 @@
 		return cleanup;
 	}
 
+	// Inert handle for environments where no renderer came up at all, so a
+	// consumer waiting on onReady can tell "unsupported" from "still starting".
+	const noRendererHandle: FluidCursorHandle = {
+		moveTo() {},
+		penUp() {},
+		burst() {},
+		renderLevel: "none",
+	};
+
+	// Hand the handle to the consumer. Guarded because the WebGPU path invokes
+	// this inside its startup promise chain: an exception from the callback would
+	// otherwise be caught as a WebGPU setup failure, retrying WebGL on a canvas
+	// already claimed by WebGPU and dropping the registered cleanup. Re-thrown
+	// asynchronously so it still surfaces as an unhandled error.
+	function notifyReady(handle: FluidCursorHandle) {
+		if (!onReady) return;
+		try {
+			onReady(handle);
+		} catch (error) {
+			queueMicrotask(() => {
+				throw error;
+			});
+		}
+	}
+
 	onMount(() => {
 		const canvas = canvasRef;
 		if (!canvas) return;
@@ -239,7 +264,7 @@
 						return;
 					}
 					activeCleanup = registerInstance(handle.cleanup);
-					onReady?.(handle);
+					notifyReady(handle);
 				})
 				.catch((error) => {
 					// Unexpected failure while wiring the WebGPU path: fall back
@@ -263,14 +288,20 @@
 			let renderLevel: FluidRenderLevel = "webgl-sdr";
 			// Dedicated synthetic pointer driven programmatically through the
 			// handle. It lives alongside the mouse pointer in the same list, so
-			// applyInputs splats both and the two inputs coexist.
-			const autopilotPointer = pointerPrototype();
-			pointers.push(autopilotPointer);
+			// applyInputs splats both and the two inputs coexist. Only created
+			// when a consumer asked for the handle: an unused extra pointer would
+			// still consume the shared fluidColors sequence in updateColors.
+			const autopilotPointer = onReady ? pointerPrototype() : null;
+			if (autopilotPointer) pointers.push(autopilotPointer);
 			let penWasUp = true;
 
 			// Get WebGL context
 			const context = getWebGLContext(canvas);
-			if (!context.gl || !context.ext) return;
+			if (!context.gl || !context.ext) {
+				// No renderer at all (WebGPU already failed if it was tried).
+				notifyReady(noRendererHandle);
+				return;
+			}
 
 			// These are guaranteed non-null after the check above
 			const gl = context.gl;
@@ -1189,6 +1220,10 @@
 				if (colorUpdateTimer >= 1) {
 					colorUpdateTimer = wrap(colorUpdateTimer, 0, 1);
 					pointers.forEach((p) => {
+						// The synthetic pointer's color belongs to the handle: pulling
+						// from the generator here would advance the shared fluidColors
+						// index twice per update and overwrite explicit stroke colors.
+						if (p === autopilotPointer) return;
 						p.color = generateColor();
 					});
 				}
@@ -1506,6 +1541,7 @@
 			// yields the same path a real mouse event's clientY takes. This is the
 			// only Y flip on the WebGL path.
 			function autopilotMoveTo(x: number, y: number, color?: ColorRGB) {
+				if (!autopilotPointer) return;
 				const posX = x * canvas.width;
 				const posY = y * canvas.height;
 				if (penWasUp) {
@@ -1521,14 +1557,20 @@
 					autopilotPointer.prevTexcoordY = autopilotPointer.texcoordY;
 					autopilotPointer.deltaX = 0;
 					autopilotPointer.deltaY = 0;
-					autopilotPointer.color = color ?? autopilotPointer.color;
+					// A stroke with no explicit color takes a fresh generated one, as
+					// a real pointer-down does: the prototype's black would inject
+					// invisible dye.
+					autopilotPointer.color = color ?? generateColor();
 					return;
 				}
 				updatePointerMoveData(autopilotPointer, posX, posY, color ?? autopilotPointer.color);
 			}
 			function autopilotPenUp() {
+				// `moved` is deliberately left alone: applyInputs consumes and clears
+				// it on the next frame, so clearing it here would swallow the final
+				// segment of a stroke finished synchronously before that frame.
 				penWasUp = true;
-				autopilotPointer.moved = false;
+				if (autopilotPointer) autopilotPointer.down = false;
 			}
 			// Top-left origin in, bottom-up texcoords out: flip y and negate dy.
 			function autopilotBurst(x: number, y: number, dx: number, dy: number, color: ColorRGB) {
@@ -1650,14 +1692,18 @@
 				}
 			}
 
-			onReady?.({
+			// Register before notifying: a throwing callback must not cost us the
+			// cleanup registration (listeners, rAF loop and GL resources would
+			// otherwise outlive the component).
+			const dispose = registerInstance(cleanup);
+			notifyReady({
 				moveTo: autopilotMoveTo,
 				penUp: autopilotPenUp,
 				burst: autopilotBurst,
 				renderLevel,
 			});
 
-			return registerInstance(cleanup);
+			return dispose;
 		}
 	});
 </script>

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -4,6 +4,8 @@
 	import {
 		type ColorRGB,
 		type Pointer,
+		type FluidCursorHandle,
+		type FluidRenderLevel,
 		pointerPrototype,
 		hexToRgb,
 		HSVtoRGB,
@@ -46,6 +48,14 @@
 		contained?: boolean;
 		hdr?: boolean;
 		hdrBoost?: number;
+		/**
+		 * Called once the fluid engine is live, with an imperative handle to
+		 * drive the simulation programmatically (trace a path via
+		 * `moveTo`/`penUp`, fire a one-off `burst`) and read back the actual
+		 * `renderLevel`. Pair with `interactive={false}` to drive it entirely
+		 * without a real cursor.
+		 */
+		onReady?: (handle: FluidCursorHandle) => void;
 	}
 
 	let {
@@ -76,6 +86,7 @@
 		contained = true,
 		hdr = false,
 		hdrBoost = 1.5,
+		onReady,
 	}: Props = $props();
 
 	const clampedColorIntensity = Math.max(0, Math.min(1, colorIntensity));
@@ -209,23 +220,26 @@
 				splatOnMount,
 				generateColor,
 			})
-				.then((cleanup) => {
+				.then((handle) => {
 					if (disposed) {
-						cleanup?.();
+						handle?.cleanup();
 						return;
 					}
 					// A newer singleton instance mounted while we were starting up:
 					// registering now would destroy it (newest-mount-wins would
 					// invert). Discard this stale completion instead.
 					if (!allowMultiple && mountToken !== mountCounter) {
-						cleanup?.();
+						handle?.cleanup();
 						return;
 					}
-					if (!cleanup) {
+					if (!handle) {
+						// WebGPU unavailable: the WebGL fallback surfaces its own
+						// handle through onReady.
 						activeCleanup = startWebGl() ?? null;
 						return;
 					}
-					activeCleanup = registerInstance(cleanup);
+					activeCleanup = registerInstance(handle.cleanup);
+					onReady?.(handle);
 				})
 				.catch((error) => {
 					// Unexpected failure while wiring the WebGPU path: fall back
@@ -245,6 +259,15 @@
 
 		// WebGL engine path (default, and fallback when WebGPU is missing).
 		function startWebGl(): (() => void) | undefined {
+			// Wide-gamut probe result, surfaced through the handle's renderLevel.
+			let renderLevel: FluidRenderLevel = "webgl-sdr";
+			// Dedicated synthetic pointer driven programmatically through the
+			// handle. It lives alongside the mouse pointer in the same list, so
+			// applyInputs splats both and the two inputs coexist.
+			const autopilotPointer = pointerPrototype();
+			pointers.push(autopilotPointer);
+			let penWasUp = true;
+
 			// Get WebGL context
 			const context = getWebGLContext(canvas);
 			if (!context.gl || !context.ext) return;
@@ -282,14 +305,23 @@
 
 				// HDR fallback: wide-gamut backbuffer when the WebGPU engine is
 				// unavailable. Colors are reinterpreted in P3 (more saturated).
+				// The property is read back because assigning an unsupported color
+				// space silently leaves the buffer in sRGB.
 				if (hdr && "drawingBufferColorSpace" in gl) {
 					try {
 						gl.drawingBufferColorSpace = "display-p3";
-						if (import.meta.env.DEV) {
-							console.info("[FluidCursor] HDR level: webgl-p3 (wide gamut fallback)");
+						if (gl.drawingBufferColorSpace === "display-p3") {
+							renderLevel = "webgl-p3";
 						}
 					} catch {
 						// Unsupported color space: buffer stays sRGB.
+					}
+					if (import.meta.env.DEV) {
+						console.info(
+							renderLevel === "webgl-p3"
+								? "[FluidCursor] HDR level: webgl-p3 (wide gamut fallback)"
+								: "[FluidCursor] HDR level: webgl-sdr (display-p3 drawing buffer rejected)"
+						);
 					}
 				}
 
@@ -1467,6 +1499,42 @@
 				return delta;
 			}
 
+			// Programmatic drive surface (exposed through onReady).
+			//
+			// x,y in [0,1], top-left origin. `updatePointerMoveData` applies
+			// `texcoordY = 1 - posY / height`, so feeding it a top-left pixel Y
+			// yields the same path a real mouse event's clientY takes. This is the
+			// only Y flip on the WebGL path.
+			function autopilotMoveTo(x: number, y: number, color?: ColorRGB) {
+				const posX = x * canvas.width;
+				const posY = y * canvas.height;
+				if (penWasUp) {
+					// First move of a new stroke: reposition only (mirrors
+					// updatePointerDownData) so the jump from the previous stroke's
+					// end never draws a connecting streak.
+					penWasUp = false;
+					autopilotPointer.down = true;
+					autopilotPointer.moved = false;
+					autopilotPointer.texcoordX = posX / canvas.width;
+					autopilotPointer.texcoordY = 1 - posY / canvas.height;
+					autopilotPointer.prevTexcoordX = autopilotPointer.texcoordX;
+					autopilotPointer.prevTexcoordY = autopilotPointer.texcoordY;
+					autopilotPointer.deltaX = 0;
+					autopilotPointer.deltaY = 0;
+					autopilotPointer.color = color ?? autopilotPointer.color;
+					return;
+				}
+				updatePointerMoveData(autopilotPointer, posX, posY, color ?? autopilotPointer.color);
+			}
+			function autopilotPenUp() {
+				penWasUp = true;
+				autopilotPointer.moved = false;
+			}
+			// Top-left origin in, bottom-up texcoords out: flip y and negate dy.
+			function autopilotBurst(x: number, y: number, dx: number, dy: number, color: ColorRGB) {
+				splat(x, 1 - y, dx, -dy, color);
+			}
+
 			// Event Listeners
 			function handleMouseDown(e: MouseEvent) {
 				const pointer = pointers[0];
@@ -1581,6 +1649,13 @@
 					window.removeEventListener("scroll", updateCanvasRectCache);
 				}
 			}
+
+			onReady?.({
+				moveTo: autopilotMoveTo,
+				penUp: autopilotPenUp,
+				burst: autopilotBurst,
+				renderLevel,
+			});
 
 			return registerInstance(cleanup);
 		}

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
@@ -146,4 +146,25 @@ describe("FluidCursor", () => {
 			expect(container.querySelector("canvas")).toBeInTheDocument();
 		});
 	});
+
+	describe("onReady handle", () => {
+		// jsdom provides no WebGL context, so this exercises the no-renderer path.
+		it('reports renderLevel "none" when no renderer is available', () => {
+			const onReady = vi.fn();
+			render(FluidCursor, { props: { onReady } });
+			expect(onReady).toHaveBeenCalledTimes(1);
+			expect(onReady.mock.calls[0][0].renderLevel).toBe("none");
+		});
+
+		it("hands over an inert handle that is safe to call", () => {
+			const onReady = vi.fn();
+			render(FluidCursor, { props: { onReady } });
+			const handle = onReady.mock.calls[0][0];
+			expect(() => {
+				handle.moveTo(0.5, 0.5);
+				handle.penUp();
+				handle.burst(0.5, 0.5, 10, 10, { r: 1, g: 0, b: 0 });
+			}).not.toThrow();
+		});
+	});
 });

--- a/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
+++ b/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
@@ -155,12 +155,17 @@ export function correctDeltaY(delta: number, width: number, height: number) {
 
 /**
  * How the fluid is actually being rendered, surfaced as data so callers can
- * react (e.g. tell a true-HDR display apart from a clamped fallback):
- * - "webgpu-hdr": WebGPU with extended tone mapping active — true HDR output.
- * - "webgpu-sdr": WebGPU float16 + P3, but the browser clamped tone mapping.
+ * react (e.g. tell true HDR output apart from a clamped fallback):
+ * - "webgpu-hdr": WebGPU with extended tone mapping active AND a display
+ *   reporting `(dynamic-range: high)` — true HDR output.
+ * - "webgpu-sdr": WebGPU float16 + P3, but the browser clamped tone mapping or
+ *   the output display is SDR.
  * - "webgl-p3":   WebGL fallback with a display-p3 drawing buffer.
  * - "webgl-sdr":  WebGL fallback, plain sRGB.
- * - "none":       no GPU rendering available at all.
+ * - "none":       no GPU rendering available at all; the handle is inert.
+ *
+ * Sampled once when the handle is created: it does not update if the window
+ * later moves to a display with a different dynamic range.
  */
 export type FluidRenderLevel = "webgpu-hdr" | "webgpu-sdr" | "webgl-p3" | "webgl-sdr" | "none";
 

--- a/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
+++ b/src/lib/fancy-ui/fluid-cursor/fluid-shared.ts
@@ -152,3 +152,32 @@ export function correctDeltaY(delta: number, width: number, height: number) {
 	if (aspectRatio > 1) return delta / aspectRatio;
 	return delta;
 }
+
+/**
+ * How the fluid is actually being rendered, surfaced as data so callers can
+ * react (e.g. tell a true-HDR display apart from a clamped fallback):
+ * - "webgpu-hdr": WebGPU with extended tone mapping active — true HDR output.
+ * - "webgpu-sdr": WebGPU float16 + P3, but the browser clamped tone mapping.
+ * - "webgl-p3":   WebGL fallback with a display-p3 drawing buffer.
+ * - "webgl-sdr":  WebGL fallback, plain sRGB.
+ * - "none":       no GPU rendering available at all.
+ */
+export type FluidRenderLevel = "webgpu-hdr" | "webgpu-sdr" | "webgl-p3" | "webgl-sdr" | "none";
+
+/**
+ * Imperative control surface handed to `FluidCursor`'s `onReady` callback so a
+ * parent can drive the simulation programmatically (trace a path, fire a
+ * one-off burst) and read back which render path actually engaged. Coordinates
+ * are in [0,1] with the ORIGIN AT THE TOP-LEFT (CSS convention); velocity is
+ * derived from consecutive `moveTo` calls, so smooth paths feel like a real
+ * cursor. Any engine-specific Y flip is internal.
+ */
+export interface FluidCursorHandle {
+	/** Drive the synthetic pointer like a mouse. The next `moveTo` after `penUp` repositions without drawing. */
+	moveTo(x: number, y: number, color?: ColorRGB): void;
+	/** Lift the pen so the next `moveTo` repositions without producing a connecting streak. */
+	penUp(): void;
+	/** One-off impulse (click-like burst). Same coord convention; dx/dy in engine velocity units. */
+	burst(x: number, y: number, dx: number, dy: number, color: ColorRGB): void;
+	readonly renderLevel: FluidRenderLevel;
+}

--- a/src/lib/fancy-ui/fluid-cursor/index.ts
+++ b/src/lib/fancy-ui/fluid-cursor/index.ts
@@ -4,3 +4,5 @@ export { default as FluidCursor } from "./FluidCursor.svelte";
  * @deprecated Use `FluidCursor` instead. `FluidCursorAdvanced` has been merged into `FluidCursor`.
  */
 export { default as FluidCursorAdvanced } from "./FluidCursor.svelte";
+
+export type { FluidCursorHandle, FluidRenderLevel } from "./fluid-shared.js";

--- a/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
+++ b/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
@@ -16,6 +16,8 @@
 import {
 	type ColorRGB,
 	type Pointer,
+	type FluidCursorHandle,
+	type FluidRenderLevel,
 	pointerPrototype,
 	correctDeltaX,
 	correctDeltaY,
@@ -279,6 +281,8 @@ interface FluidEngine {
 	resizeIfNeeded: () => void;
 	frame: (dt: number) => void;
 	readonly lost: boolean;
+	/** Whether the browser actually applied extended tone mapping (true HDR). */
+	readonly extendedToneMapping: boolean;
 	destroy: () => void;
 }
 
@@ -338,20 +342,21 @@ async function createWebGpuFluid(
 		const context: GPUCanvasContext = maybeContext;
 		context.configure(configuration);
 
+		// Browsers that do not support toneMapping drop the member, which
+		// getConfiguration() makes observable. Surface it as data (not just a
+		// DEV log) so callers can tell true HDR from a clamped fallback.
+		let extendedToneMapping = false;
+		try {
+			const applied = context.getConfiguration?.() as
+				| (GPUCanvasConfiguration & { toneMapping?: { mode?: string } })
+				| null;
+			extendedToneMapping = applied?.toneMapping?.mode === "extended";
+		} catch {
+			// getConfiguration unsupported (e.g. Safari): assume clamped output.
+		}
 		if (import.meta.env.DEV) {
-			// Browsers that do not support toneMapping drop the member, which
-			// getConfiguration() makes observable — log the real level.
-			let extended = false;
-			try {
-				const applied = context.getConfiguration?.() as
-					| (GPUCanvasConfiguration & { toneMapping?: { mode?: string } })
-					| null;
-				extended = applied?.toneMapping?.mode === "extended";
-			} catch {
-				// getConfiguration unsupported: assume clamped output.
-			}
 			console.info(
-				extended
+				extendedToneMapping
 					? "[FluidCursor] HDR level: webgpu-hdr (extended tone mapping active)"
 					: "[FluidCursor] HDR level: webgpu-sdr (float16 + P3, tone mapping clamped by browser)"
 			);
@@ -817,6 +822,7 @@ async function createWebGpuFluid(
 			get lost() {
 				return lost;
 			},
+			extendedToneMapping,
 			destroy() {
 				destroyed = true;
 				device.destroy();
@@ -832,18 +838,30 @@ async function createWebGpuFluid(
 
 /**
  * Full WebGPU setup for FluidCursor: engine + pointer wiring + rAF loop +
- * visibility pause + auto splats. Resolves with a cleanup function, or with
- * `null` when WebGPU is unavailable (caller falls back to the WebGL path).
+ * visibility pause + auto splats. Resolves with a {@link FluidCursorHandle}
+ * (augmented with `cleanup`), or with `null` when WebGPU is unavailable
+ * (caller falls back to the WebGL path).
+ *
+ * Handle coordinates are top-left origin in [0,1]; WebGPU texcoords already
+ * use a top-origin convention, so no Y flip happens here (the WebGL path owns
+ * its own flip).
  */
 export async function startWebGpuFluid(
 	canvas: HTMLCanvasElement,
 	opts: WebGpuFluidOptions
-): Promise<(() => void) | null> {
+): Promise<(FluidCursorHandle & { cleanup(): void }) | null> {
 	const maybeEngine = await createWebGpuFluid(canvas, opts);
 	if (!maybeEngine) return null;
 	const engine: FluidEngine = maybeEngine;
 
 	const pointers: Pointer[] = [pointerPrototype()];
+	// Dedicated synthetic pointer driven programmatically through the handle. It
+	// lives alongside the mouse pointer in the same list, so updateFrame splats
+	// both and the two inputs coexist.
+	const autopilotPointer = pointerPrototype();
+	pointers.push(autopilotPointer);
+	let penWasUp = true;
+
 	let animationFrameId = 0;
 	let lastUpdateTime = Date.now();
 	let colorUpdateTimer = 0;
@@ -1073,23 +1091,61 @@ export async function startWebGpuFluid(
 		}, opts.autoSplatInterval);
 	}
 
-	return () => {
-		stopped = true;
-		cancelAnimationFrame(animationFrameId);
-		if (observer) observer.disconnect();
-		if (autoSplatTimer) clearInterval(autoSplatTimer);
-		if (opts.interactive) {
-			window.removeEventListener("mousedown", handleMouseDown);
-			document.body.removeEventListener("mousemove", handleFirstMouseMove);
-			window.removeEventListener("mousemove", handleMouseMove);
-			document.body.removeEventListener("touchstart", handleFirstTouchStart);
-			window.removeEventListener("touchstart", handleTouchStart);
-			window.removeEventListener("touchmove", handleTouchMove);
-		}
-		if (opts.contained) {
-			window.removeEventListener("resize", updateCanvasRectCache);
-			window.removeEventListener("scroll", updateCanvasRectCache);
-		}
-		engine.destroy();
+	const renderLevel: FluidRenderLevel = engine.extendedToneMapping ? "webgpu-hdr" : "webgpu-sdr";
+
+	return {
+		/**
+		 * x,y in [0,1], top-left origin. WebGPU texcoords are already top-origin,
+		 * so the coordinates pass straight through.
+		 */
+		moveTo(x: number, y: number, color?: ColorRGB) {
+			const posX = x * canvas.width;
+			const posY = y * canvas.height;
+			if (penWasUp) {
+				// First move of a new stroke: reposition only (mirrors
+				// updatePointerDownData) so the jump from the previous stroke's
+				// end never draws a connecting streak.
+				penWasUp = false;
+				autopilotPointer.down = true;
+				autopilotPointer.moved = false;
+				autopilotPointer.texcoordX = posX / canvas.width;
+				autopilotPointer.texcoordY = posY / canvas.height;
+				autopilotPointer.prevTexcoordX = autopilotPointer.texcoordX;
+				autopilotPointer.prevTexcoordY = autopilotPointer.texcoordY;
+				autopilotPointer.deltaX = 0;
+				autopilotPointer.deltaY = 0;
+				autopilotPointer.color = color ?? autopilotPointer.color;
+				return;
+			}
+			updatePointerMoveData(autopilotPointer, posX, posY, color ?? autopilotPointer.color);
+		},
+		penUp() {
+			penWasUp = true;
+			autopilotPointer.moved = false;
+		},
+		/** No Y flip on the WebGPU path. */
+		burst(x: number, y: number, dx: number, dy: number, color: ColorRGB) {
+			engine.splat(x, y, dx, dy, color);
+		},
+		renderLevel,
+		cleanup() {
+			stopped = true;
+			cancelAnimationFrame(animationFrameId);
+			if (observer) observer.disconnect();
+			if (autoSplatTimer) clearInterval(autoSplatTimer);
+			if (opts.interactive) {
+				window.removeEventListener("mousedown", handleMouseDown);
+				document.body.removeEventListener("mousemove", handleFirstMouseMove);
+				window.removeEventListener("mousemove", handleMouseMove);
+				document.body.removeEventListener("touchstart", handleFirstTouchStart);
+				window.removeEventListener("touchstart", handleTouchStart);
+				window.removeEventListener("touchmove", handleTouchMove);
+			}
+			if (opts.contained) {
+				window.removeEventListener("resize", updateCanvasRectCache);
+				window.removeEventListener("scroll", updateCanvasRectCache);
+			}
+			engine.destroy();
+		},
 	};
 }

--- a/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
+++ b/src/lib/fancy-ui/fluid-cursor/webgpu-engine.ts
@@ -344,7 +344,9 @@ async function createWebGpuFluid(
 
 		// Browsers that do not support toneMapping drop the member, which
 		// getConfiguration() makes observable. Surface it as data (not just a
-		// DEV log) so callers can tell true HDR from a clamped fallback.
+		// DEV log) so callers can tell an extended-tone-mapping canvas from a
+		// clamped fallback; whether the display is HDR is checked separately by
+		// startWebGpuFluid.
 		let extendedToneMapping = false;
 		try {
 			const applied = context.getConfiguration?.() as
@@ -357,7 +359,7 @@ async function createWebGpuFluid(
 		if (import.meta.env.DEV) {
 			console.info(
 				extendedToneMapping
-					? "[FluidCursor] HDR level: webgpu-hdr (extended tone mapping active)"
+					? "[FluidCursor] extended tone mapping active (webgpu-hdr if the display reports high dynamic range)"
 					: "[FluidCursor] HDR level: webgpu-sdr (float16 + P3, tone mapping clamped by browser)"
 			);
 		}
@@ -857,10 +859,17 @@ export async function startWebGpuFluid(
 	const pointers: Pointer[] = [pointerPrototype()];
 	// Dedicated synthetic pointer driven programmatically through the handle. It
 	// lives alongside the mouse pointer in the same list, so updateFrame splats
-	// both and the two inputs coexist.
-	const autopilotPointer = pointerPrototype();
-	pointers.push(autopilotPointer);
+	// both and the two inputs coexist. Created on first programmatic use, so a
+	// consumer that never drives the handle costs nothing.
+	let autopilotPointer: Pointer | null = null;
 	let penWasUp = true;
+	function ensureAutopilotPointer(): Pointer {
+		if (!autopilotPointer) {
+			autopilotPointer = pointerPrototype();
+			pointers.push(autopilotPointer);
+		}
+		return autopilotPointer;
+	}
 
 	let animationFrameId = 0;
 	let lastUpdateTime = Date.now();
@@ -980,6 +989,10 @@ export async function startWebGpuFluid(
 		if (colorUpdateTimer >= 1) {
 			colorUpdateTimer = colorUpdateTimer % 1;
 			pointers.forEach((p) => {
+				// The synthetic pointer's color belongs to the handle: pulling from
+				// the generator here would advance the shared palette index twice per
+				// update and overwrite explicit stroke colors.
+				if (p === autopilotPointer) return;
 				p.color = opts.generateColor();
 			});
 		}
@@ -1091,7 +1104,16 @@ export async function startWebGpuFluid(
 		}, opts.autoSplatInterval);
 	}
 
-	const renderLevel: FluidRenderLevel = engine.extendedToneMapping ? "webgpu-hdr" : "webgpu-sdr";
+	// Extended tone mapping only proves the browser kept the configuration — an
+	// SDR display still clamps the output — so "webgpu-hdr" requires both. The
+	// display state is sampled once here and does not follow the window to
+	// another monitor.
+	const hdrDisplay =
+		typeof window !== "undefined" && typeof window.matchMedia === "function"
+			? window.matchMedia("(dynamic-range: high)").matches
+			: false;
+	const renderLevel: FluidRenderLevel =
+		engine.extendedToneMapping && hdrDisplay ? "webgpu-hdr" : "webgpu-sdr";
 
 	return {
 		/**
@@ -1099,6 +1121,7 @@ export async function startWebGpuFluid(
 		 * so the coordinates pass straight through.
 		 */
 		moveTo(x: number, y: number, color?: ColorRGB) {
+			const pointer = ensureAutopilotPointer();
 			const posX = x * canvas.width;
 			const posY = y * canvas.height;
 			if (penWasUp) {
@@ -1106,22 +1129,28 @@ export async function startWebGpuFluid(
 				// updatePointerDownData) so the jump from the previous stroke's
 				// end never draws a connecting streak.
 				penWasUp = false;
-				autopilotPointer.down = true;
-				autopilotPointer.moved = false;
-				autopilotPointer.texcoordX = posX / canvas.width;
-				autopilotPointer.texcoordY = posY / canvas.height;
-				autopilotPointer.prevTexcoordX = autopilotPointer.texcoordX;
-				autopilotPointer.prevTexcoordY = autopilotPointer.texcoordY;
-				autopilotPointer.deltaX = 0;
-				autopilotPointer.deltaY = 0;
-				autopilotPointer.color = color ?? autopilotPointer.color;
+				pointer.down = true;
+				pointer.moved = false;
+				pointer.texcoordX = posX / canvas.width;
+				pointer.texcoordY = posY / canvas.height;
+				pointer.prevTexcoordX = pointer.texcoordX;
+				pointer.prevTexcoordY = pointer.texcoordY;
+				pointer.deltaX = 0;
+				pointer.deltaY = 0;
+				// A stroke with no explicit color takes a fresh generated one, as a
+				// real pointer-down does: the prototype's black would inject
+				// invisible dye.
+				pointer.color = color ?? opts.generateColor();
 				return;
 			}
-			updatePointerMoveData(autopilotPointer, posX, posY, color ?? autopilotPointer.color);
+			updatePointerMoveData(pointer, posX, posY, color ?? pointer.color);
 		},
 		penUp() {
+			// `moved` is deliberately left alone: updateFrame consumes and clears it
+			// on the next frame, so clearing it here would swallow the final segment
+			// of a stroke finished synchronously before that frame.
 			penWasUp = true;
-			autopilotPointer.moved = false;
+			if (autopilotPointer) autopilotPointer.down = false;
 		},
 		/** No Y flip on the WebGPU path. */
 		burst(x: number, y: number, dx: number, dy: number, color: ColorRGB) {


### PR DESCRIPTION
## What

Adds an optional `onReady` callback to `FluidCursor` that hands the parent an **imperative handle** to drive the fluid simulation programmatically and read back the **render level actually achieved**.

```ts
onReady?: (handle: FluidCursorHandle) => void;

interface FluidCursorHandle {
  moveTo(x, y, color?): void;   // synthetic pointer, [0,1] top-left origin
  penUp(): void;                // lift pen — next moveTo repositions, no streak
  burst(x, y, dx, dy, color): void;  // one-off click-like impulse
  readonly renderLevel: "webgpu-hdr" | "webgpu-sdr" | "webgl-p3" | "webgl-sdr" | "none";
}
```

## Why

Consumers that need to *trace a path* into the fluid (not just follow the cursor) or *tell a true-HDR display apart from a clamped fallback* previously had to fork the whole engine. The level string was already computed internally — it was just never surfaced.

## Changes
- `fluid-shared.ts`: new `FluidRenderLevel` + `FluidCursorHandle` types (exported from package root).
- `webgpu-engine.ts`: `extendedToneMapping` promoted from a DEV-only log to engine data; `startWebGpuFluid` now resolves with a handle (`+ cleanup`) instead of a bare cleanup fn.
- `FluidCursor.svelte`: `onReady` prop; both the WebGPU and inline-WebGL paths build the handle (WebGL reads back the display-p3 buffer to report `webgl-p3` vs `webgl-sdr`).

## Compatibility
Fully backward compatible — behavior is unchanged when `onReady` is omitted. Pair with `interactive={false}` to drive it entirely without a real pointer.

## Verification
`pnpm check` → 0 errors · `pnpm test` (fluid-cursor) → 28 passing · `pnpm package` → publint OK.