### PR TITLE
fix(fireworks-hdr): make a shell read as a firework

### DIFF
--- a/.changeset/fireworks-visual-retune.md
+++ b/.changeset/fireworks-visual-retune.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": patch
+---
+
+FireworksHdr: retune the look so a shell reads as a firework. The particle quad is now oversized with the gaussian windowed to zero at its edge — an unwindowed halo still carried ~7% of its peak where the geometry stopped, and additive blending drew that step as a hard-edged square around every flash. Debris gravity drops to a fraction of the rocket's (a spark's terminal velocity was several times the burst's own expansion speed, so shells collapsed into downward fountains instead of opening), burst speed rises to match the drag, and each spark draws its own drag so the debris no longer falls as a parallel curtain. Sparks hand over from the magnesium white to the shell hue by a third of their life instead of three quarters, the detonation flash is smaller and decays faster, the accumulation trail and per-instance velocity stretch are shorter, ascent trails scatter laterally, rockets carry a slight positional wobble, and 6% of a shell's sparks crackle at 24 Hz (documented in the spec, previously never wired). No API change.

--- a/src/lib/fancy-ui/fireworks-hdr/README.md
+++ b/src/lib/fancy-ui/fireworks-hdr/README.md
@@ -204,13 +204,16 @@ HDR; SDR pins exposure to 1.0 with a soft knee.
 - Family (ping-pong index order): cyan `#42cfff` (196°), blue `#3d5bff` (231°),
   violet `#a142ff` (271°), magenta `#ff2fd6` (312°). Electric blue `#3d5bff` is
   the signature hue.
-- **White-hot life ramp** (life fraction `L`): `L 0–0.06` pure white (magnesium
-  bias `#f4f8ff`); `0.06–0.18` crossfade white→hue in oklab (never grey);
-  `0.18–0.75` full hue; `0.75–1.0` cool then dim to warm-white `#ffcf9c`.
+- **White-hot life ramp** (life fraction `L`): white hold to `L 0.04–0.11`
+  (magnesium bias `#f4f8ff`, per-spark), crossfade white→hue in oklab (never
+  grey) completed by `L 0.34`, full hue to `0.72`, then cool and dim to
+  warm-white `#ffcf9c`. The magnesium reads as the _detonation_, so handing over
+  late leaves the shell white for most of the time anyone is looking at it.
 - **Shell assignment**: 85% single-hue via a ping-pong sweep
   cyan→blue→violet→magenta→violet→blue→cyan; 12% adjacent-duo only
-  (`cyan+blue`, `blue+violet`, `violet+magenta`); 3% silver crackle. Never
-  rainbow, never cyan+magenta.
+  (`cyan+blue`, `blue+violet`, `violet+magenta`). Never rainbow, never
+  cyan+magenta. 6% of a shell's sparks crackle — an on/off chatter at 24 Hz
+  (`flickerNoise > 0.5 ? ×1.9 : ×0.25`) instead of a smooth fade.
 - Intro glyph hues: **H = cyan, D = blue, R = violet, ? = magenta**.
 - Hue jitter ±7° per shell, ±3° per spark.
 - Embers are palette-tinted (dimmed, desaturated parent hue), cooling to
@@ -221,9 +224,9 @@ HDR; SDR pins exposure to 1.0 with a soft knee.
 
 ### Brightness ladder (pre-exposure)
 
-Intro flash **6.0** · ambient flash **3.8** · fresh spark **2.2** · steady
+Intro flash **3.4** · ambient flash **2.1** · fresh spark **2.2** · steady
 **0.9** · terminal **0.15** · hue-hot **2.5 → 1.2** · ascent head **2.8** / tail
-**0.6** · burst streak **0.5** · ember mean **0.35** (flicker ×0.6–2.0 @
+**0.45** · burst streak **0.5** · ember mean **0.35** (flicker ×0.6–2.0 @
 8–14 Hz irregular) · smoke **0.05–0.12** · glyph hold **1.3** · glyph release
 **2.6** · haze ceiling behind the card **≤ 0.18** (hard).
 
@@ -306,14 +309,23 @@ pos.y += vel.y·dt`. Drag: `vel /= (1 + drag·dragScale·dt)`. Death gate:
 
 ### Per-type behavior
 
-| Type   | gravScale | drag (1/s)            | ttl (s)           | size (norm-h) | windScale |
-| ------ | --------- | --------------------- | ----------------- | ------------- | --------- |
-| rocket | 1.0       | 0.6                   | flight + hang     | 0.004 head    | 0.05      |
-| spark  | 0.85      | 1.8                   | 0.9–1.6           | 0.0025–0.004  | 0.30      |
-| ember  | 0.35      | 2.4 (terminal ~0.525) | 1.6–2.8           | 0.002–0.003   | 0.70      |
-| smoke  | −0.05 → 0 | 3.0                   | 1.5–3.0           | 0.010 → 0.050 | 1.0       |
-| flash  | 0         | 0                     | 0.06–0.12         | 0.08–0.16     | 0         |
-| seeker | 0 → 1.0   | 1.2 (pop)             | phased (0.9 rel.) | 0.003–0.005   | 0.4       |
+| Type   | gravScale | drag (1/s)           | ttl (s)           | size (norm-h) | windScale |
+| ------ | --------- | -------------------- | ----------------- | ------------- | --------- |
+| rocket | 1.0       | 0.6                  | flight + hang     | 0.004 head    | 0.05      |
+| spark  | 0.15      | 2.2 (terminal ~0.25) | 0.75–1.3          | 0.0025–0.004  | 0.30      |
+| ember  | 0.30      | 2.4 (terminal ~0.45) | 1.4–2.4           | 0.002–0.003   | 0.70      |
+| smoke  | −0.05 → 0 | 3.0                  | 1.5–3.0           | 0.010 → 0.050 | 1.0       |
+| flash  | 0         | 0                    | 0.05–0.09         | 0.025–0.05    | 0         |
+| seeker | 0 → 1.0   | 1.2 (pop)            | phased (0.9 rel.) | 0.003–0.005   | 0.4       |
+
+Debris gravity is a **fraction** of the rocket's, and that is a look decision,
+not a physical one: a spark's terminal velocity is `gravScale·G / drag`, and at
+full gravity that is several times the burst's own expansion speed — the shell
+never opens into a sphere, it rains straight down as a fountain. Ember gravity
+stays above spark gravity so a willow still droops harder than a peony. Each
+non-straggler spark also draws its own `dragScale ∈ [0.85, 1.30]`: identical
+drag makes every spark fall at exactly the same speed, which combs the debris
+into a parallel curtain.
 
 Session wind is seeded once: `wx ∈ ±[0.02, 0.05]`, `wy ∈ ±[0.01, 0.02]` visual
 accel, applied as `a += w · windScale[type]`.
@@ -363,8 +375,12 @@ Fuse hang 80–140 ms seeded (the intro "?" uses
 140); `breakMs = flightMs + hangMs`. At break: enqueue the shell at the current
 position plus one flash, then kill the rocket. Trail uses a fractional
 accumulator (`emit += trailRate·dt; while (emit ≥ 1) { spawn; emit-- }`) — trail
-sparks are ttl 0.3–0.5, size 0.002, ascent-tail brightness, ~zero velocity;
-the head is ascent-head brightness. The trail hue is the comet head mixed 25%
+sparks are ttl 0.22–0.45, size 0.0018, ascent-tail brightness, and scatter
+laterally (`±0.035` x, `±0.02` y) — a rigidly co-linear trail reads as a drawn
+wire rather than a comet shedding sparks. The head is ascent-head brightness,
+and the rocket's **position** (never its velocity) carries a 11 Hz lateral
+wobble of `0.045`/s so the climb is not a ruler-straight column; leaving the
+velocity alone keeps the solved apex intact. The trail hue is the comet head mixed 25%
 toward **that launch's** first shell hue (stored on the launch spec), so a
 branded palette never gets the built-in cyan on its ascent.
 
@@ -392,7 +408,18 @@ branded palette never gets the built-in cyan on its ascent.
 4. `writeInstances`.
 
 **Instance layout (8 floats)**: `[posX, posY, size, r·bright, g·bright, b·bright,
-velX·STRETCH, velY·STRETCH]` with `STRETCH ≈ 0.015 s`. The renderer draws a
-velocity-stretched quad (major axis from the velocity terms, minor from size),
-two-lobe gaussian (hot core + soft halo), additive. Swap-remove keeps the pool
-contiguous — no freelist; allocate at `count++`, reject at capacity.
+velX·STRETCH, velY·STRETCH]` with `STRETCH = 0.010 s`. The renderer draws a
+velocity-stretched quad (major axis from the velocity terms, capped at 2.5× the
+minor), two-lobe gaussian (hot core + soft halo), additive. Swap-remove keeps
+the pool contiguous — no freelist; allocate at `count++`, reject at capacity.
+
+Two things about that quad are load-bearing and identical in both renderers:
+
+- **`QUAD_PAD = 1.35`.** The quad is oversized and the gaussian is windowed to
+  exactly zero at its edge (`smoothstep(PAD, 0.6·PAD, r)`). Unwindowed, the halo
+  still carries ~7% of its peak where the geometry stops, and additive blending
+  renders that step as a **hard-edged square** around anything bright — a
+  detonation flash reads as a lit box, not a glow.
+- **Stretch is deliberately short.** The accumulation buffer already smears a
+  moving particle into a line; a long per-instance stretch on top of it turns
+  every spark into a needle.

--- a/src/lib/fancy-ui/fireworks-hdr/fireworks-shared.test.ts
+++ b/src/lib/fancy-ui/fireworks-hdr/fireworks-shared.test.ts
@@ -15,6 +15,9 @@ import {
 	sampleZone,
 	rectExpandedContains,
 	KEEP_CLEAR_MARGIN,
+	sparkColorAtLife,
+	HUE_ARRIVES_AT,
+	COOL_START,
 	flickerNoise,
 	deathGate,
 	mixOklab,
@@ -178,6 +181,97 @@ describe("rectExpandedContains (mirrored-apex revalidation)", () => {
 		// ...but its mirror is squarely inside it, which is what the scheduler
 		// re-tests before launching a mirrored double.
 		expect(rectExpandedContains(asym, 1 - picked.x, picked.y)).toBe(true);
+	});
+});
+
+describe("a shell opens instead of raining down", () => {
+	// The failure this pins: with debris gravity anywhere near the rocket's, a
+	// spark's terminal velocity dwarfs the burst speed, so every shell collapses
+	// into a downward fountain instead of a sphere.
+	const ASPECT = 1.6;
+
+	function shellShape(shell: "peony" | "ring") {
+		const sim = createSim({
+			quality: "high",
+			aspect: ASPECT,
+			hdr: true,
+			rng: mulberry32(19),
+			wind: { x: 0, y: 0 },
+		});
+		const { breakMs } = sim.launch({ apex: { x: 0.5, y: 0.4 }, shell, seed: 8 });
+		// The shell breaks a fuse-hang past the apex, so anchor on where the rocket
+		// actually was when it died, not on the requested apex.
+		const origin = { x: 0.5, y: 0.4 };
+		const frames = Math.ceil(((breakMs + 340) / 1000) * 60);
+		for (let f = 0; f < frames; f++) {
+			for (let idx = 0; idx < sim.count; idx++) {
+				const base = idx * STRIDE;
+				if (sim.data[base + F.type] !== TYPE.ROCKET) continue;
+				origin.x = sim.data[base + F.posX];
+				origin.y = sim.data[base + F.posY];
+			}
+			sim.step(1 / 60);
+		}
+		let widest = 0;
+		let highest = 0;
+		let lowest = 0;
+		for (let idx = 0; idx < sim.count; idx++) {
+			const base = idx * STRIDE;
+			const type = sim.data[base + F.type];
+			if (type !== TYPE.SPARK && type !== TYPE.EMBER) continue;
+			// Burst debris only: the ascent trail is spawned around the launch base.
+			const dy = sim.data[base + F.posY] - origin.y;
+			// x is integrated as pos.x += (vel.x / A)·dt, so normalized dx has to be
+			// multiplied back by the aspect to compare against dy — a round burst is
+			// legitimately narrower in x on a wide canvas.
+			const dx = (sim.data[base + F.posX] - origin.x) * ASPECT;
+			if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) continue;
+			widest = Math.max(widest, Math.abs(dx));
+			highest = Math.min(highest, dy);
+			lowest = Math.max(lowest, dy);
+		}
+		return { widest, up: -highest, down: lowest };
+	}
+
+	it("throws sparks sideways and upward, not only downward", () => {
+		const peony = shellShape("peony");
+		expect(peony.widest).toBeGreaterThan(0.04);
+		// A shell that opens still rises a good fraction of what it falls this
+		// early. Under the pre-retune constants (spark gravity 0.85, drag 1.8,
+		// burst speed ×2.2) gravity beat the expansion outright and this ratio was
+		// ~0: every spark was already below the break point.
+		expect(peony.up).toBeGreaterThan(0.03);
+		expect(peony.up / peony.down).toBeGreaterThan(0.35);
+	});
+
+	it("keeps a ring roughly as wide as it is deep", () => {
+		const ring = shellShape("ring");
+		// In visual units the ring's horizontal reach is its radius; gravity only
+		// adds to the downward side, so the two stay the same order.
+		expect(ring.widest).toBeGreaterThan(ring.down * 0.7);
+		expect(ring.widest).toBeGreaterThan(ring.up);
+	});
+});
+
+describe("spark life color", () => {
+	const CYAN = hexToLinearRgb("#42cfff");
+
+	it("reaches the shell hue early instead of staying white", () => {
+		// Mid-life the spark must read as its hue: blue clearly over red.
+		const mid = sparkColorAtLife(CYAN, 0.5, 0.08, 1234);
+		expect(mid.b).toBeGreaterThan(mid.r * 3);
+		// And the detonation white is still there at the very start.
+		const fresh = sparkColorAtLife(CYAN, 0.02, 0.08, 1234);
+		expect(fresh.r).toBeGreaterThan(fresh.b * 0.7);
+		expect(fresh.r).toBeGreaterThan(mid.r);
+	});
+
+	it("has fully handed over to the hue by HUE_ARRIVES_AT", () => {
+		const atArrival = sparkColorAtLife(CYAN, HUE_ARRIVES_AT + 0.01, 0.05, 77);
+		const later = sparkColorAtLife(CYAN, COOL_START - 0.01, 0.05, 77);
+		// Constant hue between arrival and the cool-down: no lingering white mix.
+		expect(atArrival.r).toBeCloseTo(later.r, 6);
+		expect(atArrival.b).toBeCloseTo(later.b, 6);
 	});
 });
 

--- a/src/lib/fancy-ui/fireworks-hdr/fireworks-shared.ts
+++ b/src/lib/fancy-ui/fireworks-hdr/fireworks-shared.ts
@@ -208,17 +208,19 @@ export const SDR_KNEE_START = 0.8;
 export const SDR_CORE_SCALE = 1.4;
 export const SDR_SAT_BOOST = 0.12;
 
-// §7 instance velocity-stretch (seconds of motion baked into the quad's major axis)
-export const STRETCH = 0.015;
+// §7 instance velocity-stretch (seconds of motion baked into the quad's major
+// axis). Small on purpose — the accumulation trail already conveys motion, and
+// stacking a long stretch on top of it turns every spark into a needle.
+export const STRETCH = 0.01;
 
 // §2.3 Brightness ladder (pre-exposure; 1.0 = SDR white)
-export const B_FLASH_INTRO = 6.0;
-export const B_FLASH_AMBIENT = 3.8;
+export const B_FLASH_INTRO = 3.4;
+export const B_FLASH_AMBIENT = 2.1;
 export const B_SPARK_FRESH = 2.2;
 export const B_SPARK_STEADY = 0.9;
 export const B_SPARK_TERMINAL = 0.15;
 export const B_ASCENT_HEAD = 2.8;
-export const B_ASCENT_TAIL = 0.6;
+export const B_ASCENT_TAIL = 0.45;
 export const B_BURST_STREAK = 0.5;
 export const B_EMBER_MEAN = 0.35;
 export const B_SMOKE_MIN = 0.05;
@@ -238,6 +240,19 @@ export const SMOKE_HEX = "#0a0b10";
 // Shell hue jitter (oklab degrees) and spark hue jitter — §2.5 / §1.6
 export const SHELL_JITTER_DEG = 7;
 export const SPARK_JITTER_DEG = 3;
+
+// Ascent wobble (§4): lateral drift rate and its frequency. Applied to the
+// rocket's position only — the velocity, and therefore the solved apex, is
+// untouched, so the wobble cannot walk a shell off its target.
+export const ROCKET_WOBBLE_AMP = 0.045;
+export const ROCKET_WOBBLE_HZ = 11;
+
+// Spark life-color schedule (§1.7): white → shell hue → cool end.
+export const HUE_ARRIVES_AT = 0.34;
+export const COOL_START = 0.72;
+// Share of a shell's sparks that crackle — a fast on/off flicker (CRACKLE_HZ)
+// on top of the normal decay. This is the "silver" chatter of a real break.
+export const CRACKLE_FRAC = 0.06;
 
 // Depth response for `depth ∈ [0,1]`: a far shell is dimmer, smaller, less
 // saturated AND spatially tighter. Every term is applied at spawn (the dim as a
@@ -262,11 +277,15 @@ const WIND_SCALE: Record<ParticleType, number> = {
 	[TYPE.SEEKER]: 0.4,
 };
 
-// Per-type gravity scale (§2.2 gravScale column)
+// Per-type gravity scale (§2.2 gravScale column). Sparks and embers fall at a
+// small fraction of the rocket's gravity: at full G their terminal velocity
+// (g·G/drag) dwarfs the burst's own expansion speed, so a shell never opens
+// into a sphere — it rains straight down as a fountain. Keeping ember gravity
+// above spark gravity is what still separates a willow's droop from a peony.
 const GRAV_SCALE: Record<ParticleType, number> = {
 	[TYPE.ROCKET]: 1.0,
-	[TYPE.SPARK]: 0.85,
-	[TYPE.EMBER]: 0.35,
+	[TYPE.SPARK]: 0.15,
+	[TYPE.EMBER]: 0.3,
 	[TYPE.SMOKE]: -0.05,
 	[TYPE.FLASH]: 0,
 	[TYPE.SEEKER]: 0, // gravity is phase-driven for seekers
@@ -275,16 +294,17 @@ const GRAV_SCALE: Record<ParticleType, number> = {
 // Per-type drag (1/s, §2.2 drag column)
 const DRAG: Record<ParticleType, number> = {
 	[TYPE.ROCKET]: 0.6,
-	[TYPE.SPARK]: 1.8,
+	[TYPE.SPARK]: 2.2,
 	[TYPE.EMBER]: 2.4,
 	[TYPE.SMOKE]: 3.0,
 	[TYPE.FLASH]: 0,
 	[TYPE.SEEKER]: 1.2,
 };
 
-// Burst initial speed = radius · this (visual units); tuned so spark drag pulls
-// them to ~radius before slowing. Not spec-pinned — a visual constant.
-const BURST_SPEED_K = 2.2;
+// Burst initial speed = radius · this (visual units). Under linear drag a spark
+// coasts v0/drag, so k ≈ drag makes the shell open to about its nominal radius
+// before the droop takes over. Not spec-pinned — a visual constant.
+const BURST_SPEED_K = 3.0;
 
 // §3 Quality tiers
 export const QUALITY: Record<QualityTier, TierSpec> = {
@@ -529,12 +549,21 @@ function sparkColorAtLifeInto(
 		out.b = MAGNESIUM.b;
 		return;
 	}
-	if (lifeT < 0.75) {
-		const t = (lifeT - whiteHold) / (0.75 - whiteHold);
+	// The magnesium flash reads as the detonation, not as the shell: it has to
+	// hand over to the shell hue early (by ~a third of the life) or a burst is
+	// a white ball for most of the time anyone is looking at it.
+	if (lifeT < HUE_ARRIVES_AT) {
+		const t = (lifeT - whiteHold) / (HUE_ARRIVES_AT - whiteHold);
 		mixOklabInto(MAGNESIUM, _sparkHue, Math.min(1, t), out);
 		return;
 	}
-	const t = (lifeT - 0.75) / 0.25;
+	if (lifeT < COOL_START) {
+		out.r = _sparkHue.r;
+		out.g = _sparkHue.g;
+		out.b = _sparkHue.b;
+		return;
+	}
+	const t = (lifeT - COOL_START) / (1 - COOL_START);
 	mixOklabInto(_sparkHue, COOL_END, Math.min(1, t), out);
 }
 
@@ -1211,10 +1240,11 @@ export function createSim(opts: SimOptions): Sim {
 			const speed = baseSpeed * asym * (straggler ? 1.4 : 1);
 			const isEmber = hash11(spec.seed + i + 313) < recipe.emberFrac;
 			const type: ParticleType = isEmber ? TYPE.EMBER : TYPE.SPARK;
+			const crackles = !isEmber && hash11(spec.seed + i + 577) < CRACKLE_FRAC;
 			const hue = depthAdjust(pickShellColor(spec, i), spec.depth);
 			const ttl = isEmber
-				? rand(seededRng(spec.seed + i + 17), 1.6, 2.8)
-				: rand(seededRng(spec.seed + i + 17), 0.9, 1.6);
+				? rand(seededRng(spec.seed + i + 17), 1.4, 2.4)
+				: rand(seededRng(spec.seed + i + 17), 0.75, 1.3);
 			const size =
 				(isEmber
 					? rand(seededRng(spec.seed + i + 29), 0.002, 0.003)
@@ -1234,9 +1264,13 @@ export function createSim(opts: SimOptions): Sim {
 				pool[base + F.type] = type;
 				pool[base + F.seed] = spec.seed + i;
 				// z-parallax folded into dragScale as a mild size/brightness proxy is
-				// avoided; dragScale carries the straggler multiplier only.
-				pool[base + F.dragScale] = straggler ? 0.7 : 1;
+				// avoided; dragScale carries the straggler multiplier and a per-spark
+				// spread — identical drag makes every spark fall at one speed, which
+				// combs the debris into a parallel curtain instead of a shell.
+				pool[base + F.dragScale] = straggler ? 0.7 : 0.85 + 0.45 * hash11(spec.seed + i + 233);
 				pool[base + F.depthDim] = dim;
+				// Field reuse for sparks: targetX flags the cracklers.
+				pool[base + F.targetX] = crackles ? 1 : 0;
 				// Stash burst z in targetY (unused for sparks/embers) for future
 				// parallax; harmless if ignored by the renderer.
 				pool[base + F.targetY] = z;
@@ -1251,7 +1285,7 @@ export function createSim(opts: SimOptions): Sim {
 		flashQueue.push({
 			pos: { ...origin },
 			brightness: flashB,
-			size: rand(seededRng(spec.seed + 5), 0.08, 0.16) * (1 - DEPTH_SIZE * spec.depth),
+			size: rand(seededRng(spec.seed + 5), 0.025, 0.05) * (1 - DEPTH_SIZE * spec.depth),
 			hue: depthAdjust(spec.colors[0], spec.depth),
 			dim,
 		});
@@ -1403,6 +1437,15 @@ export function createSim(opts: SimOptions): Sim {
 			if (type === TYPE.ROCKET) {
 				emitTrail(base, dt);
 				integrate(base, type, dt, w);
+				// Ascent wobble: a real shell corkscrews slightly on its way up, and
+				// the perfectly straight column the integrator draws reads as a wire.
+				// Positional only (velocity untouched), and small enough that the
+				// apex the launch solved for still holds.
+				const wob = pool[base + F.seed];
+				pool[base + F.posX] +=
+					Math.sin(pool[base + F.age] * ROCKET_WOBBLE_HZ + hash11(wob) * 6.283) *
+					ROCKET_WOBBLE_AMP *
+					dt;
 			} else if (type === TYPE.SEEKER) {
 				stepSeeker(base, dt);
 			} else {
@@ -1489,9 +1532,11 @@ export function createSim(opts: SimOptions): Sim {
 			const j = hash11(seed + pool[base + F.age] * 1000 + k);
 			sparkQueue.push({
 				pos: { x: px, y: py },
-				vel: { x: (j * 2 - 1) * 0.01, y: (hash11(j) * 2 - 1) * 0.01 },
-				ttl: rand(seededRng(seed + k + 71), 0.3, 0.5),
-				size: 0.002,
+				// Wider lateral scatter: a rigidly co-linear trail reads as a drawn
+				// beam rather than a comet shedding sparks.
+				vel: { x: (j * 2 - 1) * 0.035, y: (hash11(j) * 2 - 1) * 0.02 },
+				ttl: rand(seededRng(seed + k + 71), 0.22, 0.45),
+				size: 0.0018,
 				hue,
 				seed: seed + k + 500,
 			});
@@ -1555,15 +1600,22 @@ export function createSim(opts: SimOptions): Sim {
 		const age = pool[base + F.age];
 		switch (type) {
 			case TYPE.FLASH:
+				// Steep decay: the flash marks the break, it must not sit on top of
+				// the shell as a white disc while the sparks are opening.
 				return pool[base + F.brightness] > 0
-					? Math.max(pool[base + F.brightness], B_FLASH_AMBIENT) * Math.exp(-4 * lifeT)
-					: B_FLASH_AMBIENT * Math.exp(-4 * lifeT);
+					? Math.max(pool[base + F.brightness], B_FLASH_AMBIENT) * Math.exp(-5.5 * lifeT)
+					: B_FLASH_AMBIENT * Math.exp(-5.5 * lifeT);
 			case TYPE.SPARK: {
 				// Two-stage: fast drop 2.2→~0.9, then cubic ease-in to 0 past 0.7.
 				let b = B_SPARK_STEADY + (B_SPARK_FRESH - B_SPARK_STEADY) * Math.exp(-lifeT * 8);
 				if (lifeT > 0.7) {
 					const u = (lifeT - 0.7) / 0.3;
 					b = Math.max(B_SPARK_TERMINAL, b * (1 - u) * (1 - u) * (1 - u));
+				}
+				// Crackle: flagged sparks chatter on/off at CRACKLE_HZ instead of
+				// fading smoothly (field reuse — targetX is free for sparks).
+				if (pool[base + F.targetX] > 0.5) {
+					b *= flickerNoise(seed, age, CRACKLE_HZ) > 0.5 ? 1.9 : 0.25;
 				}
 				return b;
 			}
@@ -1629,7 +1681,7 @@ export function createSim(opts: SimOptions): Sim {
 		const seed = pool[base + F.seed];
 		switch (type) {
 			case TYPE.SPARK: {
-				const whiteHold = 0.06 + 0.12 * hash11(seed);
+				const whiteHold = 0.04 + 0.07 * hash11(seed);
 				sparkColorAtLifeInto(_dispHue, lifeT, whiteHold, seed, out);
 				return;
 			}

--- a/src/lib/fancy-ui/fireworks-hdr/webgl2-renderer.ts
+++ b/src/lib/fancy-ui/fireworks-hdr/webgl2-renderer.ts
@@ -44,7 +44,11 @@ import {
 	SDR_SAT_BOOST,
 	type FireworksRenderLevel,
 } from "./fireworks-shared.js";
-import { TRAIL_FADE_RATE, type FireworksEngineHandle, type FrameUniforms } from "./webgpu-renderer.js";
+import {
+	TRAIL_FADE_RATE,
+	type FireworksEngineHandle,
+	type FrameUniforms,
+} from "./webgpu-renderer.js";
 
 /** Device-pixel-ratio clamp (matches the WebGPU renderer — fill-rate is the cap). */
 const MAX_DPR = 2;
@@ -158,27 +162,33 @@ uniform float uCoreScale; // SDR trades headroom for size (§7.4); always on in 
 out vec2 vLocal;
 out vec3 vColor;
 const vec2 C[4] = vec2[4](vec2(-1.0, -1.0), vec2(1.0, -1.0), vec2(-1.0, 1.0), vec2(1.0, 1.0));
+// Quad oversize so the halo can fall to zero before the geometry ends.
+const float QUAD_PAD = 1.35;
 void main() {
 	vec2 c = C[gl_VertexID];
 	float size = iSize * uCoreScale;
 	float velLen = length(iVel);
 	vec2 dir = velLen > 1e-6 ? iVel / velLen : vec2(1.0, 0.0);
 	vec2 perp = vec2(-dir.y, dir.x);
-	float minorHalf = size;
-	float majorHalf = clamp(size + velLen, size, size * 4.0);
+	float minorHalf = size * QUAD_PAD;
+	float majorHalf = clamp(size + velLen, size, size * 2.5) * QUAD_PAD;
 	vec2 off = dir * (majorHalf * c.x) + perp * (minorHalf * c.y);
 	vec2 p01 = iPos + vec2(off.x / uAspect, off.y);
 	vec2 ndc = vec2(p01.x * 2.0 - 1.0, 1.0 - p01.y * 2.0);
 	gl_Position = vec4(ndc, 0.0, 1.0);
-	vLocal = c;
+	vLocal = c * QUAD_PAD;
 	vColor = iColor;
 }`;
 
+// Windowed to exactly zero at the quad edge — an unwindowed halo still carries
+// ~7% there, which additive blending shows as a hard-edged square.
 const PARTICLE_LOBE_GLSL = /* glsl */ `
+	const float QUAD_PAD = 1.35;
 	float r2 = dot(vLocal, vLocal);
 	float core = exp(-r2 * 6.0);
 	float halo = exp(-r2 * 1.6) * 0.35;
-	float intensity = core + halo;`;
+	float win = smoothstep(QUAD_PAD, QUAD_PAD * 0.6, sqrt(r2));
+	float intensity = (core + halo) * win;`;
 
 // Path A particle fragment: raw premultiplied HDR contribution; the display
 // pass owns the SDR ladder.
@@ -220,7 +230,11 @@ void main() {
 	frag = vec4(0.0, 0.0, 0.0, uAlpha);
 }`;
 
-function compileShader(gl: WebGL2RenderingContext, type: number, source: string): WebGLShader | null {
+function compileShader(
+	gl: WebGL2RenderingContext,
+	type: number,
+	source: string
+): WebGLShader | null {
 	const shader = gl.createShader(type);
 	if (!shader) return null;
 	gl.shaderSource(shader, source);
@@ -235,7 +249,11 @@ function compileShader(gl: WebGL2RenderingContext, type: number, source: string)
 	return shader;
 }
 
-function linkProgram(gl: WebGL2RenderingContext, vsSrc: string, fsSrc: string): WebGLProgram | null {
+function linkProgram(
+	gl: WebGL2RenderingContext,
+	vsSrc: string,
+	fsSrc: string
+): WebGLProgram | null {
 	const vs = compileShader(gl, gl.VERTEX_SHADER, vsSrc);
 	const fs = compileShader(gl, gl.FRAGMENT_SHADER, fsSrc);
 	if (!vs || !fs) {
@@ -319,8 +337,9 @@ export function startWebGl2Fireworks(
 	let renderLevel: FireworksRenderLevel = "webgl-sdr";
 	if (wantP3 && "drawingBufferColorSpace" in glc) {
 		try {
-			(glc as WebGL2RenderingContext & { drawingBufferColorSpace: string }).drawingBufferColorSpace =
-				"display-p3";
+			(
+				glc as WebGL2RenderingContext & { drawingBufferColorSpace: string }
+			).drawingBufferColorSpace = "display-p3";
 			if (
 				(glc as WebGL2RenderingContext & { drawingBufferColorSpace: string })
 					.drawingBufferColorSpace === "display-p3"
@@ -351,7 +370,9 @@ export function startWebGl2Fireworks(
 	// (No listeners/resources are allocated yet at this point.)
 	if (wantFloatAccum && !floatAccum) {
 		if (import.meta.env.DEV) {
-			console.warn("[FireworksHdr] WebGL2 float-accum probe/context mismatch; bailing to static fallback");
+			console.warn(
+				"[FireworksHdr] WebGL2 float-accum probe/context mismatch; bailing to static fallback"
+			);
 		}
 		return null;
 	}
@@ -396,7 +417,11 @@ export function startWebGl2Fireworks(
 	}
 
 	// --- programs ------------------------------------------------------------
-	particleProgram = linkProgram(glc, PARTICLE_VS, floatAccum ? PARTICLE_FS_ACCUM : PARTICLE_FS_DIRECT);
+	particleProgram = linkProgram(
+		glc,
+		PARTICLE_VS,
+		floatAccum ? PARTICLE_FS_ACCUM : PARTICLE_FS_DIRECT
+	);
 	decayProgram = floatAccum ? linkProgram(glc, FULLSCREEN_VS, DECAY_FS) : null;
 	displayProgram = floatAccum ? linkProgram(glc, FULLSCREEN_VS, DISPLAY_FS) : null;
 	fadeProgram = floatAccum ? null : linkProgram(glc, FULLSCREEN_VS, FADE_FS);

--- a/src/lib/fancy-ui/fireworks-hdr/webgpu-renderer.ts
+++ b/src/lib/fancy-ui/fireworks-hdr/webgpu-renderer.ts
@@ -33,12 +33,12 @@ import { STRETCH, EXPOSURE_AMBIENT, type FireworksRenderLevel } from "./firework
 
 /**
  * Single global accumulation fade rate (1/s). Per-frame factor is
- * exp(-TRAIL_FADE_RATE·dt); at 60 fps that is ≈0.912, giving ascent comet
- * trails ~415 ms to fade to 10% (AD §3.3 ascent range 350–500 ms). Burst
- * streaks linger a little longer than their 150–220 ms ideal — the accepted
- * single-rate compromise (a two-channel decay would be overengineering here).
+ * exp(-TRAIL_FADE_RATE·dt); at 60 fps that is ≈0.889, fading a trail to 10% in
+ * ~330 ms (AD §3.3 ascent range 350–500 ms). Held deliberately short: the
+ * accumulation buffer is what smears a moving particle into a line, so a slower
+ * fade turns falling debris into long straight filaments instead of sparks.
  */
-export const TRAIL_FADE_RATE = 5.5;
+export const TRAIL_FADE_RATE = 7.0;
 
 /** Device-pixel-ratio clamp — HDR float buffers are fill-rate heavy. */
 const MAX_DPR = 2;
@@ -123,6 +123,9 @@ fn fs_decay(in: FSOut) -> @location(0) vec4f {
 struct ParticleU { aspect: f32, sdr: f32, coreScale: f32, _pad: f32 }
 @group(0) @binding(0) var<uniform> pu: ParticleU;
 
+// Quad oversize so the halo can fall to zero before the geometry ends.
+const QUAD_PAD: f32 = 1.35;
+
 struct PVOut {
 	@builtin(position) pos: vec4f,
 	@location(0) local: vec2f,  // quad-local coords in [-1,1]
@@ -146,13 +149,15 @@ fn vs_particle(
 	// SDR trades brightness headroom for size — bigger, not brighter (§7.4).
 	let size = iSize * select(1.0, pu.coreScale, pu.sdr > 0.5);
 
-	// Velocity-stretch: major axis along velocity, clamped 1–4× the minor.
+	// Velocity-stretch: major axis along velocity, clamped 1–2.5× the minor.
 	let velLen = length(iVel);
 	var dir = vec2f(1.0, 0.0);
 	if (velLen > 1e-6) { dir = iVel / velLen; }
 	let perp = vec2f(-dir.y, dir.x);
-	let minorHalf = size;
-	let majorHalf = clamp(size + velLen, size, size * 4.0);
+	// QUAD_PAD gives the halo room to reach zero INSIDE the quad; the fragment
+	// keeps the gaussian in un-padded units so the visible size is unchanged.
+	let minorHalf = size * QUAD_PAD;
+	let majorHalf = clamp(size + velLen, size, size * 2.5) * QUAD_PAD;
 
 	// Offset in isotropic screen-height units, then map to [0,1] (x compressed
 	// by aspect) and to NDC (flip y for the top-left origin).
@@ -162,7 +167,7 @@ fn vs_particle(
 
 	var out: PVOut;
 	out.pos = vec4f(ndc, 0.0, 1.0);
-	out.local = c;
+	out.local = c * QUAD_PAD;
 	out.color = iColor;
 	return out;
 }
@@ -173,7 +178,11 @@ fn fs_particle(in: PVOut) -> @location(0) vec4f {
 	let r2 = dot(in.local, in.local);
 	let core = exp(-r2 * 6.0);
 	let halo = exp(-r2 * 1.6) * 0.35;
-	let intensity = core + halo;
+	// Window it to exactly zero at the quad edge. The halo alone still carries
+	// ~7% of its peak there, and additive blending turns that step into a
+	// hard-edged square around anything bright (a flash reads as a lit box).
+	let win = smoothstep(QUAD_PAD, QUAD_PAD * 0.6, sqrt(r2));
+	let intensity = (core + halo) * win;
 	// Additive (one/one): premultiplied contribution.
 	return vec4f(in.color * intensity, intensity);
 }


### PR DESCRIPTION
Follow-up to #173, from looking at the docs demo: the effect had two structural problems. Pattern shells (heart/star/custom) are stacked on top of this branch in #175.

## Hard-edged squares

The particle fragment drew a two-lobe gaussian with no window, so the halo still carried ~7% of its peak at the quad boundary. Additive blending turns that step into a **visible square** around anything bright — every detonation flash rendered as a lit box.

The quad is now oversized (`QUAD_PAD = 1.35`) with the lobe windowed to exactly zero at its edge, identically in the WGSL and GLSL paths. Visible size is unchanged.

## Fountains instead of shells

Debris gravity sat close to the rocket's, so a spark's terminal velocity (`gravScale·G / drag`) was several times the burst's own expansion speed. A shell never opened into a sphere — it collapsed into a downward fountain of parallel filaments.

- spark gravity `0.85 → 0.15`, ember `0.35 → 0.30`, spark drag `1.8 → 2.2`
- burst speed `radius×2.2 → radius×3.0`, so a shell coasts to about its nominal radius
- each non-straggler spark draws its own `dragScale ∈ [0.85, 1.30]` — identical drag made every spark fall at exactly one speed, combing the debris into a curtain

## Smaller things in the same pass

- Sparks reached their shell hue only at 3/4 of their life, so bursts read white. The handover now completes at 1/3 (`HUE_ARRIVES_AT`), with a shorter white hold.
- Detonation flash: brightness `3.8 → 2.1`, size `0.08–0.16 → 0.025–0.05`, decay `e^-4 → e^-5.5`. It sat on the shell as a white disc while the sparks were opening.
- Accumulation fade `5.5 → 7.0` and velocity stretch `0.015 → 0.010` (cap `4× → 2.5×`): the buffer already smears motion into a line, stacking a long stretch on top made needles.
- Ascent trail sparks scatter laterally and live shorter; the rocket carries a small 11 Hz **positional** wobble (velocity untouched, so the solved apex still holds) instead of climbing a ruler-straight column.
- Wired up the 6% spark crackle at 24 Hz that the spec documented but nothing implemented.

## Verification

Driven on the docs demo through Playwright and captured at 0.5 / 0.9 / 1.4 / 2.1 s after a launch — that harness exercises the **WebGL2** path under SwiftShader. The WebGPU path shares the physics and got the identical shader edit, but I could not drive it live here (the automated tab stays backgrounded, so rAF is parked); worth a look on a real GPU before merge.

Two new tests pin the behaviour rather than the constants: a shell must rise a real fraction of what it falls shortly after the break (the old constants scored ~0 there), and a spark must have fully handed over to its hue between `HUE_ARRIVES_AT` and the cool-down.

`pnpm check` clean, 732 tests pass, registry parity OK. No API change — `patch`.