### PR TITLE
chore: release 0.9.1 as a patch bump

### DIFF
--- a/.changeset/fireworks-hdr.md
+++ b/.changeset/fireworks-hdr.md
@@ -1,5 +1,5 @@
 ---
-"fancy-ui-svelte": minor
+"fancy-ui-svelte": patch
 ---
 
 FireworksHdr: new component — a GPU fireworks engine that renders shells into an HDR accumulation buffer, with a WebGPU path (float16 + display-p3 + extended tone mapping) and a WebGL2 fallback that resolves to display-p3 or plain sRGB. Ambient shells schedule themselves on a Poisson cadence inside weighted zones, avoid a caller-supplied keep-clear rect, and adapt their render scale and spawn density to the measured frame time; `prefers-reduced-motion` turns the scheduler off while imperative launches keep working. The `onReady` callback hands over a `FireworksHandle` (`launch`, `setAmbient`, `setKeepClear`, `setExposure`, `renderLevel`, `cleanup`) and an `onLost` callback reports a GPU context loss that could not be recovered. `FireworksHdr`, `FireworksHdrProps`, `FireworksHandle`, `LaunchOptions`, `LaunchResult`, `FireworksRenderLevel`, `ShellKind` and `QualityTier` are exported from the package root.

--- a/.changeset/fireworks-pattern-shells.md
+++ b/.changeset/fireworks-pattern-shells.md
@@ -1,5 +1,5 @@
 ---
-"fancy-ui-svelte": minor
+"fancy-ui-svelte": patch
 ---
 
 FireworksHdr: pattern shells. `shell: "heart"` and `shell: "star"` break into a figure instead of a sphere, and `shell: "shape"` draws any closed outline passed as `shapePoints` (y-up points around the origin, any scale — the outline is normalized and redrawn at the shell's radius, walking its edges so a hand-written polygon works as well as a sampled curve). The burst is cut from the outline: each spark's speed is proportional to its sample's distance from the centre, so linear drag coasts the figure into shape in the sky before it droops. Pattern shells suppress the break asymmetry, the stragglers and most embers, which exist to make a peony look natural but read as a broken figure on a heart. A new `ambientShells` prop restricts the ambient scheduler to a chosen set of shells, pattern shells included. The outline helpers (`heartOutline`, `starOutline`, `polygonOutline`, `outlineBurst`) are exported for building your own figures, and a `shape` shell launched without points falls back to a plain sphere rather than vanishing.


### PR DESCRIPTION
Retargets the pending FireworksHdr changesets from `minor` to `patch` so the next release cuts **0.9.1** instead of the 0.10.0 changesets would otherwise compute.

Owner decision for this release. Recording the trade-off plainly: CONTRIBUTING's bump guide calls a new component and new exports `minor`, and this release does ship a brand-new public component (`FireworksHdr`) along with new public API — pattern shell kinds, `shapePoints`, the `ambientShells` prop, and the exported outline helpers. Those will therefore appear in the changelog under "Patch Changes".

Only the two front-matter lines change:

- `.changeset/fireworks-hdr.md` — `minor` → `patch`
- `.changeset/fireworks-pattern-shells.md` — `minor` → `patch`

`.changeset/fireworks-visual-retune.md` was already `patch`. No changeset body is reworded, so the changelog text still describes what actually shipped, and no `package.json` version is touched — the release pipeline owns that.