### PR TITLE
feat(fluid-cursor): experimental bitmap dithering mode

### DIFF
--- a/.changeset/fluid-cursor-bitmap-dither.md
+++ b/.changeset/fluid-cursor-bitmap-dither.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+FluidCursor: experimental bitmap dithering mode. The new `dither` prop renders the fluid as a retro ordered-dither bitmap — dye is snapped to a chunky pixel grid and each color channel is quantized against a procedural 4x4 Bayer matrix, so dot density encodes brightness while hues are preserved. Tune with `ditherPixelSize` (CSS px per dot, default 3) and `ditherLevels` (color levels per channel, default 4). Dither forces the WebGL renderer; `hdr` is ignored while it is set.

--- a/src/lib/components/docs/examples/fluid-cursor/BitmapDither.svelte
+++ b/src/lib/components/docs/examples/fluid-cursor/BitmapDither.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { FluidCursor } from "$lib/fancy-ui/fluid-cursor";
+</script>
+
+<div class="relative h-64 w-full overflow-hidden rounded-lg border bg-black">
+	<FluidCursor
+		dither
+		ditherPixelSize={3}
+		ditherLevels={4}
+		fluidColors={["#a142ff", "#42cfff", "#2fe6a8", "#ffb02f"]}
+		colorIntensity={0.5}
+		autoSplat
+		splatOnMount
+		allowMultiple
+	/>
+	<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+		<p class="text-sm text-white/60 select-none">Bitmap dithering — move your cursor here</p>
+	</div>
+</div>

--- a/src/lib/components/docs/examples/registry.ts
+++ b/src/lib/components/docs/examples/registry.ts
@@ -323,6 +323,12 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 			description:
 				"WebGPU engine with extended tone mapping — glows brighter than white on HDR displays. Requires a WebGPU browser (Chrome/Edge 129+, Safari 26+) plus an HDR screen for the full glow; otherwise falls back to wide-gamut WebGL (Chrome 104+, Safari 16.4+, Firefox 132+), then to standard rendering.",
 		},
+		{
+			name: "BitmapDither",
+			title: "Bitmap Dithering",
+			description:
+				"Retro ordered-dither rendering — the fluid is snapped to a chunky pixel grid and each color channel is quantized with a 4x4 Bayer threshold, so dot density encodes brightness. Forces the WebGL renderer (hdr is ignored).",
+		},
 	],
 	"fireworks-hdr": [
 		{

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.svelte
@@ -49,6 +49,19 @@
 		hdr?: boolean;
 		hdrBoost?: number;
 		/**
+		 * Experimental: render the fluid as a retro ordered-dither bitmap.
+		 * The dye is snapped to a chunky pixel grid and each color channel is
+		 * quantized against a procedural 4x4 Bayer matrix, so dot density
+		 * encodes brightness while hues are preserved. Forces the WebGL
+		 * renderer (`hdr` is ignored while set). Applied at mount, like the
+		 * other simulation props.
+		 */
+		dither?: boolean;
+		/** Size of one dithered pixel in CSS pixels (minimum 1). */
+		ditherPixelSize?: number;
+		/** Color levels per channel in dither mode, clamped to [2, 16]. */
+		ditherLevels?: number;
+		/**
 		 * Called once the fluid engine is live, with an imperative handle to
 		 * drive the simulation programmatically (trace a path via
 		 * `moveTo`/`penUp`, fire a one-off `burst`) and read back the actual
@@ -86,11 +99,16 @@
 		contained = true,
 		hdr = false,
 		hdrBoost = 1.5,
+		dither = false,
+		ditherPixelSize = 3,
+		ditherLevels = 4,
 		onReady,
 	}: Props = $props();
 
 	const clampedColorIntensity = Math.max(0, Math.min(1, colorIntensity));
 	const clampedHdrBoost = Math.max(1, Math.min(4, hdrBoost));
+	const clampedDitherPixelSize = Math.max(1, ditherPixelSize);
+	const clampedDitherLevels = Math.max(2, Math.min(16, Math.floor(ditherLevels)));
 
 	const resolvedBackColor: ColorRGB =
 		typeof backColor === "string" ? hexToRgb(backColor) : backColor;
@@ -216,12 +234,15 @@
 			PAUSED: false,
 			BACK_COLOR: resolvedBackColor,
 			TRANSPARENT: transparent,
+			DITHER: dither,
+			DITHER_PIXEL_SIZE: clampedDitherPixelSize,
+			DITHER_LEVELS: clampedDitherLevels,
 		};
 
 		// HDR path: WebGPU engine (rgba16float backbuffer, display-p3,
 		// extended tone mapping). Falls back to the WebGL path below when
 		// WebGPU is unavailable or initialization fails.
-		if (hdr && typeof navigator !== "undefined" && "gpu" in navigator) {
+		if (hdr && !dither && typeof navigator !== "undefined" && "gpu" in navigator) {
 			let disposed = false;
 			let activeCleanup: (() => void) | null = null;
 			startWebGpuFluid(canvas, {
@@ -643,16 +664,49 @@
 			varying vec2 vT;
 			varying vec2 vB;
 			uniform sampler2D uTexture;
-			uniform sampler2D uDithering;
-			uniform vec2 ditherScale;
 			uniform vec2 texelSize;
+			#ifdef DITHERING
+			uniform float uDitherPixel;
+			uniform float uDitherLevels;
+			#endif
 
 			vec3 linearToGamma (vec3 color) {
 				color = max(color, vec3(0));
 				return max(1.055 * pow(color, vec3(0.416666667)) - 0.055, vec3(0));
 			}
 
+			#ifdef DITHERING
+			// Recursive ordered-dither thresholds (4x4 Bayer, 16 levels).
+			// GLSL ES 1.00-safe: floor/fract arithmetic only — no arrays,
+			// no integer ops, no dynamic indexing.
+			float bayer2 (vec2 a) {
+				a = floor(a);
+				return fract(a.x * 0.5 + a.y * a.y * 0.75);
+			}
+
+			float bayer4 (vec2 a) {
+				return bayer2(a * 0.5) * 0.25 + bayer2(a);
+			}
+			#endif
+
 			void main () {
+			#ifdef DITHERING
+				// One cell = one chunky pixel: every fragment in the cell samples
+				// the dye at the cell center and shares one Bayer threshold, so
+				// the cell renders as a solid square dot.
+				vec2 cell = floor(gl_FragCoord.xy / uDitherPixel);
+				vec2 uv = (cell + 0.5) * uDitherPixel * texelSize;
+				vec3 c = clamp(texture2D(uTexture, uv).rgb, 0.0, 1.0);
+
+				float steps = uDitherLevels - 1.0;
+				c = floor(c * steps + bayer4(cell)) / steps;
+
+				// Alpha from the quantized color: cells that quantize to black
+				// stay fully transparent, so dot density encodes brightness
+				// with no grey haze over the background.
+				float a = max(c.r, max(c.g, c.b));
+				gl_FragColor = vec4(c, a);
+			#else
 				vec3 c = texture2D(uTexture, vUv).rgb;
 				#ifdef SHADING
 					vec3 lc = texture2D(uTexture, vL).rgb;
@@ -672,6 +726,7 @@
 
 				float a = max(c.r, max(c.g, c.b));
 				gl_FragColor = vec4(c, a);
+			#endif
 			}
 		`;
 
@@ -1132,6 +1187,7 @@
 			function updateKeywords() {
 				const displayKeywords: string[] = [];
 				if (config.SHADING) displayKeywords.push("SHADING");
+				if (config.DITHER) displayKeywords.push("DITHERING");
 				displayMaterial.setKeywords(displayKeywords);
 			}
 
@@ -1397,11 +1453,22 @@
 				const width = target ? target.width : gl.drawingBufferWidth;
 				const height = target ? target.height : gl.drawingBufferHeight;
 				displayMaterial.bind();
-				if (config.SHADING && displayMaterial.uniforms.texelSize) {
+				if ((config.SHADING || config.DITHER) && displayMaterial.uniforms.texelSize) {
 					gl.uniform2f(displayMaterial.uniforms.texelSize, 1 / width, 1 / height);
 				}
 				if (displayMaterial.uniforms.uTexture) {
 					gl.uniform1i(displayMaterial.uniforms.uTexture, dye.read.attach(0));
+				}
+				if (config.DITHER) {
+					if (displayMaterial.uniforms.uDitherPixel) {
+						gl.uniform1f(
+							displayMaterial.uniforms.uDitherPixel,
+							config.DITHER_PIXEL_SIZE * (window.devicePixelRatio || 1)
+						);
+					}
+					if (displayMaterial.uniforms.uDitherLevels) {
+						gl.uniform1f(displayMaterial.uniforms.uDitherLevels, config.DITHER_LEVELS);
+					}
 				}
 				blit(target, false);
 			}

--- a/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
+++ b/src/lib/fancy-ui/fluid-cursor/FluidCursor.test.ts
@@ -109,6 +109,36 @@ describe("FluidCursor", () => {
 		});
 	});
 
+	describe("dither props", () => {
+		it("renders without error with dither={true}", () => {
+			const { container } = render(FluidCursor, { props: { dither: true } });
+			expect(container.querySelector("canvas")).toBeInTheDocument();
+		});
+
+		it("renders without error when dither values are out of range (clamped internally)", () => {
+			const { container } = render(FluidCursor, {
+				props: { dither: true, ditherPixelSize: 0, ditherLevels: 100 },
+			});
+			expect(container.querySelector("canvas")).toBeInTheDocument();
+		});
+
+		it("does not attempt WebGPU when dither and hdr are both set", async () => {
+			const requestAdapter = vi.fn(async () => null);
+			Object.defineProperty(navigator, "gpu", {
+				value: { requestAdapter },
+				configurable: true,
+			});
+			try {
+				const { container } = render(FluidCursor, { props: { dither: true, hdr: true } });
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				expect(requestAdapter).not.toHaveBeenCalled();
+				expect(container.querySelector("canvas")).toBeInTheDocument();
+			} finally {
+				delete (navigator as unknown as Record<string, unknown>).gpu;
+			}
+		});
+	});
+
 	describe("color props", () => {
 		it("renders without error when fluidColor is provided", () => {
 			const { container } = render(FluidCursor, { props: { fluidColor: "#00ffcc" } });

--- a/src/lib/fancy-ui/fluid-cursor/README.md
+++ b/src/lib/fancy-ui/fluid-cursor/README.md
@@ -108,3 +108,30 @@ Notes:
   On SDR displays HDR mode is still safe, just clamped.
 - With `hdr={false}` (the default) the WebGPU code path is never taken and
   rendering is identical to previous versions.
+
+## Bitmap Dithering (experimental)
+
+```svelte
+<FluidCursor dither ditherPixelSize={3} ditherLevels={4} fluidColors={["#a142ff", "#42cfff"]} />
+```
+
+With `dither` enabled the display pass renders the fluid as a retro ordered-dither
+bitmap: the dye is snapped to a chunky pixel grid (each cell samples the dye at its
+center, so cells render as solid square dots) and each color channel is quantized
+against a procedural 4×4 Bayer matrix. Dot density encodes brightness while hues
+are preserved. Cells that quantize to black stay fully transparent, so the effect
+composites cleanly over any background.
+
+| Prop              | Type      | Default | Description                                                            |
+| ----------------- | --------- | ------- | ---------------------------------------------------------------------- |
+| `dither`          | `boolean` | `false` | Enable the ordered-dither display pass. Forces the WebGL renderer.     |
+| `ditherPixelSize` | `number`  | `3`     | Size of one dithered pixel in CSS pixels, minimum `1`.                 |
+| `ditherLevels`    | `number`  | `4`     | Color levels per channel, clamped to `[2, 16]`. Lower = more dithered. |
+
+Notes:
+
+- `dither` forces the WebGL renderer — `hdr` is ignored while it is set.
+- Like the other simulation props, dither props are applied at mount; re-key the
+  component to change them at runtime.
+- Raise `colorIntensity` (≈ `0.4`+) so the dye reliably crosses the first
+  quantization step; at the default `0.15` dots stay sparse.

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -1075,6 +1075,25 @@ export const registry: Record<string, ComponentMeta> = {
 				default: "1.5",
 				description: "Display exposure multiplier in HDR mode, clamped to [1, 4]",
 			},
+			{
+				name: "dither",
+				type: "boolean",
+				default: "false",
+				description:
+					"Experimental retro bitmap dithering — pixelates the fluid to a chunky grid and quantizes color with an ordered 4x4 Bayer threshold. Forces the WebGL renderer; hdr is ignored while set",
+			},
+			{
+				name: "ditherPixelSize",
+				type: "number",
+				default: "3",
+				description: "Size of one dithered pixel in CSS pixels, minimum 1",
+			},
+			{
+				name: "ditherLevels",
+				type: "number",
+				default: "4",
+				description: "Color levels per channel in dither mode, clamped to [2, 16]",
+			},
 		],
 	},
 

--- a/src/stories/fluid-cursor.stories.svelte
+++ b/src/stories/fluid-cursor.stories.svelte
@@ -30,6 +30,9 @@
 				control: "color",
 				description: "Override all fluid with a single color",
 			},
+			dither: { control: "boolean", description: "Retro bitmap dithering" },
+			ditherPixelSize: { control: "number", description: "CSS pixels per dithered dot" },
+			ditherLevels: { control: "number", description: "Color levels per channel" },
 		},
 	});
 </script>
@@ -43,6 +46,29 @@
 	</div>
 {/snippet}
 
+{#snippet templateDark(args: any)}
+	<div class="relative h-64 w-full overflow-hidden rounded-lg border bg-black">
+		<FluidCursor {...args} />
+		<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+			<p class="text-sm text-white/60 select-none">Move your cursor here</p>
+		</div>
+	</div>
+{/snippet}
+
 <Story name="Default" {template} />
 
 <Story name="Custom Color" {template} args={{ fluidColor: "#00ffcc", colorIntensity: 0.4 }} />
+
+<Story
+	name="Bitmap Dither"
+	template={templateDark}
+	args={{
+		dither: true,
+		ditherPixelSize: 3,
+		ditherLevels: 4,
+		fluidColors: ["#a142ff", "#42cfff", "#2fe6a8", "#ffb02f"],
+		colorIntensity: 0.5,
+		autoSplat: true,
+		splatOnMount: true,
+	}}
+/>


### PR DESCRIPTION
## What

New `dither` prop on **FluidCursor** renders the fluid as a retro ordered-dither bitmap: the dye is snapped to a chunky pixel grid and each color channel is quantized against a procedural 4×4 Bayer matrix, so dot density encodes brightness while hues are preserved.

Tune with `ditherPixelSize` (CSS px per dot, default 3) and `ditherLevels` (color levels per channel, clamped [2, 16], default 4).

## How

- Single-pass `#ifdef DITHERING` branch in the existing display fragment shader, compiled via the existing `Material.setKeywords()` variant machinery (same pattern as `SHADING`).
- Pixelation: every fragment in a `ditherPixelSize`-sized screen cell samples the dye at the cell center → solid square dots, no extra FBO or render pass.
- Bayer thresholds are procedural (`floor`/`fract` arithmetic only — no arrays, no integer ops), so the shader stays GLSL ES 1.00-safe for the WebGL1 fallback.
- Alpha is computed from the quantized color: cells that quantize to black stay fully transparent — no grey haze, composites over any background.
- `dither` forces the WebGL renderer; `hdr` is ignored while set (WebGPU engine untouched).
- Removed two dead uniforms (`uDithering`, `ditherScale`) inherited from the original simulation.

Also ships: docs example **Bitmap Dithering**, Storybook story **Bitmap Dither**, registry props, README section, 3 tests, minor changeset.

## Verification

- `pnpm check` — 0 errors
- `pnpm test` — 744/744 pass (incl. 3 new dither tests: mount, clamping, hdr-bypass gate)
- `pnpm check:registry` — parity OK
- Prettier clean on all touched files
- Verified live on `/docs/components/fluid-cursor` (Chrome): chunky Bayer dots, quantized-but-preserved hues, pure black background; Basic Usage and HDR examples unchanged

## Follow-up (out of scope)

Swap the retro-os skin's DOM-based `RetroPixel` fluid-cursor preview for this real WebGL version.