### PR TITLE
feat(ai): tool-use surfaces — ToolCall, ToolTimeline, TerminalBlock, CodeDiff

### DIFF
--- a/.changeset/ai-tool-use.md
+++ b/.changeset/ai-tool-use.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+Add the tool-use surfaces of the AI/chat family: `ToolCall` (one invocation in a disclosure card — status dot, duration, pretty-printed request/result with cycle-safe JSON rendering, error calls auto-open), `ToolTimeline` (compact session summary on a vertical rail with verbs, targets, diff stats, and relative timestamps), `TerminalBlock` (live append-only command transcript with a hand-rolled ANSI SGR subset, stick-to-bottom autoscroll, running cursor, and exit-status footer), and `CodeDiff` (unified diff tuned for chat width — foldable per-file cards, tinted add/delete rows, copy-safe gutters, soft line clamping — driven by the internal diff parser). Introduces the shared `--ft-status-*` color tokens with `light-dark()` fallbacks used across the family for run-status semantics.

--- a/src/lib/components/docs/DemoRenderer.svelte
+++ b/src/lib/components/docs/DemoRenderer.svelte
@@ -72,6 +72,10 @@
 		"chat-message",
 		"prompt-suggestions",
 		"chat-error",
+		"tool-call",
+		"tool-timeline",
+		"terminal-block",
+		"code-diff",
 	]);
 </script>
 

--- a/src/lib/components/docs/examples/code-diff/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/code-diff/BasicUsage.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { CodeDiff } from "$lib/fancy-ui/code-diff";
+
+	/** A two-hunk edit to one file: the shape an agent hands back after a fix. */
+	const PATCH = [
+		"diff --git a/src/lib/query.ts b/src/lib/query.ts",
+		"index 8f2a1c4..b31e097 100644",
+		"--- a/src/lib/query.ts",
+		"+++ b/src/lib/query.ts",
+		"@@ -12,6 +12,7 @@ export async function totalsByRegion(db: Db) {",
+		"   const sql = compile(ast);",
+		"-  const rows = await db.query(sql);",
+		"-  return rows;",
+		"+  const rows = await db.query(sql, { timeout: 5_000 });",
+		"+  if (rows.length === 0) return [];",
+		"+  return rows.map(normalise);",
+		" }",
+		" ",
+		" function normalise(row: Row) {",
+		"@@ -41,3 +42,3 @@ function normalise(row: Row) {",
+		"   const region = row.region ?? UNASSIGNED;",
+		"-  return { region, total: row.total };",
+		"+  return { region, total: Number(row.total) };",
+		" }",
+		"",
+	].join("\n");
+
+	/** A move with an edit inside it, so the header has something to say. */
+	const RENAME = [
+		"diff --git a/src/lib/query.ts b/src/lib/db/totals.ts",
+		"similarity index 94%",
+		"rename from src/lib/query.ts",
+		"rename to src/lib/db/totals.ts",
+		"--- a/src/lib/query.ts",
+		"+++ b/src/lib/db/totals.ts",
+		"@@ -1,3 +1,3 @@",
+		'-import { compile } from "./ast";',
+		'+import { compile } from "../ast";',
+		" ",
+		' const UNASSIGNED = "Unassigned";',
+		"",
+	].join("\n");
+</script>
+
+<div class="flex w-full max-w-2xl flex-col gap-4">
+	<CodeDiff diff={PATCH} />
+	<CodeDiff diff={RENAME} />
+</div>

--- a/src/lib/components/docs/examples/registry.ts
+++ b/src/lib/components/docs/examples/registry.ts
@@ -432,4 +432,8 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 	"chat-message": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"prompt-suggestions": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"chat-error": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"tool-call": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"tool-timeline": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"terminal-block": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"code-diff": [{ name: "BasicUsage", title: "Basic Usage" }],
 };

--- a/src/lib/components/docs/examples/terminal-block/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/terminal-block/BasicUsage.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { TerminalBlock } from "$lib/fancy-ui/terminal-block";
+
+	// Real output arrives with the escape sequences already in it; these just
+	// spare the transcript below from spelling them out on every line.
+	const ESC = "\u001b";
+	const green = (text: string) => `${ESC}[32m${text}${ESC}[0m`;
+	const yellow = (text: string) => `${ESC}[33m${text}${ESC}[0m`;
+	const cyan = (text: string) => `${ESC}[36m${text}${ESC}[0m`;
+	const bold = (text: string) => `${ESC}[1m${text}${ESC}[0m`;
+
+	/** Each line, and how long the build "spends" before printing the next one. */
+	const TRANSCRIPT: { text: string; wait: number }[] = [
+		{ text: `${bold("building for production…")}`, wait: 700 },
+		{ text: `${green("✓")} 214 modules transformed`, wait: 900 },
+		{ text: `${yellow("warning:")} "createElapsed" is exported but never used`, wait: 500 },
+		{ text: `${cyan("build/entry.js")}      12.4 kB │ gzip:  4.1 kB`, wait: 260 },
+		{ text: `${cyan("build/app.js")}        94.7 kB │ gzip: 28.9 kB`, wait: 260 },
+		{ text: `${cyan("build/styles.css")}     8.2 kB │ gzip:  2.3 kB`, wait: 420 },
+		{ text: `${green("✓")} built in ${bold("3.42s")}`, wait: 600 },
+	];
+
+	const FULL = TRANSCRIPT.map((line) => line.text).join("\n") + "\n";
+	const DURATION_MS = 3420;
+	const REPLAY_PAUSE = 3200;
+
+	let output = $state("");
+	let running = $state(false);
+	let exitCode = $state<number | null>(null);
+
+	onMount(() => {
+		// A terminal that retypes itself forever is what reduced motion is asking
+		// us not to do, so it gets the finished transcript instead.
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			output = FULL;
+			exitCode = 0;
+			return;
+		}
+
+		let timer: ReturnType<typeof setTimeout>;
+		let i = 0;
+
+		function tick() {
+			if (i < TRANSCRIPT.length) {
+				// The whole stream so far, never just the new line — that is the contract.
+				output += `${TRANSCRIPT[i].text}\n`;
+				const wait = TRANSCRIPT[i].wait;
+				i += 1;
+				timer = setTimeout(tick, wait);
+				return;
+			}
+			running = false;
+			exitCode = 0;
+			timer = setTimeout(restart, REPLAY_PAUSE);
+		}
+
+		function restart() {
+			output = "";
+			exitCode = null;
+			running = true;
+			i = 0;
+			timer = setTimeout(tick, 500);
+		}
+
+		restart();
+		return () => clearTimeout(timer);
+	});
+</script>
+
+<div class="w-full max-w-2xl">
+	<TerminalBlock
+		command="pnpm build"
+		{output}
+		{running}
+		{exitCode}
+		durationMs={exitCode === null ? undefined : DURATION_MS}
+		maxHeight="15rem"
+	>
+		{#snippet header()}
+			<span class="flex items-center gap-1.5" aria-hidden="true">
+				<span class="size-2.5 rounded-full bg-red-400/90"></span>
+				<span class="size-2.5 rounded-full bg-amber-400/90"></span>
+				<span class="size-2.5 rounded-full bg-emerald-400/90"></span>
+			</span>
+			<span class="ml-auto text-xs opacity-60">build.log</span>
+		{/snippet}
+	</TerminalBlock>
+</div>

--- a/src/lib/components/docs/examples/tool-call/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/tool-call/BasicUsage.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { ToolCall } from "$lib/fancy-ui/tool-call";
+	import type { ToolCallData } from "$lib/fancy-ui";
+
+	/** How often the running call's stopwatch refreshes. */
+	const TICK_MS = 250;
+	/** How long a pretend call runs before another one takes its place. */
+	const CYCLE_MS = 9000;
+	/** What reduced motion sees instead of a clock that never settles. */
+	const STILL_MS = 4200;
+
+	let elapsedMs = $state(0);
+
+	const search: ToolCallData = {
+		id: "call_1",
+		name: "search_docs",
+		status: "done",
+		input: { query: "retry policy", limit: 3 },
+		output: { hits: 3, top: "billing/retries.md", tookMs: 812 },
+		durationMs: 1400,
+	};
+
+	const fetching: ToolCallData = $derived({
+		id: "call_2",
+		name: "fetch_changelog",
+		status: "running",
+		input: { repo: "acme/billing", since: "2026-07-01" },
+		durationMs: elapsedMs,
+	});
+
+	const posting: ToolCallData = {
+		id: "call_3",
+		name: "post_summary",
+		status: "error",
+		input: { channel: "#releases", blocks: 4 },
+		error: "429 Too Many Requests — that channel is rate limited for another 38s.",
+		durationMs: 240,
+	};
+
+	onMount(() => {
+		// A clock that never stops is exactly what reduced motion is asking us not
+		// to run, so it gets one plausible reading and no timer at all.
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			elapsedMs = STILL_MS;
+			return;
+		}
+
+		const started = Date.now();
+		// Wrapping at the cycle keeps the demo honest: a tool call left open on a
+		// docs page for an hour should not claim to have been running for one.
+		const timer = setInterval(() => {
+			elapsedMs = (Date.now() - started) % CYCLE_MS;
+		}, TICK_MS);
+		return () => clearInterval(timer);
+	});
+</script>
+
+<div class="flex w-full max-w-xl flex-col gap-2 p-6">
+	<ToolCall call={search} />
+	<ToolCall call={fetching} />
+	<ToolCall call={posting} />
+
+	<p class="text-muted-foreground mt-2 text-xs">
+		Click any header to see what went out and what came back. The failed call opened itself — but
+		close it and it stays closed.
+	</p>
+</div>

--- a/src/lib/components/docs/examples/tool-timeline/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/tool-timeline/BasicUsage.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { ToolTimeline } from "$lib/fancy-ui/tool-timeline";
+	import type { ToolTimelineItemData } from "$lib/fancy-ui";
+
+	// One agent session, oldest first. Timestamps are offsets from mount so the
+	// relative times read sensibly whenever the page is opened.
+	const now = Date.now();
+
+	const session: ToolTimelineItemData[] = [
+		{
+			id: "read-utils",
+			verb: "Read",
+			target: "src/lib/utils.ts",
+			detail: "Looking for the class merge helper",
+			timestamp: now - 6 * 60_000,
+		},
+		{
+			id: "search",
+			verb: "Searched",
+			target: "**/*.svelte",
+			detail: "42 files matched",
+			timestamp: now - 5 * 60_000,
+		},
+		{
+			id: "edit-page",
+			verb: "Edited",
+			target: "src/routes/+page.svelte",
+			additions: 24,
+			deletions: 7,
+			timestamp: now - 3 * 60_000,
+		},
+		{
+			id: "create-test",
+			verb: "Created",
+			target: "src/lib/fancy-ui/tool-timeline/ToolTimeline.test.ts",
+			additions: 96,
+			timestamp: now - 90_000,
+		},
+		{
+			id: "run-tests",
+			verb: "Ran",
+			target: "pnpm vitest run",
+			detail: "18 passed",
+			timestamp: now - 20_000,
+		},
+	];
+
+	// The demo starts with the first two rows and appends the rest, so the
+	// entrance animation is visible on arrival rather than only in a real session.
+	let items = $state<ToolTimelineItemData[]>(session.slice(0, 2));
+
+	onMount(() => {
+		// A loop that keeps re-animating is exactly what reduced motion asks us not
+		// to do, so it gets the finished session in one piece.
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			items = session;
+			return;
+		}
+
+		let timer: ReturnType<typeof setTimeout>;
+		let next = 2;
+
+		function tick() {
+			if (next < session.length) {
+				items = session.slice(0, next + 1);
+				next += 1;
+				timer = setTimeout(tick, 1200);
+				return;
+			}
+			timer = setTimeout(restart, 3000);
+		}
+
+		function restart() {
+			items = session.slice(0, 2);
+			next = 2;
+			timer = setTimeout(tick, 1200);
+		}
+
+		timer = setTimeout(tick, 1200);
+		return () => clearTimeout(timer);
+	});
+</script>
+
+<div class="bg-card w-full max-w-xl rounded-lg border p-5">
+	<p class="text-muted-foreground mb-3 text-xs font-medium tracking-wide uppercase">
+		Session activity
+	</p>
+	<ToolTimeline {items} />
+</div>

--- a/src/lib/fancy-ui/chat-error/ChatError.svelte
+++ b/src/lib/fancy-ui/chat-error/ChatError.svelte
@@ -109,18 +109,42 @@
 	 * Every colour derives from `--ft-error-fg` at the point of use rather than
 	 * being redeclared on the root, so setting that one variable anywhere up the
 	 * tree — inline style, a theme class — retints the whole row without having
-	 * to win a specificity fight against these scoped rules.
+	 * to win a specificity fight against these scoped rules. Unset, it falls
+	 * through to `--ft-status-error`, the failure colour this component family
+	 * shares, so a theme can speak once and be heard by all of them.
 	 */
 	.ft-error {
-		background: var(--ft-error-bg, color-mix(in oklab, var(--ft-error-fg, #d33) 8%, transparent));
+		background: var(
+			--ft-error-bg,
+			color-mix(
+				in oklab,
+				var(
+						--ft-error-fg,
+						var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+					)
+					8%,
+				transparent
+			)
+		);
 		border-color: var(
 			--ft-error-border,
-			color-mix(in oklab, var(--ft-error-fg, #d33) 20%, transparent)
+			color-mix(
+				in oklab,
+				var(
+						--ft-error-fg,
+						var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+					)
+					20%,
+				transparent
+			)
 		);
 	}
 
 	.ft-error-icon {
-		color: var(--ft-error-fg, #d33);
+		color: var(
+			--ft-error-fg,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
 	}
 
 	.ft-error-dot {

--- a/src/lib/fancy-ui/chat-error/README.md
+++ b/src/lib/fancy-ui/chat-error/README.md
@@ -65,6 +65,10 @@ The row's tint comes from a single variable. `--ft-error-fg` colours the icon an
 
 `--ft-error-bg` and `--ft-error-border` are read first and override the derived values if you want the wash and the outline to part ways with the accent. All three are read at their point of use rather than declared on the root, so a value set by a consumer wins without having to out-specify the component's own scoped rules.
 
+Left unset, `--ft-error-fg` falls through to `--ft-status-error`, the failure colour shared with `ToolCall`, `ToolTimeline`, `TerminalBlock` and `CodeDiff`. Set that one instead and everything that reports a failure moves together.
+
+Its default is a `light-dark()` pair — `oklch(0.5 0.19 25)` on light, `oklch(0.7 0.18 25)` on dark — since one token cannot clear 4.5:1 against both white and near-black. Declare `color-scheme: light` / `dark` on your theme so the right half is picked; without it a page gets the light half. See the [ToolCall README](../tool-call/README.md#styling) for the full palette.
+
 ## Implementation notes
 
 - The root is a `role="alert"` region, so the failure is announced when it appears. It carries `aria-busy="true"` only while `retrying`, which tells assistive tech the row is mid-update rather than settled.

--- a/src/lib/fancy-ui/code-diff/CodeDiff.svelte
+++ b/src/lib/fancy-ui/code-diff/CodeDiff.svelte
@@ -1,0 +1,416 @@
+<script lang="ts" module>
+	/**
+	 * Props for CodeDiff
+	 */
+	export interface CodeDiffProps {
+		/**
+		 * Raw unified diff text — whatever `git diff` printed. Parsed on every
+		 * change, so a patch that is still arriving can be handed over as it grows.
+		 */
+		diff: string;
+		/** Header label when the patch names no file, or names exactly one. */
+		filename?: string;
+		/** Whether to show the old/new line-number gutters. */
+		lineNumbers?: boolean;
+		/** Whether the bodies are folded away. Bindable — see the README. */
+		collapsed?: boolean;
+		/** Lines shown before the rest hide behind a "show more" button. 0 shows all. */
+		maxLines?: number;
+		/** Whether long lines wrap instead of scrolling sideways. */
+		wrap?: boolean;
+		/** Additional CSS classes */
+		class?: string;
+		/** The root element */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { untrack } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import { parseUnifiedDiff, type DiffFile, type DiffLine } from "../_internals/diff.js";
+
+	let {
+		diff,
+		filename,
+		lineNumbers = true,
+		collapsed = $bindable(false),
+		maxLines = 0,
+		wrap = false,
+		class: className,
+		ref = $bindable(null),
+	}: CodeDiffProps = $props();
+
+	type Row = { kind: "sep"; text: string } | { kind: "line"; line: DiffLine };
+
+	interface FileView {
+		file: DiffFile;
+		name: string;
+		rows: Row[];
+		/** Lines the clamp is currently withholding; 0 when everything is on screen. */
+		hidden: number;
+	}
+
+	/** Glyphs, not markers: they are never copied, so they can be the prettier pair. */
+	const GLYPH = { add: "+", del: "−", context: " ", meta: " " } as const;
+
+	const uid = $props.id();
+
+	const files = $derived(parseUnifiedDiff(diff));
+
+	// Per-file fold and clamp state, keyed by file name rather than position: a
+	// patch that arrives with a different set of files must not hand file 0's
+	// folded state to whatever now happens to sit first. `collapsed` is the master
+	// switch: it seeds every file and wipes the overrides whenever the consumer
+	// flips it, so binding it still folds the whole patch while a click still
+	// folds one file.
+	let folded = $state<Record<string, boolean>>({});
+	let unclamped = $state<Record<string, boolean>>({});
+	let lastCollapsed = collapsed;
+
+	$effect(() => {
+		const next = collapsed;
+		untrack(() => {
+			if (next === lastCollapsed) return;
+			lastCollapsed = next;
+			folded = {};
+		});
+	});
+
+	// Names alone would let a reused path carry state across two unrelated
+	// patches, so the whole list is watched: when it changes, both records start
+	// empty and every file is back under `collapsed`.
+	const signature = $derived(files.map((file) => nameOf(file, files.length)).join("\n"));
+	// Untracked on purpose: this is the "what did we render last" marker, and it is
+	// the effect below — not this line — that is meant to notice a change.
+	let lastSignature = untrack(() => signature);
+
+	$effect(() => {
+		const next = signature;
+		untrack(() => {
+			if (next === lastSignature) return;
+			lastSignature = next;
+			folded = {};
+			unclamped = {};
+		});
+	});
+
+	function isFolded(name: string): boolean {
+		return folded[name] ?? collapsed;
+	}
+
+	function toggle(name: string) {
+		folded[name] = !isFolded(name);
+		// `collapsed` reports the whole patch, so it is true only once nothing is left open.
+		const all = views.every((view) => folded[view.name] ?? collapsed);
+		lastCollapsed = all;
+		collapsed = all;
+	}
+
+	function nameOf(file: DiffFile, count: number): string {
+		if (filename !== undefined && count <= 1) return filename;
+		if (
+			file.isRename &&
+			file.oldPath !== null &&
+			file.newPath !== null &&
+			file.oldPath !== file.newPath
+		) {
+			return `${file.oldPath} → ${file.newPath}`;
+		}
+		return file.newPath ?? file.oldPath ?? "";
+	}
+
+	const views: FileView[] = $derived(
+		files.map((file) => {
+			const name = nameOf(file, files.length);
+			const rows: Row[] = [];
+			let total = 0;
+			for (const hunk of file.hunks) {
+				if (hunk.header !== "") rows.push({ kind: "sep", text: hunk.header });
+				for (const line of hunk.lines) {
+					rows.push({ kind: "line", line });
+					total++;
+				}
+			}
+
+			if (maxLines <= 0 || unclamped[name] || total <= maxLines) {
+				return { file, name, rows, hidden: 0 };
+			}
+
+			// Cut on a line, never on a hunk header, so the clamp never leaves a
+			// dangling `@@` with nothing under it.
+			const shown: Row[] = [];
+			let seen = 0;
+			for (const row of rows) {
+				shown.push(row);
+				if (row.kind !== "line") continue;
+				seen++;
+				if (seen === maxLines) break;
+			}
+			return { file, name, rows: shown, hidden: total - maxLines };
+		})
+	);
+</script>
+
+<div
+	bind:this={ref}
+	role="group"
+	aria-label="Code diff"
+	class={cn(
+		"border-border bg-card/50 w-full overflow-hidden rounded-lg border font-mono text-xs",
+		className
+	)}
+>
+	{#each views as view, index (index)}
+		{@const open = !isFolded(view.name)}
+		{@const headerId = `${uid}-${index}-header`}
+		{@const bodyId = `${uid}-${index}-body`}
+		<div class="border-border border-t first:border-t-0">
+			<button
+				type="button"
+				id={headerId}
+				class="text-muted-foreground hover:text-foreground flex w-full items-center gap-2 px-3 py-2 text-left transition-colors"
+				aria-expanded={open}
+				aria-controls={bodyId}
+				onclick={() => toggle(view.name)}
+			>
+				<svg
+					class="ft-chevron size-3.5 shrink-0"
+					class:ft-open={open}
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2.5"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true"
+				>
+					<path d="m9 6 6 6-6 6" />
+				</svg>
+				{#if view.name}
+					<span class="text-foreground min-w-0 truncate">{view.name}</span>
+				{/if}
+				{#if view.file.isNew}
+					<span class="ft-badge">new file</span>
+				{:else if view.file.isDeleted}
+					<span class="ft-badge">deleted</span>
+				{/if}
+				<span class="ml-auto flex shrink-0 items-center gap-2 tabular-nums">
+					{#if view.file.additions > 0}
+						<span class="ft-stat-add">+{view.file.additions}</span>
+					{/if}
+					{#if view.file.deletions > 0}
+						<span class="ft-stat-del">−{view.file.deletions}</span>
+					{/if}
+				</span>
+			</button>
+
+			<div class="ft-body" class:ft-open={open}>
+				<div class="overflow-hidden">
+					<div id={bodyId} role="group" aria-labelledby={headerId} inert={!open}>
+						<div class="ft-scroll" class:ft-wrap={wrap}>
+							{#each view.rows as row, rowIndex (rowIndex)}
+								{#if row.kind === "sep"}
+									<div class="ft-sep">{row.text}</div>
+								{:else}
+									<div
+										class="ft-row"
+										data-kind={row.line.type}
+										class:ft-add={row.line.type === "add"}
+										class:ft-del={row.line.type === "del"}
+										class:ft-context={row.line.type === "context"}
+										class:ft-meta={row.line.type === "meta"}
+									>
+										{#if lineNumbers}
+											<span class="ft-num" aria-hidden="true">{row.line.oldLine ?? ""}</span>
+											<span class="ft-num" aria-hidden="true">{row.line.newLine ?? ""}</span>
+										{/if}
+										<span class="ft-glyph" aria-hidden="true">{GLYPH[row.line.type]}</span>
+										<span class="ft-code">{row.line.text}</span>
+									</div>
+								{/if}
+							{/each}
+						</div>
+
+						{#if view.hidden > 0}
+							<button
+								type="button"
+								class="text-muted-foreground hover:text-foreground hover:bg-muted/40 border-border w-full border-t px-3 py-1.5 text-left transition-colors"
+								onclick={() => (unclamped[view.name] = true)}
+							>
+								Show {view.hidden} more {view.hidden === 1 ? "line" : "lines"}
+							</button>
+						{/if}
+					</div>
+				</div>
+			</div>
+		</div>
+	{/each}
+</div>
+
+<style>
+	/*
+	 * 0fr → 1fr on a one-row grid transitions "auto" height without measuring
+	 * anything; the inner wrapper does the clipping.
+	 */
+	.ft-body {
+		display: grid;
+		grid-template-rows: 0fr;
+	}
+
+	.ft-body.ft-open {
+		grid-template-rows: 1fr;
+	}
+
+	.ft-chevron.ft-open {
+		transform: rotate(90deg);
+	}
+
+	.ft-scroll {
+		overflow-x: auto;
+		overflow-y: hidden;
+		padding-block: 0.25rem;
+	}
+
+	.ft-scroll.ft-wrap {
+		overflow-x: hidden;
+	}
+
+	/*
+	 * `max-content` with a 100% floor keeps a row's tint running the full scroll
+	 * width instead of stopping where the shortest line ends.
+	 */
+	.ft-row,
+	.ft-sep {
+		width: max-content;
+		min-width: 100%;
+	}
+
+	.ft-wrap .ft-row,
+	.ft-wrap .ft-sep {
+		width: auto;
+	}
+
+	.ft-row {
+		display: flex;
+		align-items: flex-start;
+		line-height: 1.6;
+	}
+
+	.ft-sep {
+		padding: 0.375rem 0.75rem;
+		white-space: pre;
+		opacity: 0.55;
+	}
+
+	/*
+	 * Tint and glyph both carry the verdict, so the rows stay readable when the
+	 * hues do not land — colour is never the only signal. Both tints are mixed
+	 * from the `--ft-status-*` vocabulary this component family shares, so a
+	 * theme that recolours success and failure once recolours the diff too.
+	 */
+	.ft-add {
+		background-color: var(
+			--ft-diff-add-bg,
+			color-mix(
+				in oklab,
+				var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145))) 12%,
+				transparent
+			)
+		);
+	}
+
+	.ft-del {
+		background-color: var(
+			--ft-diff-del-bg,
+			color-mix(
+				in oklab,
+				var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25))) 12%,
+				transparent
+			)
+		);
+	}
+
+	.ft-context {
+		background-color: transparent;
+	}
+
+	.ft-meta {
+		font-style: italic;
+		opacity: 0.6;
+	}
+
+	.ft-stat-add {
+		color: var(
+			--ft-diff-add-fg,
+			var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145)))
+		);
+	}
+
+	.ft-stat-del {
+		color: var(
+			--ft-diff-del-fg,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+	}
+
+	.ft-badge {
+		flex: none;
+		border-radius: 0.25rem;
+		padding: 0.0625rem 0.375rem;
+		font-size: 0.6875rem;
+		background-color: var(--ft-diff-badge-bg, color-mix(in oklab, currentColor 12%, transparent));
+	}
+
+	/* Gutters, glyphs and hunk headers are chrome: skipping them keeps a copied
+	   selection compilable — no line numbers, no markers, no dangling `@@`. */
+	.ft-num,
+	.ft-glyph,
+	.ft-sep {
+		user-select: none;
+		-webkit-user-select: none;
+	}
+
+	.ft-num,
+	.ft-glyph {
+		flex: none;
+	}
+
+	.ft-num {
+		min-width: 4ch;
+		padding-inline: 0.5rem 0;
+		text-align: right;
+		opacity: 0.45;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.ft-glyph {
+		width: 2.5ch;
+		text-align: center;
+		opacity: 0.7;
+	}
+
+	.ft-code {
+		flex: 1 1 auto;
+		min-width: 0;
+		white-space: pre;
+		padding-inline-end: 0.75rem;
+	}
+
+	.ft-wrap .ft-code {
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+	}
+
+	/* Everything that moves lives behind the query; reduced motion gets the same
+	   states with nothing to shorten. */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-body {
+			transition: grid-template-rows 260ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+
+		.ft-chevron {
+			transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/code-diff/CodeDiff.svelte
+++ b/src/lib/fancy-ui/code-diff/CodeDiff.svelte
@@ -80,7 +80,19 @@
 	// Names alone would let a reused path carry state across two unrelated
 	// patches, so the whole list is watched: when it changes, both records start
 	// empty and every file is back under `collapsed`.
-	const signature = $derived(files.map((file) => nameOf(file, files.length)).join("\n"));
+	// A name on its own cannot tell two patches apart when both touch the same
+	// path, so a replacement would inherit the fold and clamp state of the patch
+	// before it. The first hunk's declared start pins that down, and it is fixed
+	// the moment that header parses — a patch still streaming in only ever gains
+	// lines and later hunks, so growth in place still reads as the same file.
+	const signature = $derived(
+		files
+			.map((file) => {
+				const anchor = file.hunks[0];
+				return `${nameOf(file, files.length)}:${anchor?.oldStart ?? ""}:${anchor?.newStart ?? ""}`;
+			})
+			.join("\n")
+	);
 	// Untracked on purpose: this is the "what did we render last" marker, and it is
 	// the effect below — not this line — that is meant to notice a change.
 	let lastSignature = untrack(() => signature);

--- a/src/lib/fancy-ui/code-diff/CodeDiff.test.ts
+++ b/src/lib/fancy-ui/code-diff/CodeDiff.test.ts
@@ -1,0 +1,345 @@
+import { readFileSync } from "node:fs";
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { afterEach, describe, it, expect } from "vitest";
+import CodeDiff from "./CodeDiff.svelte";
+
+/** One file, two hunks: 4 additions, 3 deletions, 10 line rows in total. */
+const MULTI_HUNK = [
+	"diff --git a/src/query.ts b/src/query.ts",
+	"index 1111111..2222222 100644",
+	"--- a/src/query.ts",
+	"+++ b/src/query.ts",
+	"@@ -10,4 +10,5 @@ export function build() {",
+	"   const sql = compile(ast);",
+	"-  const rows = await db.query(sql);",
+	"-  return rows;",
+	"+  const rows = await db.query(sql, { timeout: 5000 });",
+	"+  if (rows.length === 0) return [];",
+	"+  return rows.map(normalise);",
+	" }",
+	"@@ -30,2 +31,2 @@ export function reset() {",
+	'   log("reset");',
+	"-  cache.clear();",
+	"+  cache.reset();",
+	"",
+].join("\n");
+
+const RENAMED = [
+	"diff --git a/src/old-name.ts b/src/new-name.ts",
+	"similarity index 92%",
+	"rename from src/old-name.ts",
+	"rename to src/new-name.ts",
+	"--- a/src/old-name.ts",
+	"+++ b/src/new-name.ts",
+	"@@ -1,2 +1,2 @@",
+	'-export const name = "old";',
+	'+export const name = "new";',
+	" export default name;",
+	"",
+].join("\n");
+
+const ADDED = [
+	"diff --git a/src/added.ts b/src/added.ts",
+	"new file mode 100644",
+	"index 0000000..3333333",
+	"--- /dev/null",
+	"+++ b/src/added.ts",
+	"@@ -0,0 +1,2 @@",
+	"+export const answer = 42;",
+	"+export default answer;",
+	"",
+].join("\n");
+
+const REMOVED = [
+	"diff --git a/src/gone.ts b/src/gone.ts",
+	"deleted file mode 100644",
+	"index 4444444..0000000",
+	"--- a/src/gone.ts",
+	"+++ /dev/null",
+	"@@ -1,2 +0,0 @@",
+	"-export const gone = true;",
+	"-export default gone;",
+	"",
+].join("\n");
+
+/** A hunk on its own, with no `diff --git` or `---`/`+++` above it. */
+const BARE_HUNK = ["@@ -1,3 +1,3 @@", " const a = 1;", "-const b = 2;", "+const b = 3;", ""].join(
+	"\n"
+);
+
+function headers(container: HTMLElement): HTMLButtonElement[] {
+	return Array.from(container.querySelectorAll("button[aria-expanded]"));
+}
+
+function body(container: HTMLElement, index = 0): HTMLElement {
+	const id = headers(container)[index].getAttribute("aria-controls") as string;
+	return container.querySelector(`#${id}`) as HTMLElement;
+}
+
+function rowsOfKind(container: HTMLElement, kind: string): HTMLElement[] {
+	return Array.from(container.querySelectorAll(`[data-kind="${kind}"]`));
+}
+
+describe("CodeDiff", () => {
+	afterEach(cleanup);
+
+	it("renders every line of a multi-hunk patch under its kind", () => {
+		const { container } = render(CodeDiff, { props: { diff: MULTI_HUNK } });
+
+		expect(rowsOfKind(container, "add")).toHaveLength(4);
+		expect(rowsOfKind(container, "del")).toHaveLength(3);
+		expect(rowsOfKind(container, "context")).toHaveLength(3);
+		expect(rowsOfKind(container, "add")[0].className).toContain("ft-add");
+		expect(rowsOfKind(container, "del")[0].className).toContain("ft-del");
+		expect(rowsOfKind(container, "context")[0].className).toContain("ft-context");
+	});
+
+	it("keeps the code and drops the marker on every line", () => {
+		const { container } = render(CodeDiff, { props: { diff: MULTI_HUNK } });
+
+		const added = rowsOfKind(container, "add")[1].querySelector(".ft-code") as HTMLElement;
+		expect(added.textContent).toBe("  if (rows.length === 0) return [];");
+	});
+
+	it("renders each hunk header as its own muted separator row", () => {
+		const { container } = render(CodeDiff, { props: { diff: MULTI_HUNK } });
+
+		const separators = Array.from(container.querySelectorAll(".ft-sep"));
+		expect(separators).toHaveLength(2);
+		expect(separators[0].textContent).toBe("@@ -10,4 +10,5 @@ export function build() {");
+	});
+
+	it("names the file and tallies the additions and deletions in the header", () => {
+		const { container } = render(CodeDiff, { props: { diff: MULTI_HUNK } });
+
+		const text = headers(container)[0].textContent as string;
+		expect(text).toContain("src/query.ts");
+		expect(text).toContain("+4");
+		expect(text).toContain("−3");
+	});
+
+	it("prefers the filename override for a single-file patch", () => {
+		const { container } = render(CodeDiff, {
+			props: { diff: BARE_HUNK, filename: "scratch.ts" },
+		});
+
+		expect(headers(container)[0].textContent).toContain("scratch.ts");
+	});
+
+	it("shows both gutters with the numbers the patch declares", () => {
+		const { container } = render(CodeDiff, { props: { diff: BARE_HUNK } });
+
+		const numbers = Array.from(container.querySelectorAll(".ft-num")).map((n) => n.textContent);
+		// context 1/1, deleted 2/—, added —/2.
+		expect(numbers).toEqual(["1", "1", "2", "", "", "2"]);
+	});
+
+	it("drops both gutters when line numbers are off", () => {
+		const { container } = render(CodeDiff, {
+			props: { diff: MULTI_HUNK, lineNumbers: false },
+		});
+
+		expect(container.querySelectorAll(".ft-num")).toHaveLength(0);
+		expect(rowsOfKind(container, "add")).toHaveLength(4);
+	});
+
+	it("marks the gutters, glyphs and hunk headers as chrome so a copy is code alone", () => {
+		const { container } = render(CodeDiff, { props: { diff: MULTI_HUNK } });
+
+		// jsdom does not apply the component's scoped stylesheet, so the DOM half of
+		// the contract is checked here and the rule that backs it just below.
+		expect(container.querySelectorAll(".ft-num").length).toBeGreaterThan(0);
+		expect(container.querySelectorAll(".ft-glyph")).toHaveLength(10);
+		expect(container.querySelectorAll(".ft-sep")).toHaveLength(2);
+
+		const source = readFileSync("src/lib/fancy-ui/code-diff/CodeDiff.svelte", "utf8");
+		const rule = /\.ft-num,\s*\.ft-glyph,\s*\.ft-sep\s*\{[^}]*(?<!-)user-select:\s*none/;
+		expect(source).toMatch(rule);
+	});
+
+	it("carries the verdict in the glyph as well as the tint", () => {
+		const { container } = render(CodeDiff, { props: { diff: BARE_HUNK } });
+
+		const glyphs = Array.from(container.querySelectorAll(".ft-glyph")).map((g) => g.textContent);
+		expect(glyphs).toEqual([" ", "−", "+"]);
+	});
+
+	it("starts open, folds the body on click, and reports it through aria-expanded", async () => {
+		const { container } = render(CodeDiff, { props: { diff: MULTI_HUNK } });
+		expect(headers(container)[0].getAttribute("aria-expanded")).toBe("true");
+		expect(body(container).inert).toBe(false);
+
+		await fireEvent.click(headers(container)[0]);
+		expect(headers(container)[0].getAttribute("aria-expanded")).toBe("false");
+		// jsdom does not implement inert, so the property assignment — which is also
+		// what applies inertness in a real browser — is what there is to check.
+		expect(body(container).inert).toBe(true);
+
+		await fireEvent.click(headers(container)[0]);
+		expect(headers(container)[0].getAttribute("aria-expanded")).toBe("true");
+	});
+
+	it("starts folded when asked, header and stats still readable", () => {
+		const { container } = render(CodeDiff, { props: { diff: MULTI_HUNK, collapsed: true } });
+
+		expect(headers(container)[0].getAttribute("aria-expanded")).toBe("false");
+		expect(headers(container)[0].textContent).toContain("+4");
+	});
+
+	it("folds one file of a patch without touching its neighbours", async () => {
+		const { container } = render(CodeDiff, { props: { diff: `${ADDED}${REMOVED}` } });
+		expect(headers(container)).toHaveLength(2);
+
+		await fireEvent.click(headers(container)[0]);
+		expect(headers(container)[0].getAttribute("aria-expanded")).toBe("false");
+		expect(headers(container)[1].getAttribute("aria-expanded")).toBe("true");
+	});
+
+	it("does not hand a folded file's state to whatever takes its place", async () => {
+		const { container, rerender } = render(CodeDiff, { props: { diff: `${ADDED}${REMOVED}` } });
+
+		await fireEvent.click(headers(container)[0]);
+		expect(headers(container)[0].getAttribute("aria-expanded")).toBe("false");
+
+		await rerender({ diff: RENAMED });
+		expect(headers(container)).toHaveLength(1);
+		expect(headers(container)[0].textContent).toContain("src/old-name.ts → src/new-name.ts");
+		expect(headers(container)[0].getAttribute("aria-expanded")).toBe("true");
+	});
+
+	it("starts a replacement patch open even where it reuses a file name", async () => {
+		const { container, rerender } = render(CodeDiff, { props: { diff: `${ADDED}${REMOVED}` } });
+
+		await fireEvent.click(headers(container)[0]);
+		expect(headers(container)[0].getAttribute("aria-expanded")).toBe("false");
+
+		await rerender({ diff: ADDED });
+		expect(headers(container)[0].textContent).toContain("src/added.ts");
+		expect(headers(container)[0].getAttribute("aria-expanded")).toBe("true");
+	});
+
+	it("re-clamps a replacement patch rather than inheriting the last expansion", async () => {
+		const { container, rerender, getAllByText } = render(CodeDiff, {
+			props: { diff: `${ADDED}${REMOVED}`, maxLines: 1 },
+		});
+
+		await fireEvent.click(getAllByText("Show 1 more line")[0]);
+		expect(container.querySelectorAll("[data-kind]")).toHaveLength(3);
+
+		await rerender({ diff: ADDED, maxLines: 1 });
+		expect(container.querySelectorAll("[data-kind]")).toHaveLength(1);
+		expect(container.textContent).toContain("Show 1 more line");
+	});
+
+	it("re-folds every file when the consumer flips the master switch", async () => {
+		const { container, rerender } = render(CodeDiff, { props: { diff: `${ADDED}${REMOVED}` } });
+
+		await fireEvent.click(headers(container)[0]);
+		await rerender({ diff: `${ADDED}${REMOVED}`, collapsed: true });
+
+		expect(headers(container).map((h) => h.getAttribute("aria-expanded"))).toEqual([
+			"false",
+			"false",
+		]);
+	});
+
+	it("clamps a long file and offers the rest behind a button", async () => {
+		const { container, getByText } = render(CodeDiff, {
+			props: { diff: MULTI_HUNK, maxLines: 4 },
+		});
+
+		expect(container.querySelectorAll("[data-kind]")).toHaveLength(4);
+		const more = getByText("Show 6 more lines");
+
+		await fireEvent.click(more);
+		expect(container.querySelectorAll("[data-kind]")).toHaveLength(10);
+		expect(container.textContent).not.toContain("more lines");
+	});
+
+	it("never cuts the clamp on a hunk header", () => {
+		const { container } = render(CodeDiff, { props: { diff: MULTI_HUNK, maxLines: 7 } });
+
+		// Line 8 opens the second hunk, so its `@@` row must not be left dangling.
+		expect(container.querySelectorAll(".ft-sep")).toHaveLength(1);
+	});
+
+	it("leaves a patch shorter than the clamp alone", () => {
+		const { container } = render(CodeDiff, { props: { diff: BARE_HUNK, maxLines: 50 } });
+
+		expect(container.querySelectorAll("[data-kind]")).toHaveLength(3);
+		expect(container.textContent).not.toContain("more line");
+	});
+
+	it("renders a headerless hunk with no file name to show", () => {
+		const { container } = render(CodeDiff, { props: { diff: BARE_HUNK } });
+
+		expect(headers(container)).toHaveLength(1);
+		expect(rowsOfKind(container, "add")).toHaveLength(1);
+		expect(headers(container)[0].textContent).toContain("+1");
+	});
+
+	it("renders an empty shell for input that is not a patch", () => {
+		const { container } = render(CodeDiff, {
+			props: { diff: "nothing here resembles a unified diff" },
+		});
+
+		expect(headers(container)).toHaveLength(0);
+		expect(container.querySelectorAll("[data-kind]")).toHaveLength(0);
+		expect(container.firstElementChild?.getAttribute("aria-label")).toBe("Code diff");
+	});
+
+	it("renders an empty shell for an empty string", () => {
+		const { container } = render(CodeDiff, { props: { diff: "" } });
+
+		expect(headers(container)).toHaveLength(0);
+	});
+
+	it("shows a rename as old → new", () => {
+		const { container } = render(CodeDiff, { props: { diff: RENAMED } });
+
+		expect(headers(container)[0].textContent).toContain("src/old-name.ts → src/new-name.ts");
+	});
+
+	it("badges a created file and a removed one", () => {
+		const { container } = render(CodeDiff, { props: { diff: `${ADDED}${REMOVED}` } });
+
+		const badges = Array.from(container.querySelectorAll(".ft-badge")).map((b) => b.textContent);
+		expect(badges).toEqual(["new file", "deleted"]);
+		expect(headers(container)[0].textContent).toContain("src/added.ts");
+		expect(headers(container)[1].textContent).toContain("src/gone.ts");
+	});
+
+	it("keeps a no-newline notice as a meta row", () => {
+		const { container } = render(CodeDiff, {
+			props: { diff: `${BARE_HUNK}\\ No newline at end of file\n` },
+		});
+
+		const meta = rowsOfKind(container, "meta");
+		expect(meta).toHaveLength(1);
+		expect(meta[0].className).toContain("ft-meta");
+		expect(meta[0].textContent).toContain("No newline at end of file");
+	});
+
+	it("wraps long lines only when asked", async () => {
+		const { container, rerender } = render(CodeDiff, { props: { diff: BARE_HUNK } });
+		const scroller = () => container.querySelector(".ft-scroll") as HTMLElement;
+		expect(scroller().className).not.toContain("ft-wrap");
+
+		await rerender({ diff: BARE_HUNK, wrap: true });
+		expect(scroller().className).toContain("ft-wrap");
+	});
+
+	it("merges custom classes onto the root", () => {
+		const { container } = render(CodeDiff, { props: { diff: BARE_HUNK, class: "my-diff" } });
+
+		expect((container.firstElementChild as HTMLElement).className).toContain("my-diff");
+	});
+
+	it("re-reads the patch as it grows", async () => {
+		const { container, rerender } = render(CodeDiff, { props: { diff: BARE_HUNK } });
+		expect(rowsOfKind(container, "add")).toHaveLength(1);
+
+		await rerender({ diff: `${BARE_HUNK}+const c = 4;\n` });
+		expect(rowsOfKind(container, "add")).toHaveLength(2);
+	});
+});

--- a/src/lib/fancy-ui/code-diff/CodeDiff.test.ts
+++ b/src/lib/fancy-ui/code-diff/CodeDiff.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { afterEach, describe, it, expect } from "vitest";
 import CodeDiff from "./CodeDiff.svelte";
 
@@ -341,5 +342,36 @@ describe("CodeDiff", () => {
 
 		await rerender({ diff: `${BARE_HUNK}+const c = 4;\n` });
 		expect(rowsOfKind(container, "add")).toHaveLength(2);
+	});
+
+	describe("an unrelated patch that reuses a path", () => {
+		// Two files on purpose: folding the only file of a one-file patch flips
+		// `collapsed`, the consumer-facing master switch, and that is meant to
+		// survive a replacement. What must not survive is the per-file override.
+		const file = (path: string, hunk: string) =>
+			[
+				`diff --git a/${path} b/${path}`,
+				`--- a/${path}`,
+				`+++ b/${path}`,
+				hunk,
+				"-before",
+				"+after",
+			].join("\n");
+		const FIRST = `${file("src/query.ts", "@@ -10,2 +10,2 @@")}\n${file("src/other.ts", "@@ -1,2 +1,2 @@")}\n`;
+		const SECOND = `${file("src/query.ts", "@@ -50,2 +50,2 @@")}\n${file("src/other.ts", "@@ -1,2 +1,2 @@")}\n`;
+
+		it("unfolds instead of inheriting the previous patch's fold state", async () => {
+			const { container, rerender } = render(CodeDiff, { props: { diff: FIRST } });
+			expect(headers(container)).toHaveLength(2);
+
+			await fireEvent.click(headers(container)[0]);
+			expect(headers(container)[0].getAttribute("aria-expanded")).toBe("false");
+
+			await rerender({ diff: SECOND });
+			// The reset runs in the effect that follows the prop update, so the
+			// header it re-renders is a flush behind `rerender` itself.
+			await tick();
+			expect(headers(container)[0].getAttribute("aria-expanded")).toBe("true");
+		});
 	});
 });

--- a/src/lib/fancy-ui/code-diff/README.md
+++ b/src/lib/fancy-ui/code-diff/README.md
@@ -1,0 +1,82 @@
+# Code Diff
+
+A unified diff rendered at chat width: one file card per patched file, a header carrying the path and the `+N / −N` tally, and a foldable body of tinted lines.
+
+## Components
+
+- `CodeDiff` — parses raw patch text and renders every file it finds
+
+## Usage
+
+```svelte
+<script>
+	import { CodeDiff } from "fancy-ui-svelte";
+
+	const patch = `diff --git a/src/query.ts b/src/query.ts
+--- a/src/query.ts
++++ b/src/query.ts
+@@ -12,3 +12,4 @@ export function build() {
+ 	const rows = await db.query(sql);
+-	return rows;
++	if (rows.length === 0) return [];
++	return rows.map(normalise);
+ }`;
+</script>
+
+<CodeDiff diff={patch} />
+```
+
+The input is plain unified-diff text — whatever `git diff` printed, headers and all. Nothing needs pre-parsing, and nothing needs to be complete: a truncated or headerless patch degrades to a best-effort reading rather than throwing, so the same string can be handed over again on every chunk while it streams in.
+
+## Props
+
+| Prop          | Type                     | Default     | Description                                                   |
+| ------------- | ------------------------ | ----------- | ------------------------------------------------------------- |
+| `diff`        | `string`                 | —           | Raw unified diff text. Required.                              |
+| `filename`    | `string`                 | `undefined` | Header label when the patch names no file, or names just one  |
+| `lineNumbers` | `boolean`                | `true`      | Whether to show the old/new line-number gutters               |
+| `collapsed`   | `boolean`                | `false`     | Whether the bodies are folded away. Bindable                  |
+| `maxLines`    | `number`                 | `0`         | Lines shown before the rest hide behind a button. 0 shows all |
+| `wrap`        | `boolean`                | `false`     | Whether long lines wrap instead of scrolling sideways         |
+| `class`       | `string`                 | `undefined` | Additional CSS classes                                        |
+| `ref`         | `HTMLDivElement \| null` | `null`      | Bindable reference to the root element                        |
+
+## Folding
+
+Every file header is a toggle, and `collapsed` is the master switch above them: set it and the whole patch folds, clear it and the whole patch opens. A click folds only the file it belongs to, and `collapsed` is written back as _"nothing is left open"_ — so a bound variable stays honest for a one-file patch and still means something for a ten-file one. Headers never fold away; the path and the tally are readable whatever the body is doing.
+
+## Clamping long patches
+
+`maxLines` puts a soft ceiling on each file independently. Past it the body stops on a line — never on a `@@` header, so no hunk is ever announced with nothing under it — and a `Show N more lines` button takes its place. Expanding is per file and one-way: a reader who asked for the rest is not asked again — until the patch itself changes, which starts every file clean.
+
+## No syntax highlighting, by design
+
+Lines are monochrome. A diff in a chat transcript is read for _what moved_, and layering token colours on top of the add/delete tints turns the one distinction that matters into the hardest one to see. It also means no language detection, no grammar payloads, and no highlighter to keep current — the component stays the same size whatever the patch is written in.
+
+Every readable signal is carried twice: an add row gets the green tint _and_ a `+`, a delete row the red tint _and_ a `−`, so the rows survive a monochrome print or a reader who does not separate those hues.
+
+## Theming
+
+Added and deleted derive from the run-status vocabulary shared with `ToolCall`, `ToolTimeline`, `TerminalBlock` and `ChatError`: `--ft-status-done` and `--ft-status-error`. Set those to recolour success and failure across the whole family.
+
+Both default to a `light-dark()` pair — `oklch(0.5 0.14 145)` / `oklch(0.72 0.15 145)` for added, `oklch(0.5 0.19 25)` / `oklch(0.7 0.18 25)` for deleted — because the `+N`/`−N` tallies are text and one token cannot clear 4.5:1 against both white and near-black. Declare `color-scheme: light` / `dark` on your theme so the right half is picked; without it a page gets the light half. See the [ToolCall README](../tool-call/README.md#styling) for the full palette.
+
+Four further properties override this component alone, on it or anywhere above it:
+
+| Property           | Default                    | Applies to       |
+| ------------------ | -------------------------- | ---------------- |
+| `--ft-diff-add-bg` | `--ft-status-done` at 12%  | Added row tint   |
+| `--ft-diff-del-bg` | `--ft-status-error` at 12% | Deleted row tint |
+| `--ft-diff-add-fg` | `--ft-status-done`         | The `+N` tally   |
+| `--ft-diff-del-fg` | `--ft-status-error`        | The `−N` tally   |
+
+## Implementation Notes
+
+- Parsing runs through the shared unified-diff reader, which is total: every input yields a value and nothing throws. Text that is not a patch at all yields no files, and the component renders an empty shell rather than an error.
+- Line numbers, the `+`/`−` glyphs and the `@@` hunk headers are `user-select: none`, so dragging across a diff and hitting copy yields the code alone — no gutters or hunk markers to strip out afterwards.
+- Fold and clamp state is keyed by file name and cleared whenever the patch's file list changes, so a folded file never hands its state to whatever takes its place in the next patch.
+- Renames render as `old → new`; a file the patch creates or removes is badged `new file` or `deleted` instead of showing a `/dev/null` side.
+- Rows are `width: max-content` with a `100%` floor, so a row's tint runs the whole scroll width instead of stopping where its own text ends.
+- Expand/collapse is a one-row grid transitioning `grid-template-rows` between `0fr` and `1fr`, so `auto` height animates without measuring anything. The folded body is `inert`, keeping it out of the tab order and the accessibility tree.
+- Both animations — the fold and the chevron — live behind `prefers-reduced-motion: no-preference`.
+- Nothing touches the DOM or the clock outside effects, so the component renders identically on the server.

--- a/src/lib/fancy-ui/code-diff/index.ts
+++ b/src/lib/fancy-ui/code-diff/index.ts
@@ -1,0 +1,4 @@
+import CodeDiff from "./CodeDiff.svelte";
+import type { CodeDiffProps } from "./CodeDiff.svelte";
+
+export { CodeDiff, type CodeDiffProps };

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -75,6 +75,10 @@ export * from "./reasoning-panel/index.js";
 export * from "./chat-message/index.js";
 export * from "./prompt-suggestions/index.js";
 export * from "./chat-error/index.js";
+export * from "./tool-call/index.js";
+export * from "./tool-timeline/index.js";
+export * from "./terminal-block/index.js";
+export * from "./code-diff/index.js";
 
 // =============================================================================
 // Registry

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -2944,6 +2944,201 @@ export const registry: Record<string, ComponentMeta> = {
 			},
 		],
 	},
+	"tool-call": {
+		name: "ToolCall",
+		slug: "tool-call",
+		description:
+			"One tool invocation in a disclosure card: status dot, tool name, duration, and the request and result payloads pretty-printed on expand",
+		category: "ai-agents",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "agents", "tool", "disclosure"],
+		props: [
+			{
+				name: "call",
+				type: "ToolCallData",
+				description:
+					"The invocation to render: id, name, status, and whatever payloads exist so far",
+				required: true,
+			},
+			{
+				name: "open",
+				type: "boolean",
+				description:
+					'Expanded state (bindable). Left undefined the card stays collapsed, except that a call with status "error" opens itself — until the reader toggles it by hand',
+			},
+			{
+				name: "onToggle",
+				type: "(open: boolean) => void",
+				description: "Called on every open/close, by click or on the card's own initiative",
+			},
+		],
+		slots: [
+			{ name: "input", description: "Replaces the default request rendering; receives call.input" },
+			{
+				name: "output",
+				description: "Replaces the default result rendering; receives call.output",
+			},
+			{ name: "icon", description: "Leading icon, replacing the default wrench" },
+		],
+	},
+	"tool-timeline": {
+		name: "ToolTimeline",
+		slug: "tool-timeline",
+		description:
+			"Compact session summary of an agent's tool calls: one row per action on a vertical rail, with the target it touched, its diff stats, and when it ran",
+		category: "ai-agents",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "agents", "tool", "timeline", "activity"],
+		props: [
+			{
+				name: "items",
+				type: "ToolTimelineItemData[]",
+				description: "The agent's activity log, oldest first",
+				required: true,
+			},
+			{
+				name: "onSelect",
+				type: "(item: ToolTimelineItemData, index: number) => void",
+				description: "Called when a row is activated; supplying it turns every row into a button",
+			},
+			{
+				name: "compact",
+				type: "boolean",
+				default: "false",
+				description: "Tighter rows with the detail line dropped",
+			},
+			{
+				name: "label",
+				type: "string",
+				default: '"Activity"',
+				description: "Accessible name for the list",
+			},
+		],
+		slots: [
+			{
+				name: "item",
+				description: "Replaces the built-in row body, keeping the rail and its dot",
+			},
+		],
+	},
+	"terminal-block": {
+		name: "TerminalBlock",
+		slug: "terminal-block",
+		description:
+			"Live command transcript: the prompt line, output as it streams in with its ANSI colours read, a block cursor while it runs, and an exit-status footer when it stops",
+		category: "ai-agents",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "agents", "terminal", "streaming", "output"],
+		props: [
+			{
+				name: "output",
+				type: "string",
+				description:
+					"Everything the command has printed so far, not the latest chunk; reassign as lines arrive",
+				required: true,
+			},
+			{
+				name: "command",
+				type: "string",
+				description: "The command that produced the output, shown after the prompt glyph",
+			},
+			{
+				name: "prompt",
+				type: "string",
+				default: '"$"',
+				description: "Prompt glyph in front of the command",
+			},
+			{
+				name: "running",
+				type: "boolean",
+				default: "false",
+				description: "Whether the command is still running: shows the cursor, pins the scroll",
+			},
+			{
+				name: "exitCode",
+				type: "number | null",
+				default: "null",
+				description: "Anything other than null ends the run and shows the status footer",
+			},
+			{
+				name: "durationMs",
+				type: "number",
+				description: "How long the run took, shown next to the exit status",
+			},
+			{
+				name: "ansi",
+				type: "boolean",
+				default: "true",
+				description:
+					"Read the SGR subset and colour the output; false still strips the escapes, it just paints nothing",
+			},
+			{
+				name: "maxHeight",
+				type: "string",
+				default: '"20rem"',
+				description: "Height at which the output starts scrolling",
+			},
+		],
+		slots: [
+			{
+				name: "header",
+				description: "Title bar above the output — window dots, a file name, a copy button",
+			},
+		],
+	},
+	"code-diff": {
+		name: "CodeDiff",
+		slug: "code-diff",
+		description:
+			"Unified diff tuned for chat width: one foldable card per file, tinted add/delete rows, and a copy-safe gutter",
+		category: "ai-agents",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "agents", "diff", "code", "review"],
+		props: [
+			{
+				name: "diff",
+				type: "string",
+				description:
+					"Raw unified diff text, headers and all; parsed on every change, so a patch still arriving can be handed over as it grows",
+				required: true,
+			},
+			{
+				name: "filename",
+				type: "string",
+				description: "Header label when the patch names no file, or names exactly one",
+			},
+			{
+				name: "lineNumbers",
+				type: "boolean",
+				default: "true",
+				description: "Whether to show the old/new line-number gutters",
+			},
+			{
+				name: "collapsed",
+				type: "boolean",
+				default: "false",
+				description:
+					"Whether the bodies are folded away (bindable). Set it and the whole patch folds; a click folds one file and writes back whether anything is left open",
+			},
+			{
+				name: "maxLines",
+				type: "number",
+				default: "0",
+				description:
+					'Lines shown per file before the rest hide behind a "Show N more lines" button; 0 shows everything',
+			},
+			{
+				name: "wrap",
+				type: "boolean",
+				default: "false",
+				description: "Whether long lines wrap instead of scrolling sideways",
+			},
+		],
+	},
 };
 
 // =============================================================================

--- a/src/lib/fancy-ui/terminal-block/README.md
+++ b/src/lib/fancy-ui/terminal-block/README.md
@@ -1,0 +1,109 @@
+# Terminal Block
+
+A live command transcript: the prompt line, the output as it arrives, a block cursor while the command runs, and an exit status once it stops. ANSI colours in the stream are read and rendered.
+
+## Components
+
+- `TerminalBlock` — the whole block: header, scrolling output, exit footer
+
+## Not to be confused with `TerminalText`
+
+The two look alike and behave nothing alike. Pick by what you have in hand:
+
+|             | `TerminalBlock`                                         | `TerminalText`                                                  |
+| ----------- | ------------------------------------------------------- | --------------------------------------------------------------- |
+| Input       | `output: string`, a stream you keep appending to        | `lines: string[]`, known up front                               |
+| Time        | Text appears when _you_ append it                       | Text is typed out char by char on a schedule the component owns |
+| A new value | Appends; what is already on screen stays                | Restarts the whole animation from an empty screen               |
+| ANSI        | Parsed and coloured                                     | Rendered as literal characters                                  |
+| Status      | Cursor while `running`, `✓ exited 0` footer when done   | No notion of running or finishing, beyond `onComplete`          |
+| Use it for  | A real command, an agent's shell tool call, a build log | Set dressing: a hero animation, a fake boot sequence            |
+
+So: something actually ran → `TerminalBlock`. Nothing ran and you want the typing effect → `TerminalText`.
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { TerminalBlock } from "fancy-ui-svelte";
+
+	let output = $state("");
+	let running = $state(true);
+	let exitCode = $state<number | null>(null);
+</script>
+
+<TerminalBlock command="pnpm build" {output} {running} {exitCode} durationMs={3420} />
+```
+
+The consumer owns the stream: append to `output` as chunks arrive, then flip `running` to `false` and set `exitCode` when the process exits. Append, never replace — `output` is everything printed so far, not the latest chunk.
+
+```svelte
+<!-- A title bar: window dots, a file name, a copy button — anything -->
+<TerminalBlock {output} running>
+	{#snippet header()}
+		<span class="ml-auto text-xs opacity-60">build.log</span>
+	{/snippet}
+</TerminalBlock>
+```
+
+## Props
+
+| Prop         | Type                     | Default     | Description                                                              |
+| ------------ | ------------------------ | ----------- | ------------------------------------------------------------------------ |
+| `output`     | `string`                 | —           | Everything the command has printed so far. Required                      |
+| `command`    | `string`                 | `undefined` | Shown on the first line, after the prompt glyph                          |
+| `prompt`     | `string`                 | `'$'`       | Prompt glyph in front of the command                                     |
+| `running`    | `boolean`                | `false`     | Whether the command is still running: shows the cursor, pins the scroll  |
+| `exitCode`   | `number \| null`         | `null`      | Anything other than `null`/`undefined` ends the run and shows the footer |
+| `durationMs` | `number`                 | `undefined` | How long the run took, shown next to the exit status                     |
+| `ansi`       | `boolean`                | `true`      | Read the SGR subset and colour the output                                |
+| `maxHeight`  | `string`                 | `'20rem'`   | Height at which the output starts scrolling                              |
+| `header`     | `Snippet`                | `undefined` | Title bar above the output                                               |
+| `class`      | `string`                 | `undefined` | Additional CSS classes                                                   |
+| `ref`        | `HTMLDivElement \| null` | `null`      | Bindable reference to the root element                                   |
+
+## ANSI
+
+Output is parsed into an array of styled text runs, never into a string of HTML, so a sequence can only ever become a colour or nothing at all.
+
+| Sequence            | Effect                                                            |
+| ------------------- | ----------------------------------------------------------------- |
+| `ESC[0m`, `ESC[m`   | Reset — clears bold and colour                                    |
+| `ESC[1m`            | Bold                                                              |
+| `ESC[30m`–`ESC[37m` | Foreground: black, red, green, yellow, blue, magenta, cyan, white |
+| `ESC[90m`–`ESC[97m` | The same eight, bright                                            |
+| `ESC[1;32m`         | Compound — every parameter is applied in order                    |
+| Anything else       | Stripped, leaving no trace in the text                            |
+
+"Anything else" is everything: cursor moves, erase-line, OSC window titles, background colours, 256-colour and truecolour, underline, and a sequence cut off mid-write by the end of the stream. Bright codes fold onto the same eight variables rather than doubling the palette — on a dark surface the normal set is already the readable one.
+
+`ansi={false}` does not mean "render the escapes". Sequences are still stripped — nobody wants `ESC[32m` on screen — the colours are simply not applied.
+
+Attributes carry across line breaks: a colour opened on one line and reset three lines later applies to the lines in between, the way a terminal would show it.
+
+## Styling
+
+The surface is dark in a light page too, because terminals are. Every colour is a CSS variable with a built-in fallback, so overriding one anywhere above the block is enough:
+
+| Variable                                                         | Purpose                        |
+| ---------------------------------------------------------------- | ------------------------------ |
+| `--ft-terminal-bg`                                               | Surface behind the whole block |
+| `--ft-terminal-fg`                                               | Default text, and the cursor   |
+| `--ft-terminal-{black,red,green,yellow,blue,magenta,cyan,white}` | The eight ANSI foregrounds     |
+
+`--ft-terminal-green` doubles as the prompt glyph's colour.
+
+The exit footer's `✓`/`✗` is a status rather than terminal output, so it reads off `--ft-status-done` and `--ft-status-error` — the run-status vocabulary shared with `ToolCall`, `ToolTimeline`, `CodeDiff` and `ChatError` — and not off the ANSI palette. Recolour those and a run that failed here looks like a failure everywhere else. See the [ToolCall README](../tool-call/README.md#styling) for the full palette.
+
+Those defaults are `light-dark()` pairs, and the block declares `color-scheme: dark` on its own root so they resolve to the dark half here whatever the page around it is doing. That is the point of the declaration: this surface is near-black in a light page too, so the light half — tuned for white — would be the wrong choice on it. Setting `--ft-status-done` or `--ft-status-error` to a flat colour overrides both halves, so pick one that reads on a dark surface.
+
+## Implementation Notes
+
+- The scrolling region is `role="log"`: additions are announced politely and only the new lines are read, where `aria-live` on the same element would re-read the whole transcript on every chunk.
+- The shared `autoscroll` action keeps the view pinned to the bottom while `running`, and lets go the moment the reader scrolls up to look back.
+- The stream is parsed once and then cut at the newlines, rather than parsed line by line, which is what lets an unclosed colour span several lines.
+- `\r\n` becomes one line break; a lone `\r` is dropped rather than rewinding the line, so a progress bar collapses onto one line instead of exploding into hundreds.
+- A trailing newline leaves an empty row for the cursor to sit on while running, and that row is dropped once the run is over so the footer does not float below a blank line.
+- The cursor is a steady block first and a blinking one second: the blink lives behind `prefers-reduced-motion: no-preference`, so reduced motion still gets the "this is running" signal without the flashing.
+- Durations under a second are reported in milliseconds (`340ms`), not rounded to `0s`; non-finite or negative values are left out entirely.
+- Nothing is scheduled or measured at render time, and no browser API is touched outside the action, so the block server-renders as-is.

--- a/src/lib/fancy-ui/terminal-block/TerminalBlock.svelte
+++ b/src/lib/fancy-ui/terminal-block/TerminalBlock.svelte
@@ -1,0 +1,254 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	/**
+	 * Props for TerminalBlock
+	 */
+	export interface TerminalBlockProps {
+		/** Everything the command has printed so far, not the latest chunk. Reassign as lines arrive. */
+		output: string;
+		/** The command that produced the output, shown on the first line after the prompt glyph. */
+		command?: string;
+		/** Prompt glyph in front of the command. */
+		prompt?: string;
+		/** Whether the command is still running. Shows the cursor and keeps the view pinned. */
+		running?: boolean;
+		/** Exit status. Anything other than null or undefined ends the run and shows the footer. */
+		exitCode?: number | null;
+		/** How long the run took, shown next to the exit status. */
+		durationMs?: number;
+		/** Read the SGR subset and colour the output. False renders the same text, unstyled. */
+		ansi?: boolean;
+		/** Height at which the output starts scrolling. */
+		maxHeight?: string;
+		/** Title bar above the output — window dots, a file name, a copy button. */
+		header?: Snippet;
+		/** Additional CSS classes */
+		class?: string;
+		/** The root element */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { autoscroll } from "../_internals/autoscroll.js";
+	import { parseAnsi, type AnsiSegment } from "./ansi.js";
+
+	let {
+		output,
+		command,
+		prompt = "$",
+		running = false,
+		exitCode = null,
+		durationMs,
+		ansi = true,
+		maxHeight = "20rem",
+		header,
+		class: className,
+		ref = $bindable(null),
+	}: TerminalBlockProps = $props();
+
+	/**
+	 * The palette a consumer overrides by setting `--ft-terminal-*` anywhere above
+	 * the block. Each entry is the readable-on-dark version of its colour, which
+	 * is also why the bright SGR codes fold onto the same eight values.
+	 */
+	const FALLBACK: Record<string, string> = {
+		"--ft-terminal-black": "oklch(0.44 0.01 260)",
+		"--ft-terminal-red": "oklch(0.7 0.18 22)",
+		"--ft-terminal-green": "oklch(0.78 0.17 150)",
+		"--ft-terminal-yellow": "oklch(0.85 0.15 90)",
+		"--ft-terminal-blue": "oklch(0.74 0.13 250)",
+		"--ft-terminal-magenta": "oklch(0.74 0.18 330)",
+		"--ft-terminal-cyan": "oklch(0.82 0.11 200)",
+		"--ft-terminal-white": "oklch(0.95 0.005 260)",
+	};
+
+	const finished = $derived(exitCode !== null && exitCode !== undefined);
+	const ok = $derived(exitCode === 0);
+	const duration = $derived(formatDuration(durationMs));
+
+	const rows = $derived.by(() => {
+		const lines = toRows(output, ansi);
+		// A stream that has printed nothing yet still needs a line to put the
+		// cursor on; a finished one should not end on a blank line just because
+		// its last write ended in a newline.
+		if (lines.length === 0) return running ? [[]] : [];
+		const last = lines[lines.length - 1];
+		if (!running && lines.length > 1 && last.length === 0) lines.pop();
+		return lines;
+	});
+
+	/**
+	 * Parse once over the whole stream, then cut the segments at the newlines:
+	 * a colour opened on one line and closed three lines later stays in effect
+	 * for the lines in between, the way a terminal would show it.
+	 */
+	function toRows(src: string, styled: boolean): AnsiSegment[][] {
+		if (src === "") return [];
+		// CRLF becomes one newline; a lone CR is dropped rather than rewinding
+		// the line, so a progress bar collapses instead of exploding into rows.
+		const normalized = src.replace(/\r\n/g, "\n").replace(/\r/g, "");
+		const lines: AnsiSegment[][] = [[]];
+		for (const segment of parseAnsi(normalized)) {
+			const parts = segment.text.split("\n");
+			for (let i = 0; i < parts.length; i++) {
+				if (i > 0) lines.push([]);
+				if (parts[i] === "") continue;
+				lines[lines.length - 1].push({
+					text: parts[i],
+					bold: styled && segment.bold,
+					fg: styled ? segment.fg : null,
+				});
+			}
+		}
+		return lines;
+	}
+
+	function colour(fg: string | null): string | undefined {
+		if (fg === null) return undefined;
+		return `var(${fg}, ${FALLBACK[fg] ?? "inherit"})`;
+	}
+
+	/**
+	 * Command durations live in the sub-second range often enough that a
+	 * stopwatch reading of "0s" would be the wrong answer most of the time.
+	 */
+	function formatDuration(ms: number | undefined): string | null {
+		if (ms === undefined || !Number.isFinite(ms) || ms < 0) return null;
+		if (ms < 1000) return `${Math.round(ms)}ms`;
+		if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+		const minutes = Math.floor(ms / 60_000);
+		const seconds = Math.round((ms % 60_000) / 1000);
+		return `${minutes}m ${seconds < 10 ? "0" : ""}${seconds}s`;
+	}
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("ft-terminal overflow-hidden rounded-lg font-mono text-sm", className)}
+>
+	{#if header}
+		<div class="ft-rule flex items-center gap-2 border-b px-4 py-2">{@render header()}</div>
+	{/if}
+
+	<div
+		role="log"
+		class="overflow-y-auto px-4 py-3 leading-relaxed"
+		style:max-height={maxHeight}
+		use:autoscroll={{ enabled: running }}
+	>
+		{#if command}
+			<div class="ft-line flex gap-2">
+				<span class="ft-prompt shrink-0 select-none" aria-hidden="true">{prompt}</span>
+				<span class="ft-wrap">{command}</span>
+			</div>
+		{/if}
+		{#each rows as segments, row (row)}
+			<div class="ft-line ft-wrap">
+				{#each segments as segment, i (i)}<span
+						class:ft-bold={segment.bold}
+						style:color={colour(segment.fg)}>{segment.text}</span
+					>{/each}{#if running && row === rows.length - 1}<span class="ft-cursor" aria-hidden="true"
+						>▊</span
+					>{/if}
+			</div>
+		{/each}
+	</div>
+
+	{#if finished}
+		<div
+			role="status"
+			class="ft-rule ft-status flex items-center gap-2 border-t px-4 py-2 text-xs"
+			class:ft-ok={ok}
+		>
+			<span aria-hidden="true">{ok ? "✓" : "✗"}</span>
+			<span>exited {exitCode}</span>
+			{#if duration}
+				<span class="ft-muted ml-auto tabular-nums">{duration}</span>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style>
+	/*
+	 * A terminal is dark in a light page too, so the surface is its own colour
+	 * rather than the theme's. Everything inside inherits from it — including
+	 * `color-scheme`, which is declared dark for exactly that reason: the shared
+	 * `--ft-status-*` fallbacks are `light-dark()` pairs, and on this surface the
+	 * dark half is the legible one whatever the page around it is doing.
+	 */
+	.ft-terminal {
+		color-scheme: dark;
+		background-color: var(--ft-terminal-bg, oklch(0.18 0.02 260));
+		color: var(--ft-terminal-fg, oklch(0.92 0.01 260));
+	}
+
+	.ft-rule {
+		border-color: color-mix(in oklab, currentColor 16%, transparent);
+	}
+
+	.ft-prompt {
+		color: var(--ft-terminal-green, oklch(0.78 0.17 150));
+	}
+
+	/* Output is preformatted, but a long line wraps rather than scrolling sideways. */
+	.ft-wrap {
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+	}
+
+	/* Keeps a blank line the height of a written one. Matches leading-relaxed. */
+	.ft-line {
+		min-height: 1.625em;
+	}
+
+	.ft-bold {
+		font-weight: 700;
+	}
+
+	.ft-cursor {
+		display: inline-block;
+		opacity: 0.85;
+	}
+
+	/*
+	 * The exit verdict is a status, not terminal output: it reads off the
+	 * `--ft-status-*` vocabulary this component family shares rather than the ANSI
+	 * palette above, so a run that failed here looks like a failure everywhere else.
+	 */
+	.ft-status {
+		color: var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)));
+	}
+
+	.ft-status.ft-ok {
+		color: var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145)));
+	}
+
+	.ft-muted {
+		color: var(--ft-terminal-fg, oklch(0.92 0.01 260));
+		opacity: 0.55;
+	}
+
+	/*
+	 * The cursor is a steady block first and a blinking one second: reduced
+	 * motion still gets the "this is still running" signal, without the blink.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-cursor {
+			animation: ft-terminal-cursor 1.1s step-end infinite;
+		}
+
+		@keyframes ft-terminal-cursor {
+			0%,
+			100% {
+				opacity: 0.85;
+			}
+			50% {
+				opacity: 0;
+			}
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/terminal-block/TerminalBlock.svelte
+++ b/src/lib/fancy-ui/terminal-block/TerminalBlock.svelte
@@ -118,9 +118,18 @@
 	function formatDuration(ms: number | undefined): string | null {
 		if (ms === undefined || !Number.isFinite(ms) || ms < 0) return null;
 		if (ms < 1000) return `${Math.round(ms)}ms`;
-		if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
-		const minutes = Math.floor(ms / 60_000);
-		const seconds = Math.round((ms % 60_000) / 1000);
+		if (ms < 60_000) {
+			// Rounded to a tenth first: a value that rounds up to a full 60.0s has
+			// to fall through to the minute form rather than print a second count
+			// that does not exist.
+			const deciseconds = Math.round(ms / 100);
+			if (deciseconds < 600) return `${(deciseconds / 10).toFixed(1)}s`;
+		}
+		// Rounding to whole seconds before splitting means the carry happens on its
+		// own: rounding each unit separately is what produced "1m 60s".
+		const totalSeconds = Math.round(ms / 1000);
+		const minutes = Math.floor(totalSeconds / 60);
+		const seconds = totalSeconds % 60;
 		return `${minutes}m ${seconds < 10 ? "0" : ""}${seconds}s`;
 	}
 </script>
@@ -137,7 +146,7 @@
 		role="log"
 		class="overflow-y-auto px-4 py-3 leading-relaxed"
 		style:max-height={maxHeight}
-		use:autoscroll={{ enabled: running }}
+		use:autoscroll={{ enabled: running, pinOnConnect: true }}
 	>
 		{#if command}
 			<div class="ft-line flex gap-2">

--- a/src/lib/fancy-ui/terminal-block/TerminalBlock.test.ts
+++ b/src/lib/fancy-ui/terminal-block/TerminalBlock.test.ts
@@ -217,4 +217,31 @@ describe("TerminalBlock", () => {
 		expect(root(container).className).toContain("my-block");
 		expect(root(container).className).toContain("font-mono");
 	});
+
+	it.each([
+		[59_999, "1m 00s"],
+		[119_999, "2m 00s"],
+		[3_599_999, "60m 00s"],
+	])("carries a rounded %ims into the next minute", (durationMs, expected) => {
+		// Rounding each unit on its own produced counts that do not exist: "60.0s",
+		// "1m 60s", "59m 60s".
+		const { container } = render(TerminalBlock, {
+			props: { output: "x", exitCode: 0, durationMs },
+		});
+		expect(container.querySelector(".ft-muted")?.textContent).toContain(expected);
+	});
+
+	it("pins an already-running transcript that mounts overflowing", () => {
+		// jsdom lays nothing out, so the container has to be told it overflows.
+		const original = Object.getOwnPropertyDescriptor(Element.prototype, "scrollHeight");
+		Object.defineProperty(Element.prototype, "scrollHeight", { configurable: true, value: 1000 });
+		try {
+			const { container } = render(TerminalBlock, {
+				props: { output: "line\n".repeat(50), running: true },
+			});
+			expect(log(container).scrollTop).toBe(1000);
+		} finally {
+			if (original) Object.defineProperty(Element.prototype, "scrollHeight", original);
+		}
+	});
 });

--- a/src/lib/fancy-ui/terminal-block/TerminalBlock.test.ts
+++ b/src/lib/fancy-ui/terminal-block/TerminalBlock.test.ts
@@ -1,0 +1,220 @@
+import { render, cleanup } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect } from "vitest";
+import TerminalBlock from "./TerminalBlock.svelte";
+
+const ESC = "\u001b";
+
+function root(container: HTMLElement): HTMLElement {
+	return container.firstElementChild as HTMLElement;
+}
+
+function log(container: HTMLElement): HTMLElement {
+	return container.querySelector('[role="log"]') as HTMLElement;
+}
+
+/** The output rows, in order, excluding the command line. */
+function rows(container: HTMLElement): HTMLElement[] {
+	return Array.from(log(container).querySelectorAll(".ft-line")).filter(
+		(el) => !el.classList.contains("flex")
+	) as HTMLElement[];
+}
+
+function textOf(container: HTMLElement): string[] {
+	return rows(container).map((el) => el.textContent ?? "");
+}
+
+describe("TerminalBlock", () => {
+	afterEach(cleanup);
+
+	it("renders the command after the prompt glyph", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: "", command: "pnpm build", prompt: ">" },
+		});
+
+		const commandLine = log(container).querySelector(".flex") as HTMLElement;
+		expect(commandLine.textContent).toContain(">");
+		expect(commandLine.textContent).toContain("pnpm build");
+		expect(commandLine.querySelector(".ft-prompt")?.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it("renders no command line at all when no command is given", () => {
+		const { container } = render(TerminalBlock, { props: { output: "done" } });
+		expect(log(container).querySelector(".ft-prompt")).toBeNull();
+	});
+
+	it("renders one row per line of output", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: "added 214 packages\naudited 215 packages\nfound 0 vulnerabilities" },
+		});
+
+		expect(textOf(container)).toEqual([
+			"added 214 packages",
+			"audited 215 packages",
+			"found 0 vulnerabilities",
+		]);
+	});
+
+	it("appends rows as the output grows, keeping the ones already there", async () => {
+		const { container, rerender } = render(TerminalBlock, {
+			props: { output: "resolving…", running: true },
+		});
+		expect(textOf(container)).toEqual(["resolving…▊"]);
+
+		await rerender({ output: "resolving…\nfetching…\n", running: true });
+
+		// The trailing newline leaves an empty row for the cursor to sit on,
+		// exactly where a terminal would put it.
+		expect(textOf(container)).toEqual(["resolving…", "fetching…", "▊"]);
+	});
+
+	it("drops the trailing blank row once the run is over", async () => {
+		const { container, rerender } = render(TerminalBlock, {
+			props: { output: "building\n", running: true },
+		});
+		expect(textOf(container)).toHaveLength(2);
+
+		await rerender({ output: "building\n", running: false, exitCode: 0 });
+		expect(textOf(container)).toEqual(["building"]);
+	});
+
+	it("colours a segment through the CSS variable for its ANSI code", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: `${ESC}[32m✓ ok${ESC}[0m done` },
+		});
+
+		const spans = rows(container)[0].querySelectorAll("span");
+		expect(spans[0].getAttribute("style")).toContain("var(--ft-terminal-green");
+		expect(spans[0].textContent).toBe("✓ ok");
+		expect(spans[1].getAttribute("style")).toBeNull();
+		expect(spans[1].textContent).toBe(" done");
+	});
+
+	it("marks a bold segment without touching its colour", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: `${ESC}[1;31mERR!${ESC}[0m` },
+		});
+
+		const span = rows(container)[0].querySelector("span") as HTMLElement;
+		expect(span.classList.contains("ft-bold")).toBe(true);
+		expect(span.getAttribute("style")).toContain("var(--ft-terminal-red");
+	});
+
+	it("joins the segments of a line with no whitespace of its own", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: `${ESC}[32mA${ESC}[0mB${ESC}[33mC` },
+		});
+
+		expect(rows(container)[0].textContent).toBe("ABC");
+	});
+
+	it("keeps a colour open across the lines it spans", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: `${ESC}[33mfirst\nsecond${ESC}[0m` },
+		});
+
+		const [one, two] = rows(container);
+		expect((one.querySelector("span") as HTMLElement).getAttribute("style")).toContain(
+			"--ft-terminal-yellow"
+		);
+		expect((two.querySelector("span") as HTMLElement).getAttribute("style")).toContain(
+			"--ft-terminal-yellow"
+		);
+	});
+
+	it("still strips escapes when ansi is false, but paints nothing", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: `${ESC}[1;32mpassed${ESC}[0m`, ansi: false },
+		});
+
+		const span = rows(container)[0].querySelector("span") as HTMLElement;
+		expect(span.textContent).toBe("passed");
+		expect(span.getAttribute("style")).toBeNull();
+		expect(span.classList.contains("ft-bold")).toBe(false);
+	});
+
+	it("shows the block cursor on the last row only while running", async () => {
+		const { container, rerender } = render(TerminalBlock, {
+			props: { output: "step one\nstep two", running: true },
+		});
+
+		expect(container.querySelectorAll(".ft-cursor")).toHaveLength(1);
+		expect(rows(container)[1].textContent).toBe("step two▊");
+
+		await rerender({ output: "step one\nstep two", running: false });
+		expect(container.querySelector(".ft-cursor")).toBeNull();
+	});
+
+	it("gives an empty running stream a row for the cursor to sit on", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: "", command: "pnpm test", running: true },
+		});
+
+		expect(container.querySelectorAll(".ft-cursor")).toHaveLength(1);
+	});
+
+	it("shows no footer until an exit code arrives", async () => {
+		const { container, rerender } = render(TerminalBlock, {
+			props: { output: "working", running: true },
+		});
+		expect(container.querySelector('[role="status"]')).toBeNull();
+
+		await rerender({ output: "working", running: false, exitCode: 0, durationMs: 1240 });
+
+		const footer = container.querySelector('[role="status"]') as HTMLElement;
+		expect(footer.textContent).toContain("✓");
+		expect(footer.textContent).toContain("exited 0");
+		expect(footer.textContent).toContain("1.2s");
+		expect(footer.classList.contains("ft-ok")).toBe(true);
+	});
+
+	it("marks a non-zero exit as a failure", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: "boom", exitCode: 1, durationMs: 340 },
+		});
+
+		const footer = container.querySelector('[role="status"]') as HTMLElement;
+		expect(footer.textContent).toContain("✗");
+		expect(footer.textContent).toContain("exited 1");
+		expect(footer.textContent).toContain("340ms");
+		expect(footer.classList.contains("ft-ok")).toBe(false);
+	});
+
+	it("leaves the duration out when it is absent or nonsense", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: "x", exitCode: 0, durationMs: Number.NaN },
+		});
+
+		expect(container.querySelector(".ft-muted")).toBeNull();
+	});
+
+	it("scrolls the output region at the height it was given, as a log", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: "a", maxHeight: "8rem" },
+		});
+
+		expect(log(container).style.maxHeight).toBe("8rem");
+		expect(log(container).className).toContain("overflow-y-auto");
+	});
+
+	it("renders the header snippet above the output", () => {
+		const { container } = render(TerminalBlock, {
+			props: {
+				output: "a",
+				header: createRawSnippet(() => ({ render: () => "<span>build.log</span>" })),
+			},
+		});
+
+		expect(root(container).textContent).toContain("build.log");
+		expect(container.querySelector(".ft-rule")).not.toBeNull();
+	});
+
+	it("merges custom classes onto the root alongside the base ones", () => {
+		const { container } = render(TerminalBlock, {
+			props: { output: "a", class: "my-block" },
+		});
+
+		expect(root(container).className).toContain("my-block");
+		expect(root(container).className).toContain("font-mono");
+	});
+});

--- a/src/lib/fancy-ui/terminal-block/ansi.test.ts
+++ b/src/lib/fancy-ui/terminal-block/ansi.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { parseAnsi, type AnsiSegment } from "./ansi.js";
+
+const ESC = "\u001b";
+const BEL = "\u0007";
+
+/** Everything a reader would actually see, escapes removed. */
+function plain(segments: AnsiSegment[]): string {
+	return segments.map((s) => s.text).join("");
+}
+
+describe("parseAnsi", () => {
+	it("returns a single unstyled segment for text with no escapes", () => {
+		expect(parseAnsi("npm install")).toEqual([{ text: "npm install", bold: false, fg: null }]);
+	});
+
+	it("returns nothing for an empty string", () => {
+		expect(parseAnsi("")).toEqual([]);
+	});
+
+	it("maps the eight foreground codes onto their CSS variables", () => {
+		const names = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"];
+		names.forEach((name, i) => {
+			const segments = parseAnsi(`${ESC}[${30 + i}mx`);
+			expect(segments).toEqual([{ text: "x", bold: false, fg: `--ft-terminal-${name}` }]);
+		});
+	});
+
+	it("folds the bright range onto the same eight variables", () => {
+		const bright = parseAnsi(`${ESC}[92mok`);
+		const normal = parseAnsi(`${ESC}[32mok`);
+		expect(bright).toEqual(normal);
+		expect(bright[0].fg).toBe("--ft-terminal-green");
+	});
+
+	it("carries bold on its own", () => {
+		expect(parseAnsi(`${ESC}[1mheads up`)).toEqual([{ text: "heads up", bold: true, fg: null }]);
+	});
+
+	it("applies every parameter of a compound sequence", () => {
+		expect(parseAnsi(`${ESC}[1;32mpassed`)).toEqual([
+			{ text: "passed", bold: true, fg: "--ft-terminal-green" },
+		]);
+	});
+
+	it("resets both attributes on ESC[0m and on the empty ESC[m", () => {
+		expect(parseAnsi(`${ESC}[1;31mbad${ESC}[0m fine`)).toEqual([
+			{ text: "bad", bold: true, fg: "--ft-terminal-red" },
+			{ text: " fine", bold: false, fg: null },
+		]);
+		expect(parseAnsi(`${ESC}[33mwarn${ESC}[m done`)).toEqual([
+			{ text: "warn", bold: false, fg: "--ft-terminal-yellow" },
+			{ text: " done", bold: false, fg: null },
+		]);
+	});
+
+	it("keeps attributes across a switch of colour without resetting", () => {
+		expect(parseAnsi(`${ESC}[1;31mred${ESC}[32mgreen`)).toEqual([
+			{ text: "red", bold: true, fg: "--ft-terminal-red" },
+			{ text: "green", bold: true, fg: "--ft-terminal-green" },
+		]);
+	});
+
+	it("ignores SGR parameters outside the supported subset", () => {
+		// Underline, background colour, and 256-colour foreground all pass through
+		// as nothing: the text survives, the styling does not.
+		const segments = parseAnsi(`${ESC}[4munderlined${ESC}[41;38;5;208mtinted`);
+		expect(plain(segments)).toBe("underlinedtinted");
+		expect(segments.every((s) => s.fg === null && !s.bold)).toBe(true);
+	});
+
+	it("strips cursor moves and erase sequences, merging the runs they split", () => {
+		expect(parseAnsi(`${ESC}[2K${ESC}[1Aone${ESC}[Ktwo`)).toEqual([
+			{ text: "onetwo", bold: false, fg: null },
+		]);
+	});
+
+	it("strips OSC strings terminated by BEL or by ST", () => {
+		expect(plain(parseAnsi(`${ESC}]0;build${BEL}running`))).toBe("running");
+		expect(plain(parseAnsi(`${ESC}]0;build${ESC}\\running`))).toBe("running");
+	});
+
+	it("strips two-byte escapes and charset selections", () => {
+		expect(plain(parseAnsi(`${ESC}(Bplain${ESC}=text`))).toBe("plaintext");
+	});
+
+	it("strips a sequence truncated by the end of the stream", () => {
+		expect(parseAnsi(`ok${ESC}[3`)).toEqual([{ text: "ok", bold: false, fg: null }]);
+		expect(parseAnsi(`ok${ESC}[`)).toEqual([{ text: "ok", bold: false, fg: null }]);
+		expect(parseAnsi(`ok${ESC}`)).toEqual([{ text: "ok", bold: false, fg: null }]);
+		expect(parseAnsi(`ok${ESC}]0;never closed`)).toEqual([{ text: "ok", bold: false, fg: null }]);
+	});
+
+	it("keeps newlines and whitespace intact", () => {
+		expect(plain(parseAnsi(`${ESC}[32ma\n  b\tc\n`))).toBe("a\n  b\tc\n");
+	});
+
+	it("never throws, and never leaks an escape into the text", () => {
+		const alphabet = [ESC, BEL, "[", "]", ";", "?", "0", "1", "3", "9", "m", "K", "\\", "a", "\n"];
+		// Deterministic pseudo-random walk: same corpus on every run.
+		let seed = 1337;
+		const next = () => {
+			seed = (seed * 1103515245 + 12345) % 2147483648;
+			return seed / 2147483648;
+		};
+		for (let n = 0; n < 500; n++) {
+			let garbage = "";
+			const length = Math.floor(next() * 40);
+			for (let k = 0; k < length; k++) {
+				garbage += alphabet[Math.floor(next() * alphabet.length)];
+			}
+			const segments = parseAnsi(garbage);
+			expect(plain(segments)).not.toContain(ESC);
+		}
+	});
+
+	it("is total for input that is not a string", () => {
+		expect(parseAnsi(undefined as unknown as string)).toEqual([]);
+		expect(parseAnsi(null as unknown as string)).toEqual([]);
+		expect(parseAnsi(42 as unknown as string)).toEqual([]);
+	});
+});

--- a/src/lib/fancy-ui/terminal-block/ansi.test.ts
+++ b/src/lib/fancy-ui/terminal-block/ansi.test.ts
@@ -119,4 +119,28 @@ describe("parseAnsi", () => {
 		expect(parseAnsi(null as unknown as string)).toEqual([]);
 		expect(parseAnsi(42 as unknown as string)).toEqual([]);
 	});
+
+	describe("extended colour sequences", () => {
+		it("reads a palette index as data, not as a code of its own", () => {
+			// The 31 is the palette entry of `38;5;31`, not the code for red.
+			expect(parseAnsi(`${ESC}[38;5;31mx`)).toEqual([{ text: "x", bold: false, fg: null }]);
+		});
+
+		it("reads a colour channel as data, not as bold", () => {
+			expect(parseAnsi(`${ESC}[38;2;1;2;3mx`)).toEqual([{ text: "x", bold: false, fg: null }]);
+		});
+
+		it("still applies a real code that follows the sequence", () => {
+			expect(parseAnsi(`${ESC}[38;5;208;1mx`)).toEqual([{ text: "x", bold: true, fg: null }]);
+		});
+
+		it("consumes only what is there when the sequence is truncated", () => {
+			expect(parseAnsi(`${ESC}[38;5mx`)).toEqual([{ text: "x", bold: false, fg: null }]);
+			expect(parseAnsi(`${ESC}[38;2;1;2mx`)).toEqual([{ text: "x", bold: false, fg: null }]);
+		});
+
+		it("treats a background sequence the same way", () => {
+			expect(parseAnsi(`${ESC}[48;5;1mx`)).toEqual([{ text: "x", bold: false, fg: null }]);
+		});
+	});
 });

--- a/src/lib/fancy-ui/terminal-block/ansi.ts
+++ b/src/lib/fancy-ui/terminal-block/ansi.ts
@@ -65,7 +65,9 @@ interface Sgr {
 }
 
 function applySgr(params: string, state: Sgr): void {
-	for (const part of params.split(";")) {
+	const parts = params.split(";");
+	for (let i = 0; i < parts.length; i++) {
+		const part = parts[i];
 		// An omitted parameter means 0, so `ESC[m` and `ESC[;32m` both behave.
 		const code = part === "" ? 0 : Number(part);
 		if (!Number.isInteger(code)) continue;
@@ -76,6 +78,16 @@ function applySgr(params: string, state: Sgr): void {
 		}
 		if (code === 1) {
 			state.bold = true;
+			continue;
+		}
+		// An extended colour carries its value in the parameters that follow it —
+		// `38;5;n` or `38;2;r;g;b` — and those are data, not codes: the 31 in
+		// `38;5;31` is a palette index, not "red". Both forms are dropped either
+		// way; taking the whole run at once is what stops the payload being read
+		// back out as styling. A truncated run consumes only what is there, since
+		// the loop bound catches an index past the end.
+		if (code === 38 || code === 48) {
+			i += parts[i + 1] === "5" ? 2 : parts[i + 1] === "2" ? 4 : 1;
 			continue;
 		}
 		const colour = fgVar(code);

--- a/src/lib/fancy-ui/terminal-block/ansi.ts
+++ b/src/lib/fancy-ui/terminal-block/ansi.ts
@@ -1,0 +1,176 @@
+/**
+ * A deliberately small ANSI reader for terminal output surfaces.
+ *
+ * It produces an array of styled segments, never a string of HTML: the renderer
+ * walks the segments with plain Svelte markup, so escape sequences can only ever
+ * become styling or nothing at all — never markup.
+ *
+ * Supported: SGR reset (`0`), bold (`1`), and the eight foreground colours in
+ * both their normal (`30`–`37`) and bright (`90`–`97`) ranges, alone or
+ * compounded (`ESC[1;32m`). Everything else — cursor moves, erase sequences,
+ * OSC titles, background colours, 256/truecolour, unknown SGR parameters — is
+ * stripped without leaving a trace in the text.
+ *
+ * Every entry point is total: it returns a value for any input, including a
+ * half-written escape sequence at the end of a stream.
+ */
+
+/** A run of text sharing one set of attributes. */
+export interface AnsiSegment {
+	/** The text itself, with every escape sequence already removed. */
+	text: string;
+	/** Whether SGR bold is in effect for this run. */
+	bold: boolean;
+	/** Name of the CSS custom property holding the colour, or null for the default. */
+	fg: string | null;
+}
+
+/** The eight colour names the SGR foreground codes map onto. */
+export const ANSI_COLORS = [
+	"black",
+	"red",
+	"green",
+	"yellow",
+	"blue",
+	"magenta",
+	"cyan",
+	"white",
+] as const;
+
+export type AnsiColor = (typeof ANSI_COLORS)[number];
+
+const ESC = "\u001b";
+const BEL = "\u0007";
+
+/** CSI parameter bytes, per ECMA-48: `0-9 : ; < = > ?`. */
+const PARAM_MIN = 0x30;
+const PARAM_MAX = 0x3f;
+/** CSI/escape intermediate bytes: space through `/`. */
+const INTERMEDIATE_MIN = 0x20;
+const INTERMEDIATE_MAX = 0x2f;
+
+/**
+ * Bright codes reuse the same eight variables rather than doubling the palette:
+ * on a dark surface the "normal" set is already the readable one.
+ */
+function fgVar(code: number): string | null {
+	if (code >= 30 && code <= 37) return `--ft-terminal-${ANSI_COLORS[code - 30]}`;
+	if (code >= 90 && code <= 97) return `--ft-terminal-${ANSI_COLORS[code - 90]}`;
+	return null;
+}
+
+interface Sgr {
+	bold: boolean;
+	fg: string | null;
+}
+
+function applySgr(params: string, state: Sgr): void {
+	for (const part of params.split(";")) {
+		// An omitted parameter means 0, so `ESC[m` and `ESC[;32m` both behave.
+		const code = part === "" ? 0 : Number(part);
+		if (!Number.isInteger(code)) continue;
+		if (code === 0) {
+			state.bold = false;
+			state.fg = null;
+			continue;
+		}
+		if (code === 1) {
+			state.bold = true;
+			continue;
+		}
+		const colour = fgVar(code);
+		if (colour !== null) state.fg = colour;
+	}
+}
+
+/** Split a chunk of terminal output into styled runs. Never throws. */
+export function parseAnsi(src: string): AnsiSegment[] {
+	if (typeof src !== "string" || src.length === 0) return [];
+	// Most lines of output carry no styling at all.
+	if (!src.includes(ESC)) return [{ text: src, bold: false, fg: null }];
+
+	const out: AnsiSegment[] = [];
+	const state: Sgr = { bold: false, fg: null };
+	let buf = "";
+	let i = 0;
+
+	function flush(): void {
+		if (buf === "") return;
+		// A stripped sequence (a cursor move mid-line, say) splits the buffer
+		// without changing the attributes; those two runs are one run.
+		const last = out[out.length - 1];
+		if (last !== undefined && last.bold === state.bold && last.fg === state.fg) {
+			last.text += buf;
+		} else {
+			out.push({ text: buf, bold: state.bold, fg: state.fg });
+		}
+		buf = "";
+	}
+
+	while (i < src.length) {
+		if (src[i] !== ESC) {
+			buf += src[i];
+			i += 1;
+			continue;
+		}
+
+		flush();
+		const next = src[i + 1];
+
+		if (next === "[") {
+			// CSI: parameter bytes, then intermediates, then exactly one final byte.
+			let j = i + 2;
+			while (j < src.length && src.charCodeAt(j) >= PARAM_MIN && src.charCodeAt(j) <= PARAM_MAX) {
+				j += 1;
+			}
+			const params = src.slice(i + 2, j);
+			while (
+				j < src.length &&
+				src.charCodeAt(j) >= INTERMEDIATE_MIN &&
+				src.charCodeAt(j) <= INTERMEDIATE_MAX
+			) {
+				j += 1;
+			}
+			// Truncated mid-sequence: the rest of the stream is escape, not text.
+			if (j >= src.length) break;
+			if (src[j] === "m") applySgr(params, state);
+			i = j + 1;
+			continue;
+		}
+
+		if (next === "]") {
+			// OSC: a string terminated by BEL or ST, or by the end of the stream.
+			let j = i + 2;
+			while (j < src.length) {
+				if (src[j] === BEL) {
+					j += 1;
+					break;
+				}
+				if (src[j] === ESC && src[j + 1] === "\\") {
+					j += 2;
+					break;
+				}
+				j += 1;
+			}
+			i = j;
+			continue;
+		}
+
+		// A lone ESC at the very end has nothing left to introduce.
+		if (next === undefined) break;
+
+		// Two- and three-byte escapes: optional intermediates, then one final byte.
+		let j = i + 1;
+		while (
+			j < src.length &&
+			src.charCodeAt(j) >= INTERMEDIATE_MIN &&
+			src.charCodeAt(j) <= INTERMEDIATE_MAX
+		) {
+			j += 1;
+		}
+		i = j < src.length ? j + 1 : src.length;
+	}
+
+	flush();
+	return out;
+}

--- a/src/lib/fancy-ui/terminal-block/index.ts
+++ b/src/lib/fancy-ui/terminal-block/index.ts
@@ -1,0 +1,4 @@
+import TerminalBlock from "./TerminalBlock.svelte";
+import type { TerminalBlockProps } from "./TerminalBlock.svelte";
+
+export { TerminalBlock, type TerminalBlockProps };

--- a/src/lib/fancy-ui/tool-call/README.md
+++ b/src/lib/fancy-ui/tool-call/README.md
@@ -1,0 +1,135 @@
+# Tool Call
+
+One tool invocation, folded into a disclosure card: a status dot, the tool name in mono, how long it took, and — once expanded — the request that went out and the result that came back.
+
+## Components
+
+- `ToolCall` — header button plus the payload sections it controls
+
+## Usage
+
+```svelte
+<script>
+	import { ToolCall } from "fancy-ui-svelte";
+
+	const call = {
+		id: "call_1",
+		name: "search_docs",
+		status: "done",
+		input: { query: "retry policy", limit: 3 },
+		output: { hits: 3, top: "billing/retries.md" },
+		durationMs: 1400,
+	};
+</script>
+
+<ToolCall {call} />
+```
+
+## The data contract
+
+`call` is a `ToolCallData`, the shape shared by every component in this family — the same object can flow from a tool timeline into this card without translation:
+
+```ts
+interface ToolCallData {
+	id: string;
+	name: string;
+	status: "pending" | "running" | "done" | "error" | "cancelled";
+	input?: unknown;
+	output?: unknown;
+	error?: string;
+	durationMs?: number;
+}
+```
+
+Only `id`, `name`, and `status` are required. Everything else appears as it arrives: send the object with just `input` while the tool runs, then the same object with `output` and `durationMs` when it returns.
+
+## Props
+
+| Prop       | Type                      | Default     | Description                                        |
+| ---------- | ------------------------- | ----------- | -------------------------------------------------- |
+| `call`     | `ToolCallData`            | —           | The invocation to render. Required.                |
+| `open`     | `boolean`                 | `undefined` | Expanded state. Bindable — see the contract below  |
+| `input`    | `Snippet<[unknown]>`      | `undefined` | Replaces the default request rendering             |
+| `output`   | `Snippet<[unknown]>`      | `undefined` | Replaces the default result rendering              |
+| `icon`     | `Snippet`                 | `undefined` | Leading icon, replacing the default wrench         |
+| `onToggle` | `(open: boolean) => void` | `undefined` | Called on every open/close, by click or on its own |
+| `class`    | `string`                  | `undefined` | Additional CSS classes                             |
+| `ref`      | `HTMLDivElement \| null`  | `null`      | Bindable reference to the root element             |
+
+## The open-behaviour contract
+
+`open` is bindable but starts life as `undefined`, which the card reads as _"nobody has decided yet, so I will"_. In that state it stays collapsed, with one exception: **a call whose status is `"error"` opens itself**, because a failure is the one payload worth reading without being asked.
+
+The moment the reader clicks the header, the card hands over for good — a later failure will not pop it open again behind their back. Every change, whichever side caused it, is written back through `open` and announced through `onToggle`. So:
+
+- Ignore `open` entirely and you get the automatic behaviour above.
+- `bind:open={expanded}` and you get that behaviour _plus_ a variable that always reflects the truth.
+- Write to `expanded` yourself and the card obeys — but that does not count as a reader toggle, so the auto-open stays armed.
+
+## Rendering payloads
+
+By default, objects and arrays are pretty-printed JSON in a `<pre>`; primitives render bare, so a string result reads as prose rather than as a quoted literal.
+
+Cycles and bigints are the two things `JSON.stringify` refuses outright, and both turn up in real tool payloads — so neither costs you the payload. A self-reference prints as `"[Circular]"` and a bigint as `"9007199254740993n"`, with the rest of the object intact. Only a value that defeats even that — a `toJSON` that throws, say — falls back to `String(value)`, rather than taking the card down with it.
+
+Pass `input` or `output` to render your own, each receiving the matching value:
+
+```svelte
+<ToolCall {call}>
+	{#snippet output(value)}
+		<ul>
+			{#each value.hits as hit (hit.id)}
+				<li>{hit.title}</li>
+			{/each}
+		</ul>
+	{/snippet}
+</ToolCall>
+```
+
+An `error` on the call is shown in the result section whatever the snippets do, tinted, above any output that still made it back.
+
+## Styling
+
+Colour comes from `--ft-status-*`, the run-status vocabulary shared with `ToolTimeline`, `TerminalBlock`, `CodeDiff` and `ChatError`. Set one of them anywhere up the tree and every component in the family follows:
+
+| Variable                | Default (light / dark)                          | Meaning                      |
+| ----------------------- | ----------------------------------------------- | ---------------------------- |
+| `--ft-status-pending`   | `oklch(0.55 0.02 260)` / `oklch(0.72 0.02 260)` | Queued, nothing has run yet  |
+| `--ft-status-running`   | `oklch(0.5 0.18 265)` / `oklch(0.72 0.15 265)`  | In flight                    |
+| `--ft-status-done`      | `oklch(0.5 0.14 145)` / `oklch(0.72 0.15 145)`  | Succeeded                    |
+| `--ft-status-error`     | `oklch(0.5 0.19 25)` / `oklch(0.7 0.18 25)`     | Failed                       |
+| `--ft-status-cancelled` | `oklch(0.55 0.02 260)` / `oklch(0.72 0.02 260)` | Abandoned before it finished |
+
+Each default is a `light-dark()` pair, because no single token clears 4.5:1 against both white and near-black — the light half is tuned for a light page and the dark half for a dark one. Which half applies is decided by `color-scheme`, so **your theme must declare it**:
+
+```css
+:root {
+	color-scheme: light;
+}
+.dark {
+	color-scheme: dark;
+}
+```
+
+Without that declaration a page resolves to the light half, which is the safe default on the white background most unthemed pages have. Overriding a `--ft-status-*` with a flat colour is fine — you then own its contrast on both themes, and `light-dark()` is available to you too.
+
+Every colour is read at the point of use, so a value set by a consumer wins without having to out-specify the component's own scoped rules. The `--ft-toolcall-*` names below sit in front of the shared ones for the case where this card alone should differ:
+
+| Variable                   | Default                        | Applies to                     |
+| -------------------------- | ------------------------------ | ------------------------------ |
+| `--ft-toolcall-pending`    | `--ft-status-pending` at 55%   | Hollow dot, pending            |
+| `--ft-toolcall-running`    | `--ft-status-running`          | Dot and its pulse, running     |
+| `--ft-toolcall-done`       | `--ft-status-done`             | Dot, completed                 |
+| `--ft-toolcall-error`      | `--ft-status-error`            | Dot and the error line         |
+| `--ft-toolcall-cancelled`  | `--ft-status-cancelled` at 40% | Hollow dot, cancelled          |
+| `--ft-toolcall-payload-bg` | `currentColor` at 6%           | Background behind each `<pre>` |
+| `--ft-toolcall-max-height` | `16rem`                        | Scroll cap on a long payload   |
+
+## Implementation Notes
+
+- Status is carried by shape as well as hue — pending and cancelled are hollow, the rest filled — and spelled out in a screen-reader-only label beside the tool name, so colour is never the only signal. A cancelled name is struck through.
+- Expand/collapse is a one-row grid transitioning `grid-template-rows` between `0fr` and `1fr`, so `auto` height animates without measuring anything.
+- The collapsed body is `inert`, keeping hidden payloads out of the tab order and the accessibility tree.
+- Long payloads wrap rather than scroll sideways, and cap their height at `--ft-toolcall-max-height` with a vertical scrollbar.
+- Every animation — the running pulse, the chevron, the expand — lives behind `prefers-reduced-motion: no-preference`. Reduced motion gets the same states, instantly.
+- Nothing is scheduled and no DOM is touched at construction time, so the card renders under SSR unchanged.

--- a/src/lib/fancy-ui/tool-call/ToolCall.svelte
+++ b/src/lib/fancy-ui/tool-call/ToolCall.svelte
@@ -1,0 +1,408 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { ToolCallData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for ToolCall
+	 */
+	export interface ToolCallProps {
+		/** The invocation to render: name, status, and whatever payloads exist so far. */
+		call: ToolCallData;
+		/**
+		 * Whether the payloads are expanded. Bindable, and left alone until either
+		 * the reader or a failure decides — see the open-behaviour contract in the
+		 * README.
+		 */
+		open?: boolean;
+		/** Replaces the default request rendering. Receives `call.input`. */
+		input?: Snippet<[unknown]>;
+		/** Replaces the default result rendering. Receives `call.output`. */
+		output?: Snippet<[unknown]>;
+		/** Leading icon, replacing the default wrench. */
+		icon?: Snippet;
+		/** Called whenever the card opens or closes, by click or on its own. */
+		onToggle?: (open: boolean) => void;
+		/** Additional CSS classes */
+		class?: string;
+		/** The root element */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { untrack } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import { formatElapsed } from "../_internals/elapsed.svelte.js";
+
+	let {
+		call,
+		open = $bindable(),
+		input,
+		output,
+		icon,
+		onToggle,
+		class: className,
+		ref = $bindable(null),
+	}: ToolCallProps = $props();
+
+	/** Spoken alongside the tool name, since the dot's colour says nothing out loud. */
+	const STATUS_LABELS = {
+		pending: "Pending",
+		running: "Running",
+		done: "Completed",
+		error: "Failed",
+		cancelled: "Cancelled",
+	} as const;
+
+	/** Shown when a call reports failure without saying why. */
+	const FALLBACK_ERROR = "The tool call failed.";
+
+	const uid = $props.id();
+	const headerId = `${uid}-header`;
+	const bodyId = `${uid}-body`;
+	const requestId = `${uid}-request`;
+	const resultId = `${uid}-result`;
+
+	// `open` stays undefined until something actually decides: `autoOpen` carries
+	// the answer in the meantime, so a consumer that never touches the prop still
+	// gets the automatic behaviour and one that binds it still owns the value.
+	let autoOpen = $state(false);
+	let userToggled = $state(false);
+
+	const isOpen = $derived(open ?? autoOpen);
+	const status = $derived(call.status);
+	const isError = $derived(status === "error");
+	const errorText = $derived(isError ? (call.error ?? FALLBACK_ERROR) : "");
+	const duration = $derived(call.durationMs === undefined ? "" : formatElapsed(call.durationMs));
+
+	// A snippet counts as content on its own: a caller who renders the payload
+	// themselves may well have nothing on `call` for us to look at.
+	const hasRequest = $derived(input !== undefined || call.input !== undefined);
+	const hasOutput = $derived(output !== undefined || call.output !== undefined);
+	const hasResult = $derived(hasOutput || errorText !== "");
+
+	const requestText = $derived(hasRequest ? formatPayload(call.input) : "");
+	const resultText = $derived(hasOutput ? formatPayload(call.output) : "");
+
+	/**
+	 * Objects and arrays get pretty-printed JSON; primitives are rendered bare so
+	 * a string result reads as prose rather than as a quoted literal.
+	 *
+	 * The two things `JSON.stringify` refuses outright — a cycle and a bigint —
+	 * are what tool payloads are actually made of, and `String()` turns both into
+	 * `[object Object]`, which tells the reader nothing. So a refusal earns a
+	 * second attempt through a replacer that names them instead; `String` is left
+	 * for the payload that defeats even that, such as a `toJSON` that throws.
+	 */
+	function formatPayload(value: unknown): string {
+		if (value === undefined) return "";
+		if (value === null || typeof value !== "object") return String(value);
+		try {
+			return JSON.stringify(value, null, 2) ?? String(value);
+		} catch {
+			try {
+				const seen = new WeakSet<object>();
+				const json = JSON.stringify(
+					value,
+					(_key, entry: unknown) => {
+						if (typeof entry === "bigint") return `${entry}n`;
+						if (entry !== null && typeof entry === "object") {
+							if (seen.has(entry)) return "[Circular]";
+							seen.add(entry);
+						}
+						return entry;
+					},
+					2
+				);
+				return json ?? String(value);
+			} catch {
+				return String(value);
+			}
+		}
+	}
+
+	function commit(next: boolean) {
+		if (untrack(() => open ?? autoOpen) === next) return;
+		open = next;
+		autoOpen = next;
+		onToggle?.(next);
+	}
+
+	function toggle() {
+		// From here on the reader owns the card: a later failure will not pop it
+		// open again behind their back.
+		userToggled = true;
+		commit(!isOpen);
+	}
+
+	// A failure is the one thing worth reading without being asked, so it expands
+	// itself — unless the reader has already taken over. `userToggled` is read
+	// untracked so that taking over does not itself re-run this.
+	$effect(() => {
+		const failed = call.status === "error";
+		untrack(() => {
+			if (!failed || userToggled) return;
+			commit(true);
+		});
+	});
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("ft-toolcall border-border bg-card/50 w-full rounded-lg border text-sm", className)}
+	data-status={status}
+>
+	<button
+		type="button"
+		id={headerId}
+		class="text-muted-foreground hover:text-foreground flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors"
+		aria-expanded={isOpen}
+		aria-controls={bodyId}
+		onclick={toggle}
+	>
+		<span class="ft-toolcall-icon flex-none" aria-hidden="true">
+			{#if icon}
+				{@render icon()}
+			{:else}
+				<svg
+					class="size-3.5"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path
+						d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
+					/>
+				</svg>
+			{/if}
+		</span>
+
+		<!--
+			Filled versus hollow, not just hue: the four states stay apart for anyone
+			who cannot tell the colours apart, and the label below says it in words.
+		-->
+		<span
+			class="ft-toolcall-dot flex-none"
+			class:ft-status-pending={status === "pending"}
+			class:ft-status-running={status === "running"}
+			class:ft-status-done={status === "done"}
+			class:ft-status-error={isError}
+			class:ft-status-cancelled={status === "cancelled"}
+			aria-hidden="true"
+		></span>
+
+		<span
+			class="ft-toolcall-name text-foreground min-w-0 truncate font-mono text-xs"
+			class:ft-struck={status === "cancelled"}>{call.name}</span
+		>
+		<span class="sr-only">{STATUS_LABELS[status]}</span>
+
+		<span class="ml-auto flex flex-none items-center gap-2">
+			{#if duration}
+				<span class="text-xs tabular-nums">{duration}</span>
+			{/if}
+			<svg
+				class="ft-toolcall-chevron size-3.5"
+				class:ft-open={isOpen}
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2.5"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				aria-hidden="true"
+			>
+				<path d="m9 6 6 6-6 6" />
+			</svg>
+		</span>
+	</button>
+
+	<div class="ft-toolcall-body" class:ft-open={isOpen}>
+		<div class="overflow-hidden">
+			<div
+				id={bodyId}
+				role="group"
+				aria-labelledby={headerId}
+				inert={!isOpen}
+				class="flex flex-col gap-3 px-3 pb-3"
+			>
+				{#if hasRequest}
+					<section aria-labelledby={requestId}>
+						<div id={requestId} class="text-muted-foreground mb-1 text-xs font-medium">Request</div>
+						{#if input}
+							{@render input(call.input)}
+						{:else}
+							<pre class="ft-toolcall-payload">{requestText}</pre>
+						{/if}
+					</section>
+				{/if}
+
+				{#if hasResult}
+					<section aria-labelledby={resultId}>
+						<div id={resultId} class="text-muted-foreground mb-1 text-xs font-medium">Result</div>
+						{#if errorText}
+							<p class="ft-toolcall-error-text">{errorText}</p>
+						{/if}
+						{#if output}
+							{@render output(call.output)}
+						{:else if hasOutput}
+							<pre class="ft-toolcall-payload" class:mt-2={errorText}>{resultText}</pre>
+						{/if}
+					</section>
+				{/if}
+
+				{#if !hasRequest && !hasResult}
+					<p class="text-muted-foreground text-xs italic">Nothing recorded yet.</p>
+				{/if}
+			</div>
+		</div>
+	</div>
+</div>
+
+<style>
+	/*
+	 * Every status colour is read at the point of use through two hooks: the
+	 * component's own `--ft-toolcall-*`, then the `--ft-status-*` vocabulary every
+	 * component in this family shares, then the literal. Setting either anywhere up
+	 * the tree retints the state without having to win a specificity fight against
+	 * these scoped rules — the shared one recolours the whole family at once.
+	 */
+	.ft-toolcall-dot {
+		position: relative;
+		display: inline-block;
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 9999px;
+	}
+
+	/* Hollow: nothing has happened yet, or nothing ever will. The two share a hue
+	   and stay apart on the ring's weight, plus the struck-through name below. */
+	.ft-toolcall-dot.ft-status-pending {
+		box-shadow: inset 0 0 0 1.5px
+			var(
+				--ft-toolcall-pending,
+				color-mix(
+					in oklab,
+					var(--ft-status-pending, light-dark(oklch(0.55 0.02 260), oklch(0.72 0.02 260))) 55%,
+					transparent
+				)
+			);
+	}
+
+	.ft-toolcall-dot.ft-status-cancelled {
+		box-shadow: inset 0 0 0 1.5px
+			var(
+				--ft-toolcall-cancelled,
+				color-mix(
+					in oklab,
+					var(--ft-status-cancelled, light-dark(oklch(0.55 0.02 260), oklch(0.72 0.02 260))) 40%,
+					transparent
+				)
+			);
+	}
+
+	.ft-toolcall-dot.ft-status-running {
+		background: var(
+			--ft-toolcall-running,
+			var(--ft-status-running, light-dark(oklch(0.5 0.18 265), oklch(0.72 0.15 265)))
+		);
+	}
+
+	.ft-toolcall-dot.ft-status-done {
+		background: var(
+			--ft-toolcall-done,
+			var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145)))
+		);
+	}
+
+	.ft-toolcall-dot.ft-status-error {
+		background: var(
+			--ft-toolcall-error,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+	}
+
+	.ft-toolcall-name.ft-struck {
+		text-decoration: line-through;
+		opacity: 0.7;
+	}
+
+	.ft-toolcall-error-text {
+		color: var(
+			--ft-toolcall-error,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+		font-size: 0.75rem;
+		line-height: 1.5;
+	}
+
+	.ft-toolcall-payload {
+		max-height: var(--ft-toolcall-max-height, 16rem);
+		overflow-y: auto;
+		border-radius: 0.375rem;
+		background: var(--ft-toolcall-payload-bg, color-mix(in oklab, currentColor 6%, transparent));
+		padding: 0.5rem 0.625rem;
+		font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+		font-size: 0.75rem;
+		line-height: 1.5;
+		/* Wrapping rather than scrolling sideways: a long URL in a payload should
+		   not put the whole card on a horizontal rail. */
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+	}
+
+	/*
+	 * 0fr → 1fr on a one-row grid is the only way to transition "auto" height
+	 * without measuring anything. The inner wrapper does the clipping.
+	 */
+	.ft-toolcall-body {
+		display: grid;
+		grid-template-rows: 0fr;
+	}
+
+	.ft-toolcall-body.ft-open {
+		grid-template-rows: 1fr;
+	}
+
+	.ft-toolcall-chevron.ft-open {
+		transform: rotate(90deg);
+	}
+
+	/*
+	 * Everything that moves lives behind the query, so reduced motion gets the
+	 * same states with nothing to shorten or fall back from — a running call is
+	 * still a filled accent dot, it just stops breathing.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-toolcall-body {
+			transition: grid-template-rows 260ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+
+		.ft-toolcall-chevron {
+			transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+
+		.ft-toolcall-dot.ft-status-running::after {
+			content: "";
+			position: absolute;
+			inset: 0;
+			border-radius: inherit;
+			background: inherit;
+			animation: ft-toolcall-ping 1.6s cubic-bezier(0, 0, 0.2, 1) infinite;
+		}
+	}
+
+	@keyframes ft-toolcall-ping {
+		from {
+			opacity: 0.55;
+			transform: scale(1);
+		}
+		to {
+			opacity: 0;
+			transform: scale(2.4);
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/tool-call/ToolCall.svelte
+++ b/src/lib/fancy-ui/tool-call/ToolCall.svelte
@@ -66,14 +66,17 @@
 	// `open` stays undefined until something actually decides: `autoOpen` carries
 	// the answer in the meantime, so a consumer that never touches the prop still
 	// gets the automatic behaviour and one that binds it still owns the value.
-	let autoOpen = $state(false);
+	// Seeded from the initial status as well, because the effect that opens a
+	// failed call never runs on the server: a call that already reports failure
+	// would otherwise be rendered folded and only spring open at hydration.
+	let autoOpen = $state(untrack(() => call.status === "error"));
 	let userToggled = $state(false);
 
 	const isOpen = $derived(open ?? autoOpen);
 	const status = $derived(call.status);
 	const isError = $derived(status === "error");
 	const errorText = $derived(isError ? (call.error ?? FALLBACK_ERROR) : "");
-	const duration = $derived(call.durationMs === undefined ? "" : formatElapsed(call.durationMs));
+	const duration = $derived(call.durationMs === undefined ? "" : formatDuration(call.durationMs));
 
 	// A snippet counts as content on its own: a caller who renders the payload
 	// themselves may well have nothing on `call` for us to look at.
@@ -83,6 +86,17 @@
 
 	const requestText = $derived(hasRequest ? formatPayload(call.input) : "");
 	const resultText = $derived(hasOutput ? formatPayload(call.output) : "");
+
+	/**
+	 * The shared formatter floors to the second, which reads as "0s" for anything
+	 * quicker than that — and a tool call more often than not is. Sub-second work
+	 * is reported in milliseconds here; everything else defers to the shared
+	 * formatter, whose contract other callers depend on.
+	 */
+	function formatDuration(ms: number): string {
+		if (Number.isFinite(ms) && ms >= 0 && ms < 1000) return `${Math.round(ms)}ms`;
+		return formatElapsed(ms);
+	}
 
 	/**
 	 * Objects and arrays get pretty-printed JSON; primitives are rendered bare so
@@ -101,14 +115,22 @@
 			return JSON.stringify(value, null, 2) ?? String(value);
 		} catch {
 			try {
-				const seen = new WeakSet<object>();
+				// Tracking every object ever seen would call the second of two
+				// siblings pointing at one value a cycle, which it is not. Only the
+				// chain currently being descended counts. `this` is whatever object
+				// owns the key being visited, so popping back to it before the check
+				// unwinds the stack on the way out of a branch.
+				const ancestors: unknown[] = [];
 				const json = JSON.stringify(
 					value,
-					(_key, entry: unknown) => {
+					function (this: unknown, _key, entry: unknown) {
 						if (typeof entry === "bigint") return `${entry}n`;
 						if (entry !== null && typeof entry === "object") {
-							if (seen.has(entry)) return "[Circular]";
-							seen.add(entry);
+							while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
+								ancestors.pop();
+							}
+							if (ancestors.includes(entry)) return "[Circular]";
+							ancestors.push(entry);
 						}
 						return entry;
 					},

--- a/src/lib/fancy-ui/tool-call/ToolCall.test.ts
+++ b/src/lib/fancy-ui/tool-call/ToolCall.test.ts
@@ -85,7 +85,10 @@ describe("ToolCall", () => {
 		});
 
 		expect(header(container).getAttribute("aria-expanded")).toBe("true");
-		expect(onToggle).toHaveBeenLastCalledWith(true);
+		// Open from the first render rather than toggled there, which is what keeps
+		// server markup expanded instead of folding until hydration catches up.
+		// Nothing moved, so there is nothing for onToggle to report.
+		expect(onToggle).not.toHaveBeenCalled();
 	});
 
 	it("opens itself when a running call turns into a failure", async () => {
@@ -156,6 +159,19 @@ describe("ToolCall", () => {
 		});
 
 		expect(payloads(container)).toEqual(['{\n  "name": "loop",\n  "self": "[Circular]"\n}']);
+	});
+
+	it("keeps a value shared by two siblings intact rather than calling the repeat a cycle", () => {
+		// The bigint is what forces this payload down the replacer path at all: a
+		// plain shared reference serializes on the first attempt.
+		const shared = { id: "x" };
+		const { container } = render(ToolCall, {
+			props: { call: call({ output: { first: shared, second: shared, count: 1n } }), open: true },
+		});
+
+		expect(payloads(container)).toEqual([
+			'{\n  "first": {\n    "id": "x"\n  },\n  "second": {\n    "id": "x"\n  },\n  "count": "1n"\n}',
+		]);
 	});
 
 	it("renders a bigint JSON refuses outright", () => {
@@ -264,6 +280,9 @@ describe("ToolCall", () => {
 	});
 
 	it.each([
+		// Sub-second work is what most calls actually are; the shared formatter
+		// floors to the second and would report every one of them as "0s".
+		[240, "240ms"],
 		[1400, "1s"],
 		[65_000, "1m 05s"],
 	])("formats a duration of %ims", (durationMs, expected) => {

--- a/src/lib/fancy-ui/tool-call/ToolCall.test.ts
+++ b/src/lib/fancy-ui/tool-call/ToolCall.test.ts
@@ -1,0 +1,288 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import ToolCall from "./ToolCall.svelte";
+import type { ToolCallData } from "../_internals/ai-types.js";
+
+function call(overrides: Partial<ToolCallData> = {}): ToolCallData {
+	return { id: "call_1", name: "search_docs", status: "done", ...overrides };
+}
+
+function header(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector("button[aria-expanded]") as HTMLButtonElement;
+}
+
+function body(container: HTMLElement): HTMLElement {
+	const id = header(container).getAttribute("aria-controls") as string;
+	return container.querySelector(`#${id}`) as HTMLElement;
+}
+
+function dot(container: HTMLElement): HTMLElement {
+	return container.querySelector(".ft-toolcall-dot") as HTMLElement;
+}
+
+function payloads(container: HTMLElement): string[] {
+	return [...container.querySelectorAll(".ft-toolcall-payload")].map((el) => el.textContent ?? "");
+}
+
+describe("ToolCall", () => {
+	afterEach(cleanup);
+
+	it("renders the tool name in the header", () => {
+		const { container } = render(ToolCall, { props: { call: call({ name: "run_query" }) } });
+
+		expect(header(container).textContent).toContain("run_query");
+	});
+
+	it.each([
+		["pending", "ft-status-pending"],
+		["running", "ft-status-running"],
+		["done", "ft-status-done"],
+		["error", "ft-status-error"],
+		["cancelled", "ft-status-cancelled"],
+	] as const)("marks the status dot for %s", (status, className) => {
+		const { container } = render(ToolCall, { props: { call: call({ status }) } });
+
+		expect(dot(container).classList.contains(className)).toBe(true);
+		expect((container.firstElementChild as HTMLElement).dataset.status).toBe(status);
+	});
+
+	it("names the status out loud, since the dot is hidden from assistive tech", () => {
+		const { container } = render(ToolCall, { props: { call: call({ status: "running" }) } });
+
+		expect(dot(container).getAttribute("aria-hidden")).toBe("true");
+		expect(container.querySelector(".sr-only")?.textContent).toBe("Running");
+	});
+
+	it("starts collapsed and points the header at the payloads it controls", () => {
+		const { container } = render(ToolCall, { props: { call: call() } });
+
+		expect(header(container).getAttribute("aria-expanded")).toBe("false");
+		expect(header(container).getAttribute("aria-controls")).toBe(body(container).id);
+		expect(body(container).getAttribute("role")).toBe("group");
+		expect(body(container).inert).toBe(true);
+	});
+
+	it("toggles aria-expanded on click and reports every flip through onToggle", async () => {
+		const onToggle = vi.fn();
+		const { container } = render(ToolCall, { props: { call: call(), onToggle } });
+
+		await fireEvent.click(header(container));
+		expect(header(container).getAttribute("aria-expanded")).toBe("true");
+		expect(body(container).inert).toBe(false);
+		expect(onToggle).toHaveBeenLastCalledWith(true);
+
+		await fireEvent.click(header(container));
+		expect(header(container).getAttribute("aria-expanded")).toBe("false");
+		expect(onToggle).toHaveBeenLastCalledWith(false);
+		expect(onToggle).toHaveBeenCalledTimes(2);
+	});
+
+	it("opens itself when the call comes back failed", () => {
+		const onToggle = vi.fn();
+		const { container } = render(ToolCall, {
+			props: { call: call({ status: "error", error: "429 Too Many Requests" }), onToggle },
+		});
+
+		expect(header(container).getAttribute("aria-expanded")).toBe("true");
+		expect(onToggle).toHaveBeenLastCalledWith(true);
+	});
+
+	it("opens itself when a running call turns into a failure", async () => {
+		const { container, rerender } = render(ToolCall, {
+			props: { call: call({ status: "running" }) },
+		});
+		expect(header(container).getAttribute("aria-expanded")).toBe("false");
+
+		await rerender({ call: call({ status: "error", error: "boom" }) });
+		expect(header(container).getAttribute("aria-expanded")).toBe("true");
+	});
+
+	it("does not reopen on a failure once the reader has closed it", async () => {
+		const { container, rerender } = render(ToolCall, {
+			props: { call: call({ status: "running" }) },
+		});
+
+		// Open then close by hand: the card is the reader's from here on.
+		await fireEvent.click(header(container));
+		await fireEvent.click(header(container));
+
+		await rerender({ call: call({ status: "error", error: "boom" }) });
+		expect(header(container).getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("follows an open prop driven from outside", async () => {
+		const { container, rerender } = render(ToolCall, { props: { call: call(), open: false } });
+		expect(header(container).getAttribute("aria-expanded")).toBe("false");
+
+		await rerender({ call: call(), open: true });
+		expect(header(container).getAttribute("aria-expanded")).toBe("true");
+		expect(body(container).inert).toBe(false);
+
+		await rerender({ call: call(), open: false });
+		expect(header(container).getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("pretty-prints object payloads as JSON under labelled sections", () => {
+		const { container } = render(ToolCall, {
+			props: {
+				call: call({ input: { query: "retry policy", limit: 3 }, output: { hits: 3 } }),
+				open: true,
+			},
+		});
+
+		expect(body(container).textContent).toContain("Request");
+		expect(body(container).textContent).toContain("Result");
+		expect(payloads(container)).toEqual([
+			'{\n  "query": "retry policy",\n  "limit": 3\n}',
+			'{\n  "hits": 3\n}',
+		]);
+	});
+
+	it("renders primitive payloads bare rather than as quoted literals", () => {
+		const { container } = render(ToolCall, {
+			props: { call: call({ input: "retry policy", output: 42 }), open: true },
+		});
+
+		expect(payloads(container)).toEqual(["retry policy", "42"]);
+	});
+
+	it("names the cycle rather than collapsing a self-referential payload", () => {
+		const cyclic: Record<string, unknown> = { name: "loop" };
+		cyclic.self = cyclic;
+
+		const { container } = render(ToolCall, {
+			props: { call: call({ output: cyclic }), open: true },
+		});
+
+		expect(payloads(container)).toEqual(['{\n  "name": "loop",\n  "self": "[Circular]"\n}']);
+	});
+
+	it("renders a bigint JSON refuses outright", () => {
+		const { container } = render(ToolCall, {
+			props: { call: call({ output: { tokens: 9007199254740993n } }), open: true },
+		});
+
+		expect(payloads(container)).toEqual(['{\n  "tokens": "9007199254740993n"\n}']);
+	});
+
+	it("falls back to String() on a payload even the replacer cannot serialise", () => {
+		const hostile = {
+			toJSON() {
+				throw new Error("nope");
+			},
+		};
+
+		const { container } = render(ToolCall, {
+			props: { call: call({ output: hostile }), open: true },
+		});
+
+		expect(payloads(container)).toEqual(["[object Object]"]);
+	});
+
+	it("omits a section whose payload never arrived", () => {
+		const { container } = render(ToolCall, {
+			props: { call: call({ status: "running", input: { query: "x" } }), open: true },
+		});
+
+		expect(body(container).textContent).toContain("Request");
+		expect(body(container).textContent).not.toContain("Result");
+	});
+
+	it("says so when there is nothing to show at all", () => {
+		const { container } = render(ToolCall, {
+			props: { call: call({ status: "pending" }), open: true },
+		});
+
+		expect(body(container).textContent).toContain("Nothing recorded yet.");
+	});
+
+	it("shows the error text in the result section", () => {
+		const { container } = render(ToolCall, {
+			props: { call: call({ status: "error", error: "429 Too Many Requests" }) },
+		});
+
+		expect(body(container).textContent).toContain("Result");
+		expect(container.querySelector(".ft-toolcall-error-text")?.textContent).toBe(
+			"429 Too Many Requests"
+		);
+	});
+
+	it("still explains a failure that arrived without a reason", () => {
+		const { container } = render(ToolCall, { props: { call: call({ status: "error" }) } });
+
+		expect(container.querySelector(".ft-toolcall-error-text")?.textContent).toBe(
+			"The tool call failed."
+		);
+	});
+
+	it("lets the input and output snippets replace the default rendering", () => {
+		const { container } = render(ToolCall, {
+			props: {
+				call: call({ input: { query: "retry policy" }, output: { hits: 3 } }),
+				open: true,
+				input: createRawSnippet<[unknown]>((value) => ({
+					render: () => `<p class="custom-in">in: ${(value() as { query: string }).query}</p>`,
+				})),
+				output: createRawSnippet<[unknown]>((value) => ({
+					render: () => `<p class="custom-out">out: ${(value() as { hits: number }).hits}</p>`,
+				})),
+			},
+		});
+
+		expect(payloads(container)).toEqual([]);
+		expect(container.querySelector(".custom-in")?.textContent).toBe("in: retry policy");
+		expect(container.querySelector(".custom-out")?.textContent).toBe("out: 3");
+	});
+
+	it("keeps the error line above an output snippet", () => {
+		const { container } = render(ToolCall, {
+			props: {
+				call: call({ status: "error", error: "timed out", output: { partial: true } }),
+				output: createRawSnippet<[unknown]>(() => ({
+					render: () => `<p class="custom-out">partial</p>`,
+				})),
+			},
+		});
+
+		expect(container.querySelector(".ft-toolcall-error-text")?.textContent).toBe("timed out");
+		expect(container.querySelector(".custom-out")?.textContent).toBe("partial");
+	});
+
+	it("replaces the default icon with the one it is handed", () => {
+		const { container } = render(ToolCall, {
+			props: {
+				call: call(),
+				icon: createRawSnippet(() => ({ render: () => `<span class="custom-icon">!</span>` })),
+			},
+		});
+
+		const slot = container.querySelector(".ft-toolcall-icon") as HTMLElement;
+		expect(slot.querySelector(".custom-icon")).not.toBeNull();
+		expect(slot.querySelector("svg")).toBeNull();
+		expect(slot.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it.each([
+		[1400, "1s"],
+		[65_000, "1m 05s"],
+	])("formats a duration of %ims", (durationMs, expected) => {
+		const { container } = render(ToolCall, { props: { call: call({ durationMs }) } });
+
+		expect(header(container).textContent).toContain(expected);
+	});
+
+	it("says nothing about duration when the call did not report one", () => {
+		const { container } = render(ToolCall, { props: { call: call({ status: "running" }) } });
+
+		expect(header(container).querySelector(".tabular-nums")).toBeNull();
+	});
+
+	it("merges custom classes onto the root", () => {
+		const { container } = render(ToolCall, { props: { call: call(), class: "my-card" } });
+		const root = container.firstElementChild as HTMLElement;
+
+		expect(root.className).toContain("my-card");
+		expect(root.className).toContain("ft-toolcall");
+	});
+});

--- a/src/lib/fancy-ui/tool-call/index.ts
+++ b/src/lib/fancy-ui/tool-call/index.ts
@@ -1,0 +1,4 @@
+import ToolCall from "./ToolCall.svelte";
+import type { ToolCallProps } from "./ToolCall.svelte";
+
+export { ToolCall, type ToolCallProps };

--- a/src/lib/fancy-ui/tool-timeline/README.md
+++ b/src/lib/fancy-ui/tool-timeline/README.md
@@ -1,0 +1,106 @@
+# ToolTimeline
+
+A compact session summary of what an agent actually did: one row per tool call, on a vertical rail, with the file it touched, how much it changed, and when.
+
+This is the "what happened" panel you put under a finished answer or beside a running session — a log the reader skims top to bottom, not a feature the reader scrolls through.
+
+> **Not to be confused with [`timeline`](../timeline).** `timeline` is a scroll-driven **content** timeline: a full-width marketing layout with sticky headings and a gradient progress line that fills as the page scrolls. `tool-timeline` is a dense **activity** log for agent tool calls, sized to sit inside a card. They share a name and a vertical rail, and nothing else — different data, different density, different job.
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { ToolTimeline } from "fancy-ui-svelte";
+	import type { ToolTimelineItemData } from "fancy-ui-svelte";
+
+	const items: ToolTimelineItemData[] = [
+		{
+			id: "read-utils",
+			verb: "Read",
+			target: "src/lib/utils.ts",
+			detail: "Looking for the class merge helper",
+			timestamp: Date.now() - 6 * 60_000,
+		},
+		{
+			id: "edit-page",
+			verb: "Edited",
+			target: "src/routes/+page.svelte",
+			additions: 24,
+			deletions: 7,
+			timestamp: Date.now() - 3 * 60_000,
+		},
+	];
+</script>
+
+<ToolTimeline {items} />
+```
+
+```svelte
+<!-- Tighter rows for a sidebar, and rows that open the underlying tool call -->
+<ToolTimeline {items} compact onSelect={(item, index) => open(item, index)} />
+```
+
+```svelte
+<!-- Own the row body outright; the rail and its dot stay -->
+<ToolTimeline {items}>
+	{#snippet item(entry, index)}
+		<span class="flex-1">{index + 1}. {entry.verb} {entry.target}</span>
+	{/snippet}
+</ToolTimeline>
+```
+
+## Props
+
+| Prop       | Type                                                  | Default      | Description                                                          |
+| ---------- | ----------------------------------------------------- | ------------ | -------------------------------------------------------------------- |
+| `items`    | `ToolTimelineItemData[]`                              | —            | The agent's activity log, oldest first (required)                    |
+| `onSelect` | `(item: ToolTimelineItemData, index: number) => void` | —            | Called when a row is activated; supplying it turns rows into buttons |
+| `compact`  | `boolean`                                             | `false`      | Tighter rows with the detail line dropped                            |
+| `label`    | `string`                                              | `"Activity"` | Accessible name for the list                                         |
+| `class`    | `string`                                              | —            | Additional CSS classes                                               |
+| `ref`      | `HTMLDivElement \| null`                              | `null`       | Bindable element reference                                           |
+
+## Snippets
+
+| Snippet | Args                                  | Description                                              |
+| ------- | ------------------------------------- | -------------------------------------------------------- |
+| `item`  | `(item: ToolTimelineItemData, index)` | Replaces the built-in row body, keeping the rail and dot |
+
+## The row
+
+Each entry is a `ToolTimelineItemData` from the shared AI data model, so the same object can come straight off a tool-call stream:
+
+- **`verb` + `target`** — what was done and to what. The verb is emphasised, the target is monospaced and truncates on overflow with the full string kept in a `title` attribute, so a long path never widens the card.
+- **`detail`** — a muted second line, dropped entirely in `compact` mode.
+- **`additions` / `deletions`** — right-aligned `+N` / `−N` in `tabular-nums`, rendered only for the entries that carry them, and independently of each other. `0` is a value, not an absence: `additions: 0` renders `+0`.
+- **`timestamp`** — a relative time ("5 minutes ago") via `_internals/relative-time`, with the exact instant in both `datetime` and `title`.
+
+## Implementation notes
+
+- Rows are a real `<ol>` / `<li>` list under an `aria-label`, so assistive tech reports the activity count and position rather than a wall of text.
+- The `{#each}` is keyed by `item.id`. That is what makes an appended entry mount as a fresh node and play the entrance animation by itself, while the rows already on screen keep their DOM nodes and stay put. Reusing indices as keys would animate the wrong row.
+- The entrance (a short fade and 4px slide) lives entirely inside `@media (prefers-reduced-motion: no-preference)`. Reduced motion is therefore not a degraded variant to keep in sync: with the rule gone, a new row simply appears at its final position and opacity.
+- The connecting line is a `::before` on each row rather than one absolutely-positioned line behind the list, so it stretches with the row it belongs to and needs no height measurement or `ResizeObserver`. The first and last rows trim it to their dot, and a lone row hides it — the rail never overshoots into empty space.
+- `onSelect` is the only thing that decides the row element: with it, each row is a `<button type="button">` with hover and focus-visible affordances; without it, a plain span with no tab stop and no pointer cursor. There is no "clickable" prop to keep in sync with the handler.
+- The diff stats carry `role="img"` alongside their `aria-label` ("24 additions"). On a bare span an `aria-label` is ignored, and `+24` on its own is announced as a bare number.
+- Rail and dot colours are `color-mix` fades of `currentColor`, so one set of values reads correctly in both themes. The stat colours cannot borrow that trick — they are text against the page, and a single mid-lightness hue measures under 4.5:1 on white — so they come from the shared `--ft-status-*` vocabulary instead, whose defaults are per-theme `light-dark()` pairs.
+- `ft-tooltimeline-compact` is applied with a `class:` directive rather than through `cn()`, so the compiler can see the class is used and does not prune its scoped rule.
+
+## CSS variables
+
+Set on the root element to restyle without a fork:
+
+| Variable                           | Default                                    | Controls                            |
+| ---------------------------------- | ------------------------------------------ | ----------------------------------- |
+| `--ft-tooltimeline-rail`           | `color-mix(in oklab, currentColor 16%, …)` | The connecting line                 |
+| `--ft-tooltimeline-dot`            | `color-mix(in oklab, currentColor 38%, …)` | The per-row dot                     |
+| `--ft-tooltimeline-additions`      | `--ft-status-done`                         | `+N` colour                         |
+| `--ft-tooltimeline-deletions`      | `--ft-status-error`                        | `−N` colour                         |
+| `--ft-tooltimeline-row-pad`        | `0.375rem` (`0.125rem` compact)            | Vertical row padding                |
+| `--ft-tooltimeline-enter-duration` | `320ms`                                    | Entrance animation duration         |
+| `--ft-tooltimeline-dot-size`       | `0.5rem`                                   | Dot diameter                        |
+| `--ft-tooltimeline-rail-x`         | `0.25rem`                                  | Rail centre, shared by line and dot |
+
+The two stat colours default to the run-status vocabulary shared with `ToolCall`, `TerminalBlock`, `CodeDiff` and `ChatError` — `--ft-status-done` and `--ft-status-error`. Set those to recolour success and failure across the whole family; set the `--ft-tooltimeline-*` names to change this list alone.
+
+Both defaults are `light-dark()` pairs — `oklch(0.5 0.14 145)` / `oklch(0.72 0.15 145)` for `+N`, `oklch(0.5 0.19 25)` / `oklch(0.7 0.18 25)` for `−N` — because those tallies are text and one token cannot clear 4.5:1 against both white and near-black. Declare `color-scheme: light` / `dark` on your theme so the right half is picked; without it a page gets the light half. See the [ToolCall README](../tool-call/README.md#styling) for the full palette.

--- a/src/lib/fancy-ui/tool-timeline/ToolTimeline.svelte
+++ b/src/lib/fancy-ui/tool-timeline/ToolTimeline.svelte
@@ -26,6 +26,7 @@
 <script lang="ts">
 	import { cn } from "$lib/utils.js";
 	import { formatRelativeTime } from "../_internals/relative-time.js";
+	import { createNow } from "../_internals/elapsed.svelte.js";
 
 	let {
 		items,
@@ -36,6 +37,13 @@
 		class: className,
 		ref = $bindable(null),
 	}: ToolTimelineProps = $props();
+
+	// A relative label is only recomputed when something makes this component
+	// render, so a timeline left mounted across a minute boundary would keep
+	// reporting the age its rows had when they first appeared. One shared clock
+	// for the whole list costs a single interval, whatever the row count.
+	const now = createNow();
+	$effect(() => now.start());
 
 	function iso(timestamp: Date | number) {
 		const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
@@ -105,7 +113,8 @@
 								<time
 									class="ft-tooltimeline-time text-muted-foreground tabular-nums"
 									datetime={iso(entry.timestamp)}
-									title={iso(entry.timestamp)}>{formatRelativeTime(entry.timestamp)}</time
+									title={iso(entry.timestamp)}
+									>{formatRelativeTime(entry.timestamp, { now: now.value })}</time
 								>
 							{/if}
 						</span>

--- a/src/lib/fancy-ui/tool-timeline/ToolTimeline.svelte
+++ b/src/lib/fancy-ui/tool-timeline/ToolTimeline.svelte
@@ -1,0 +1,254 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { ToolTimelineItemData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for ToolTimeline
+	 */
+	export interface ToolTimelineProps {
+		/** The agent's activity log, oldest first */
+		items: ToolTimelineItemData[];
+		/** Called when a row is activated; supplying it turns every row into a button */
+		onSelect?: (item: ToolTimelineItemData, index: number) => void;
+		/** Replaces the built-in row body, keeping the rail and its dot */
+		item?: Snippet<[ToolTimelineItemData, number]>;
+		/** Tighter rows with the detail line dropped */
+		compact?: boolean;
+		/** Accessible name for the list */
+		label?: string;
+		/** Additional CSS classes */
+		class?: string;
+		/** Element reference */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { formatRelativeTime } from "../_internals/relative-time.js";
+
+	let {
+		items,
+		onSelect,
+		item,
+		compact = false,
+		label = "Activity",
+		class: className,
+		ref = $bindable(null),
+	}: ToolTimelineProps = $props();
+
+	function iso(timestamp: Date | number) {
+		const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+		return Number.isFinite(date.getTime()) ? date.toISOString() : "";
+	}
+</script>
+
+<!--
+	`ft-tooltimeline-compact` rides a `class:` directive rather than `cn()` so the
+	compiler can see the class is used and keeps its scoped rule.
+-->
+<div
+	bind:this={ref}
+	class={cn("ft-tooltimeline w-full text-sm", className)}
+	class:ft-tooltimeline-compact={compact}
+>
+	<ol class="ft-tooltimeline-list" aria-label={label}>
+		<!--
+			Keyed by id so an appended entry mounts as a fresh node and plays the
+			entrance animation on its own, while the rows already on screen keep the
+			DOM nodes they had and stay put.
+		-->
+		{#each items as entry, index (entry.id)}
+			<li class="ft-tooltimeline-row">
+				<span class="ft-tooltimeline-dot" aria-hidden="true"></span>
+
+				{#snippet body()}
+					{#if item}
+						{@render item(entry, index)}
+					{:else}
+						<span class="ft-tooltimeline-text min-w-0 flex-1">
+							<span class="flex min-w-0 items-baseline gap-1.5">
+								<span class="ft-tooltimeline-verb font-medium">{entry.verb}</span>
+								<span
+									class="ft-tooltimeline-target truncate font-mono text-[0.8125rem]"
+									title={entry.target}>{entry.target}</span
+								>
+							</span>
+							{#if !compact && entry.detail}
+								<span class="ft-tooltimeline-detail text-muted-foreground mt-0.5 block truncate"
+									>{entry.detail}</span
+								>
+							{/if}
+						</span>
+
+						<span class="ft-tooltimeline-meta flex shrink-0 items-baseline gap-2">
+							{#if entry.additions != null}
+								<!--
+									`role="img"` is what carries the label into the accessibility
+									tree: on a bare span an aria-label is ignored, and "+12" on its
+									own is announced as a bare number.
+								-->
+								<span
+									class="ft-tooltimeline-additions tabular-nums"
+									role="img"
+									aria-label="{entry.additions} additions">+{entry.additions}</span
+								>
+							{/if}
+							{#if entry.deletions != null}
+								<span
+									class="ft-tooltimeline-deletions tabular-nums"
+									role="img"
+									aria-label="{entry.deletions} deletions">−{entry.deletions}</span
+								>
+							{/if}
+							{#if entry.timestamp != null}
+								<time
+									class="ft-tooltimeline-time text-muted-foreground tabular-nums"
+									datetime={iso(entry.timestamp)}
+									title={iso(entry.timestamp)}>{formatRelativeTime(entry.timestamp)}</time
+								>
+							{/if}
+						</span>
+					{/if}
+				{/snippet}
+
+				{#if onSelect}
+					<button
+						type="button"
+						class="ft-tooltimeline-body hover:bg-muted/60 focus-visible:ring-ring flex w-full cursor-pointer items-baseline gap-3 rounded-md text-left transition-colors focus-visible:ring-1 focus-visible:outline-none"
+						onclick={() => onSelect?.(entry, index)}
+					>
+						{@render body()}
+					</button>
+				{:else}
+					<span class="ft-tooltimeline-body flex items-baseline gap-3 rounded-md">
+						{@render body()}
+					</span>
+				{/if}
+			</li>
+		{/each}
+	</ol>
+</div>
+
+<style>
+	.ft-tooltimeline {
+		/* Rail and dot are mixes of currentColor, so one set of values reads
+		   correctly in both light and dark themes. The stat colours cannot do that
+		   — they are text, and no single token clears 4.5:1 on both white and near
+		   black — so they are read at their point of use off the `--ft-status-*`
+		   vocabulary this family shares, whose defaults are `light-dark()` pairs. */
+		--ft-tooltimeline-rail: color-mix(in oklab, currentColor 16%, transparent);
+		--ft-tooltimeline-dot: color-mix(in oklab, currentColor 38%, transparent);
+		--ft-tooltimeline-row-pad: 0.375rem;
+		--ft-tooltimeline-enter-duration: 320ms;
+
+		/* Geometry shared by the rail, the dot, and the row indent, so moving the
+		   rail moves all three together. */
+		--ft-tooltimeline-dot-size: 0.5rem;
+		--ft-tooltimeline-rail-x: 0.25rem;
+	}
+
+	.ft-tooltimeline-compact {
+		--ft-tooltimeline-row-pad: 0.125rem;
+	}
+
+	.ft-tooltimeline-list {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.ft-tooltimeline-row {
+		position: relative;
+		/* Leaves room for the rail; the body adds the rest of the text indent. */
+		padding-left: 0.875rem;
+	}
+
+	/* The connecting line is drawn per row rather than once behind the list, so it
+	   stretches with the row it belongs to and needs no height measurement. */
+	.ft-tooltimeline-row::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: calc(var(--ft-tooltimeline-rail-x) - 1px);
+		width: 2px;
+		background: var(--ft-tooltimeline-rail);
+	}
+
+	/* Trim the line at the first and last dot instead of letting it overshoot the
+	   list into empty space. */
+	.ft-tooltimeline-row:first-child::before {
+		top: calc(var(--ft-tooltimeline-row-pad) + 0.625rem);
+	}
+
+	.ft-tooltimeline-row:last-child::before {
+		bottom: auto;
+		height: calc(var(--ft-tooltimeline-row-pad) + 0.625rem);
+	}
+
+	.ft-tooltimeline-row:only-child::before {
+		display: none;
+	}
+
+	.ft-tooltimeline-dot {
+		position: absolute;
+		/* Aligned to the middle of the first text line: half a 1.25rem line box
+		   minus half the dot. */
+		top: calc(var(--ft-tooltimeline-row-pad) + 0.375rem);
+		left: 0;
+		width: var(--ft-tooltimeline-dot-size);
+		height: var(--ft-tooltimeline-dot-size);
+		border-radius: 9999px;
+		background: var(--ft-tooltimeline-dot);
+	}
+
+	.ft-tooltimeline-body {
+		padding: var(--ft-tooltimeline-row-pad) 0.5rem;
+	}
+
+	.ft-tooltimeline-text {
+		min-width: 0;
+	}
+
+	.ft-tooltimeline-meta {
+		margin-left: auto;
+	}
+
+	.ft-tooltimeline-additions {
+		color: var(
+			--ft-tooltimeline-additions,
+			var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145)))
+		);
+	}
+
+	.ft-tooltimeline-deletions {
+		color: var(
+			--ft-tooltimeline-deletions,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+	}
+
+	/*
+	 * The entrance lives entirely inside `no-preference`, so reduced motion is not
+	 * a degraded variant to keep in sync: with the rule gone a new row simply
+	 * appears at its final position and opacity.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-tooltimeline-row {
+			animation: ft-tooltimeline-enter var(--ft-tooltimeline-enter-duration)
+				cubic-bezier(0.16, 1, 0.3, 1) both;
+		}
+	}
+
+	@keyframes ft-tooltimeline-enter {
+		from {
+			opacity: 0;
+			transform: translateY(-0.25rem);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/tool-timeline/ToolTimeline.test.ts
+++ b/src/lib/fancy-ui/tool-timeline/ToolTimeline.test.ts
@@ -1,0 +1,178 @@
+import { render, cleanup } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import ToolTimeline from "./ToolTimeline.svelte";
+import { formatRelativeTime } from "../_internals/relative-time.js";
+import type { ToolTimelineItemData } from "../_internals/ai-types.js";
+
+const T0 = new Date("2026-01-01T00:00:00.000Z").getTime();
+
+const items: ToolTimelineItemData[] = [
+	{ id: "a", verb: "Read", target: "src/lib/utils.ts", detail: "312 lines" },
+	{ id: "b", verb: "Edited", target: "src/routes/+page.svelte", additions: 24, deletions: 7 },
+	{ id: "c", verb: "Searched", target: "**/*.svelte" },
+];
+
+function snippet(html: string) {
+	return createRawSnippet(() => ({ render: () => html }));
+}
+
+describe("ToolTimeline", () => {
+	afterEach(() => {
+		cleanup();
+		vi.useRealTimers();
+	});
+
+	it("renders one row per item", () => {
+		const { container } = render(ToolTimeline, { props: { items } });
+		expect(container.querySelectorAll(".ft-tooltimeline-row")).toHaveLength(3);
+	});
+
+	it("renders the verb and the target of each item", () => {
+		const { container } = render(ToolTimeline, { props: { items } });
+		const verbs = [...container.querySelectorAll(".ft-tooltimeline-verb")].map(
+			(el) => el.textContent
+		);
+		const targets = [...container.querySelectorAll(".ft-tooltimeline-target")].map(
+			(el) => el.textContent
+		);
+		expect(verbs).toEqual(["Read", "Edited", "Searched"]);
+		expect(targets).toEqual(["src/lib/utils.ts", "src/routes/+page.svelte", "**/*.svelte"]);
+	});
+
+	it("carries the full target in a title attribute, since the visible text truncates", () => {
+		const { container } = render(ToolTimeline, { props: { items } });
+		expect(container.querySelector(".ft-tooltimeline-target")?.getAttribute("title")).toBe(
+			"src/lib/utils.ts"
+		);
+	});
+
+	it("renders the detail line only for items that carry one", () => {
+		const { container } = render(ToolTimeline, { props: { items } });
+		const details = container.querySelectorAll(".ft-tooltimeline-detail");
+		expect(details).toHaveLength(1);
+		expect(details[0].textContent).toBe("312 lines");
+	});
+
+	it("renders the diff stats with counted aria-labels", () => {
+		const { container } = render(ToolTimeline, { props: { items } });
+		const additions = container.querySelector(".ft-tooltimeline-additions") as HTMLElement;
+		const deletions = container.querySelector(".ft-tooltimeline-deletions") as HTMLElement;
+		expect(additions.textContent).toBe("+24");
+		expect(additions.getAttribute("aria-label")).toBe("24 additions");
+		expect(deletions.textContent).toBe("−7");
+		expect(deletions.getAttribute("aria-label")).toBe("7 deletions");
+	});
+
+	it("renders no stats for items without them", () => {
+		const { container } = render(ToolTimeline, {
+			props: { items: [{ id: "a", verb: "Read", target: "a.ts" }] },
+		});
+		expect(container.querySelector(".ft-tooltimeline-additions")).toBeFalsy();
+		expect(container.querySelector(".ft-tooltimeline-deletions")).toBeFalsy();
+	});
+
+	it("renders each stat independently of the other", () => {
+		const { container } = render(ToolTimeline, {
+			props: { items: [{ id: "a", verb: "Deleted", target: "old.ts", deletions: 41 }] },
+		});
+		expect(container.querySelector(".ft-tooltimeline-additions")).toBeFalsy();
+		expect(container.querySelector(".ft-tooltimeline-deletions")?.textContent).toBe("−41");
+	});
+
+	it("renders a zero stat rather than treating it as absent", () => {
+		const { container } = render(ToolTimeline, {
+			props: { items: [{ id: "a", verb: "Edited", target: "a.ts", additions: 0, deletions: 3 }] },
+		});
+		expect(container.querySelector(".ft-tooltimeline-additions")?.textContent).toBe("+0");
+	});
+
+	it("hides the detail line in compact mode", () => {
+		const { container } = render(ToolTimeline, { props: { items, compact: true } });
+		expect(container.querySelector(".ft-tooltimeline-detail")).toBeFalsy();
+		expect(container.querySelectorAll(".ft-tooltimeline-row")).toHaveLength(3);
+		expect((container.firstElementChild as HTMLElement).className).toContain(
+			"ft-tooltimeline-compact"
+		);
+	});
+
+	it("renders plain rows with no button when onSelect is absent", () => {
+		const { container } = render(ToolTimeline, { props: { items } });
+		expect(container.querySelectorAll("button")).toHaveLength(0);
+	});
+
+	it("turns rows into buttons and reports the item and its index on click", async () => {
+		const onSelect = vi.fn();
+		const { container } = render(ToolTimeline, { props: { items, onSelect } });
+		const buttons = container.querySelectorAll("button");
+		expect(buttons).toHaveLength(3);
+
+		(buttons[1] as HTMLButtonElement).click();
+		expect(onSelect).toHaveBeenCalledTimes(1);
+		expect(onSelect).toHaveBeenCalledWith(items[1], 1);
+	});
+
+	it("renders the item snippet in place of the built-in row body", () => {
+		const { container } = render(ToolTimeline, {
+			props: { items, item: snippet("<span class='custom-row'>custom</span>") },
+		});
+		expect(container.querySelectorAll(".custom-row")).toHaveLength(3);
+		expect(container.querySelector(".ft-tooltimeline-verb")).toBeFalsy();
+		// The rail survives the override: only the body is replaced.
+		expect(container.querySelectorAll(".ft-tooltimeline-dot")).toHaveLength(3);
+	});
+
+	it("renders the timestamp as relative text with the exact time in the attributes", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const timestamp = T0 - 5 * 60_000;
+		const { container } = render(ToolTimeline, {
+			props: { items: [{ id: "a", verb: "Read", target: "a.ts", timestamp }] },
+		});
+		const time = container.querySelector(".ft-tooltimeline-time") as HTMLTimeElement;
+		const iso = new Date(timestamp).toISOString();
+		expect(time.textContent).toBe(formatRelativeTime(timestamp, { now: T0 }));
+		expect(time.textContent).not.toBe("");
+		expect(time.getAttribute("datetime")).toBe(iso);
+		expect(time.getAttribute("title")).toBe(iso);
+	});
+
+	it("accepts a Date timestamp as readily as epoch ms", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const timestamp = new Date(T0 - 60 * 60_000);
+		const { container } = render(ToolTimeline, {
+			props: { items: [{ id: "a", verb: "Read", target: "a.ts", timestamp }] },
+		});
+		const time = container.querySelector(".ft-tooltimeline-time") as HTMLTimeElement;
+		expect(time.textContent).toBe(formatRelativeTime(timestamp, { now: T0 }));
+		expect(time.getAttribute("datetime")).toBe(timestamp.toISOString());
+	});
+
+	it("renders no time element for items without a timestamp", () => {
+		const { container } = render(ToolTimeline, { props: { items } });
+		expect(container.querySelector(".ft-tooltimeline-time")).toBeFalsy();
+	});
+
+	it("names the list Activity by default and takes an override", () => {
+		const { container } = render(ToolTimeline, { props: { items } });
+		expect(container.querySelector("ol")?.getAttribute("aria-label")).toBe("Activity");
+		cleanup();
+
+		const named = render(ToolTimeline, { props: { items, label: "Session log" } });
+		expect(named.container.querySelector("ol")?.getAttribute("aria-label")).toBe("Session log");
+	});
+
+	it("renders an empty list without rows", () => {
+		const { container } = render(ToolTimeline, { props: { items: [] } });
+		expect(container.querySelector("ol")).toBeTruthy();
+		expect(container.querySelectorAll(".ft-tooltimeline-row")).toHaveLength(0);
+	});
+
+	it("merges custom class names alongside the base classes", () => {
+		const { container } = render(ToolTimeline, { props: { items, class: "my-timeline" } });
+		const root = container.firstElementChild as HTMLElement;
+		expect(root.className).toContain("my-timeline");
+		expect(root.className).toContain("ft-tooltimeline");
+	});
+});

--- a/src/lib/fancy-ui/tool-timeline/ToolTimeline.test.ts
+++ b/src/lib/fancy-ui/tool-timeline/ToolTimeline.test.ts
@@ -175,4 +175,21 @@ describe("ToolTimeline", () => {
 		expect(root.className).toContain("my-timeline");
 		expect(root.className).toContain("ft-tooltimeline");
 	});
+
+	it("ages its timestamps while it stays mounted", async () => {
+		// Nothing re-renders a quiet timeline, so a label written once would keep
+		// reporting the age its row had when it first appeared.
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const { container } = render(ToolTimeline, {
+			props: { items: [{ id: "a", verb: "Read", target: "a.ts", timestamp: T0 - 20_000 }] },
+		});
+		const label = () => container.querySelector(".ft-tooltimeline-time")?.textContent;
+		expect(label()).toBe("now");
+
+		// Two refreshes of the shared clock: the row is 80s old by then, which is
+		// the first reading that leaves the "now" bucket.
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(label()).toBe("1 minute ago");
+	});
 });

--- a/src/lib/fancy-ui/tool-timeline/index.ts
+++ b/src/lib/fancy-ui/tool-timeline/index.ts
@@ -1,0 +1,4 @@
+import ToolTimeline from "./ToolTimeline.svelte";
+import type { ToolTimelineProps } from "./ToolTimeline.svelte";
+
+export { ToolTimeline, type ToolTimelineProps };

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -4,6 +4,10 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+	/* Resolves light-dark() tokens (e.g. the library's --ft-status-* fallbacks)
+	   and native form/scrollbar chrome against the active theme. */
+	color-scheme: light;
+
 	/* Layout */
 	--radius: 0.625rem;
 
@@ -84,6 +88,7 @@
 }
 
 .dark {
+	color-scheme: dark;
 	--background: oklch(0.05 0 0);
 	--foreground: oklch(0.984 0.003 247.858);
 	--card: oklch(0.1 0.005 265);

--- a/src/stories/code-diff.stories.svelte
+++ b/src/stories/code-diff.stories.svelte
@@ -1,0 +1,77 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { CodeDiff } from "$lib/fancy-ui/code-diff";
+
+	const PATCH = [
+		"diff --git a/src/lib/query.ts b/src/lib/query.ts",
+		"index 8f2a1c4..b31e097 100644",
+		"--- a/src/lib/query.ts",
+		"+++ b/src/lib/query.ts",
+		"@@ -12,6 +12,7 @@ export async function totalsByRegion(db: Db) {",
+		"   const sql = compile(ast);",
+		"-  const rows = await db.query(sql);",
+		"-  return rows;",
+		"+  const rows = await db.query(sql, { timeout: 5_000 });",
+		"+  if (rows.length === 0) return [];",
+		"+  return rows.map(normalise);",
+		" }",
+		" ",
+		" function normalise(row: Row) {",
+		"@@ -41,3 +42,3 @@ function normalise(row: Row) {",
+		"   const region = row.region ?? UNASSIGNED;",
+		"-  return { region, total: row.total };",
+		"+  return { region, total: Number(row.total) };",
+		" }",
+		"",
+	].join("\n");
+
+	const { Story } = defineMeta({
+		title: "AI Agents/CodeDiff",
+		component: CodeDiff,
+		tags: ["autodocs"],
+		args: {
+			diff: PATCH,
+			lineNumbers: true,
+			collapsed: false,
+			maxLines: 0,
+			wrap: false,
+		},
+		argTypes: {
+			diff: { control: "text", description: "Raw unified diff text" },
+			filename: {
+				control: "text",
+				description: "Header label when the patch names no file, or names just one",
+			},
+			lineNumbers: {
+				control: "boolean",
+				description: "Whether to show the old/new line-number gutters",
+			},
+			collapsed: {
+				control: "boolean",
+				description: "Whether the bodies are folded away; a click folds one file",
+			},
+			maxLines: {
+				control: "number",
+				description: "Lines shown before the rest hide behind a button; 0 shows all",
+			},
+			wrap: {
+				control: "boolean",
+				description: "Whether long lines wrap instead of scrolling sideways",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-2xl p-6">
+		<CodeDiff {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Collapsed" {template} args={{ collapsed: true }} />
+
+<Story name="No Line Numbers" {template} args={{ lineNumbers: false }} />
+
+<Story name="Clamped" {template} args={{ maxLines: 4 }} />

--- a/src/stories/terminal-block.stories.svelte
+++ b/src/stories/terminal-block.stories.svelte
@@ -1,0 +1,95 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { TerminalBlock } from "$lib/fancy-ui/terminal-block";
+
+	const ESC = "\u001b";
+	const green = (text: string) => `${ESC}[32m${text}${ESC}[0m`;
+	const red = (text: string) => `${ESC}[1;31m${text}${ESC}[0m`;
+	const yellow = (text: string) => `${ESC}[33m${text}${ESC}[0m`;
+	const cyan = (text: string) => `${ESC}[36m${text}${ESC}[0m`;
+
+	const RUNNING = [
+		"building for production…",
+		`${green("✓")} 214 modules transformed`,
+		`${yellow("warning:")} "createElapsed" is exported but never used`,
+		`${cyan("build/entry.js")}      12.4 kB │ gzip:  4.1 kB`,
+	].join("\n");
+
+	const SUCCESS = `${RUNNING}\n${cyan("build/app.js")}        94.7 kB │ gzip: 28.9 kB\n${green("✓")} built in 3.42s\n`;
+
+	const FAILURE = [
+		"building for production…",
+		`${green("✓")} 118 modules transformed`,
+		`${red("error:")} could not resolve "./_internals/waveform-core.js"`,
+		"  imported by src/lib/fancy-ui/audio-wave/AudioWave.svelte",
+	].join("\n");
+
+	const { Story } = defineMeta({
+		title: "AI Agents/TerminalBlock",
+		component: TerminalBlock,
+		tags: ["autodocs"],
+		args: {
+			output: SUCCESS,
+			command: "pnpm build",
+			prompt: "$",
+			running: false,
+			exitCode: 0,
+			durationMs: 3420,
+			ansi: true,
+			maxHeight: "20rem",
+		},
+		argTypes: {
+			output: { control: "text", description: "Everything the command has printed so far" },
+			command: { control: "text", description: "The command shown after the prompt glyph" },
+			prompt: { control: "text", description: "Prompt glyph in front of the command" },
+			running: {
+				control: "boolean",
+				description: "Whether the command is still running — shows the cursor, pins the scroll",
+			},
+			exitCode: {
+				control: "number",
+				description: "Exit status; null while the command is still in flight",
+			},
+			durationMs: { control: "number", description: "How long the run took, shown in the footer" },
+			ansi: { control: "boolean", description: "Read the SGR subset and colour the output" },
+			maxHeight: { control: "text", description: "Height at which the output starts scrolling" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-2xl p-6">
+		<TerminalBlock {...args} />
+	</div>
+{/snippet}
+
+{#snippet titled(args: any)}
+	<div class="w-full max-w-2xl p-6">
+		<TerminalBlock {...args}>
+			{#snippet header()}
+				<span class="flex items-center gap-1.5" aria-hidden="true">
+					<span class="size-2.5 rounded-full bg-red-400/90"></span>
+					<span class="size-2.5 rounded-full bg-amber-400/90"></span>
+					<span class="size-2.5 rounded-full bg-emerald-400/90"></span>
+				</span>
+				<span class="ml-auto text-xs opacity-60">build.log</span>
+			{/snippet}
+		</TerminalBlock>
+	</div>
+{/snippet}
+
+<Story
+	name="Running"
+	{template}
+	args={{ output: RUNNING, running: true, exitCode: null, durationMs: undefined }}
+/>
+
+<Story name="Success" {template} />
+
+<Story
+	name="Failure"
+	{template}
+	args={{ output: FAILURE, exitCode: 1, durationMs: 1180, command: "pnpm build" }}
+/>
+
+<Story name="With a title bar" template={titled} />

--- a/src/stories/tool-call.stories.svelte
+++ b/src/stories/tool-call.stories.svelte
@@ -1,0 +1,118 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ToolCall } from "$lib/fancy-ui/tool-call";
+	import type { ToolCallData } from "$lib/fancy-ui";
+
+	const DONE: ToolCallData = {
+		id: "call_1",
+		name: "search_docs",
+		status: "done",
+		input: { query: "retry policy", limit: 3 },
+		output: { hits: 3, top: "billing/retries.md", tookMs: 812 },
+		durationMs: 1400,
+	};
+
+	const { Story } = defineMeta({
+		title: "AI Agents/ToolCall",
+		component: ToolCall,
+		tags: ["autodocs"],
+		args: {
+			call: DONE,
+		},
+		argTypes: {
+			call: {
+				control: "object",
+				description: "The invocation to render: name, status, and whatever payloads exist so far",
+			},
+			open: {
+				control: "boolean",
+				description:
+					"Expanded state; left undefined the card stays collapsed until a failure or a click",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-xl p-6">
+		<ToolCall {...args} />
+	</div>
+{/snippet}
+
+<Story name="Done" {template} />
+
+<Story name="Done Open" {template} args={{ open: true }} />
+
+<Story
+	name="Running"
+	{template}
+	args={{
+		call: {
+			id: "call_2",
+			name: "fetch_changelog",
+			status: "running",
+			input: { repo: "acme/billing", since: "2026-07-01" },
+			durationMs: 4200,
+		},
+	}}
+/>
+
+<Story
+	name="Pending"
+	{template}
+	args={{
+		call: { id: "call_3", name: "run_migrations", status: "pending" },
+	}}
+/>
+
+<Story
+	name="Error"
+	{template}
+	args={{
+		call: {
+			id: "call_4",
+			name: "post_summary",
+			status: "error",
+			input: { channel: "#releases", blocks: 4 },
+			error: "429 Too Many Requests — that channel is rate limited for another 38s.",
+			durationMs: 240,
+		},
+	}}
+/>
+
+<Story
+	name="Cancelled"
+	{template}
+	args={{
+		call: {
+			id: "call_5",
+			name: "deploy_preview",
+			status: "cancelled",
+			input: { branch: "feat/retries" },
+			durationMs: 900,
+		},
+	}}
+/>
+
+<Story
+	name="Long Payload"
+	{template}
+	args={{
+		open: true,
+		call: {
+			id: "call_6",
+			name: "list_invoices",
+			status: "done",
+			input: { customer: "cus_9K2", status: "open", limit: 20 },
+			output: {
+				invoices: Array.from({ length: 12 }, (_, i) => ({
+					id: `in_${1000 + i}`,
+					amountDue: 1200 + i * 37,
+					currency: "eur",
+					dueAt: `2026-08-${String(i + 1).padStart(2, "0")}`,
+				})),
+			},
+			durationMs: 2600,
+		},
+	}}
+/>

--- a/src/stories/tool-timeline.stories.svelte
+++ b/src/stories/tool-timeline.stories.svelte
@@ -1,0 +1,87 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ToolTimeline } from "$lib/fancy-ui/tool-timeline";
+	import type { ToolTimelineItemData } from "$lib/fancy-ui";
+
+	// Relative to module load rather than a baked-in date, so the timestamps stay
+	// fresh instead of drifting further off on every reload.
+	const now = Date.now();
+
+	const session: ToolTimelineItemData[] = [
+		{
+			id: "read-utils",
+			verb: "Read",
+			target: "src/lib/utils.ts",
+			detail: "Looking for the class merge helper",
+			timestamp: now - 6 * 60_000,
+		},
+		{
+			id: "search",
+			verb: "Searched",
+			target: "**/*.svelte",
+			detail: "42 files matched",
+			timestamp: now - 5 * 60_000,
+		},
+		{
+			id: "edit-page",
+			verb: "Edited",
+			target: "src/routes/+page.svelte",
+			additions: 24,
+			deletions: 7,
+			timestamp: now - 3 * 60_000,
+		},
+		{
+			id: "create-test",
+			verb: "Created",
+			target: "src/lib/fancy-ui/tool-timeline/ToolTimeline.test.ts",
+			additions: 96,
+			timestamp: now - 90_000,
+		},
+		{
+			id: "run-tests",
+			verb: "Ran",
+			target: "pnpm vitest run",
+			detail: "18 passed",
+			timestamp: now - 20_000,
+		},
+	];
+
+	const { Story } = defineMeta({
+		title: "AI Agents/ToolTimeline",
+		component: ToolTimeline,
+		tags: ["autodocs"],
+		args: {
+			items: session,
+			compact: false,
+			label: "Activity",
+		},
+		argTypes: {
+			items: { control: "object", description: "The agent's activity log, oldest first" },
+			compact: {
+				control: "boolean",
+				description: "Tighter rows with the detail line dropped",
+			},
+			label: { control: "text", description: "Accessible name for the list" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="bg-card w-full max-w-xl rounded-lg border p-5">
+		<ToolTimeline {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Compact" {template} args={{ compact: true }} />
+
+<!-- Supplying onSelect is what turns every row into a button. -->
+<Story
+	name="Clickable"
+	{template}
+	args={{
+		onSelect: (item: ToolTimelineItemData, index: number) =>
+			console.log("selected", index, item.verb, item.target),
+	}}
+/>


### PR DESCRIPTION
## Summary

Part 4/8 of the AI/chat family (stacks on #184). The `ai-agents` tool-use layer — 34 files.

| Component | What it does |
|---|---|
| `ToolCall` | One invocation in a disclosure card: status dot, name, duration, pretty-printed request/result (cycle-safe JSON with `[Circular]`/bigint recovery); error calls auto-open until the reader toggles |
| `ToolTimeline` | Compact session summary on a vertical rail: verbs, mono targets, `+N/−N` diff stats, relative timestamps; rows become buttons only when `onSelect` is provided |
| `TerminalBlock` | Live append-only command transcript: hand-rolled ANSI SGR subset (8 colors + bold, token-array rendering — zero HTML sinks, adversarially fuzzed), stick-to-bottom autoscroll, running cursor, exit-status footer, `role="log"` |
| `CodeDiff` | Unified diff for chat width: foldable per-file cards with `+N/−N` badges and rename/new/deleted detection, tinted rows + glyph column (color-blind safe), copy-safe gutters and hunk headers, soft line clamping |

## Shared status vocabulary
Review found three diverging run-status palettes forming across the family. This PR introduces the canonical `--ft-status-{pending,running,done,error,cancelled}` tokens with `light-dark()` fallbacks — WCAG AA text contrast on both themes, measured — adopted by all five status-bearing components (incl. wave-2 `ChatError`). The docs site now declares `color-scheme`; consumers without it resolve to the AA-on-light values.

## Review passes
- **Contracts (adversarial)**: PASS — ANSI/diff XSS smuggling attempts all inert (script/OSC/intermediate-byte vectors), parser totality fuzzed, true server-compile SSR proven, disclosure mechanics consistent with wave 1. Fixed: registry default mismatch, deep `_internals` imports, JSON fallback that hid payloads, cross-patch fold-state leak, selectable hunk headers.
- **Visual QA (pixel-measured)**: PASS — ANSI colors painted (10–12:1), diff tints correct in both themes, terminal surface theme-independent, pulse/cursor animation verified by frame diff, reduced-motion degradations exact. The 3 contrast findings drove the `light-dark()` palette above.

## Gates
`check:registry` ✅ (74) · `check:i18n` ✅ · `svelte-check` ✅ 0 errors · `vitest` ✅ 1139/1139 (120 in this wave incl. ANSI fuzz + security suites) · `build` ✅ · `package` + publint ✅

Next in stack: knowledge (sources, inline-citation, web-search, image-generation).