### PR TITLE
feat(ai): knowledge surfaces — Sources, InlineCitation, WebSearch, ImageGeneration

### DIFF
--- a/.changeset/ai-citations.md
+++ b/.changeset/ai-citations.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+Add the knowledge surfaces of the AI/chat family: the `Sources` compound (`Sources`, `SourcesTrigger`, `SourcesList`, `SourceCard`, plus the exported `SOURCES_CONTEXT_KEY`/`SourcesContext` contract) rendering an answer's citations as a monogram-stack pill that expands into scannable source cards; `InlineCitation` (a numbered in-sentence reference revealing a `SourceCard` preview in a floating card on hover or focus, tooltip-pattern accessible); `WebSearch` (a search the agent ran — query header, indeterminate scanning bar, results landing row by row without re-keying settled entries); and `ImageGeneration` (a fixed-aspect frame that holds layout while a model draws — pixel-grid generating state, blur-to-sharp reveal that can never strand a server-rendered image blurred, and an error state with retry). Shared host/monogram helpers land in the internals layer used across the three citation-bearing components.

--- a/src/lib/components/docs/DemoRenderer.svelte
+++ b/src/lib/components/docs/DemoRenderer.svelte
@@ -76,6 +76,10 @@
 		"tool-timeline",
 		"terminal-block",
 		"code-diff",
+		"sources",
+		"inline-citation",
+		"web-search",
+		"image-generation",
 	]);
 </script>
 

--- a/src/lib/components/docs/examples/image-generation/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/image-generation/BasicUsage.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { ImageGeneration } from "$lib/fancy-ui/image-generation";
+
+	const PROMPT = "a lone barn under a sodium sunset, 35mm, grain";
+
+	// The "generated" artwork is drawn here rather than fetched: the demo has no
+	// network dependency, and the reveal always has something real to sharpen.
+	// Single-quoted attributes survive encodeURIComponent untouched, which keeps
+	// the encoded URI at about a third of the size double quotes would cost.
+	const artwork = `data:image/svg+xml,${encodeURIComponent(
+		`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'>
+			<defs>
+				<linearGradient id='sky' x1='0' y1='0' x2='0.4' y2='1'>
+					<stop offset='0' stop-color='hsl(258 85% 40%)'/>
+					<stop offset='0.55' stop-color='hsl(318 78% 55%)'/>
+					<stop offset='1' stop-color='hsl(28 95% 62%)'/>
+				</linearGradient>
+				<radialGradient id='sun' cx='0.68' cy='0.34' r='0.34'>
+					<stop offset='0' stop-color='hsl(48 100% 82%)'/>
+					<stop offset='1' stop-color='hsl(38 100% 68%)' stop-opacity='0'/>
+				</radialGradient>
+			</defs>
+			<rect width='512' height='512' fill='url(#sky)'/>
+			<circle cx='348' cy='174' r='52' fill='hsl(46 100% 76%)'/>
+			<rect width='512' height='512' fill='url(#sun)'/>
+			<path d='M0 372 120 292 236 356 336 286 512 348 512 512 0 512Z' fill='hsl(266 55% 20%)' opacity='0.85'/>
+			<path d='M0 438 132 384 292 448 512 402 512 512 0 512Z' fill='hsl(266 65% 12%)'/>
+			<path d='M196 470 196 402 254 372 312 402 312 470Z' fill='hsl(12 45% 26%)'/>
+			<path d='M254 470 254 430 288 430 288 470Z' fill='hsl(40 90% 66%)'/>
+		</svg>`.replace(/\s+/g, " ")
+	)}`;
+
+	// idle is a beat, generating is the wait, done holds until the reader asks
+	// for another run.
+	const IDLE_MS = 700;
+	const GENERATING_MS = 2500;
+
+	let status = $state<"idle" | "generating" | "done" | "error">("idle");
+	let timers: ReturnType<typeof setTimeout>[] = [];
+
+	function stop() {
+		for (const timer of timers) clearTimeout(timer);
+		timers = [];
+	}
+
+	function run() {
+		stop();
+		status = "idle";
+		timers.push(setTimeout(() => (status = "generating"), IDLE_MS));
+		timers.push(setTimeout(() => (status = "done"), IDLE_MS + GENERATING_MS));
+	}
+
+	onMount(() => {
+		// A reader who asked for less motion gets the finished frame rather than
+		// a timed sequence they did not ask to sit through.
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			status = "done";
+			return;
+		}
+
+		run();
+		return stop;
+	});
+</script>
+
+<div class="grid w-full max-w-2xl gap-6 p-6 sm:grid-cols-2">
+	<ImageGeneration {status} src={artwork} alt={PROMPT} prompt={PROMPT} />
+
+	<ImageGeneration
+		status="error"
+		alt="a rain-slicked alley at night, neon signage"
+		prompt="a rain-slicked alley at night, neon signage"
+		errorText="The model returned no image"
+		onRetry={run}
+	/>
+</div>

--- a/src/lib/components/docs/examples/inline-citation/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/inline-citation/BasicUsage.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { InlineCitation } from "$lib/fancy-ui/inline-citation";
+	import type { SourceData } from "$lib/fancy-ui/_internals/ai-types.js";
+
+	const decoding: SourceData = {
+		id: "s1",
+		title: "Constrained decoding for structured tool calls",
+		url: "https://www.example.com/papers/constrained-decoding",
+		snippet:
+			"Sampling under a grammar removes the parse-and-retry loop entirely: an invalid token is never drawn, so there is nothing left to repair downstream.",
+	};
+
+	const reranking: SourceData = {
+		id: "s2",
+		title: "Measuring retrieval quality after reranking",
+		url: "https://research.example.org/notes/rerank-metrics",
+		domain: "research.example.org",
+		snippet:
+			"Recall at k stops being informative once a reranker sits between retrieval and the model; what matters is whether the passage survived into the context window.",
+	};
+
+	const latency: SourceData = {
+		id: "s3",
+		title: "Latency budgets in agent loops",
+		url: "https://www.example.net/blog/agent-latency",
+		snippet:
+			"Every tool round trip costs a full forward pass over the growing transcript, so the second call is never as cheap as the first.",
+	};
+
+	// `onOpen` fires once per appearance rather than once per hover event, which
+	// is what turns it into "which sources did the reader actually open" instead
+	// of a raw pointer count.
+	let opened = $state<string[]>([]);
+
+	function markOpened(id: string) {
+		if (opened.includes(id)) return;
+		opened = [...opened, id];
+	}
+</script>
+
+<div class="w-full max-w-xl p-6">
+	<p class="text-sm leading-7">
+		Structured output is a decoding constraint rather than a prompting technique<InlineCitation
+			source={decoding}
+			index={1}
+			onOpen={() => markOpened(decoding.id)}
+		/>, which is why the guarantee survives a raised temperature. Retrieval is the half that stays
+		stubbornly empirical: recall at k says less than you would hope once a reranker sits in the
+		middle<InlineCitation source={reranking} index={2} onOpen={() => markOpened(reranking.id)} />.
+		And each extra tool call is paid for twice — once in the round trip, once in the longer
+		transcript the next forward pass has to read<InlineCitation
+			source={latency}
+			index={3}
+			onOpen={() => markOpened(latency.id)}
+		/>.
+	</p>
+
+	<p class="text-muted-foreground mt-5 border-t pt-3 text-xs">
+		Hover a marker, or press <kbd class="bg-muted rounded px-1 py-0.5 font-mono">Tab</kbd> to reach
+		one and watch its card open on focus;
+		<kbd class="bg-muted rounded px-1 py-0.5 font-mono">Esc</kbd> dismisses it.
+		{#if opened.length > 0}
+			<span class="text-foreground">Opened {opened.length} of 3.</span>
+		{/if}
+	</p>
+</div>

--- a/src/lib/components/docs/examples/registry.ts
+++ b/src/lib/components/docs/examples/registry.ts
@@ -436,4 +436,8 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 	"tool-timeline": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"terminal-block": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"code-diff": [{ name: "BasicUsage", title: "Basic Usage" }],
+	sources: [{ name: "BasicUsage", title: "Basic Usage" }],
+	"inline-citation": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"web-search": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"image-generation": [{ name: "BasicUsage", title: "Basic Usage" }],
 };

--- a/src/lib/components/docs/examples/sources/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/sources/BasicUsage.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { Sources } from "$lib/fancy-ui/sources";
+	import type { SourceData } from "$lib/fancy-ui/_internals/ai-types.js";
+
+	const answer =
+		"Readers rarely click a citation — they look at it. So the pill has to carry enough signal on its own to say where an answer came from, and open into something scannable for the one time in ten that looking is not enough.";
+
+	const sources: SourceData[] = [
+		{
+			id: "s1",
+			title: "Designing citation surfaces for generated answers",
+			url: "https://docs.example.dev/patterns/citations",
+			domain: "docs.example.dev",
+			snippet: "A citation is a promise that the answer can be checked, not a footnote.",
+		},
+		{
+			id: "s2",
+			title: "Retrieval quality and the illusion of grounding",
+			url: "https://research.example.org/papers/grounding",
+			domain: "research.example.org",
+			snippet: "Four plausible sources under a wrong answer make it read as a right one.",
+		},
+		{
+			id: "s3",
+			title: "Why readers glance at sources instead of opening them",
+			url: "https://notes.example.net/reading-citations",
+			domain: "notes.example.net",
+			snippet: "The host name does most of the work; the title does the rest.",
+		},
+		{
+			id: "s4",
+			title: "A field guide to attribution in assistant answers",
+			url: "https://handbook.example.io/attribution",
+			domain: "handbook.example.io",
+			snippet: "Say where it came from before anyone has to ask.",
+		},
+	];
+
+	let open = $state(false);
+	// Set by the pill's own onToggle, which only fires on a real click — the rig
+	// drives `open` through the binding and so never trips it. Plain let: nothing
+	// renders from it.
+	let readerTookOver = false;
+
+	onMount(() => {
+		// The preview opens itself once so the expansion is visible without a
+		// click; reduced motion gets the pill at rest instead, still interactive.
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+		let timer: ReturnType<typeof setTimeout>;
+
+		function cycle(next: boolean, after: number) {
+			timer = setTimeout(() => {
+				if (readerTookOver) return;
+				open = next;
+				cycle(!next, next ? 5200 : 1600);
+			}, after);
+		}
+
+		cycle(true, 1200);
+		return () => clearTimeout(timer);
+	});
+</script>
+
+<div class="bg-card flex w-full max-w-xl flex-col gap-3 rounded-lg border p-5">
+	<p class="text-sm leading-relaxed">{answer}</p>
+
+	<Sources {sources} bind:open onToggle={() => (readerTookOver = true)} />
+</div>

--- a/src/lib/components/docs/examples/web-search/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/web-search/BasicUsage.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { WebSearch } from "$lib/fancy-ui/web-search";
+
+	const QUERY = "postgres connection pool exhausted under load";
+
+	const HITS = [
+		{
+			id: "h1",
+			title: "Why your pool runs dry before your database does",
+			url: "https://www.example.dev/posts/pool-exhaustion",
+			snippet:
+				"Connection limits are usually reached by leaked handles rather than by traffic. The give-away is a pool that never recovers after the spike passes.",
+		},
+		{
+			id: "h2",
+			title: "Sizing a connection pool",
+			url: "https://notes.example.org/pool-sizing",
+			snippet:
+				"A pool larger than the server's max_connections turns a queue you can observe into an error you cannot.",
+		},
+		{
+			id: "h3",
+			title: "Tracking down a leaked transaction",
+			url: "https://example.net/guides/leaked-transactions",
+			snippet:
+				"pg_stat_activity tells you which query is holding a connection open and for how long it has been idle in transaction.",
+		},
+		{
+			id: "h4",
+			title: "Backpressure beats a bigger pool",
+			url: "https://blog.example.com/backpressure",
+			snippet: "Queueing at the edge fails a request in milliseconds instead of in thirty seconds.",
+		},
+	];
+
+	/** The beat between two hits arriving. */
+	const HIT_MS = 700;
+	/** How long the finished list sits before the search runs again. */
+	const REPLAY_MS = 2600;
+
+	let results = $state<typeof HITS>([]);
+	let searching = $state(true);
+
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	onMount(() => {
+		// Nothing to stage when motion is reduced: the finished list is the state
+		// the whole sequence was building towards anyway.
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			results = HITS;
+			searching = false;
+			return;
+		}
+
+		tick();
+		return () => clearTimeout(timer);
+	});
+
+	function tick() {
+		// Whether this is the last hit or the pause before starting over is decided
+		// before the wait, since it is what sets the wait's length.
+		const done = results.length === HITS.length;
+
+		timer = setTimeout(
+			() => {
+				if (done) {
+					results = [];
+					searching = true;
+				} else {
+					results = HITS.slice(0, results.length + 1);
+					// The last hit landing is also the end of the search.
+					searching = results.length < HITS.length;
+				}
+				tick();
+			},
+			done ? REPLAY_MS : HIT_MS
+		);
+	}
+</script>
+
+<!--
+	The loop empties the list to start over, which without a floor under the block
+	would drop the page by the height of four rows and pull everything below it up
+	— once every cycle, forever. The floor is the full state's height, so the
+	sequence plays inside a box that never changes size.
+-->
+<div class="min-h-[24rem] w-full max-w-xl">
+	<WebSearch query={QUERY} {results} {searching} />
+</div>

--- a/src/lib/fancy-ui/_internals/host.test.ts
+++ b/src/lib/fancy-ui/_internals/host.test.ts
@@ -61,4 +61,9 @@ describe("monogram", () => {
 		expect(monogram("!?…")).toBe("?");
 		expect(monogram(undefined)).toBe("?");
 	});
+
+	it("keeps a letter that upper-cases into two, since there is room for one", () => {
+		expect(monogram("ßeta docs")).toBe("ß");
+		expect(monogram("ﬄ ligature")).toBe("ﬄ");
+	});
 });

--- a/src/lib/fancy-ui/_internals/host.test.ts
+++ b/src/lib/fancy-ui/_internals/host.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { hostOf, monogram } from "./host.js";
+
+describe("hostOf", () => {
+	it("returns the host of an absolute URL, without its path or query", () => {
+		expect(hostOf("https://docs.example.dev/a/b?q=1#frag")).toBe("docs.example.dev");
+	});
+
+	it("drops the www prefix, whatever its case", () => {
+		expect(hostOf("https://www.example.org/a")).toBe("example.org");
+		expect(hostOf("https://WWW.example.org/a")).toBe("example.org");
+		// Only the leading label: a host that merely contains "www" keeps it.
+		expect(hostOf("https://wwwex.example.org")).toBe("wwwex.example.org");
+	});
+
+	it("parses the scheme-less and protocol-relative forms new URL rejects", () => {
+		expect(hostOf("docs.example.dev/guide")).toBe("docs.example.dev");
+		expect(hostOf("//docs.example.dev/guide")).toBe("docs.example.dev");
+		expect(hostOf("www.example.org/guide")).toBe("example.org");
+	});
+
+	it("keeps credentials out of the host, on either parsing path", () => {
+		expect(hostOf("https://user:pass@example.dev/guide")).toBe("example.dev");
+		expect(hostOf("//user@example.dev/guide")).toBe("example.dev");
+	});
+
+	it("has nothing to show for a relative link, rather than echoing its path", () => {
+		expect(hostOf("/local/notes")).toBe("");
+		expect(hostOf("local-notes")).toBe("");
+	});
+
+	it("has nothing to show for a missing url", () => {
+		expect(hostOf("")).toBe("");
+		expect(hostOf(undefined)).toBe("");
+	});
+
+	it("keeps a port out of the way and an IDN host intact", () => {
+		expect(hostOf("http://localhost:5173/x")).toBe("localhost");
+		expect(hostOf("https://exämple.dev/x")).toBe("xn--exmple-cua.dev");
+	});
+});
+
+describe("monogram", () => {
+	it("upper-cases the first character", () => {
+		expect(monogram("zebra")).toBe("Z");
+		expect(monogram("docs.example.dev")).toBe("D");
+	});
+
+	it("skips leading punctuation and whitespace to the first letter or digit", () => {
+		expect(monogram('"Attention Is All You Need"')).toBe("A");
+		expect(monogram("  · ranking passages")).toBe("R");
+		expect(monogram("— 2026 in review")).toBe("2");
+	});
+
+	it("keeps a whole character when the initial is outside the BMP", () => {
+		expect(monogram("𝒜pex")).toBe("𝒜");
+	});
+
+	it("falls back to a question mark when there is nothing to draw", () => {
+		expect(monogram("")).toBe("?");
+		expect(monogram("!?…")).toBe("?");
+		expect(monogram(undefined)).toBe("?");
+	});
+});

--- a/src/lib/fancy-ui/_internals/host.ts
+++ b/src/lib/fancy-ui/_internals/host.ts
@@ -52,7 +52,11 @@ export function hostOf(url: string | undefined): string {
  */
 export function monogram(text: string | undefined): string {
 	const match = /[\p{L}\p{N}]/u.exec(text ?? "");
-	return (match?.[0] ?? "?").toUpperCase();
+	const upper = (match?.[0] ?? "?").toUpperCase();
+	// A few letters upper-case into more than one character — "ß" becomes "SS" —
+	// and this has one glyph's worth of room. The original stands in those cases:
+	// a lone "ß" reads better than half of "SS".
+	return [...upper].length > 1 ? (match?.[0] ?? "?") : upper;
 }
 
 function stripWww(host: string): string {

--- a/src/lib/fancy-ui/_internals/host.ts
+++ b/src/lib/fancy-ui/_internals/host.ts
@@ -1,0 +1,60 @@
+/**
+ * The two scraps of text that identify a cited document on screen: the host it
+ * came from, and the single character that stands in for a favicon.
+ *
+ * Loading a real favicon would mean a request to the cited site from every
+ * reader's browser, which is a tracking beacon nobody asked for and a broken
+ * image the moment the site is gone. A letter drawn from the host says the same
+ * thing, costs nothing, and cannot fail.
+ *
+ * Every citation surface — source cards, the collapsed sources pill, search
+ * result rows — reads hosts through here, so a `www.` is stripped and a
+ * scheme-less fixture is parsed the same way everywhere. Internal: not exported
+ * from the package.
+ */
+
+/**
+ * The host of a URL with any `www.` prefix removed, or an empty string when
+ * there is no host to show.
+ *
+ * `new URL` is the parser of record; the regex behind it only exists for the
+ * protocol-relative and scheme-less strings it rejects (`//docs.example.dev/x`,
+ * `docs.example.dev/x`), which turn up constantly in hand-written fixtures and
+ * in model output.
+ *
+ * `undefined` is accepted rather than merely typed away: the data reaching these
+ * components comes off the wire, where an optional field is a real possibility
+ * whatever the interface says.
+ */
+export function hostOf(url: string | undefined): string {
+	if (typeof url !== "string" || url === "") return "";
+
+	try {
+		return stripWww(new URL(url).hostname);
+	} catch {
+		const match = /^(?:[a-z][a-z0-9+.-]*:)?(?:\/\/)?([^/?#\s]+)/i.exec(url);
+		if (!match) return "";
+		// Whatever is left has to look like a host, or we are just echoing the
+		// path of a relative link back at the reader.
+		const host = match[1].split("@").pop() as string;
+		return host.includes(".") ? stripWww(host) : "";
+	}
+}
+
+/**
+ * The character in a monogram circle: the first letter or digit of the text,
+ * upper-cased, falling back to a question mark so the circle is never empty.
+ *
+ * First letter or digit rather than first character, because a title that opens
+ * with a quote or a bullet would otherwise put punctuation in the circle. The
+ * `u` flag is what keeps a character outside the BMP whole instead of matching
+ * half a surrogate pair.
+ */
+export function monogram(text: string | undefined): string {
+	const match = /[\p{L}\p{N}]/u.exec(text ?? "");
+	return (match?.[0] ?? "?").toUpperCase();
+}
+
+function stripWww(host: string): string {
+	return host.replace(/^www\./i, "");
+}

--- a/src/lib/fancy-ui/image-generation/ImageGeneration.svelte
+++ b/src/lib/fancy-ui/image-generation/ImageGeneration.svelte
@@ -1,0 +1,266 @@
+<script lang="ts" module>
+	/**
+	 * Props for ImageGeneration
+	 */
+	export interface ImageGenerationProps {
+		/** Which stage of the generation to render */
+		status: "idle" | "generating" | "done" | "error";
+		/** The generated image, shown once status is "done" */
+		src?: string | null;
+		/** Describes the image to assistive tech — typically the prompt */
+		alt: string;
+		/** CSS aspect-ratio of the frame, holding the layout across every state */
+		aspectRatio?: string;
+		/** Muted caption line under the frame */
+		prompt?: string;
+		/** The failure line shown in the error state */
+		errorText?: string;
+		/** Pressing retry calls this; the retry button only exists when it is set */
+		onRetry?: () => void;
+		/** Called once the generated image has finished loading */
+		onLoad?: () => void;
+		/** Additional CSS classes */
+		class?: string;
+		/** Element reference */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import PixelLoader from "../pixel-loader/PixelLoader.svelte";
+
+	let {
+		status,
+		src,
+		alt,
+		aspectRatio = "1 / 1",
+		prompt,
+		errorText = "Generation failed",
+		onRetry,
+		onLoad,
+		class: className,
+		ref = $bindable(null),
+	}: ImageGenerationProps = $props();
+
+	let imageEl: HTMLImageElement | null = $state(null);
+
+	/*
+	 * The reveal is opt-in rather than opt-out: `mounted` is false through the
+	 * whole server render, so the markup that leaves the server carries no blur
+	 * class and a page that never hydrates — or hydrates with JavaScript
+	 * disabled — shows a sharp image instead of a permanently smeared one.
+	 * Turning it on in `onMount` is early enough to still catch the load event,
+	 * which the browser queues as a separate task at the earliest.
+	 */
+	let mounted = $state(false);
+
+	/*
+	 * Which URL finished loading, rather than a boolean: a second generation
+	 * swaps `src` while the same <img> stays mounted, and comparing the two
+	 * re-arms the reveal for the new image without an effect to reset a flag.
+	 */
+	let loadedSrc: string | null = $state(null);
+
+	const blurred = $derived(mounted && loadedSrc !== src);
+
+	function handleLoad() {
+		// A cached image can be complete before `onMount` runs and fire its load
+		// event after; both paths land here, and only the first one counts.
+		if (loadedSrc === src) return;
+		loadedSrc = src ?? null;
+		onLoad?.();
+	}
+
+	function handleError() {
+		// A broken image would otherwise sit blurred forever waiting for a load
+		// that is never coming. Reveal it — the browser's own broken-image mark
+		// is the honest thing to show — without claiming it loaded.
+		loadedSrc = src ?? null;
+	}
+
+	onMount(() => {
+		// An image that is already `complete` here has settled its fate before this
+		// code existed — hydration over server markup, a cache hit, or a failure —
+		// and neither `load` nor `error` is coming to settle it later. So being
+		// complete at mount is decisive on its own: the reveal is never armed over
+		// one, whichever way it went.
+		if (imageEl?.complete) {
+			if (imageEl.naturalWidth > 0) {
+				// Decoded and on screen: blurring it back out would be a regression the
+				// reader can see, and the caller still deserves the arrival it missed.
+				handleLoad();
+			} else {
+				// No intrinsic width — a broken image, or an SVG sized only by its
+				// viewBox. Reveal it without claiming a load that may never have
+				// happened; the browser's own broken-image mark is the honest thing to
+				// show, and an SVG that renders fine has nothing to hide behind.
+				loadedSrc = src ?? null;
+			}
+		}
+		mounted = true;
+	});
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("ft-imagegen flex w-full flex-col gap-2", className)}
+	aria-busy={status === "generating" ? "true" : undefined}
+>
+	<div
+		class={cn(
+			"ft-imagegen-frame relative w-full overflow-hidden rounded-lg border",
+			status === "idle" && "ft-imagegen-frame-idle"
+		)}
+		style="aspect-ratio: {aspectRatio}"
+	>
+		{#if status === "generating"}
+			<div class="ft-imagegen-dots" aria-hidden="true"></div>
+			<div class="absolute inset-0 flex items-center justify-center">
+				<PixelLoader cols={8} rows={8} />
+			</div>
+		{:else if status === "done" && src}
+			<img
+				bind:this={imageEl}
+				{src}
+				{alt}
+				class={cn(
+					"ft-imagegen-img absolute inset-0 h-full w-full object-cover",
+					blurred && "ft-imagegen-img-blurred"
+				)}
+				onload={handleLoad}
+				onerror={handleError}
+			/>
+		{:else if status === "error"}
+			<div
+				class="ft-imagegen-error absolute inset-0 flex flex-col items-center justify-center gap-2 px-4 text-center"
+				role="alert"
+			>
+				<span class="ft-imagegen-error-icon" aria-hidden="true">
+					<svg
+						class="size-5"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<path
+							d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"
+						/>
+						<path d="M12 9v4" />
+						<path d="M12 17h.01" />
+					</svg>
+				</span>
+				<p class="ft-imagegen-error-text text-sm">{errorText}</p>
+				{#if onRetry}
+					<button
+						type="button"
+						class="ft-imagegen-retry rounded border px-2.5 py-1 text-xs font-medium transition-colors"
+						onclick={onRetry}
+					>
+						Retry
+					</button>
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	{#if prompt}
+		<p class="ft-imagegen-prompt text-muted-foreground text-xs leading-relaxed">{prompt}</p>
+	{/if}
+</div>
+
+<style>
+	/*
+	 * The neutral chrome mixes `currentColor` into transparency rather than
+	 * naming a colour, so the frame sits at the same distance from whatever
+	 * surface it lands on in either scheme, with no light-dark() pair to keep
+	 * balanced. Only the error state names a colour, and it names the family
+	 * token so every failure surface moves together.
+	 */
+	.ft-imagegen-frame {
+		background: var(--ft-imagegen-bg, color-mix(in oklab, currentColor 4%, transparent));
+		border-color: var(--ft-imagegen-border, color-mix(in oklab, currentColor 12%, transparent));
+	}
+
+	.ft-imagegen-frame-idle {
+		border-style: dashed;
+	}
+
+	/*
+	 * Inset by two tiles so the layer overhangs the frame on every side: the
+	 * drift translates a whole tile, and the overhang is what keeps the edges
+	 * covered while it does. `overflow-hidden` on the frame clips the surplus.
+	 */
+	.ft-imagegen-dots {
+		position: absolute;
+		inset: calc(var(--ft-imagegen-dot-size, 12px) * -2);
+		background-image: radial-gradient(
+			circle at center,
+			var(--ft-imagegen-dot, color-mix(in oklab, currentColor 20%, transparent)) 1px,
+			transparent 1.5px
+		);
+		background-size: var(--ft-imagegen-dot-size, 12px) var(--ft-imagegen-dot-size, 12px);
+	}
+
+	.ft-imagegen-error-icon,
+	.ft-imagegen-error-text {
+		color: var(
+			--ft-imagegen-error-fg,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+	}
+
+	.ft-imagegen-retry {
+		color: var(
+			--ft-imagegen-error-fg,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+		border-color: color-mix(in oklab, currentColor 30%, transparent);
+	}
+
+	.ft-imagegen-retry:hover {
+		background: color-mix(in oklab, currentColor 10%, transparent);
+	}
+
+	/*
+	 * Both halves of the reveal — the blurred starting point and the transition
+	 * out of it — live behind `no-preference`. With those rules gone there is
+	 * nothing to override and nothing to keep in sync: the image is simply
+	 * sharp the moment it arrives, which is also what a server render ships.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-imagegen-img {
+			transition:
+				filter var(--ft-imagegen-reveal, 700ms) ease-out,
+				transform var(--ft-imagegen-reveal, 700ms) ease-out;
+		}
+
+		.ft-imagegen-img-blurred {
+			filter: blur(var(--ft-imagegen-blur, 24px));
+			/* The overscale hides the transparent fringe a blur pulls in from
+			   outside the image's own edges. */
+			transform: scale(1.05);
+		}
+
+		.ft-imagegen-dots {
+			animation: ft-imagegen-drift var(--ft-imagegen-drift, 14s) linear infinite;
+		}
+
+		@keyframes ft-imagegen-drift {
+			from {
+				transform: translate3d(0, 0, 0);
+			}
+			to {
+				transform: translate3d(
+					var(--ft-imagegen-dot-size, 12px),
+					var(--ft-imagegen-dot-size, 12px),
+					0
+				);
+			}
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/image-generation/ImageGeneration.svelte
+++ b/src/lib/fancy-ui/image-generation/ImageGeneration.svelte
@@ -62,14 +62,22 @@
 	 * re-arms the reveal for the new image without an effect to reset a flag.
 	 */
 	let loadedSrc: string | null = $state(null);
+	/*
+	 * Which URL failed, kept apart from which one loaded. Recording a failure as
+	 * a load reveals the image, but it also makes a retry of the same URL look
+	 * like something that already arrived, so the retry that finally works
+	 * reports nothing to the caller.
+	 */
+	let erroredSrc: string | null = $state(null);
 
-	const blurred = $derived(mounted && loadedSrc !== src);
+	const blurred = $derived(mounted && loadedSrc !== src && erroredSrc !== src);
 
 	function handleLoad() {
 		// A cached image can be complete before `onMount` runs and fire its load
 		// event after; both paths land here, and only the first one counts.
 		if (loadedSrc === src) return;
 		loadedSrc = src ?? null;
+		erroredSrc = null;
 		onLoad?.();
 	}
 
@@ -77,7 +85,7 @@
 		// A broken image would otherwise sit blurred forever waiting for a load
 		// that is never coming. Reveal it — the browser's own broken-image mark
 		// is the honest thing to show — without claiming it loaded.
-		loadedSrc = src ?? null;
+		erroredSrc = src ?? null;
 	}
 
 	onMount(() => {
@@ -96,7 +104,7 @@
 				// viewBox. Reveal it without claiming a load that may never have
 				// happened; the browser's own broken-image mark is the honest thing to
 				// show, and an SVG that renders fine has nothing to hide behind.
-				loadedSrc = src ?? null;
+				erroredSrc = src ?? null;
 			}
 		}
 		mounted = true;

--- a/src/lib/fancy-ui/image-generation/ImageGeneration.test.ts
+++ b/src/lib/fancy-ui/image-generation/ImageGeneration.test.ts
@@ -1,0 +1,287 @@
+import { render, cleanup, fireEvent, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import ImageGeneration from "./ImageGeneration.svelte";
+
+// A 1x1 transparent GIF: a real, non-empty src that jsdom will never actually
+// fetch, so `complete` stays false and the load event is ours to dispatch.
+const SRC = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+
+function image(container: HTMLElement): HTMLImageElement | null {
+	return container.querySelector("img");
+}
+
+function frame(container: HTMLElement): HTMLElement {
+	return container.querySelector(".ft-imagegen-frame") as HTMLElement;
+}
+
+/**
+ * Makes every <img> in the test look already decoded, the way it is when the
+ * client hydrates markup the server already painted. A width of `0` is the other
+ * shape of "complete": a fetch that failed, or an SVG whose only intrinsic size
+ * is a viewBox.
+ */
+function withCompleteImages(run: () => void, width = 512) {
+	const proto = HTMLImageElement.prototype;
+	const complete = Object.getOwnPropertyDescriptor(proto, "complete");
+	const naturalWidth = Object.getOwnPropertyDescriptor(proto, "naturalWidth");
+
+	Object.defineProperty(proto, "complete", { get: () => true, configurable: true });
+	Object.defineProperty(proto, "naturalWidth", { get: () => width, configurable: true });
+	try {
+		run();
+	} finally {
+		if (complete) Object.defineProperty(proto, "complete", complete);
+		if (naturalWidth) Object.defineProperty(proto, "naturalWidth", naturalWidth);
+	}
+}
+
+describe("ImageGeneration", () => {
+	afterEach(cleanup);
+
+	it("renders an empty dashed frame when idle", () => {
+		const { container } = render(ImageGeneration, { props: { status: "idle", alt: "A red barn" } });
+
+		expect(frame(container).className).toContain("ft-imagegen-frame-idle");
+		expect(image(container)).toBeFalsy();
+		expect(container.querySelector(".ft-imagegen-dots")).toBeFalsy();
+		expect(container.querySelector(".ft-imagegen-error")).toBeFalsy();
+	});
+
+	it("renders the pixel loader over a dot grid while generating", () => {
+		const { container } = render(ImageGeneration, {
+			props: { status: "generating", alt: "A red barn" },
+		});
+		const root = container.firstElementChild as HTMLElement;
+
+		expect(container.querySelector(".ft-pixel")).toBeTruthy();
+		expect(container.querySelectorAll(".ft-pixel")).toHaveLength(64);
+		expect(container.querySelector(".ft-imagegen-dots")).toBeTruthy();
+		expect(root.getAttribute("aria-busy")).toBe("true");
+		expect(image(container)).toBeFalsy();
+	});
+
+	it("leaves the row unbusy outside the generating state", () => {
+		const { container } = render(ImageGeneration, {
+			props: { status: "done", src: SRC, alt: "A red barn" },
+		});
+		expect((container.firstElementChild as HTMLElement).getAttribute("aria-busy")).toBeNull();
+	});
+
+	it("renders the image with its alt text when done", () => {
+		const { container } = render(ImageGeneration, {
+			props: { status: "done", src: SRC, alt: "A red barn at dusk" },
+		});
+		const img = image(container) as HTMLImageElement;
+
+		expect(img).toBeTruthy();
+		expect(img.getAttribute("src")).toBe(SRC);
+		expect(screen.getByAltText("A red barn at dusk")).toBe(img);
+	});
+
+	it("holds the empty frame when done arrives without a src", () => {
+		const { container } = render(ImageGeneration, {
+			props: { status: "done", src: null, alt: "A red barn" },
+		});
+
+		expect(image(container)).toBeFalsy();
+		expect(frame(container)).toBeTruthy();
+	});
+
+	it("announces the error text with a retry button", () => {
+		const { container } = render(ImageGeneration, {
+			props: {
+				status: "error",
+				alt: "A red barn",
+				errorText: "The model refused",
+				onRetry: () => {},
+			},
+		});
+
+		expect(container.querySelector(".ft-imagegen-error")?.getAttribute("role")).toBe("alert");
+		expect(container.querySelector(".ft-imagegen-error-text")?.textContent).toBe(
+			"The model refused"
+		);
+		expect(container.querySelector(".ft-imagegen-retry")?.textContent?.trim()).toBe("Retry");
+	});
+
+	it("defaults the error text", () => {
+		const { container } = render(ImageGeneration, {
+			props: { status: "error", alt: "A red barn" },
+		});
+		expect(container.querySelector(".ft-imagegen-error-text")?.textContent).toBe(
+			"Generation failed"
+		);
+	});
+
+	it("renders no retry button without an onRetry handler", () => {
+		const { container } = render(ImageGeneration, {
+			props: { status: "error", alt: "A red barn" },
+		});
+		expect(container.querySelector(".ft-imagegen-retry")).toBeFalsy();
+	});
+
+	it("calls onRetry when the retry button is pressed", async () => {
+		const onRetry = vi.fn();
+		const { container } = render(ImageGeneration, {
+			props: { status: "error", alt: "A red barn", onRetry },
+		});
+
+		await fireEvent.click(container.querySelector(".ft-imagegen-retry") as HTMLButtonElement);
+		expect(onRetry).toHaveBeenCalledTimes(1);
+	});
+
+	it("blurs the image once mounted and sharpens it on load", async () => {
+		const { container } = render(ImageGeneration, {
+			props: { status: "done", src: SRC, alt: "A red barn" },
+		});
+		await tick();
+
+		const img = image(container) as HTMLImageElement;
+		expect(img.className).toContain("ft-imagegen-img-blurred");
+
+		await fireEvent.load(img);
+		expect(img.className).not.toContain("ft-imagegen-img-blurred");
+	});
+
+	it("calls onLoad once when the image finishes loading", async () => {
+		const onLoad = vi.fn();
+		const { container } = render(ImageGeneration, {
+			props: { status: "done", src: SRC, alt: "A red barn", onLoad },
+		});
+
+		const img = image(container) as HTMLImageElement;
+		await fireEvent.load(img);
+		expect(onLoad).toHaveBeenCalledTimes(1);
+
+		// A second load event for the same src — a re-decode, a cache revalidation
+		// — is not a second arrival.
+		await fireEvent.load(img);
+		expect(onLoad).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-arms the reveal when a new src replaces a loaded one", async () => {
+		const onLoad = vi.fn();
+		const next = SRC.replace("R0lGOD", "R0lGOE");
+		const { container, rerender } = render(ImageGeneration, {
+			props: { status: "done", src: SRC, alt: "A red barn", onLoad },
+		});
+		await tick();
+
+		const img = image(container) as HTMLImageElement;
+		await fireEvent.load(img);
+		expect(img.className).not.toContain("ft-imagegen-img-blurred");
+
+		await rerender({ status: "done", src: next, alt: "A blue barn", onLoad });
+		expect((image(container) as HTMLImageElement).className).toContain("ft-imagegen-img-blurred");
+
+		await fireEvent.load(image(container) as HTMLImageElement);
+		expect(onLoad).toHaveBeenCalledTimes(2);
+	});
+
+	it("never blurs an image that was already decoded at mount", async () => {
+		const onLoad = vi.fn();
+		let container!: HTMLElement;
+
+		withCompleteImages(() => {
+			container = render(ImageGeneration, {
+				props: { status: "done", src: SRC, alt: "A red barn", onLoad },
+			}).container;
+		});
+		await tick();
+
+		// This is the hydration path: the server shipped a sharp <img>, the
+		// browser painted it, and arming the reveal afterwards would smear an
+		// image the reader can already see.
+		expect((image(container) as HTMLImageElement).className).not.toContain(
+			"ft-imagegen-img-blurred"
+		);
+		expect(onLoad).toHaveBeenCalledTimes(1);
+	});
+
+	it("never blurs a complete image that reports no intrinsic width", async () => {
+		const onLoad = vi.fn();
+		let container!: HTMLElement;
+
+		withCompleteImages(() => {
+			container = render(ImageGeneration, {
+				props: { status: "done", src: SRC, alt: "A red barn", onLoad },
+			}).container;
+		}, 0);
+		await tick();
+
+		// Complete with no width is either a fetch that already failed or an SVG
+		// sized only by its viewBox. Both settled before this component existed, so
+		// no load and no error is coming to lift a blur applied now — which is why
+		// being complete at mount settles it either way.
+		expect((image(container) as HTMLImageElement).className).not.toContain(
+			"ft-imagegen-img-blurred"
+		);
+		// Nothing was seen arriving, so nothing is announced as having arrived.
+		expect(onLoad).not.toHaveBeenCalled();
+	});
+
+	it("reveals a broken image instead of leaving it blurred", async () => {
+		const onLoad = vi.fn();
+		const { container } = render(ImageGeneration, {
+			props: { status: "done", src: SRC, alt: "A red barn", onLoad },
+		});
+		await tick();
+
+		const img = image(container) as HTMLImageElement;
+		expect(img.className).toContain("ft-imagegen-img-blurred");
+
+		await fireEvent.error(img);
+		expect(img.className).not.toContain("ft-imagegen-img-blurred");
+		expect(onLoad).not.toHaveBeenCalled();
+	});
+
+	it("applies the default square aspect ratio to the frame", () => {
+		const { container } = render(ImageGeneration, {
+			props: { status: "idle", alt: "A red barn" },
+		});
+		expect(frame(container).getAttribute("style")).toContain("aspect-ratio: 1 / 1");
+	});
+
+	it("applies a custom aspect ratio to the frame", () => {
+		const { container } = render(ImageGeneration, {
+			props: { status: "generating", alt: "A red barn", aspectRatio: "16 / 9" },
+		});
+		expect(frame(container).getAttribute("style")).toContain("aspect-ratio: 16 / 9");
+	});
+
+	it("keeps the frame across every status so the layout never shifts", () => {
+		for (const status of ["idle", "generating", "done", "error"] as const) {
+			const { container } = render(ImageGeneration, {
+				props: { status, src: SRC, alt: "A red barn", aspectRatio: "4 / 3" },
+			});
+			expect(frame(container).getAttribute("style")).toContain("aspect-ratio: 4 / 3");
+			cleanup();
+		}
+	});
+
+	it("renders the prompt as a caption only when one is given", () => {
+		const { container } = render(ImageGeneration, {
+			props: { status: "done", src: SRC, alt: "A red barn", prompt: "a red barn at dusk, 35mm" },
+		});
+		expect(container.querySelector(".ft-imagegen-prompt")?.textContent).toBe(
+			"a red barn at dusk, 35mm"
+		);
+
+		cleanup();
+		const bare = render(ImageGeneration, {
+			props: { status: "done", src: SRC, alt: "A red barn" },
+		});
+		expect(bare.container.querySelector(".ft-imagegen-prompt")).toBeFalsy();
+	});
+
+	it("merges custom class names alongside the base classes", () => {
+		const { container } = render(ImageGeneration, {
+			props: { status: "idle", alt: "A red barn", class: "my-frame" },
+		});
+		const root = container.firstElementChild as HTMLElement;
+
+		expect(root.className).toContain("my-frame");
+		expect(root.className).toContain("ft-imagegen");
+	});
+});

--- a/src/lib/fancy-ui/image-generation/ImageGeneration.test.ts
+++ b/src/lib/fancy-ui/image-generation/ImageGeneration.test.ts
@@ -160,6 +160,24 @@ describe("ImageGeneration", () => {
 		expect(onLoad).toHaveBeenCalledTimes(1);
 	});
 
+	it("still reports the arrival when a retry of the same src finally loads", async () => {
+		// A failure reveals the image, but recording it as a load would make the
+		// retry look like something that already arrived.
+		const onLoad = vi.fn();
+		const { container } = render(ImageGeneration, {
+			props: { status: "done", src: SRC, alt: "A red barn", onLoad },
+		});
+		await tick();
+
+		const img = image(container) as HTMLImageElement;
+		await fireEvent.error(img);
+		expect(onLoad).not.toHaveBeenCalled();
+		expect(img.className).not.toContain("ft-imagegen-img-blurred");
+
+		await fireEvent.load(img);
+		expect(onLoad).toHaveBeenCalledTimes(1);
+	});
+
 	it("re-arms the reveal when a new src replaces a loaded one", async () => {
 		const onLoad = vi.fn();
 		const next = SRC.replace("R0lGOD", "R0lGOE");

--- a/src/lib/fancy-ui/image-generation/README.md
+++ b/src/lib/fancy-ui/image-generation/README.md
@@ -1,0 +1,96 @@
+# ImageGeneration
+
+A fixed frame that holds its place while a model draws: an empty outline, then a pixel grid working over a drifting dot field, then the finished image easing out of a blur.
+
+The four states share one aspect-ratio box, so the frame is the same size before the request goes out as it is after the image lands. Nothing below it moves.
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { ImageGeneration } from "fancy-ui-svelte";
+
+	let status = $state<"idle" | "generating" | "done" | "error">("idle");
+	let src = $state<string | null>(null);
+	const prompt = "a lone barn under a sodium sunset, 35mm, grain";
+
+	async function generate() {
+		status = "generating";
+		try {
+			src = await requestImage(prompt);
+			status = "done";
+		} catch {
+			status = "error";
+		}
+	}
+</script>
+
+<ImageGeneration {status} {src} alt={prompt} {prompt} onRetry={generate} />
+```
+
+```svelte
+<!-- A wide frame, no caption -->
+<ImageGeneration status="done" src={url} alt="A red barn at dusk" aspectRatio="16 / 9" />
+```
+
+```svelte
+<!-- Failure with its own copy -->
+<ImageGeneration
+	status="error"
+	alt="a rain-slicked alley at night"
+	errorText="The model returned no image"
+	onRetry={generate}
+/>
+```
+
+## Props
+
+| Prop          | Type                                          | Default               | Description                                                            |
+| ------------- | --------------------------------------------- | --------------------- | ---------------------------------------------------------------------- |
+| `status`      | `"idle" \| "generating" \| "done" \| "error"` | —                     | Which stage of the generation to render (required)                     |
+| `src`         | `string \| null`                              | —                     | The generated image, shown once `status` is `"done"`                   |
+| `alt`         | `string`                                      | —                     | Describes the image to assistive tech, typically the prompt (required) |
+| `aspectRatio` | `string`                                      | `"1 / 1"`             | CSS aspect-ratio of the frame, holding the layout across every state   |
+| `prompt`      | `string`                                      | —                     | Muted caption line under the frame                                     |
+| `errorText`   | `string`                                      | `"Generation failed"` | The failure line shown in the error state                              |
+| `onRetry`     | `() => void`                                  | —                     | Pressing retry calls this; the retry button only exists when it is set |
+| `onLoad`      | `() => void`                                  | —                     | Called once the generated image has finished loading                   |
+| `class`       | `string`                                      | —                     | Additional CSS classes                                                 |
+| `ref`         | `HTMLDivElement \| null` (bindable)           | `null`                | Bound reference to the root element                                    |
+
+## Theming
+
+The frame's chrome is neutral by construction: the background and border mix `currentColor` into transparency, so they sit the same distance from whatever surface the component lands on without a light/dark pair to keep balanced. Override either directly:
+
+| Variable                 | Default                                              | Controls                            |
+| ------------------------ | ---------------------------------------------------- | ----------------------------------- |
+| `--ft-imagegen-bg`       | `color-mix(in oklab, currentColor 4%, transparent)`  | Frame background                    |
+| `--ft-imagegen-border`   | `color-mix(in oklab, currentColor 12%, transparent)` | Frame outline                       |
+| `--ft-imagegen-dot`      | `color-mix(in oklab, currentColor 20%, transparent)` | Colour of the generating dots       |
+| `--ft-imagegen-dot-size` | `12px`                                               | Pitch of the dot grid               |
+| `--ft-imagegen-drift`    | `14s`                                                | Time for the dots to cross one tile |
+| `--ft-imagegen-blur`     | `24px`                                               | Blur the image starts at            |
+| `--ft-imagegen-reveal`   | `700ms`                                              | Time it takes to sharpen            |
+| `--ft-imagegen-error-fg` | `var(--ft-status-error, …)`                          | Glyph, error line, retry button     |
+
+```svelte
+<div style="--ft-imagegen-dot-size: 18px; --ft-imagegen-reveal: 1200ms">
+	<ImageGeneration status="generating" alt={prompt} />
+</div>
+```
+
+The loader inside the generating state is `PixelLoader`, so `--ft-pixel-color` retints it; unset, it inherits the surrounding text colour.
+
+Left unset, `--ft-imagegen-error-fg` falls through to `--ft-status-error`, the failure colour shared with `ChatError`, `ToolCall`, `ToolTimeline`, `TerminalBlock` and `CodeDiff`. Set that one instead and every failure surface moves together. Its default is a `light-dark()` pair — `oklch(0.5 0.19 25)` on light, `oklch(0.7 0.18 25)` on dark — so declare `color-scheme` on your theme for the right half to be picked.
+
+## Implementation notes
+
+- **Sharp on the server.** The blur is opt-in, not opt-out. `mounted` is false for the whole server render, so the markup that leaves the server carries no blur class at all — a page that never hydrates, or hydrates with JavaScript disabled, shows a finished image rather than a permanently smeared one. `onMount` arms the reveal, which is early enough to still catch the load event: the browser queues that as a separate task at the earliest.
+- **Nothing already on screen gets blurred.** An image that is `complete` when `onMount` runs has settled its fate before this code existed, and neither `load` nor `error` is coming to settle it later — so being complete at mount is decisive on its own. With a real `naturalWidth` it is a decoded image the reader can already see: it stays sharp and `onLoad` fires, since the load event the caller would have heard fired too early. With a `naturalWidth` of `0` — a fetch that already failed, or an SVG sized only by its `viewBox` — it is revealed just the same, but without `onLoad`, because nothing was seen arriving. Either way the reveal is armed afterwards, and no image is ever left blurred waiting for an event that has already been and gone.
+- **The reveal re-arms on a new `src`.** What is tracked is which URL finished loading, not a boolean. A second generation swapping `src` on the same `<img>` re-arms the blur on its own, with no effect to reset a flag, and `onLoad` fires once per image — a repeated load event for the same URL, from a re-decode or a cache revalidation, is not a second arrival.
+- **A broken image is revealed, not left blurred.** An `error` on the `<img>` clears the blur without claiming the image loaded, so a failed URL shows the browser's own broken-image mark instead of waiting forever for a load that is not coming.
+- **Reduced motion.** Both halves of the reveal — the blurred starting point and the transition out of it — live inside `@media (prefers-reduced-motion: no-preference)`, as does the dot drift. With those rules gone there is nothing to override and nothing to keep in sync: the image is simply sharp when it arrives, and the dot field is a static texture.
+- **No layout shift.** Every state renders inside the same `aspect-ratio` box, absolutely positioned, so idle, generating, done and error all occupy identical space. The frame clips with `overflow: hidden`, which is also what keeps the blur from bleeding past its edges; the `scale(1.05)` covers the transparent fringe a blur otherwise pulls in from outside the image.
+- **The dot field drifts on the compositor.** The layer is inset by two tiles so it overhangs the frame, and the animation translates it exactly one tile — a `transform`, not a `background-position`, and seamless because the pattern repeats at that interval.
+- **`alt` is required.** It is the only way the generated image says anything to a reader who cannot see it, and the prompt is almost always the right text.
+- **No state, no timers.** Which stage the generation is in is the caller's fact to hold, because only the caller knows when the request comes back.

--- a/src/lib/fancy-ui/image-generation/index.ts
+++ b/src/lib/fancy-ui/image-generation/index.ts
@@ -1,0 +1,4 @@
+import ImageGeneration from "./ImageGeneration.svelte";
+import type { ImageGenerationProps } from "./ImageGeneration.svelte";
+
+export { ImageGeneration, type ImageGenerationProps };

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -79,6 +79,10 @@ export * from "./tool-call/index.js";
 export * from "./tool-timeline/index.js";
 export * from "./terminal-block/index.js";
 export * from "./code-diff/index.js";
+export * from "./sources/index.js";
+export * from "./inline-citation/index.js";
+export * from "./web-search/index.js";
+export * from "./image-generation/index.js";
 
 // =============================================================================
 // Registry

--- a/src/lib/fancy-ui/inline-citation/InlineCitation.svelte
+++ b/src/lib/fancy-ui/inline-citation/InlineCitation.svelte
@@ -1,0 +1,283 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { SourceData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for InlineCitation
+	 */
+	export interface InlineCitationProps {
+		/** The document being cited. Its title, domain and snippet fill the preview. */
+		source: SourceData;
+		/** The reference number shown in the marker, e.g. `3` renders `[3]` */
+		index: number;
+		/** Link target. Defaults to `source.url`; pass `""` to render an unlinked marker. */
+		href?: string;
+		/** Replaces the default preview card body. Receives the source. */
+		preview?: Snippet<[SourceData]>;
+		/** Called each time the preview is shown, once per appearance */
+		onOpen?: () => void;
+		/** Additional CSS classes */
+		class?: string;
+		/** Element reference to the marker */
+		ref?: HTMLElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { float } from "../_internals/float.js";
+	import SourceCard from "../sources/SourceCard.svelte";
+
+	let {
+		source,
+		index,
+		href,
+		preview,
+		onOpen,
+		class: className,
+		ref = $bindable(null),
+	}: InlineCitationProps = $props();
+
+	/** How long the pointer must rest on the marker before the card appears. */
+	const OPEN_DELAY_MS = 150;
+	/** How long the card survives after the pointer leaves, so it can be walked into. */
+	const CLOSE_GRACE_MS = 250;
+
+	const uid = $props.id();
+	const previewId = `${uid}-preview`;
+
+	// An explicit `""` is the opt-out, which is why this is `??` and not `||`:
+	// only an omitted prop falls through to the source's own URL.
+	const resolvedHref = $derived(href ?? source.url);
+	const isLink = $derived(resolvedHref !== "");
+
+	let open = $state(false);
+	// Plain lets: the timers must not wake anything that writes them.
+	let openTimer: ReturnType<typeof setTimeout> | undefined;
+	let closeTimer: ReturnType<typeof setTimeout> | undefined;
+
+	function cancelOpen() {
+		if (openTimer === undefined) return;
+		clearTimeout(openTimer);
+		openTimer = undefined;
+	}
+
+	function cancelClose() {
+		if (closeTimer === undefined) return;
+		clearTimeout(closeTimer);
+		closeTimer = undefined;
+	}
+
+	function show() {
+		cancelOpen();
+		cancelClose();
+		// `onOpen` reports appearances, not intentions: a card already on screen
+		// has nothing new to announce.
+		if (open) return;
+		open = true;
+		onOpen?.();
+	}
+
+	function hide() {
+		cancelOpen();
+		cancelClose();
+		open = false;
+	}
+
+	function scheduleShow() {
+		// A pointer that comes back during the grace window keeps the card it
+		// already has rather than starting the open delay over.
+		cancelClose();
+		if (open || openTimer !== undefined) return;
+		openTimer = setTimeout(() => {
+			openTimer = undefined;
+			show();
+		}, OPEN_DELAY_MS);
+	}
+
+	function scheduleHide() {
+		cancelOpen();
+		if (!open || closeTimer !== undefined) return;
+		closeTimer = setTimeout(() => {
+			closeTimer = undefined;
+			hide();
+		}, CLOSE_GRACE_MS);
+	}
+
+	// Escape is bound to the window rather than the marker so it also dismisses a
+	// card that was opened by hover, when nothing on the page holds focus.
+	$effect(() => {
+		if (!open) return;
+		const onKeydown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") hide();
+		};
+		window.addEventListener("keydown", onKeydown);
+		return () => window.removeEventListener("keydown", onKeydown);
+	});
+
+	// Reads nothing, so it runs once and its teardown is the unmount cleanup.
+	$effect(() => () => {
+		cancelOpen();
+		cancelClose();
+	});
+
+	// The superscript is done in the scoped stylesheet rather than with utilities:
+	// its font size, line height and lift are one setting, and splitting them
+	// across two files is how a marker ends up taller than the line it sits on.
+	const markerClass = $derived(
+		cn(
+			"ft-citation-marker inline-flex cursor-pointer items-center rounded px-[0.2em] font-medium tabular-nums no-underline transition-colors focus-visible:ring-1 focus-visible:outline-none",
+			className
+		)
+	);
+
+	// The card is a SourceCard, which already carries a border, a surface and its
+	// own padding. Wrapping that in a second bordered, padded box would draw a card
+	// inside a card, so the chrome here is only put back for a body we do not
+	// control.
+	const previewClass = $derived(
+		cn(
+			"ft-citation-preview text-popover-foreground z-50 block rounded-lg text-left text-sm shadow-lg",
+			preview && "border p-3"
+		)
+	);
+
+	// The marker's text is a bare number; on its own it names nothing, so the
+	// title rides along as the accessible name and the card stays supplementary.
+	const markerLabel = $derived(`Source ${index}: ${source.title}`);
+</script>
+
+<!--
+	The marker block and the card block below are joined tag-to-tag on purpose. A
+	newline between `{/if}` and `{#if open}` compiles to a whitespace text node,
+	and that node lands between the marker and whatever the sentence does next —
+	which is how `read[3].` becomes `read[3] .` in every sentence ending on a
+	citation. The test named for it is the guard; keep them touching.
+-->
+{#if isLink}
+	<a
+		bind:this={ref}
+		href={resolvedHref}
+		target="_blank"
+		rel="noopener noreferrer nofollow ugc"
+		class={markerClass}
+		aria-label={markerLabel}
+		aria-describedby={open ? previewId : undefined}
+		onmouseenter={scheduleShow}
+		onmouseleave={scheduleHide}
+		onfocus={show}
+		onblur={hide}
+	>
+		[{index}]
+	</a>
+{:else}
+	<button
+		bind:this={ref}
+		type="button"
+		class={markerClass}
+		aria-label={markerLabel}
+		aria-describedby={open ? previewId : undefined}
+		onmouseenter={scheduleShow}
+		onmouseleave={scheduleHide}
+		onfocus={show}
+		onblur={hide}
+		onclick={show}
+	>
+		[{index}]
+	</button>
+{/if}{#if open}
+	<!--
+		Rendered only while it is on screen: a tooltip that lives in the DOM
+		permanently is a hidden paragraph every crawler and every screen-reader
+		element list has to step over, mid-sentence, once per citation.
+
+		The anchor is read through a getter so the action re-measures the marker on
+		every scroll and resize tick instead of holding a stale element rect.
+	-->
+	<span
+		id={previewId}
+		role="tooltip"
+		class={previewClass}
+		use:float={{
+			anchor: () => ref?.getBoundingClientRect() ?? null,
+			placement: "top",
+			offset: 8,
+		}}
+		onmouseenter={cancelClose}
+		onmouseleave={scheduleHide}
+	>
+		{#if preview}
+			{@render preview(source)}
+		{:else}
+			<!--
+				The same card the sources list shows, so a document a reader met in one
+				place is recognisable in the other and there is one set of rules for
+				deriving its host and its monogram.
+			-->
+			<SourceCard {source} />
+		{/if}
+	</span>
+{/if}
+
+<style>
+	/*
+	 * Both surfaces read their variables at the point of use with a fallback
+	 * rather than declaring them on a root, so a value set anywhere up the tree —
+	 * a wrapper's `style`, a theme class, `:root` — wins without having to
+	 * out-specify these scoped rules.
+	 */
+	/*
+	 * A hand-made superscript, because `vertical-align: super` is not one: it lifts
+	 * the box without shrinking the line it belongs to, so a marker inheriting the
+	 * prose line-height stretches the line box it sits in and leaves the paragraph
+	 * with uneven leading — wider gaps under exactly the lines that carry a
+	 * citation. Here the box is `0.75em × 1`, comfortably shorter than any line
+	 * height it lands in, and the lift is a relative offset, which moves the paint
+	 * without touching layout at all.
+	 */
+	.ft-citation-marker {
+		position: relative;
+		top: -0.35em;
+		vertical-align: baseline;
+		font-size: 0.75em;
+		line-height: 1;
+		color: var(--ft-citation-fg, var(--color-primary, currentColor));
+	}
+
+	/*
+	 * The pill is mixed from `currentColor`, so retinting the marker retints its
+	 * hover state with it and the two can never drift apart.
+	 */
+	.ft-citation-marker:hover,
+	.ft-citation-marker:focus-visible {
+		background: var(--ft-citation-bg, color-mix(in oklab, currentColor 14%, transparent));
+	}
+
+	.ft-citation-preview {
+		width: var(--ft-citation-preview-width, 16rem);
+		max-width: calc(100vw - 1rem);
+		background: var(--ft-citation-preview-bg, var(--color-popover, canvas));
+		border-color: var(--ft-citation-preview-border, var(--color-border, currentColor));
+	}
+
+	/*
+	 * The entrance lives entirely inside `no-preference`, so reduced motion is not
+	 * a degraded variant to keep in sync: the card simply appears, already placed.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-citation-preview {
+			animation: ft-citation-in 140ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+	}
+
+	@keyframes ft-citation-in {
+		from {
+			opacity: 0;
+			transform: translateY(3px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/inline-citation/InlineCitation.svelte
+++ b/src/lib/fancy-ui/inline-citation/InlineCitation.svelte
@@ -26,6 +26,7 @@
 <script lang="ts">
 	import { cn } from "$lib/utils.js";
 	import { float } from "../_internals/float.js";
+	import { sanitizeHref } from "../_internals/markdown.js";
 	import SourceCard from "../sources/SourceCard.svelte";
 
 	let {
@@ -47,8 +48,10 @@
 	const previewId = `${uid}-preview`;
 
 	// An explicit `""` is the opt-out, which is why this is `??` and not `||`:
-	// only an omitted prop falls through to the source's own URL.
-	const resolvedHref = $derived(href ?? source.url);
+	// only an omitted prop falls through to the source's own URL. Whatever it
+	// ends up being clears the same scheme check every link in this family runs
+	// through, since a url on a source is as model-supplied as the prose around it.
+	const resolvedHref = $derived(sanitizeHref(href ?? source.url ?? "") ?? "");
 	const isLink = $derived(resolvedHref !== "");
 
 	let open = $state(false);
@@ -212,9 +215,12 @@
 			<!--
 				The same card the sources list shows, so a document a reader met in one
 				place is recognisable in the other and there is one set of rules for
-				deriving its host and its monogram.
+				deriving its host and its monogram — but in its plain, non-anchor shape:
+				this preview is dismissed on blur, so a link inside it is one no keyboard
+				can ever reach. The marker itself is already that link. A consumer's own
+				`preview` snippet is theirs to compose and is left alone.
 			-->
-			<SourceCard {source} />
+			<SourceCard {source} interactive={false} />
 		{/if}
 	</span>
 {/if}

--- a/src/lib/fancy-ui/inline-citation/InlineCitation.test.ts
+++ b/src/lib/fancy-ui/inline-citation/InlineCitation.test.ts
@@ -1,0 +1,333 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import InlineCitation from "./InlineCitation.svelte";
+import Harness from "./InlineCitationHarness.test.svelte";
+import type { SourceData } from "../_internals/ai-types.js";
+
+function source(overrides: Partial<SourceData> = {}): SourceData {
+	return {
+		id: "src_1",
+		title: "Structured outputs for tool calls",
+		url: "https://www.example.com/docs/structured-outputs",
+		snippet: "Constrained decoding guarantees the model returns a payload matching your schema.",
+		...overrides,
+	};
+}
+
+function marker(container: HTMLElement): HTMLElement {
+	return container.querySelector(".ft-citation-marker") as HTMLElement;
+}
+
+function preview(container: HTMLElement): HTMLElement | null {
+	return container.querySelector(".ft-citation-preview");
+}
+
+/** Hover the marker and let the open delay elapse. */
+async function hoverOpen(container: HTMLElement) {
+	await fireEvent.mouseEnter(marker(container));
+	await vi.advanceTimersByTimeAsync(150);
+}
+
+describe("InlineCitation", () => {
+	beforeEach(() => vi.useFakeTimers());
+
+	afterEach(() => {
+		vi.useRealTimers();
+		cleanup();
+	});
+
+	it("renders the index as a bracketed marker", () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 3 } });
+
+		expect(marker(container).textContent?.trim()).toBe("[3]");
+	});
+
+	it("names the marker with its title, since a bare number names nothing", () => {
+		const { container } = render(InlineCitation, {
+			props: { source: source({ title: "Retrieval evaluation" }), index: 1 },
+		});
+
+		expect(marker(container).getAttribute("aria-label")).toBe("Source 1: Retrieval evaluation");
+	});
+
+	it("links to the source URL by default, safely and in a new tab", () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+		const el = marker(container);
+
+		expect(el.tagName).toBe("A");
+		expect(el.getAttribute("href")).toBe("https://www.example.com/docs/structured-outputs");
+		expect(el.getAttribute("target")).toBe("_blank");
+		expect(el.getAttribute("rel")).toBe("noopener noreferrer nofollow ugc");
+	});
+
+	it("prefers an explicit href over the source URL", () => {
+		const { container } = render(InlineCitation, {
+			props: { source: source(), index: 1, href: "https://example.org/mirror" },
+		});
+
+		expect(marker(container).getAttribute("href")).toBe("https://example.org/mirror");
+	});
+
+	it("renders a button, not a link, when href is an empty string", () => {
+		const { container } = render(InlineCitation, {
+			props: { source: source(), index: 1, href: "" },
+		});
+		const el = marker(container);
+
+		expect(el.tagName).toBe("BUTTON");
+		expect(el.getAttribute("type")).toBe("button");
+		expect(el.hasAttribute("href")).toBe(false);
+	});
+
+	it("keeps the preview out of the DOM until it is shown", () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+
+		expect(preview(container)).toBeFalsy();
+	});
+
+	it("opens on hover only after the delay has elapsed", async () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+
+		await fireEvent.mouseEnter(marker(container));
+		await vi.advanceTimersByTimeAsync(140);
+		expect(preview(container)).toBeFalsy();
+
+		await vi.advanceTimersByTimeAsync(10);
+		expect(preview(container)).toBeTruthy();
+	});
+
+	it("does not open when the pointer leaves before the delay", async () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+
+		await fireEvent.mouseEnter(marker(container));
+		await vi.advanceTimersByTimeAsync(100);
+		await fireEvent.mouseLeave(marker(container));
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(preview(container)).toBeFalsy();
+	});
+
+	it("holds the card open through the grace window, then closes", async () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+		await hoverOpen(container);
+
+		await fireEvent.mouseLeave(marker(container));
+		await vi.advanceTimersByTimeAsync(240);
+		expect(preview(container)).toBeTruthy();
+
+		await vi.advanceTimersByTimeAsync(20);
+		expect(preview(container)).toBeFalsy();
+	});
+
+	it("survives a pointer that travels into the card during the grace window", async () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+		await hoverOpen(container);
+
+		await fireEvent.mouseLeave(marker(container));
+		await vi.advanceTimersByTimeAsync(100);
+		await fireEvent.mouseEnter(preview(container) as HTMLElement);
+		await vi.advanceTimersByTimeAsync(500);
+		expect(preview(container)).toBeTruthy();
+
+		await fireEvent.mouseLeave(preview(container) as HTMLElement);
+		await vi.advanceTimersByTimeAsync(250);
+		expect(preview(container)).toBeFalsy();
+	});
+
+	it("opens immediately on focus and closes when focus leaves", async () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+
+		await fireEvent.focus(marker(container));
+		expect(preview(container)).toBeTruthy();
+
+		await fireEvent.blur(marker(container));
+		expect(preview(container)).toBeFalsy();
+	});
+
+	it("closes on Escape", async () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+		await fireEvent.focus(marker(container));
+
+		await fireEvent.keyDown(window, { key: "Escape" });
+		expect(preview(container)).toBeFalsy();
+	});
+
+	it("ignores other keys", async () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+		await fireEvent.focus(marker(container));
+
+		await fireEvent.keyDown(window, { key: "a" });
+		expect(preview(container)).toBeTruthy();
+	});
+
+	it("shows the preview when an unlinked marker is activated", async () => {
+		const { container } = render(InlineCitation, {
+			props: { source: source(), index: 1, href: "" },
+		});
+
+		await fireEvent.click(marker(container));
+		expect(preview(container)).toBeTruthy();
+	});
+
+	it("fires onOpen once per appearance, not once per hover event", async () => {
+		const onOpen = vi.fn();
+		const { container } = render(InlineCitation, {
+			props: { source: source(), index: 1, onOpen },
+		});
+
+		await hoverOpen(container);
+		expect(onOpen).toHaveBeenCalledTimes(1);
+
+		// Still the same card on screen: re-entering announces nothing new.
+		await fireEvent.mouseEnter(marker(container));
+		await vi.advanceTimersByTimeAsync(200);
+		expect(onOpen).toHaveBeenCalledTimes(1);
+
+		await fireEvent.mouseLeave(marker(container));
+		await vi.advanceTimersByTimeAsync(250);
+		await hoverOpen(container);
+		expect(onOpen).toHaveBeenCalledTimes(2);
+	});
+
+	it("fills the card with a SourceCard, so a cited document looks the same everywhere", async () => {
+		const { container } = render(InlineCitation, {
+			props: {
+				source: source({
+					title: "Retrieval evaluation",
+					domain: "research.example.com",
+					snippet: "Recall at k is the wrong metric once the reranker is in play.",
+				}),
+				index: 1,
+			},
+		});
+		await hoverOpen(container);
+
+		expect(preview(container)?.querySelector(".ft-source-card")).toBeTruthy();
+		expect(container.querySelector(".ft-source-title")?.textContent?.trim()).toBe(
+			"Retrieval evaluation"
+		);
+		expect(container.querySelector(".ft-source-domain")?.textContent?.trim()).toBe(
+			"research.example.com"
+		);
+		expect(container.querySelector(".ft-source-snippet")?.textContent?.trim()).toBe(
+			"Recall at k is the wrong metric once the reranker is in play."
+		);
+	});
+
+	it("leaves the card's own chrome to the card, and puts it back for a custom body", async () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+		await hoverOpen(container);
+
+		// A bordered, padded box around a bordered, padded card is a card in a card.
+		expect(preview(container)?.className).not.toContain("p-3");
+
+		cleanup();
+		const custom = render(InlineCitation, {
+			props: {
+				source: source(),
+				index: 1,
+				preview: createRawSnippet(() => ({ render: () => `<span>own</span>` })),
+			},
+		});
+		await hoverOpen(custom.container);
+
+		expect(preview(custom.container)?.className).toContain("p-3");
+	});
+
+	it("derives the domain from the URL when the source omits one", async () => {
+		const { container } = render(InlineCitation, {
+			props: { source: source({ url: "https://www.example.com/a/b" }), index: 1 },
+		});
+		await hoverOpen(container);
+
+		expect(container.querySelector(".ft-source-domain")?.textContent?.trim()).toBe("example.com");
+	});
+
+	it("drops the domain line when there is no host to show", async () => {
+		const { container } = render(InlineCitation, {
+			props: { source: source({ url: "/local/notes" }), index: 1, href: "" },
+		});
+		await hoverOpen(container);
+
+		expect(container.querySelector(".ft-source-domain")).toBeFalsy();
+	});
+
+	it("drops the snippet line when the source has none", async () => {
+		const { container } = render(InlineCitation, {
+			props: { source: source({ snippet: undefined }), index: 1 },
+		});
+		await hoverOpen(container);
+
+		expect(container.querySelector(".ft-source-snippet")).toBeFalsy();
+	});
+
+	it("replaces the card body with the preview snippet", async () => {
+		const { container } = render(InlineCitation, {
+			props: {
+				source: source(),
+				index: 1,
+				preview: createRawSnippet((data: () => SourceData) => ({
+					render: () => `<span class="custom">${data().title} · own card</span>`,
+				})),
+			},
+		});
+		await hoverOpen(container);
+
+		expect(container.querySelector(".custom")?.textContent).toBe(
+			"Structured outputs for tool calls · own card"
+		);
+		expect(container.querySelector(".ft-source-card")).toBeFalsy();
+	});
+
+	it("wires the marker to the card it describes", async () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+
+		expect(marker(container).hasAttribute("aria-describedby")).toBe(false);
+
+		await hoverOpen(container);
+		const card = preview(container) as HTMLElement;
+
+		expect(card.getAttribute("role")).toBe("tooltip");
+		expect(card.id).toBeTruthy();
+		expect(marker(container).getAttribute("aria-describedby")).toBe(card.id);
+	});
+
+	it("leaves no whitespace behind the marker for the sentence to trip over", () => {
+		const { container } = render(Harness, { props: { source: source(), index: 3 } });
+		const prose = container.querySelector('[data-testid="prose"]') as HTMLElement;
+
+		// A single stray text node between the marker and the closing block is
+		// enough to render "read[3] ." — the full stop detached from the citation.
+		expect(prose.textContent).toBe("Worth a read[3].");
+
+		const after = [...prose.childNodes]
+			.slice([...prose.childNodes].indexOf(marker(container)) + 1)
+			.filter((node) => node.nodeType === Node.TEXT_NODE)
+			.map((node) => node.textContent)
+			.join("");
+		expect(after).toBe(".");
+	});
+
+	it("superscripts the marker without stretching the line box it sits in", () => {
+		const { container } = render(InlineCitation, { props: { source: source(), index: 1 } });
+		const el = marker(container);
+
+		// jsdom lays nothing out, so the geometry is asserted where it is decided:
+		// the marker carries no utility that inflates the line box, and its size and
+		// lift come from the scoped rule on this class instead.
+		expect(el.classList.contains("ft-citation-marker")).toBe(true);
+		expect(el.classList.contains("align-super")).toBe(false);
+		expect(el.className).not.toMatch(/text-\[0\.7/);
+	});
+
+	it("merges the class prop onto the marker", () => {
+		const { container } = render(InlineCitation, {
+			props: { source: source(), index: 1, class: "text-rose-500" },
+		});
+		const el = marker(container);
+
+		expect(el.classList.contains("text-rose-500")).toBe(true);
+		expect(el.classList.contains("ft-citation-marker")).toBe(true);
+	});
+});

--- a/src/lib/fancy-ui/inline-citation/InlineCitation.test.ts
+++ b/src/lib/fancy-ui/inline-citation/InlineCitation.test.ts
@@ -330,4 +330,24 @@ describe("InlineCitation", () => {
 		expect(el.classList.contains("text-rose-500")).toBe(true);
 		expect(el.classList.contains("ft-citation-marker")).toBe(true);
 	});
+
+	it("does not become a link for a scheme the family refuses", () => {
+		const { container } = render(InlineCitation, {
+			props: { index: 1, source: source({ url: "javascript:alert(1)" }) },
+		});
+
+		expect(container.querySelector("a")).toBeNull();
+		expect(marker(container).tagName).not.toBe("A");
+	});
+
+	it("keeps the default preview free of a link no keyboard can reach", async () => {
+		// The preview is dismissed on blur, so an anchor inside it is unreachable
+		// by Tab. The marker itself is already the link.
+		const { container } = render(InlineCitation, { props: { index: 1, source: source() } });
+
+		await fireEvent.focus(marker(container));
+		const preview = container.querySelector(".ft-citation-preview") as HTMLElement;
+		expect(preview).not.toBeNull();
+		expect(preview.querySelector("a")).toBeNull();
+	});
 });

--- a/src/lib/fancy-ui/inline-citation/InlineCitationHarness.test.svelte
+++ b/src/lib/fancy-ui/inline-citation/InlineCitationHarness.test.svelte
@@ -1,0 +1,21 @@
+<!--
+  Test-only rig for the one thing a `.ts` test cannot set up: the marker inside
+  real prose, with punctuation pressed straight up against it. Whether the
+  component leaks a whitespace text node of its own is only observable from the
+  outside, in the sentence it interrupts. Not exported from index.ts, and not
+  collected by Vitest (the run includes `*.test.ts` only).
+-->
+<script lang="ts">
+	import type { SourceData } from "../_internals/ai-types.js";
+	import InlineCitation from "./InlineCitation.svelte";
+
+	interface Props {
+		source: SourceData;
+		index?: number;
+		href?: string;
+	}
+
+	let { source, index = 1, href }: Props = $props();
+</script>
+
+<p data-testid="prose">Worth a read<InlineCitation {source} {index} {href} />.</p>

--- a/src/lib/fancy-ui/inline-citation/README.md
+++ b/src/lib/fancy-ui/inline-citation/README.md
@@ -1,0 +1,107 @@
+# InlineCitation
+
+A numbered reference that sits inside a sentence and shows the document behind it on hover.
+
+Grounded answers need somewhere to put the receipt. A footnote list at the bottom makes the reader leave the sentence to find out which claim it backs; a full card inline breaks the prose apart. This is the third option: a small `[3]` that stays out of the way until asked, and a floating card that arrives with the title, the domain and enough of the text to judge whether the link is worth following.
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { InlineCitation } from "fancy-ui-svelte";
+
+	const source = {
+		id: "s1",
+		title: "Constrained decoding for tool calls",
+		url: "https://example.com/papers/constrained-decoding",
+		snippet: "Schema-constrained sampling removes the retry loop entirely.",
+	};
+</script>
+
+<p>
+	Structured output is a decoding constraint, not a prompt<InlineCitation {source} index={1} />, so
+	the guarantee holds even at temperature 1.
+</p>
+```
+
+```svelte
+<!-- No link: the marker only reveals the card -->
+<InlineCitation {source} index={2} href="" />
+```
+
+```svelte
+<!-- Your own card body -->
+<InlineCitation {source} index={3}>
+	{#snippet preview(s)}
+		<span class="block font-medium">{s.title}</span>
+		<span class="text-muted-foreground block text-xs">Retrieved 2 minutes ago</span>
+	{/snippet}
+</InlineCitation>
+```
+
+## Props
+
+| Prop      | Type                    | Default      | Description                                                  |
+| --------- | ----------------------- | ------------ | ------------------------------------------------------------ |
+| `source`  | `SourceData`            | —            | The document being cited; fills the card                     |
+| `index`   | `number`                | —            | The reference number; `3` renders `[3]`                      |
+| `href`    | `string`                | `source.url` | Link target; `""` renders an unlinked marker                 |
+| `preview` | `Snippet<[SourceData]>` | —            | Replaces the default `SourceCard` body, receiving the source |
+| `onOpen`  | `() => void`            | —            | Called each time the card appears, once per appearance       |
+| `class`   | `string`                | —            | Additional CSS classes, merged onto the marker               |
+| `ref`     | `HTMLElement\|null`     | `null`       | Bindable reference to the marker element                     |
+
+## Behavior
+
+The card body is a `SourceCard` — the same card the sources list shows — so a document a reader meets under an answer is recognisable when they meet it again mid-sentence, and there is one implementation of "what is this document's host and monogram" rather than two that drift. `preview` replaces that body; the floating surface, its placement and its dismissal stay with this component either way.
+
+The card is a tooltip, not a popover: supplementary content that appears on hover or focus, never takes focus itself, and holds nothing the reader cannot get another way.
+
+| Input                         | What happens                                                            |
+| ----------------------------- | ----------------------------------------------------------------------- |
+| Pointer rests on the marker   | Card appears after 150 ms                                               |
+| Pointer leaves before 150 ms  | Nothing appears; the pending open is cancelled                          |
+| Pointer leaves the marker     | Card stays for 250 ms, long enough to walk the pointer into it          |
+| Pointer enters the card       | The pending close is cancelled; the card stays as long as it is hovered |
+| Marker receives focus         | Card appears immediately — no delay for keyboard users                  |
+| Marker loses focus            | Card closes immediately                                                 |
+| `Escape`                      | Card closes, whether it was opened by hover or by focus                 |
+| `Enter` on a linked marker    | Follows the link, as any anchor would                                   |
+| Activating an unlinked marker | Shows the card, which is all an unlinked marker can do                  |
+
+`href=""` is the opt-out, not an omitted `href`: leaving the prop off falls through to `source.url`. Linked markers are real anchors carrying `target="_blank"` and `rel="noopener noreferrer nofollow ugc"`, since a cited URL is by definition somebody else's page. Unlinked markers are buttons, so they are still in the tab order and still reachable without a pointer.
+
+## Accessibility
+
+- The marker's visible text is a bare `[3]`, which names nothing out loud, so its accessible name is `Source 3: <title>`. The number stays for sighted readers; the title carries the meaning for everyone else.
+- The card is `role="tooltip"` and is pointed at by the marker's `aria-describedby` — but only while it is on screen, since a reference to an absent element is a dangling one.
+- The card exists in the DOM only while it is shown. A permanently mounted hidden tooltip is a paragraph that every screen-reader element list and every crawler steps over, mid-sentence, once per citation.
+- Focus never enters the card. There is nothing in it to operate, and moving focus into a hover-triggered surface is how tooltips turn into traps.
+
+## Theming
+
+```svelte
+<div style="--ft-citation-fg: oklch(0.6 0.2 260); --ft-citation-preview-width: 20rem">
+	<InlineCitation {source} index={1} />
+</div>
+```
+
+| Variable                       | Default                  | Effect                                   |
+| ------------------------------ | ------------------------ | ---------------------------------------- |
+| `--ft-citation-fg`             | `--color-primary`        | Marker colour                            |
+| `--ft-citation-bg`             | 14% of the marker colour | The hover/focus pill behind the marker   |
+| `--ft-citation-preview-bg`     | `--color-popover`        | Floating surface under the card          |
+| `--ft-citation-preview-border` | `--color-border`         | Outline, drawn only around a custom body |
+| `--ft-citation-preview-width`  | `16rem`                  | Card width, capped at the viewport       |
+
+The hover pill is mixed from `currentColor`, so retinting the marker retints its hover state with it — the two cannot drift apart. Every variable is read at its point of use with a fallback rather than declared on a root, so a consumer's value inherits in without having to out-specify the component's own scoped rules.
+
+## Implementation notes
+
+- Positioning comes from the shared `float` action in `_internals/float.ts`, with `placement: "top"` and an 8px offset. It pins the card with `position: fixed`, flips it below the marker when the top of the viewport is too tight, clamps it inside the padding on both axes, and re-measures on scroll and resize. The anchor is passed as a getter rather than the element itself, so each re-measure reads the marker's current rect instead of a stale one.
+- The card renders in the component's own DOM position — there is no portal. `position: fixed` takes it out of flow, so it never disturbs the line it interrupts, and it is a `<span>` with block display rather than a `<div>`, which keeps the markup valid inside the `<p>` it usually lives in.
+- The entrance animation lives entirely inside `@media (prefers-reduced-motion: no-preference)`. With that rule gone the card simply appears, already correctly placed.
+- `onOpen` reports appearances, not intentions. Re-entering a card that is already on screen fires nothing; it is the right hook for logging which sources a reader actually looked at.
+- `source.domain` wins when it is set; otherwise the host is derived from `source.url` with any `www.` stripped. A URL with no parsable host simply drops the domain line rather than printing something that is not a domain. The card brings its own border, surface and padding, so the floating box around it adds none — a second frame would draw a card inside a card. A `preview` snippet gets that padded, bordered box back, since its body is not one.
+- The marker is a hand-made superscript: `font-size: 0.75em`, `line-height: 1`, and a relative offset off the baseline. `vertical-align: super` lifts a box without shrinking it, so a marker inheriting the prose line-height stretches the line box it sits in — leaving a paragraph with visibly wider gaps under exactly the lines that carry a citation. A relative offset moves paint without touching layout, and the short line box fits inside any sensible leading.
+- The marker's markup ends where the marker does. A whitespace text node between it and whatever follows would push the next character off the citation, turning `read[3].` into `read[3] .` in every sentence that ends on a reference.

--- a/src/lib/fancy-ui/inline-citation/index.ts
+++ b/src/lib/fancy-ui/inline-citation/index.ts
@@ -1,0 +1,4 @@
+import InlineCitation from "./InlineCitation.svelte";
+import type { InlineCitationProps } from "./InlineCitation.svelte";
+
+export { InlineCitation, type InlineCitationProps };

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -3139,6 +3139,206 @@ export const registry: Record<string, ComponentMeta> = {
 			},
 		],
 	},
+	sources: {
+		name: "Sources",
+		slug: "sources",
+		description:
+			"The citations under an answer: a pill carrying a stack of domain monograms and a count, expanding into scannable source cards with title, host, and the line worth reading",
+		category: "ai-chat",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "chat", "citations", "sources", "compound"],
+		props: [
+			{
+				name: "sources",
+				type: "SourceData[]",
+				description: "The documents backing the answer, in reading order",
+				required: true,
+			},
+			{
+				name: "open",
+				type: "boolean",
+				default: "false",
+				description: "Whether the list is expanded; bindable",
+			},
+			{
+				name: "onToggle",
+				type: "(open: boolean) => void",
+				description:
+					"Called when the pill is clicked, with the state it moved to; driving open yourself does not fire it",
+			},
+		],
+		slots: [
+			{
+				name: "children",
+				description:
+					"Replaces the default trigger-and-list composition entirely; omit it and the root renders both",
+			},
+			{
+				name: "item",
+				description:
+					"On SourcesList — replaces the default card; receives the source and its index",
+			},
+			{
+				name: "icon",
+				description: "On SourceCard — replaces the monogram: a favicon you host, a logo",
+			},
+		],
+	},
+	"inline-citation": {
+		name: "InlineCitation",
+		slug: "inline-citation",
+		description:
+			"A numbered reference that sits inside a sentence and reveals the document behind it — title, domain and snippet — in a floating card on hover or focus",
+		category: "ai-chat",
+		status: "done",
+		dependencies: ["sources"],
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "chat", "citations", "tooltip"],
+		props: [
+			{
+				name: "source",
+				type: "SourceData",
+				description: "The document being cited; its title, domain and snippet fill the card",
+				required: true,
+			},
+			{
+				name: "index",
+				type: "number",
+				description: "The reference number shown in the marker, e.g. 3 renders [3]",
+				required: true,
+			},
+			{
+				name: "href",
+				type: "string",
+				default: "source.url",
+				description:
+					"Link target; an explicit empty string renders an unlinked marker that only reveals the card",
+			},
+			{
+				name: "onOpen",
+				type: "() => void",
+				description: "Called each time the card appears, once per appearance rather than per hover",
+			},
+		],
+		slots: [
+			{
+				name: "preview",
+				description: "Replaces the default card body; receives the source",
+			},
+		],
+	},
+	"web-search": {
+		name: "WebSearch",
+		slug: "web-search",
+		description:
+			"A search the agent ran: the query in a search-bar header, an indeterminate scanning bar while it runs, and results that land one row at a time",
+		category: "ai-chat",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "chat", "search", "results", "knowledge"],
+		props: [
+			{
+				name: "query",
+				type: "string",
+				description: "What the agent looked up, shown in the search-bar header",
+				required: true,
+			},
+			{
+				name: "results",
+				type: "SearchResultData[]",
+				description: "Hits found so far, oldest first; appending to it lands a new row",
+				required: true,
+			},
+			{
+				name: "searching",
+				type: "boolean",
+				default: "false",
+				description:
+					"Whether the lookup is still running: drives the scanning bar and the waiting state",
+			},
+			{
+				name: "onSelect",
+				type: "(result: SearchResultData, index: number) => void",
+				description: "Called when a row is activated; supplying it turns every row into a button",
+			},
+			{
+				name: "maxVisible",
+				type: "number",
+				default: "0",
+				description: "Rows shown before the expander takes over; 0 shows every result",
+			},
+			{
+				name: "label",
+				type: "string",
+				default: '"Web search"',
+				description: "Accessible name for the whole block",
+			},
+		],
+		slots: [
+			{
+				name: "item",
+				description: "Replaces the built-in row body, keeping the row element and its behaviour",
+			},
+		],
+	},
+	"image-generation": {
+		name: "ImageGeneration",
+		slug: "image-generation",
+		description:
+			"Fixed frame that holds its place while a model draws: an empty outline, then a pixel grid working over a drifting dot field, then the finished image easing out of a blur",
+		category: "ai-chat",
+		status: "done",
+		dependencies: ["pixel-loader"],
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "chat", "image", "generation", "media"],
+		props: [
+			{
+				name: "status",
+				type: '"idle" | "generating" | "done" | "error"',
+				description: "Which stage of the generation to render",
+				required: true,
+			},
+			{
+				name: "src",
+				type: "string | null",
+				description: 'The generated image, shown once status is "done"',
+			},
+			{
+				name: "alt",
+				type: "string",
+				description: "Describes the image to assistive tech — typically the prompt",
+				required: true,
+			},
+			{
+				name: "aspectRatio",
+				type: "string",
+				default: '"1 / 1"',
+				description: "CSS aspect-ratio of the frame, holding the layout across every state",
+			},
+			{
+				name: "prompt",
+				type: "string",
+				description: "Muted caption line under the frame",
+			},
+			{
+				name: "errorText",
+				type: "string",
+				default: '"Generation failed"',
+				description: "The failure line shown in the error state",
+			},
+			{
+				name: "onRetry",
+				type: "() => void",
+				description: "Pressing retry calls this; the retry button only exists when it is set",
+			},
+			{
+				name: "onLoad",
+				type: "() => void",
+				description: "Called once the generated image has finished loading",
+			},
+		],
+	},
 };
 
 // =============================================================================

--- a/src/lib/fancy-ui/sources/README.md
+++ b/src/lib/fancy-ui/sources/README.md
@@ -1,0 +1,189 @@
+# Sources
+
+The citations under an answer, as a pill you can ignore and a set of cards you can scan. Collapsed, it is a stack of monograms and a count; open, it is one card per document — title, host, and the line worth reading.
+
+## Components
+
+- `Sources` — the root. Holds the citation set and the open state, publishes context.
+- `SourcesTrigger` — the collapsed pill: monogram stack, count, chevron.
+- `SourcesList` — the expanding region of cards.
+- `SourceCard` — one citation. Works on its own, anywhere.
+
+The parts read the root through context, so they can sit anywhere inside it — directly in the root, or nested a few components deep in your own wrapper — without the sources or the open state being threaded down as props.
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { Sources } from "fancy-ui-svelte";
+
+	const sources = [
+		{
+			id: "s1",
+			title: "Designing citation surfaces",
+			url: "https://docs.example.dev/patterns/citations",
+			snippet: "A citation is a promise that the answer can be checked.",
+		},
+	];
+</script>
+
+<p>{answer}</p>
+<Sources {sources} />
+```
+
+That is the whole component. With no `children`, the root renders its own trigger and list, so the bare form is the one most answers want.
+
+### Composing it yourself
+
+Pass `children` and you place the parts — reordered, wrapped, or with only one of them present:
+
+```svelte
+<script lang="ts">
+	import { Sources, SourcesTrigger, SourcesList } from "fancy-ui-svelte";
+
+	let open = $state(false);
+</script>
+
+<Sources {sources} bind:open onToggle={(next) => track("sources", next)}>
+	<SourcesTrigger label="Checked against 4 papers" />
+	<SourcesList>
+		{#snippet item(source, index)}
+			<a href={source.url}>{index + 1}. {source.title}</a>
+		{/snippet}
+	</SourcesList>
+</Sources>
+```
+
+### `SourceCard` on its own
+
+The card has no context dependency at all, so it works anywhere a single citation needs rendering — a hover preview over an inline citation, a "cited by" rail, a search result:
+
+```svelte
+<script lang="ts">
+	import { SourceCard } from "fancy-ui-svelte";
+</script>
+
+<SourceCard source={sources[0]} />
+```
+
+It is the only part that behaves this way. The trigger and the list also survive being rendered outside a root — the pill reads `0 sources` and does nothing, the list renders empty and stays open — but there is no reason to do that on purpose.
+
+## Props
+
+### Sources
+
+| Prop       | Type                      | Default     | Description                                                  |
+| ---------- | ------------------------- | ----------- | ------------------------------------------------------------ |
+| `sources`  | `SourceData[]`            | —           | The documents backing the answer, in reading order. Required |
+| `open`     | `boolean`                 | `false`     | Whether the list is expanded. Bindable                       |
+| `onToggle` | `(open: boolean) => void` | `undefined` | Called when the pill is clicked, with the state it moved to  |
+| `children` | `Snippet`                 | `undefined` | Replaces the default trigger-and-list composition entirely   |
+| `class`    | `string`                  | `undefined` | Additional CSS classes                                       |
+| `ref`      | `HTMLDivElement \| null`  | `null`      | Bindable reference to the root `<div>`                       |
+
+`onToggle` fires only when the pill is clicked. Driving `open` yourself — through the binding or the prop — changes the state without calling it, which is what lets a caller tell "the reader opened this" apart from "I opened this".
+
+### SourcesTrigger
+
+| Prop    | Type     | Default     | Description                                                        |
+| ------- | -------- | ----------- | ------------------------------------------------------------------ |
+| `label` | `string` | `undefined` | Overrides the count line. Defaults to `4 sources`, singular at one |
+| `class` | `string` | `undefined` | Additional CSS classes                                             |
+
+### SourcesList
+
+| Prop    | Type                            | Default     | Description                                              |
+| ------- | ------------------------------- | ----------- | -------------------------------------------------------- |
+| `item`  | `Snippet<[SourceData, number]>` | `undefined` | Replaces the default card. Gets the source and its index |
+| `class` | `string`                        | `undefined` | Additional CSS classes, on the grid                      |
+
+### SourceCard
+
+| Prop     | Type         | Default     | Description                                       |
+| -------- | ------------ | ----------- | ------------------------------------------------- |
+| `source` | `SourceData` | —           | The document being cited. Required                |
+| `icon`   | `Snippet`    | `undefined` | Replaces the monogram: a favicon you host, a logo |
+| `class`  | `string`     | `undefined` | Additional CSS classes                            |
+
+## The data
+
+Every part reads the shared `SourceData` shape:
+
+```ts
+interface SourceData {
+	id: string;
+	title: string;
+	url: string;
+	snippet?: string;
+	domain?: string;
+}
+```
+
+Only `title` always renders. `domain` is shown when given and otherwise derived from `url` (minus the `www.`), so a caller who wants `the standards body` under a title can say so instead of getting `www.example.org`. A source with no usable `url` renders as a plain card rather than a link — a citation with nowhere to go is still worth showing, it just must not pretend to be clickable.
+
+## The context contract
+
+The root publishes this under `SOURCES_CONTEXT_KEY`:
+
+```ts
+interface SourcesContext {
+	readonly open: { readonly current: boolean };
+	readonly count: number;
+	readonly sources: readonly SourceData[];
+	readonly listId: string;
+	toggle(): void;
+}
+```
+
+Everything is a getter over the root's own props, so a part that reads it inside a reactive scope updates with the root. `listId` is the id the list puts on its region and the trigger points `aria-controls` at, which is the only way two sibling components can agree on one.
+
+Both the key and the type are exported, so you can build your own parts:
+
+```svelte
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { SOURCES_CONTEXT_KEY, type SourcesContext } from "fancy-ui-svelte";
+
+	const sources = getContext<SourcesContext | undefined>(SOURCES_CONTEXT_KEY);
+</script>
+
+<button onclick={() => sources?.toggle()}>{sources?.count ?? 0} references</button>
+```
+
+Read it as optional. Every shipped part does, so a part rendered outside a root degrades instead of throwing.
+
+## Styling
+
+| Custom property              | Default                                              | Effect                                   |
+| ---------------------------- | ---------------------------------------------------- | ---------------------------------------- |
+| `--ft-sources-min-column`    | `13rem`                                              | Narrowest a card column may get          |
+| `--ft-sources-gap`           | `0.5rem`                                             | Space between cards                      |
+| `--ft-sources-card-bg`       | `color-mix(in oklab, currentColor 3%, transparent)`  | Card fill                                |
+| `--ft-sources-card-hover-bg` | `color-mix(in oklab, currentColor 7%, transparent)`  | Card and pill fill on hover              |
+| `--ft-sources-card-border`   | `var(--color-border, …)`                             | Card and pill border                     |
+| `--ft-sources-trigger-bg`    | `transparent`                                        | Pill fill at rest                        |
+| `--ft-sources-chip-bg`       | `color-mix(in oklab, currentColor 12%, transparent)` | Monogram fill                            |
+| `--ft-sources-chip-fg`       | `inherit`                                            | Monogram letter colour                   |
+| `--ft-sources-chip-ring`     | `var(--color-background, canvas)`                    | Ring cutting the stacked monograms apart |
+
+Set them on the component, or on any ancestor:
+
+```svelte
+<div style="--ft-sources-min-column: 100%; --ft-sources-chip-bg: var(--color-primary);">
+	<Sources {sources} />
+</div>
+```
+
+Setting `--ft-sources-min-column` to `100%` is how you force the single-column stack a narrow chat needs.
+
+## Implementation Notes
+
+- The list expands with `grid-template-rows: 0fr → 1fr`, which is the only way to transition an auto height without measuring anything. The inner wrapper does the clipping.
+- The collapsed region is `inert`. The cards are links, so leaving them reachable would drop a keyboard into content nobody can see.
+- Cards flow into `repeat(auto-fill, minmax(--ft-sources-min-column, 1fr))`, so the same list is a stack in a chat column and a grid in a document, with no breakpoint to configure.
+- The entrance stagger hangs off a class rather than mount, because the cards never unmount — collapsing is a height transition over live DOM, so re-adding the class is the only thing that can replay it. The delay is clamped at the seventh card: past a handful, a stagger stops reading as sequence and starts reading as lag.
+- Everything that moves — the expansion, the chevron, the stagger, the hover tints — lives inside `@media (prefers-reduced-motion: no-preference)`. Reduced motion gets the same states, instantly.
+- The monogram is a letter, never a favicon. Loading real favicons would mean a request from every reader's browser to every cited site — a tracking beacon nobody asked for, and a broken image the moment a site is gone. Pass `icon` if you host your own.
+- The letter is taken with the spread rather than `charAt`, so a title starting outside the BMP yields a whole character instead of half a surrogate pair.
+- Links carry `rel="noopener noreferrer nofollow ugc"` and `target="_blank"`: a model chose the destination, not the author of the page it sits on, and the tab it opens has no business reaching back into the app.
+- The trigger's monogram stack is `aria-hidden`. It is decoration; every name in it is spelled out in the list below.

--- a/src/lib/fancy-ui/sources/SourceCard.svelte
+++ b/src/lib/fancy-ui/sources/SourceCard.svelte
@@ -10,6 +10,12 @@
 		source: SourceData;
 		/** Replaces the monogram: a favicon you host, a logo, an icon. */
 		icon?: Snippet;
+		/**
+		 * Renders the plain, non-anchor shape even when the source has a url. For a
+		 * card embedded in a surface — a tooltip preview — that cannot host a link
+		 * reachable by keyboard.
+		 */
+		interactive?: boolean;
 		/** Additional CSS classes */
 		class?: string;
 	}
@@ -18,8 +24,9 @@
 <script lang="ts">
 	import { cn } from "$lib/utils.js";
 	import { hostOf, monogram } from "../_internals/host.js";
+	import { sanitizeHref } from "../_internals/markdown.js";
 
-	let { source, icon, class: className }: SourceCardProps = $props();
+	let { source, icon, interactive = true, class: className }: SourceCardProps = $props();
 
 	// An explicit `domain` always wins — a caller who says "the standards body"
 	// means that, not `www.w3.org`.
@@ -28,8 +35,29 @@
 	// with no parsable host falls back to its own title.
 	const mark = $derived(monogram(domain || source.title));
 	// A citation with nowhere to go is still worth showing — it just must not
-	// pretend to be a link.
-	const href = $derived(typeof source.url === "string" && source.url !== "" ? source.url : "");
+	// pretend to be a link. A model-provided url also has to clear the same
+	// scheme check every link in this family runs through, and a bare host
+	// ("docs.example.dev/guide") has to become absolute before it goes in an
+	// `href`, or the browser resolves it against this app's own origin instead
+	// of the cited site.
+	const href = $derived(
+		interactive && typeof source.url === "string" ? (resolveHref(source.url) ?? "") : ""
+	);
+
+	/**
+	 * A model-provided url made safe for an anchor's `href`, or `null` when it
+	 * must not render as a link at all: a disallowed scheme is rejected outright
+	 * by the shared markdown-link sanitizer, and a scheme-less host is promoted
+	 * to `https://` first. A genuine relative path ("/local/guide") has nowhere
+	 * else to resolve against and is left alone.
+	 */
+	function resolveHref(raw: string): string | null {
+		if (raw === "") return null;
+		const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(raw) || raw.startsWith("//");
+		const host = raw.split(/[/?#]/, 1)[0];
+		const looksHostLike = !hasScheme && !raw.startsWith("/") && host.includes(".");
+		return sanitizeHref(looksHostLike ? `https://${raw}` : raw);
+	}
 </script>
 
 {#snippet body()}

--- a/src/lib/fancy-ui/sources/SourceCard.svelte
+++ b/src/lib/fancy-ui/sources/SourceCard.svelte
@@ -1,0 +1,146 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { SourceData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for SourceCard
+	 */
+	export interface SourceCardProps {
+		/** The document being cited. Only `title` is ever guaranteed to render. */
+		source: SourceData;
+		/** Replaces the monogram: a favicon you host, a logo, an icon. */
+		icon?: Snippet;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { hostOf, monogram } from "../_internals/host.js";
+
+	let { source, icon, class: className }: SourceCardProps = $props();
+
+	// An explicit `domain` always wins — a caller who says "the standards body"
+	// means that, not `www.w3.org`.
+	const domain = $derived(source.domain || hostOf(source.url));
+	// The host names the place, so it is what the circle stands for; a source
+	// with no parsable host falls back to its own title.
+	const mark = $derived(monogram(domain || source.title));
+	// A citation with nowhere to go is still worth showing — it just must not
+	// pretend to be a link.
+	const href = $derived(typeof source.url === "string" && source.url !== "" ? source.url : "");
+</script>
+
+{#snippet body()}
+	<span class="ft-source-mark flex-none" aria-hidden="true">
+		{#if icon}
+			{@render icon()}
+		{:else}
+			{mark}
+		{/if}
+	</span>
+
+	<span class="flex min-w-0 flex-col gap-0.5">
+		<span class="ft-source-title text-foreground text-xs leading-snug font-medium">
+			{source.title}
+		</span>
+		{#if domain}
+			<span class="ft-source-domain text-muted-foreground text-[0.6875rem] leading-none">
+				{domain}
+			</span>
+		{/if}
+		{#if source.snippet}
+			<span class="ft-source-snippet text-muted-foreground mt-0.5 text-[0.6875rem] leading-snug">
+				{source.snippet}
+			</span>
+		{/if}
+	</span>
+{/snippet}
+
+{#if href}
+	<!--
+		`nofollow ugc` because a model chose this link, not the author of the page
+		it sits on; `noopener noreferrer` because the tab it opens has no business
+		reaching back into the app or announcing where the reader came from.
+	-->
+	<a
+		{href}
+		target="_blank"
+		rel="noopener noreferrer nofollow ugc"
+		class={cn("ft-source-card ft-source-linked", className)}
+	>
+		{@render body()}
+	</a>
+{:else}
+	<div class={cn("ft-source-card", className)}>
+		{@render body()}
+	</div>
+{/if}
+
+<style>
+	.ft-source-card {
+		display: flex;
+		gap: 0.5rem;
+		border-radius: 0.5rem;
+		border: 1px solid
+			var(
+				--ft-sources-card-border,
+				var(--color-border, color-mix(in oklab, currentColor 15%, transparent))
+			);
+		background: var(--ft-sources-card-bg, color-mix(in oklab, currentColor 3%, transparent));
+		padding: 0.5rem 0.625rem;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.ft-source-linked:hover,
+	.ft-source-linked:focus-visible {
+		background: var(--ft-sources-card-hover-bg, color-mix(in oklab, currentColor 7%, transparent));
+	}
+
+	/*
+	 * The monogram stands in for a favicon: no request leaves the reader's browser
+	 * to the cited site, and there is no broken image to fall back from.
+	 */
+	.ft-source-mark {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.25rem;
+		height: 1.25rem;
+		border-radius: 9999px;
+		background: var(--ft-sources-chip-bg, color-mix(in oklab, currentColor 10%, transparent));
+		color: var(--ft-sources-chip-fg, inherit);
+		font-size: 0.625rem;
+		font-weight: 600;
+		line-height: 1;
+	}
+
+	/*
+	 * Two lines for a title, two for the snippet: enough to tell two results
+	 * apart, few enough that a row of cards stays a row.
+	 */
+	.ft-source-title,
+	.ft-source-snippet {
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		overflow: hidden;
+	}
+
+	/* A host is an identifier, so it is set like one — and never wrapped. */
+	.ft-source-domain {
+		overflow: hidden;
+		font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-source-linked {
+			transition: background-color 150ms ease;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/sources/Sources.svelte
+++ b/src/lib/fancy-ui/sources/Sources.svelte
@@ -1,0 +1,75 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { SourceData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for Sources
+	 */
+	export interface SourcesProps {
+		/** The documents backing the answer, in the order they should be read. */
+		sources: SourceData[];
+		/** Whether the list is expanded. Bindable; starts closed. */
+		open?: boolean;
+		/** Called whenever the list opens or closes. */
+		onToggle?: (open: boolean) => void;
+		/** Replaces the default trigger-and-list composition entirely. */
+		children?: Snippet;
+		/** Additional CSS classes */
+		class?: string;
+		/** The root element */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { setContext } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import SourcesTrigger from "./SourcesTrigger.svelte";
+	import SourcesList from "./SourcesList.svelte";
+	import { SOURCES_CONTEXT_KEY, type SourcesContext } from "./types.js";
+
+	let {
+		sources,
+		open = $bindable(false),
+		onToggle,
+		children,
+		class: className,
+		ref = $bindable(null),
+	}: SourcesProps = $props();
+
+	const uid = $props.id();
+	const listId = `${uid}-list`;
+
+	// Getters throughout: a part reading any of these inside its own reactive
+	// scope re-runs when the root's props change, without the object being
+	// rebuilt and re-published on every keystroke upstream.
+	const context: SourcesContext = {
+		open: {
+			get current() {
+				return open;
+			},
+		},
+		get count() {
+			return sources.length;
+		},
+		get sources() {
+			return sources;
+		},
+		listId,
+		toggle() {
+			open = !open;
+			onToggle?.(open);
+		},
+	};
+
+	setContext(SOURCES_CONTEXT_KEY, context);
+</script>
+
+<div bind:this={ref} class={cn("ft-sources w-full", className)} data-open={open}>
+	{#if children}
+		{@render children()}
+	{:else}
+		<SourcesTrigger />
+		<SourcesList />
+	{/if}
+</div>

--- a/src/lib/fancy-ui/sources/Sources.test.ts
+++ b/src/lib/fancy-ui/sources/Sources.test.ts
@@ -1,0 +1,178 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import type { SourceData } from "../_internals/ai-types.js";
+import Sources from "./Sources.svelte";
+import Harness from "./SourcesHarness.test.svelte";
+
+const SOURCES: SourceData[] = [
+	{
+		id: "s1",
+		title: "Designing citation surfaces",
+		url: "https://docs.example.dev/citations",
+		domain: "docs.example.dev",
+		snippet: "A citation is a promise that the answer can be checked.",
+	},
+	{
+		id: "s2",
+		title: "Attribution in generated answers",
+		url: "https://research.example.org/attribution",
+		domain: "research.example.org",
+	},
+	{ id: "s3", title: "Ranking retrieved passages", url: "https://notes.example.net/ranking" },
+	{ id: "s4", title: "An uncited note", url: "" },
+];
+
+function snippet(html: string) {
+	return createRawSnippet(() => ({ render: () => html }));
+}
+
+function trigger(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector("button") as HTMLButtonElement;
+}
+
+function cards(container: HTMLElement): NodeListOf<HTMLElement> {
+	return container.querySelectorAll(".ft-source-card");
+}
+
+function list(container: HTMLElement): HTMLElement {
+	return container.querySelector("ul") as HTMLElement;
+}
+
+describe("Sources", () => {
+	afterEach(cleanup);
+
+	it("renders a trigger and a list without being given any children", () => {
+		const { container } = render(Sources, { props: { sources: SOURCES } });
+
+		expect(trigger(container)).toBeTruthy();
+		expect(trigger(container).getAttribute("aria-expanded")).toBe("false");
+		expect(cards(container)).toHaveLength(SOURCES.length);
+	});
+
+	it("starts closed, and says so on the root and the region", () => {
+		const { container } = render(Sources, { props: { sources: SOURCES } });
+
+		expect((container.querySelector(".ft-sources") as HTMLElement).dataset.open).toBe("false");
+		expect(container.querySelector(".ft-sources-list")?.className).not.toContain("ft-open");
+		// Collapsed cards are links: leaving them reachable would drop the keyboard
+		// into content nobody can see. jsdom does not implement inert, so Svelte's
+		// property assignment is what there is to check — it is also what applies
+		// inertness in a real browser.
+		expect(list(container).inert).toBe(true);
+	});
+
+	it("opens on click and reports the new state", async () => {
+		const onToggle = vi.fn();
+		const { container } = render(Sources, { props: { sources: SOURCES, onToggle } });
+
+		await fireEvent.click(trigger(container));
+		expect(trigger(container).getAttribute("aria-expanded")).toBe("true");
+		expect(list(container).inert).toBe(false);
+		expect(onToggle).toHaveBeenLastCalledWith(true);
+
+		await fireEvent.click(trigger(container));
+		expect(trigger(container).getAttribute("aria-expanded")).toBe("false");
+		expect(onToggle).toHaveBeenLastCalledWith(false);
+		expect(onToggle).toHaveBeenCalledTimes(2);
+	});
+
+	it("honours an initial open, and follows the prop when it changes", async () => {
+		const { container, rerender } = render(Sources, {
+			props: { sources: SOURCES, open: true },
+		});
+		expect(trigger(container).getAttribute("aria-expanded")).toBe("true");
+
+		await rerender({ sources: SOURCES, open: false });
+		expect(trigger(container).getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("writes the open state back out through the binding", async () => {
+		const { container, getByTestId } = render(Harness, { props: { sources: SOURCES } });
+		expect(getByTestId("bound-open").textContent).toBe("false");
+
+		await fireEvent.click(trigger(container));
+		expect(getByTestId("bound-open").textContent).toBe("true");
+
+		await fireEvent.click(trigger(container));
+		expect(getByTestId("bound-open").textContent).toBe("false");
+	});
+
+	it("counts the sources in the trigger label, singular at one", () => {
+		const many = render(Sources, { props: { sources: SOURCES } });
+		expect(trigger(many.container).textContent).toContain("4 sources");
+
+		cleanup();
+		const one = render(Sources, { props: { sources: [SOURCES[0]] } });
+		expect(trigger(one.container).textContent).toContain("1 source");
+		expect(trigger(one.container).textContent).not.toContain("1 sources");
+	});
+
+	it("survives an empty source list", () => {
+		const { container } = render(Sources, { props: { sources: [] } });
+
+		expect(trigger(container).textContent).toContain("0 sources");
+		expect(cards(container)).toHaveLength(0);
+		expect(container.querySelector(".ft-sources-stack")).toBeFalsy();
+	});
+
+	it("renders one card per source, in order", () => {
+		const { container } = render(Sources, { props: { sources: SOURCES, open: true } });
+		const titles = [...cards(container)].map((card) =>
+			card.querySelector(".ft-source-title")?.textContent?.trim()
+		);
+
+		expect(titles).toEqual(SOURCES.map((source) => source.title));
+	});
+
+	it("reacts to a new set of sources", async () => {
+		const { container, rerender } = render(Sources, { props: { sources: SOURCES } });
+		expect(cards(container)).toHaveLength(4);
+
+		await rerender({ sources: SOURCES.slice(0, 2) });
+		expect(cards(container)).toHaveLength(2);
+		expect(trigger(container).textContent).toContain("2 sources");
+	});
+
+	it("lets children replace the default composition entirely", () => {
+		const { container } = render(Sources, {
+			props: { sources: SOURCES, children: snippet('<p data-testid="custom">Mine</p>') },
+		});
+
+		expect(container.querySelector('[data-testid="custom"]')?.textContent).toBe("Mine");
+		expect(trigger(container)).toBeFalsy();
+		expect(cards(container)).toHaveLength(0);
+	});
+
+	it("points the trigger at the region it controls", () => {
+		const { container } = render(Sources, { props: { sources: SOURCES } });
+		const controls = trigger(container).getAttribute("aria-controls");
+
+		expect(controls).toBeTruthy();
+		expect(list(container).id).toBe(controls);
+	});
+
+	it("merges custom classes onto the root", () => {
+		const { container } = render(Sources, {
+			props: { sources: SOURCES, class: "my-sources" },
+		});
+		const root = container.querySelector(".ft-sources") as HTMLElement;
+
+		expect(root.className).toContain("my-sources");
+		expect(root.className).toContain("ft-sources");
+	});
+
+	it("composes its parts without warnings", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const { container } = render(Harness, { props: { sources: SOURCES } });
+		await fireEvent.click(trigger(container));
+
+		expect(cards(container)).toHaveLength(SOURCES.length);
+		expect(warn).not.toHaveBeenCalled();
+		expect(error).not.toHaveBeenCalled();
+		warn.mockRestore();
+		error.mockRestore();
+	});
+});

--- a/src/lib/fancy-ui/sources/SourcesHarness.test.svelte
+++ b/src/lib/fancy-ui/sources/SourcesHarness.test.svelte
@@ -1,0 +1,36 @@
+<!--
+  Test-only composition rig. Snippets that mount components cannot be built from
+  a `.ts` test file, so the parts get exercised through real markup here — which
+  is also the only way to prove they read the context the root actually
+  publishes, rather than one the test invented. The bound `open` is echoed into
+  the DOM so a test can watch the binding write outwards. Not exported from
+  index.ts, and not collected by Vitest (the run includes `*.test.ts` only).
+-->
+<script lang="ts">
+	import type { SourceData } from "../_internals/ai-types.js";
+	import Sources from "./Sources.svelte";
+	import SourcesTrigger from "./SourcesTrigger.svelte";
+	import SourcesList from "./SourcesList.svelte";
+
+	interface Props {
+		sources: SourceData[];
+		open?: boolean;
+		label?: string;
+		onToggle?: (open: boolean) => void;
+		/** Swaps the default card for the local `row` snippet below. */
+		customItem?: boolean;
+	}
+
+	let { sources, open = $bindable(false), label, onToggle, customItem = false }: Props = $props();
+</script>
+
+{#snippet row(source: SourceData, index: number)}
+	<span data-testid="custom-item">{index}:{source.title}</span>
+{/snippet}
+
+<Sources {sources} bind:open {onToggle}>
+	<SourcesTrigger {label} />
+	<SourcesList item={customItem ? row : undefined} />
+</Sources>
+
+<span data-testid="bound-open">{open}</span>

--- a/src/lib/fancy-ui/sources/SourcesList.svelte
+++ b/src/lib/fancy-ui/sources/SourcesList.svelte
@@ -1,0 +1,123 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { SourceData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for SourcesList
+	 */
+	export interface SourcesListProps {
+		/** Replaces the default card. Receives the source and its index. */
+		item?: Snippet<[SourceData, number]>;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import SourceCard from "./SourceCard.svelte";
+	import { SOURCES_CONTEXT_KEY, type SourcesContext } from "./types.js";
+
+	let { item, class: className }: SourcesListProps = $props();
+
+	// Undefined when the list is used outside a Sources root: it then renders an
+	// empty, permanently open region rather than throwing.
+	const sources = getContext<SourcesContext | undefined>(SOURCES_CONTEXT_KEY);
+
+	const items = $derived(sources?.sources ?? []);
+	const isOpen = $derived(sources?.open.current ?? true);
+</script>
+
+<div class="ft-sources-list" class:ft-open={isOpen}>
+	<div class="overflow-hidden">
+		<ul
+			id={sources?.listId}
+			inert={!isOpen}
+			aria-label="Sources"
+			class={cn("ft-sources-grid", className)}
+		>
+			{#each items as source, index (source.id)}
+				<!--
+					The entrance animation hangs off `.ft-in` rather than mount, because
+					the cards never unmount: collapsing is a height transition over live
+					DOM, so re-adding the class is the only thing that can replay it.
+				-->
+				<li class="ft-sources-item" class:ft-in={isOpen} style:--ft-sources-index={index}>
+					{#if item}
+						{@render item(source, index)}
+					{:else}
+						<SourceCard {source} />
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	</div>
+</div>
+
+<style>
+	/*
+	 * 0fr → 1fr on a one-row grid is the only way to transition "auto" height
+	 * without measuring anything. The inner wrapper does the clipping.
+	 */
+	.ft-sources-list {
+		display: grid;
+		grid-template-rows: 0fr;
+	}
+
+	.ft-sources-list.ft-open {
+		grid-template-rows: 1fr;
+	}
+
+	/*
+	 * Cards flow into as many columns as the container can hold, so the same list
+	 * is a stack in a chat column and a grid in a document.
+	 */
+	.ft-sources-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(var(--ft-sources-min-column, 13rem), 1fr));
+		gap: var(--ft-sources-gap, 0.5rem);
+		/* The list reset is written out rather than borrowed from a utility, so the
+		   compound looks the same in an app whose CSS never resets `ul`. */
+		margin: 0;
+		padding: 0.5rem 0 0;
+		list-style: none;
+	}
+
+	.ft-sources-item {
+		display: flex;
+	}
+
+	.ft-sources-item > :global(*) {
+		flex: 1;
+		min-width: 0;
+	}
+
+	/*
+	 * Everything that moves lives behind the query, so reduced motion gets the
+	 * same two states with nothing to shorten or fall back from.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-sources-list {
+			transition: grid-template-rows 260ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+
+		.ft-sources-item.ft-in {
+			animation: ft-sources-in 240ms cubic-bezier(0.2, 0, 0, 1) backwards;
+			/* Clamped: past a handful of cards the stagger stops reading as sequence
+			   and starts reading as lag, so the tail all lands together. */
+			animation-delay: calc(min(var(--ft-sources-index, 0), 6) * 45ms);
+		}
+	}
+
+	@keyframes ft-sources-in {
+		from {
+			opacity: 0;
+			transform: translateY(0.375rem);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/sources/SourcesParts.test.ts
+++ b/src/lib/fancy-ui/sources/SourcesParts.test.ts
@@ -1,0 +1,273 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import type { SourceData } from "../_internals/ai-types.js";
+import SourceCard from "./SourceCard.svelte";
+import SourcesList from "./SourcesList.svelte";
+import SourcesTrigger from "./SourcesTrigger.svelte";
+import Harness from "./SourcesHarness.test.svelte";
+
+const SOURCES: SourceData[] = [
+	{ id: "s1", title: "Designing citation surfaces", url: "https://docs.example.dev/citations" },
+	{ id: "s2", title: "Attribution in answers", url: "https://research.example.org/attribution" },
+	{ id: "s3", title: "Ranking passages", url: "https://notes.example.net/ranking" },
+	{ id: "s4", title: "Evaluating retrieval", url: "https://eval.example.io/retrieval" },
+];
+
+function snippet(html: string) {
+	return createRawSnippet(() => ({ render: () => html }));
+}
+
+function card(container: HTMLElement): HTMLElement {
+	return container.querySelector(".ft-source-card") as HTMLElement;
+}
+
+function text(container: HTMLElement, selector: string): string {
+	return container.querySelector(selector)?.textContent?.trim() ?? "";
+}
+
+describe("SourceCard", () => {
+	afterEach(cleanup);
+
+	it("renders title, domain and snippet with no Sources root anywhere above it", () => {
+		const { container } = render(SourceCard, {
+			props: {
+				source: {
+					id: "s1",
+					title: "Designing citation surfaces",
+					url: "https://docs.example.dev/citations",
+					domain: "docs.example.dev",
+					snippet: "A citation is a promise that the answer can be checked.",
+				},
+			},
+		});
+
+		expect(text(container, ".ft-source-title")).toBe("Designing citation surfaces");
+		expect(text(container, ".ft-source-domain")).toBe("docs.example.dev");
+		expect(text(container, ".ft-source-snippet")).toBe(
+			"A citation is a promise that the answer can be checked."
+		);
+	});
+
+	it("derives the domain from the url when none is given, dropping the www", async () => {
+		const { container, rerender } = render(SourceCard, {
+			props: { source: { id: "s1", title: "T", url: "https://docs.example.dev/a/b?q=1" } },
+		});
+		expect(text(container, ".ft-source-domain")).toBe("docs.example.dev");
+
+		await rerender({ source: { id: "s1", title: "T", url: "https://www.example.org/a" } });
+		expect(text(container, ".ft-source-domain")).toBe("example.org");
+
+		// Hand-written fixtures rarely carry a scheme; `new URL` rejects those, so
+		// the fallback parser has to recognise a bare host.
+		await rerender({ source: { id: "s1", title: "T", url: "docs.example.dev/guide" } });
+		expect(text(container, ".ft-source-domain")).toBe("docs.example.dev");
+
+		// A relative link has no host at all — echoing its path back would be a lie.
+		await rerender({ source: { id: "s1", title: "T", url: "/local/guide" } });
+		expect(container.querySelector(".ft-source-domain")).toBeFalsy();
+	});
+
+	it("prefers an explicit domain over the one in the url", () => {
+		const { container } = render(SourceCard, {
+			props: {
+				source: {
+					id: "s1",
+					title: "T",
+					url: "https://cdn.example.dev/mirror/paper.pdf",
+					domain: "the standards body",
+				},
+			},
+		});
+		expect(text(container, ".ft-source-domain")).toBe("the standards body");
+	});
+
+	it("shows no domain line when there is nothing to show", () => {
+		const { container } = render(SourceCard, {
+			props: { source: { id: "s1", title: "An uncited note", url: "" } },
+		});
+
+		expect(container.querySelector(".ft-source-domain")).toBeFalsy();
+		expect(container.querySelector(".ft-source-snippet")).toBeFalsy();
+		expect(text(container, ".ft-source-title")).toBe("An uncited note");
+	});
+
+	it("is a link only when there is somewhere to go, and opens it safely", () => {
+		const { container } = render(SourceCard, {
+			props: { source: { id: "s1", title: "T", url: "https://docs.example.dev/a" } },
+		});
+		const anchor = container.querySelector("a") as HTMLAnchorElement;
+
+		expect(anchor).toBeTruthy();
+		expect(anchor.getAttribute("href")).toBe("https://docs.example.dev/a");
+		expect(anchor.getAttribute("target")).toBe("_blank");
+		expect(anchor.getAttribute("rel")).toBe("noopener noreferrer nofollow ugc");
+
+		cleanup();
+		const bare = render(SourceCard, { props: { source: { id: "s1", title: "T", url: "" } } });
+		expect(bare.container.querySelector("a")).toBeFalsy();
+		expect(card(bare.container).tagName).toBe("DIV");
+	});
+
+	it("stands in for a favicon with the domain's initial", () => {
+		const { container } = render(SourceCard, {
+			props: { source: { id: "s1", title: "Zebra", url: "https://docs.example.dev/a" } },
+		});
+		expect(text(container, ".ft-source-mark")).toBe("D");
+	});
+
+	it("falls back to the title's initial, then to a question mark", () => {
+		const titled = render(SourceCard, { props: { source: { id: "s1", title: "zebra", url: "" } } });
+		expect(text(titled.container, ".ft-source-mark")).toBe("Z");
+
+		cleanup();
+		const nameless = render(SourceCard, { props: { source: { id: "s1", title: "", url: "" } } });
+		expect(text(nameless.container, ".ft-source-mark")).toBe("?");
+	});
+
+	it("keeps a whole character when the initial is outside the BMP", () => {
+		const { container } = render(SourceCard, {
+			props: { source: { id: "s1", title: "𝒜pex", url: "" } },
+		});
+		expect(text(container, ".ft-source-mark")).toBe("𝒜");
+	});
+
+	it("lets an icon snippet replace the monogram", () => {
+		const { container } = render(SourceCard, {
+			props: {
+				source: { id: "s1", title: "T", url: "https://docs.example.dev/a" },
+				icon: snippet('<span data-testid="icon">*</span>'),
+			},
+		});
+
+		expect(container.querySelector('[data-testid="icon"]')).toBeTruthy();
+		expect(text(container, ".ft-source-mark")).toBe("*");
+	});
+
+	it("merges custom classes onto both the link and the plain shapes", () => {
+		const linked = render(SourceCard, {
+			props: { source: { id: "s1", title: "T", url: "https://docs.example.dev/a" }, class: "mine" },
+		});
+		expect(card(linked.container).className).toContain("mine");
+
+		cleanup();
+		const plain = render(SourceCard, {
+			props: { source: { id: "s1", title: "T", url: "" }, class: "mine" },
+		});
+		expect(card(plain.container).className).toContain("mine");
+	});
+});
+
+describe("SourcesTrigger", () => {
+	afterEach(cleanup);
+
+	it("degrades to an empty, harmless pill outside a Sources root", async () => {
+		const { container } = render(SourcesTrigger, {});
+		const button = container.querySelector("button") as HTMLButtonElement;
+
+		expect(button.textContent).toContain("0 sources");
+		expect(button.getAttribute("aria-expanded")).toBe("false");
+		expect(button.getAttribute("type")).toBe("button");
+		await fireEvent.click(button);
+		expect(button.getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("takes the count from the root it sits in", () => {
+		const { container } = render(Harness, { props: { sources: SOURCES } });
+		expect(container.querySelector("button")?.textContent).toContain("4 sources");
+	});
+
+	it("lets an explicit label override the count line", () => {
+		const { container } = render(Harness, {
+			props: { sources: SOURCES, label: "Checked against 4 papers" },
+		});
+		const button = container.querySelector("button") as HTMLButtonElement;
+
+		expect(button.textContent).toContain("Checked against 4 papers");
+		expect(button.textContent).not.toContain("4 sources");
+	});
+
+	it("stacks at most three monograms, in order, hidden from the reader", () => {
+		const { container } = render(Harness, { props: { sources: SOURCES } });
+		const stack = container.querySelector(".ft-sources-stack") as HTMLElement;
+		const chips = [...stack.querySelectorAll(".ft-sources-chip")].map((chip) =>
+			chip.textContent?.trim()
+		);
+
+		expect(chips).toEqual(["D", "R", "N"]);
+		expect(stack.getAttribute("aria-hidden")).toBe("true");
+	});
+});
+
+describe("SourcesList", () => {
+	afterEach(cleanup);
+
+	it("renders nothing but an open region outside a Sources root", () => {
+		const { container } = render(SourcesList, {});
+
+		expect(container.querySelectorAll(".ft-source-card")).toHaveLength(0);
+		// Nothing can open it from out here, so it must not start closed and
+		// swallow whatever a consumer put in it.
+		expect(container.querySelector(".ft-sources-list")?.className).toContain("ft-open");
+	});
+
+	it("renders one card per source from context", () => {
+		const { container } = render(Harness, { props: { sources: SOURCES, open: true } });
+		expect(container.querySelectorAll(".ft-source-card")).toHaveLength(4);
+	});
+
+	it("hands each source and its index to an item snippet instead of the card", () => {
+		const { container } = render(Harness, {
+			props: { sources: SOURCES, open: true, customItem: true },
+		});
+		const rows = [...container.querySelectorAll('[data-testid="custom-item"]')].map(
+			(row) => row.textContent
+		);
+
+		expect(rows).toEqual([
+			"0:Designing citation surfaces",
+			"1:Attribution in answers",
+			"2:Ranking passages",
+			"3:Evaluating retrieval",
+		]);
+		expect(container.querySelectorAll(".ft-source-card")).toHaveLength(0);
+	});
+
+	it("staggers the cards by index, and only while it is open", async () => {
+		const { container } = render(Harness, { props: { sources: SOURCES } });
+		const items = () => [...container.querySelectorAll(".ft-sources-item")] as HTMLElement[];
+
+		expect(items()[0].className).not.toContain("ft-in");
+
+		await fireEvent.click(container.querySelector("button") as HTMLButtonElement);
+		expect(items()[0].className).toContain("ft-in");
+		expect(items().map((item) => item.style.getPropertyValue("--ft-sources-index"))).toEqual([
+			"0",
+			"1",
+			"2",
+			"3",
+		]);
+	});
+
+	it("merges custom classes onto the grid", () => {
+		const { container } = render(SourcesList, { props: { class: "my-grid" } });
+		const grid = container.querySelector("ul") as HTMLElement;
+
+		expect(grid.className).toContain("my-grid");
+		expect(grid.className).toContain("ft-sources-grid");
+		expect(grid.getAttribute("aria-label")).toBe("Sources");
+	});
+
+	it("mounts without warnings when the parts are used bare", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		render(SourcesTrigger, {});
+		render(SourcesList, {});
+
+		expect(warn).not.toHaveBeenCalled();
+		expect(error).not.toHaveBeenCalled();
+		warn.mockRestore();
+		error.mockRestore();
+	});
+});

--- a/src/lib/fancy-ui/sources/SourcesParts.test.ts
+++ b/src/lib/fancy-ui/sources/SourcesParts.test.ts
@@ -271,3 +271,38 @@ describe("SourcesList", () => {
 		error.mockRestore();
 	});
 });
+
+describe("SourceCard — model-supplied urls", () => {
+	afterEach(cleanup);
+
+	const card = (url: string, props: Record<string, unknown> = {}) =>
+		render(SourceCard, {
+			props: { source: { id: "s", title: "A document", url } as SourceData, ...props },
+		});
+
+	it("refuses a scheme the family does not link to", () => {
+		for (const url of ["javascript:alert(1)", "data:text/html,<script>", "vbscript:x"]) {
+			const { container } = card(url);
+			expect(container.querySelector("a"), url).toBeNull();
+			cleanup();
+		}
+	});
+
+	it("makes a bare host absolute, so it cannot resolve against this app's origin", () => {
+		const { container } = card("docs.example.dev/guide");
+		expect(container.querySelector("a")?.getAttribute("href")).toBe(
+			"https://docs.example.dev/guide"
+		);
+	});
+
+	it("leaves a genuine relative path alone", () => {
+		const { container } = card("/local/guide");
+		expect(container.querySelector("a")?.getAttribute("href")).toBe("/local/guide");
+	});
+
+	it("renders the plain shape when it is told it cannot host a link", () => {
+		const { container } = card("https://docs.example.dev/guide", { interactive: false });
+		expect(container.querySelector("a")).toBeNull();
+		expect(container.textContent).toContain("A document");
+	});
+});

--- a/src/lib/fancy-ui/sources/SourcesTrigger.svelte
+++ b/src/lib/fancy-ui/sources/SourcesTrigger.svelte
@@ -1,0 +1,126 @@
+<script lang="ts" module>
+	/**
+	 * Props for SourcesTrigger
+	 */
+	export interface SourcesTriggerProps {
+		/** Overrides the count line. Defaults to "4 sources", singular at one. */
+		label?: string;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import { hostOf, monogram } from "../_internals/host.js";
+	import { SOURCES_CONTEXT_KEY, type SourcesContext } from "./types.js";
+
+	let { label, class: className }: SourcesTriggerProps = $props();
+
+	/** How many monograms fit in the stack before it stops meaning anything. */
+	const STACK_LIMIT = 3;
+
+	// Undefined when the pill is used outside a Sources root: it then renders an
+	// empty, inert count rather than throwing.
+	const sources = getContext<SourcesContext | undefined>(SOURCES_CONTEXT_KEY);
+
+	const count = $derived(sources?.count ?? 0);
+	const isOpen = $derived(sources?.open.current ?? false);
+	const stack = $derived((sources?.sources ?? []).slice(0, STACK_LIMIT));
+	const text = $derived(label ?? `${count} ${count === 1 ? "source" : "sources"}`);
+</script>
+
+<button
+	type="button"
+	class={cn(
+		"ft-sources-trigger text-muted-foreground hover:text-foreground inline-flex items-center gap-2 rounded-full px-2 py-1 text-xs",
+		className
+	)}
+	aria-expanded={isOpen}
+	aria-controls={sources?.listId}
+	onclick={() => sources?.toggle()}
+>
+	{#if stack.length > 0}
+		<!-- Decorative: every name in it is spelled out in the list below. -->
+		<span class="ft-sources-stack flex flex-none items-center" aria-hidden="true">
+			{#each stack as source (source.id)}
+				<span class="ft-sources-chip"
+					>{monogram(source.domain || hostOf(source.url) || source.title)}</span
+				>
+			{/each}
+		</span>
+	{/if}
+
+	<span class="font-medium">{text}</span>
+
+	<svg
+		class="ft-sources-chevron size-3 flex-none"
+		class:ft-open={isOpen}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2.5"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		aria-hidden="true"
+	>
+		<path d="m9 6 6 6-6 6" />
+	</svg>
+</button>
+
+<style>
+	.ft-sources-trigger {
+		border: 1px solid
+			var(
+				--ft-sources-card-border,
+				var(--color-border, color-mix(in oklab, currentColor 15%, transparent))
+			);
+		background: var(--ft-sources-trigger-bg, transparent);
+	}
+
+	.ft-sources-trigger:hover,
+	.ft-sources-trigger:focus-visible {
+		background: var(--ft-sources-card-hover-bg, color-mix(in oklab, currentColor 7%, transparent));
+	}
+
+	/*
+	 * Overlapping monograms read as "a handful of places", which is the whole job
+	 * of the collapsed pill. The ring is the surface colour rather than a border,
+	 * so the circles cut into each other instead of stacking two outlines.
+	 */
+	.ft-sources-chip {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1rem;
+		height: 1rem;
+		border-radius: 9999px;
+		box-shadow: 0 0 0 1.5px var(--ft-sources-chip-ring, var(--color-background, canvas));
+		background: var(--ft-sources-chip-bg, color-mix(in oklab, currentColor 12%, transparent));
+		color: var(--ft-sources-chip-fg, inherit);
+		font-size: 0.5rem;
+		font-weight: 600;
+		line-height: 1;
+	}
+
+	.ft-sources-chip:not(:first-child) {
+		margin-inline-start: -0.3125rem;
+	}
+
+	.ft-sources-chevron.ft-open {
+		transform: rotate(90deg);
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-sources-trigger {
+			transition:
+				background-color 150ms ease,
+				color 150ms ease;
+		}
+
+		.ft-sources-chevron {
+			transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/sources/index.ts
+++ b/src/lib/fancy-ui/sources/index.ts
@@ -1,0 +1,20 @@
+import Sources from "./Sources.svelte";
+import SourcesTrigger from "./SourcesTrigger.svelte";
+import SourcesList from "./SourcesList.svelte";
+import SourceCard from "./SourceCard.svelte";
+import type { SourcesProps } from "./Sources.svelte";
+import type { SourcesTriggerProps } from "./SourcesTrigger.svelte";
+import type { SourcesListProps } from "./SourcesList.svelte";
+import type { SourceCardProps } from "./SourceCard.svelte";
+
+export {
+	Sources,
+	SourcesTrigger,
+	SourcesList,
+	SourceCard,
+	type SourcesProps,
+	type SourcesTriggerProps,
+	type SourcesListProps,
+	type SourceCardProps,
+};
+export { SOURCES_CONTEXT_KEY, type SourcesContext } from "./types.js";

--- a/src/lib/fancy-ui/sources/types.ts
+++ b/src/lib/fancy-ui/sources/types.ts
@@ -1,0 +1,27 @@
+/**
+ * The contract between the sources root and its parts.
+ *
+ * `Sources` publishes a live, read-only view of the citation set it holds, plus
+ * the one function that changes anything about it. Every part reads it through
+ * `getContext` rather than having the same values threaded back down as props,
+ * so a trigger and a list can sit at different depths of a consumer's own markup
+ * and still agree on what is open and what is being cited.
+ */
+
+import type { SourceData } from "../_internals/ai-types.js";
+
+/** What the root publishes. Parts read it; only the root writes it. */
+export interface SourcesContext {
+	/** Whether the list is expanded. A getter, so reading it in a reactive scope tracks it. */
+	readonly open: { readonly current: boolean };
+	/** How many sources back the answer. */
+	readonly count: number;
+	/** The sources themselves, so a list never needs them threaded down as a prop. */
+	readonly sources: readonly SourceData[];
+	/** The id the list puts on its region, so a trigger can point `aria-controls` at it. */
+	readonly listId: string;
+	/** Flip the list open or closed. */
+	toggle(): void;
+}
+
+export const SOURCES_CONTEXT_KEY = Symbol("sources-context");

--- a/src/lib/fancy-ui/web-search/README.md
+++ b/src/lib/fancy-ui/web-search/README.md
@@ -1,0 +1,105 @@
+# Web Search
+
+A search the agent ran, shown as it happens: the query in a search-bar header, a scanning bar while the lookup is in flight, and result rows that land one at a time as they are found.
+
+## Components
+
+- `WebSearch` - Query header, scanning bar, and an appending list of hits
+
+## Usage
+
+```svelte
+<script>
+	import { WebSearch } from "fancy-ui-svelte";
+
+	let searching = $state(true);
+	let results = $state([]);
+
+	// Each hit is pushed onto the array as it arrives; the row for it animates in
+	// on its own and the ones already on screen stay put.
+	for await (const hit of agent.search("svelte 5 runes reactivity")) {
+		results = [...results, hit];
+	}
+	searching = false;
+</script>
+
+<WebSearch query="svelte 5 runes reactivity" {results} {searching} maxVisible={4} />
+```
+
+Results are `SearchResultData`, the shape shared across the AI family:
+
+```ts
+import type { SearchResultData } from "fancy-ui-svelte";
+
+const result: SearchResultData = {
+	id: "r1",
+	title: "Runes, one year in",
+	url: "https://www.example.dev/blog/runes",
+	snippet: "What changed once fine-grained reactivity replaced the compiler heuristics.",
+};
+```
+
+## Props
+
+| Prop         | Type                                                | Default        | Description                                                                    |
+| ------------ | --------------------------------------------------- | -------------- | ------------------------------------------------------------------------------ |
+| `query`      | `string`                                            | —              | What the agent looked up, shown in the search-bar header (required)            |
+| `results`    | `SearchResultData[]`                                | —              | Hits found so far, oldest first; appending to it lands a new row (required)    |
+| `searching`  | `boolean`                                           | `false`        | Whether the lookup is still running: drives the scanning bar and waiting state |
+| `onSelect`   | `(result: SearchResultData, index: number) => void` | `undefined`    | Called when a row is activated; supplying it turns every row into a button     |
+| `maxVisible` | `number`                                            | `0`            | Rows shown before the expander takes over; `0` shows every result              |
+| `label`      | `string`                                            | `'Web search'` | Accessible name for the whole block                                            |
+| `class`      | `string`                                            | `undefined`    | Additional CSS classes                                                         |
+| `ref`        | `HTMLDivElement \| null`                            | `null`         | Bindable element reference                                                     |
+
+## Slots
+
+| Snippet | Arguments                                   | Description                                                       |
+| ------- | ------------------------------------------- | ----------------------------------------------------------------- |
+| `item`  | `(result: SearchResultData, index: number)` | Replaces the built-in row body, keeping the row and its behaviour |
+
+```svelte
+<WebSearch {query} {results}>
+	{#snippet item(result)}
+		<span class="flex min-w-0 flex-col">
+			<span class="truncate font-medium">{result.title}</span>
+			<span class="text-muted-foreground truncate text-xs">{result.url}</span>
+		</span>
+	{/snippet}
+</WebSearch>
+```
+
+The override owns the row's contents, not the row itself: a hit with a `url` is still a link, and one with an `onSelect` is still a button.
+
+## Theming
+
+| Variable                        | Default               | Effect                           |
+| ------------------------------- | --------------------- | -------------------------------- |
+| `--ft-websearch-beam`           | `--ft-status-running` | Colour of the scanning bar       |
+| `--ft-websearch-track`          | `currentColor` at 12% | The groove the beam runs in      |
+| `--ft-websearch-monogram-bg`    | `currentColor` at 10% | Background of the domain initial |
+| `--ft-websearch-scan-duration`  | `1.4s`                | One sweep of the scanning bar    |
+| `--ft-websearch-enter-duration` | `260ms`               | How long a new row takes to land |
+| `--ft-websearch-snippet-lines`  | `2`                   | Lines of snippet before clamping |
+
+The beam defaults to `--ft-status-running`, the run-status vocabulary shared with `ToolCall`, `ToolTimeline`, `TerminalBlock`, `CodeDiff` and `ChatError` — set that to retint every in-flight state in the family at once, or `--ft-websearch-beam` to move this component alone. Its own default is a `light-dark()` pair, so a page that declares `color-scheme` gets a legible accent on both themes without configuring anything.
+
+```css
+.transcript {
+	--ft-websearch-snippet-lines: 3;
+	--ft-websearch-scan-duration: 2s;
+}
+```
+
+## Implementation Notes
+
+- The `{#each}` is keyed on `result.id`, which is what makes the list append rather than redraw. A preserved node has already played its entrance and a CSS animation does not replay on an element that has one, so pushing a hit onto `results` animates exactly the new row and leaves the rest untouched. Reusing an id for a different result would put the old row's node behind the new data and skip its entrance.
+- No stagger. The delay a cascade needs belongs to a row's position in a batch, and these rows arrive one at a time — a fourth hit landing three stagger-beats after it was found would read as lag, not as choreography.
+- The scanning bar is deliberately indeterminate: a search reports no progress, so nothing here may look like a percentage. Under reduced motion the beam fills the whole groove at low opacity instead of freezing 40% of the way along, which would read as a bar stuck at 40%.
+- Both animations live entirely inside `@media (prefers-reduced-motion: no-preference)`. With the rules gone a new row is simply present at its final position and the bar is a steady tint; there is no reduced-motion variant to keep in sync.
+- The row element follows the data. `onSelect` wins and makes every row a `type="button"`; otherwise a `url` makes it an `<a>`, and a hit with neither — a blank `url` and no handler — is an inert `<div>`. Nothing is a fake button, and nothing focusable does nothing.
+- Links carry `rel="noopener noreferrer nofollow ugc"` and `target="_blank"`. These are somebody else's pages surfaced by a model: `nofollow ugc` stops the host from vouching for them to search engines, and `noopener noreferrer` keeps the opened tab from reaching back.
+- The monogram is the first letter or digit of the registrable domain, so a title starting with a quote or a bullet does not put punctuation in the circle. A blank, relative, or malformed `url` has no host to show: the domain line disappears and the monogram falls back to the title. Hosts and monograms are derived the same way here as on source cards, from one shared helper.
+- `maxVisible` is a display cap, not a slice of the data — the count in the header always reports everything in `results`, and the expander label tracks new hits as they land behind it.
+- Expanding is a request about one result set, and it retires with it. Emptying `results` — which is how a component driven by a live agent starts its next search — collapses the list again, so the following set arrives capped like the first instead of inheriting an expansion the reader asked for on results they can no longer see.
+- The group is `role="group"` with `aria-label` from `label`, and carries `aria-busy` while the search runs, so a transcript announces the whole block as one named set rather than as loose links. The scanning bar is `aria-hidden`; "Searching…" says it in words while there is nothing to read.

--- a/src/lib/fancy-ui/web-search/WebSearch.svelte
+++ b/src/lib/fancy-ui/web-search/WebSearch.svelte
@@ -1,0 +1,318 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { SearchResultData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for WebSearch
+	 */
+	export interface WebSearchProps {
+		/** What the agent looked up, shown in the search-bar header */
+		query: string;
+		/** Hits found so far, oldest first; appending to it lands a new row */
+		results: SearchResultData[];
+		/** Whether the lookup is still running: drives the scanning bar and the waiting state */
+		searching?: boolean;
+		/** Called when a row is activated; supplying it turns every row into a button */
+		onSelect?: (result: SearchResultData, index: number) => void;
+		/** Replaces the built-in row body, keeping the row element and its behaviour */
+		item?: Snippet<[SearchResultData, number]>;
+		/** Rows shown before the expander takes over; `0` shows every result */
+		maxVisible?: number;
+		/** Accessible name for the whole block */
+		label?: string;
+		/** Additional CSS classes */
+		class?: string;
+		/** Element reference */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { hostOf, monogram } from "../_internals/host.js";
+
+	let {
+		query,
+		results,
+		searching = false,
+		onSelect,
+		item,
+		maxVisible = 0,
+		label = "Web search",
+		class: className,
+		ref = $bindable(null),
+	}: WebSearchProps = $props();
+
+	const ROW_BASE =
+		"ft-websearch-row flex w-full items-start gap-2.5 rounded-md px-2 py-1.5 text-left";
+	const ROW_INTERACTIVE =
+		"hover:bg-muted/60 focus-visible:bg-muted/60 focus-visible:ring-ring cursor-pointer transition-colors focus-visible:ring-1 focus-visible:outline-none";
+
+	const uid = $props.id();
+	const listId = `${uid}-list`;
+
+	let expanded = $state(false);
+
+	// `0` — and any value below it, which would otherwise hide everything — means
+	// the list is its own cap.
+	const cap = $derived(maxVisible > 0 ? Math.floor(maxVisible) : results.length);
+	const hiddenCount = $derived(Math.max(0, results.length - cap));
+
+	// Expansion only means anything while something is hidden: with nothing behind
+	// the cap there is no expanded state to be in, and the label and `aria-expanded`
+	// would otherwise describe a button that is not on screen.
+	const isExpanded = $derived(expanded && hiddenCount > 0);
+	const visible = $derived(isExpanded || hiddenCount === 0 ? results : results.slice(0, cap));
+	const countText = $derived(results.length === 1 ? "1 result" : `${results.length} results`);
+
+	// An emptied list is a new search starting, not the old one still expanded: the
+	// reader asked to see the rest of a result set that no longer exists, so the
+	// request retires with it and the next set arrives capped like the first.
+	$effect(() => {
+		if (results.length === 0) expanded = false;
+	});
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("ft-websearch w-full text-sm", className)}
+	role="group"
+	aria-label={label}
+	aria-busy={searching}
+>
+	<div
+		class="ft-websearch-header border-border bg-background/60 flex items-center gap-2 rounded-lg border px-3 py-2"
+	>
+		<svg
+			class="text-muted-foreground size-3.5 flex-none"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<circle cx="11" cy="11" r="7" />
+			<path d="m20 20-3.6-3.6" />
+		</svg>
+
+		<span class="ft-websearch-query text-foreground min-w-0 flex-1 truncate" title={query}
+			>{query}</span
+		>
+
+		{#if results.length > 0}
+			<span class="ft-websearch-count text-muted-foreground flex-none text-xs tabular-nums"
+				>{countText}</span
+			>
+		{/if}
+	</div>
+
+	<!--
+		Decorative: `aria-busy` on the group already says the lookup is running, and
+		the waiting line below says it in words while there is nothing to read.
+	-->
+	{#if searching}
+		<div class="ft-websearch-scan mt-1.5" aria-hidden="true">
+			<span class="ft-websearch-beam"></span>
+		</div>
+	{/if}
+
+	{#if visible.length > 0}
+		<ul id={listId} class="ft-websearch-list mt-1.5">
+			<!--
+				Keyed by id so an appended hit mounts as a fresh node and plays the
+				entrance on its own, while the rows already on screen keep the DOM nodes
+				they had — a CSS animation does not replay on an element that has one.
+			-->
+			{#each visible as result, index (result.id)}
+				{@const domain = hostOf(result.url)}
+				<li class="ft-websearch-item">
+					{#snippet body()}
+						{#if item}
+							{@render item(result, index)}
+						{:else}
+							<!-- A row with no parsable host falls back to its title for the circle. -->
+							<span class="ft-websearch-monogram" aria-hidden="true"
+								>{monogram(domain || result.title)}</span
+							>
+							<span class="ft-websearch-text min-w-0 flex-1">
+								<span class="ft-websearch-title text-foreground block truncate font-medium"
+									>{result.title}</span
+								>
+								{#if domain}
+									<span class="ft-websearch-domain text-muted-foreground block truncate text-xs"
+										>{domain}</span
+									>
+								{/if}
+								{#if result.snippet}
+									<span class="ft-websearch-snippet text-muted-foreground mt-0.5 text-xs"
+										>{result.snippet}</span
+									>
+								{/if}
+							</span>
+						{/if}
+					{/snippet}
+
+					{#if onSelect}
+						<button
+							type="button"
+							class={cn(ROW_BASE, ROW_INTERACTIVE)}
+							onclick={() => onSelect?.(result, index)}
+						>
+							{@render body()}
+						</button>
+					{:else if result.url}
+						<!--
+							Somebody else's page, arriving from a model: `nofollow ugc` keeps the
+							host from vouching for it, and `noopener noreferrer` keeps the opened
+							tab away from this one.
+						-->
+						<a
+							class={cn(ROW_BASE, ROW_INTERACTIVE)}
+							href={result.url}
+							target="_blank"
+							rel="noopener noreferrer nofollow ugc"
+						>
+							{@render body()}
+						</a>
+					{:else}
+						<div class={ROW_BASE}>
+							{@render body()}
+						</div>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	{:else if searching}
+		<p class="ft-websearch-status text-muted-foreground mt-1.5 px-2 text-xs">Searching…</p>
+	{:else}
+		<p class="ft-websearch-empty text-muted-foreground mt-1.5 px-2 text-xs">No results</p>
+	{/if}
+
+	{#if hiddenCount > 0}
+		<button
+			type="button"
+			class="ft-websearch-more text-muted-foreground hover:text-foreground focus-visible:ring-ring mt-1 cursor-pointer rounded-md px-2 py-1 text-xs transition-colors focus-visible:ring-1 focus-visible:outline-none"
+			aria-expanded={isExpanded}
+			aria-controls={listId}
+			onclick={() => (expanded = !isExpanded)}
+		>
+			{isExpanded ? "Show less" : `Show ${hiddenCount} more`}
+		</button>
+	{/if}
+</div>
+
+<style>
+	.ft-websearch {
+		/* Neutral surfaces are mixes of currentColor, so one set of values reads
+		   correctly in both themes. The beam cannot do that — an accent that is a
+		   fade of the text colour is not an accent — so it is read at its point of
+		   use off the `--ft-status-*` vocabulary this family shares, whose defaults
+		   are per-theme `light-dark()` pairs. */
+		--ft-websearch-track: color-mix(in oklab, currentColor 12%, transparent);
+		--ft-websearch-monogram-bg: color-mix(in oklab, currentColor 10%, transparent);
+		--ft-websearch-scan-duration: 1.4s;
+		--ft-websearch-enter-duration: 260ms;
+		--ft-websearch-snippet-lines: 2;
+	}
+
+	.ft-websearch-list {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.ft-websearch-scan {
+		position: relative;
+		height: 2px;
+		overflow: hidden;
+		border-radius: 9999px;
+		background: var(--ft-websearch-track);
+	}
+
+	/*
+	 * Reduced motion gets a filled bar rather than a parked beam: a 40% sliver
+	 * frozen at the left edge reads as a progress bar stuck at 40%, which is a
+	 * claim this component cannot make.
+	 */
+	.ft-websearch-beam {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		border-radius: inherit;
+		background: var(
+			--ft-websearch-beam,
+			var(--ft-status-running, light-dark(oklch(0.5 0.18 265), oklch(0.72 0.15 265)))
+		);
+		opacity: 0.45;
+	}
+
+	.ft-websearch-monogram {
+		display: inline-flex;
+		flex: none;
+		align-items: center;
+		justify-content: center;
+		/* Sits on the middle of the title's line box rather than its top. */
+		margin-top: 0.0625rem;
+		width: 1.25rem;
+		height: 1.25rem;
+		border-radius: 9999px;
+		background: var(--ft-websearch-monogram-bg);
+		font-size: 0.625rem;
+		font-weight: 600;
+		line-height: 1;
+	}
+
+	/* The clamp owns `display`, so the snippet carries no display utility. */
+	.ft-websearch-snippet {
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: var(--ft-websearch-snippet-lines);
+		line-clamp: var(--ft-websearch-snippet-lines);
+		overflow: hidden;
+		line-height: 1.45;
+	}
+
+	/*
+	 * Both animations live entirely inside `no-preference`, so reduced motion is
+	 * not a degraded variant to keep in sync: a new row simply appears where it
+	 * belongs, and the scanning bar is a steady tint instead of a sweep.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-websearch-item {
+			animation: ft-websearch-enter var(--ft-websearch-enter-duration) cubic-bezier(0.16, 1, 0.3, 1);
+		}
+
+		.ft-websearch-beam {
+			right: auto;
+			width: 40%;
+			opacity: 1;
+			animation: ft-websearch-scan var(--ft-websearch-scan-duration) ease-in-out infinite;
+		}
+	}
+
+	@keyframes ft-websearch-enter {
+		from {
+			opacity: 0;
+			transform: translateY(4px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+
+	/* 250% of a 40%-wide beam is one full track, so it leaves on the right exactly
+	   as it entered on the left. */
+	@keyframes ft-websearch-scan {
+		from {
+			transform: translateX(-100%);
+		}
+		to {
+			transform: translateX(250%);
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/web-search/WebSearch.svelte
+++ b/src/lib/fancy-ui/web-search/WebSearch.svelte
@@ -30,6 +30,22 @@
 <script lang="ts">
 	import { cn } from "$lib/utils.js";
 	import { hostOf, monogram } from "../_internals/host.js";
+	import { sanitizeHref } from "../_internals/markdown.js";
+
+	/**
+	 * A result url made safe for an `href`, or `null` when it must not be a link
+	 * at all. These arrive from a model with the rest of the answer, so they clear
+	 * the same scheme check as every link in this family; a bare host is promoted
+	 * to `https://` first, since an `href` of "docs.example.dev/guide" resolves
+	 * against this app's own origin. A genuine relative path is left alone.
+	 */
+	function resolveHref(raw: string | undefined): string | null {
+		if (typeof raw !== "string" || raw === "") return null;
+		const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(raw) || raw.startsWith("//");
+		const host = raw.split(/[/?#]/, 1)[0];
+		const looksHostLike = !hasScheme && !raw.startsWith("/") && host.includes(".");
+		return sanitizeHref(looksHostLike ? `https://${raw}` : raw);
+	}
 
 	let {
 		query,
@@ -127,6 +143,7 @@
 			-->
 			{#each visible as result, index (result.id)}
 				{@const domain = hostOf(result.url)}
+				{@const safeHref = resolveHref(result.url)}
 				<li class="ft-websearch-item">
 					{#snippet body()}
 						{#if item}
@@ -162,7 +179,7 @@
 						>
 							{@render body()}
 						</button>
-					{:else if result.url}
+					{:else if safeHref}
 						<!--
 							Somebody else's page, arriving from a model: `nofollow ugc` keeps the
 							host from vouching for it, and `noopener noreferrer` keeps the opened
@@ -170,7 +187,7 @@
 						-->
 						<a
 							class={cn(ROW_BASE, ROW_INTERACTIVE)}
-							href={result.url}
+							href={safeHref}
 							target="_blank"
 							rel="noopener noreferrer nofollow ugc"
 						>

--- a/src/lib/fancy-ui/web-search/WebSearch.test.ts
+++ b/src/lib/fancy-ui/web-search/WebSearch.test.ts
@@ -320,4 +320,24 @@ describe("WebSearch", () => {
 		expect(cls).toContain("w-full");
 		expect(cls).toContain("mt-4");
 	});
+
+	describe("model-supplied result urls", () => {
+		const one = (url: string) =>
+			render(WebSearch, {
+				props: { query: "runes", results: [{ id: "r", title: "A result", url }] },
+			});
+
+		it("refuses a scheme the family does not link to, and still shows the row", () => {
+			const { container } = one("javascript:alert(1)");
+			expect(container.querySelector("a")).toBeNull();
+			expect(container.textContent).toContain("A result");
+		});
+
+		it("makes a bare host absolute rather than resolving it against this origin", () => {
+			const { container } = one("docs.example.dev/guide");
+			expect(container.querySelector("a")?.getAttribute("href")).toBe(
+				"https://docs.example.dev/guide"
+			);
+		});
+	});
 });

--- a/src/lib/fancy-ui/web-search/WebSearch.test.ts
+++ b/src/lib/fancy-ui/web-search/WebSearch.test.ts
@@ -1,0 +1,323 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import type { SearchResultData } from "../_internals/ai-types.js";
+import WebSearch from "./WebSearch.svelte";
+
+const QUERY = "svelte 5 runes reactivity";
+
+const RESULTS: SearchResultData[] = [
+	{
+		id: "r1",
+		title: "Runes, one year in",
+		url: "https://www.example.dev/blog/runes",
+		snippet: "What changed once fine-grained reactivity replaced the compiler heuristics.",
+	},
+	{
+		id: "r2",
+		title: "Deriving state without effects",
+		url: "https://notes.example.org/derived",
+		snippet: "A tour of $derived and when $effect is the wrong tool.",
+	},
+	{
+		id: "r3",
+		title: "Migration notes",
+		url: "https://example.net/migration",
+	},
+];
+
+function root(container: HTMLElement): HTMLElement {
+	return container.firstElementChild as HTMLElement;
+}
+
+function items(container: HTMLElement): HTMLLIElement[] {
+	return [...container.querySelectorAll<HTMLLIElement>(".ft-websearch-item")];
+}
+
+function rows(container: HTMLElement): HTMLElement[] {
+	return [...container.querySelectorAll<HTMLElement>(".ft-websearch-row")];
+}
+
+function more(container: HTMLElement): HTMLButtonElement | null {
+	return container.querySelector<HTMLButtonElement>(".ft-websearch-more");
+}
+
+function text(container: HTMLElement, selector: string): string {
+	return container.querySelector(selector)?.textContent?.trim() ?? "";
+}
+
+describe("WebSearch", () => {
+	afterEach(cleanup);
+
+	it("renders the query in the header", () => {
+		const { container } = render(WebSearch, { props: { query: QUERY, results: [] } });
+		expect(text(container, ".ft-websearch-query")).toBe(QUERY);
+	});
+
+	it("renders one row per result, in order", () => {
+		const { container } = render(WebSearch, { props: { query: QUERY, results: RESULTS } });
+
+		expect(items(container)).toHaveLength(3);
+		expect(
+			[...container.querySelectorAll(".ft-websearch-title")].map((n) => n.textContent)
+		).toEqual(RESULTS.map((r) => r.title));
+	});
+
+	it("counts the results in the header, singular and plural", () => {
+		const { container, rerender } = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS },
+		});
+		expect(text(container, ".ft-websearch-count")).toBe("3 results");
+
+		void rerender({ query: QUERY, results: RESULTS.slice(0, 1) });
+		expect(text(container, ".ft-websearch-count")).toBe("1 result");
+	});
+
+	it("omits the count while nothing has been found", () => {
+		const { container } = render(WebSearch, { props: { query: QUERY, results: [] } });
+		expect(container.querySelector(".ft-websearch-count")).toBeNull();
+	});
+
+	it("shows the domain without its www prefix, and a monogram taken from it", () => {
+		const { container } = render(WebSearch, { props: { query: QUERY, results: RESULTS } });
+		const domains = [...container.querySelectorAll(".ft-websearch-domain")].map(
+			(n) => n.textContent
+		);
+
+		expect(domains).toEqual(["example.dev", "notes.example.org", "example.net"]);
+		expect(text(container, ".ft-websearch-monogram")).toBe("E");
+	});
+
+	it("drops the domain line and falls back to the title when the url is blank", () => {
+		const { container } = render(WebSearch, {
+			props: { query: QUERY, results: [{ id: "r1", title: "Local note", url: "" }] },
+		});
+
+		expect(container.querySelector(".ft-websearch-domain")).toBeNull();
+		expect(text(container, ".ft-websearch-monogram")).toBe("L");
+	});
+
+	it("survives a url it cannot parse", () => {
+		const { container } = render(WebSearch, {
+			props: { query: QUERY, results: [{ id: "r1", title: "Relative", url: "/not/absolute" }] },
+		});
+
+		expect(container.querySelector(".ft-websearch-domain")).toBeNull();
+		expect(rows(container)[0].tagName).toBe("A");
+	});
+
+	it("keeps the rows already on screen when a result is appended", async () => {
+		const first = RESULTS.slice(0, 2);
+		const { container, rerender } = render(WebSearch, {
+			props: { query: QUERY, results: first },
+		});
+
+		const before = items(container);
+		expect(before).toHaveLength(2);
+
+		await rerender({ query: QUERY, results: [...first, RESULTS[2]] });
+		const after = items(container);
+
+		// Identity is what the entrance hangs off: a preserved node has already
+		// played its animation and will not replay it, so only the node that is new
+		// here animates.
+		expect(after).toHaveLength(3);
+		expect(after[0]).toBe(before[0]);
+		expect(after[1]).toBe(before[1]);
+		expect(after[2]).not.toBe(before[1]);
+	});
+
+	it("renders the scanning bar only while searching", async () => {
+		const { container, rerender } = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS, searching: true },
+		});
+
+		expect(container.querySelector(".ft-websearch-scan")).not.toBeNull();
+		expect(root(container).getAttribute("aria-busy")).toBe("true");
+
+		await rerender({ query: QUERY, results: RESULTS, searching: false });
+
+		expect(container.querySelector(".ft-websearch-scan")).toBeNull();
+		expect(root(container).getAttribute("aria-busy")).toBe("false");
+	});
+
+	it("says it is searching while nothing has landed yet", () => {
+		const { container } = render(WebSearch, {
+			props: { query: QUERY, results: [], searching: true },
+		});
+
+		expect(text(container, ".ft-websearch-status")).toBe("Searching…");
+		expect(container.querySelector(".ft-websearch-empty")).toBeNull();
+	});
+
+	it("reports an empty result set once the search is over", () => {
+		const { container } = render(WebSearch, {
+			props: { query: QUERY, results: [], searching: false },
+		});
+
+		expect(text(container, ".ft-websearch-empty")).toBe("No results");
+		expect(container.querySelector(".ft-websearch-status")).toBeNull();
+	});
+
+	it("links each row out when there is a url and no onSelect", () => {
+		const { container } = render(WebSearch, { props: { query: QUERY, results: RESULTS } });
+		const anchor = rows(container)[0] as HTMLAnchorElement;
+
+		expect(anchor.tagName).toBe("A");
+		expect(anchor.getAttribute("href")).toBe(RESULTS[0].url);
+		expect(anchor.getAttribute("target")).toBe("_blank");
+		expect(anchor.getAttribute("rel")).toBe("noopener noreferrer nofollow ugc");
+	});
+
+	it("turns every row into a button when onSelect is given, url or not", () => {
+		const { container } = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS, onSelect: vi.fn() },
+		});
+
+		for (const row of rows(container)) {
+			expect(row.tagName).toBe("BUTTON");
+			expect(row.getAttribute("type")).toBe("button");
+			expect(row.hasAttribute("href")).toBe(false);
+		}
+	});
+
+	it("renders an inert row when there is neither a url nor an onSelect", () => {
+		const { container } = render(WebSearch, {
+			props: { query: QUERY, results: [{ id: "r1", title: "Nowhere to go", url: "" }] },
+		});
+		expect(rows(container)[0].tagName).toBe("DIV");
+	});
+
+	it("calls onSelect with the result and its index", async () => {
+		const onSelect = vi.fn();
+		const { container } = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS, onSelect },
+		});
+
+		await fireEvent.click(rows(container)[1]);
+
+		expect(onSelect).toHaveBeenCalledTimes(1);
+		expect(onSelect).toHaveBeenCalledWith(RESULTS[1], 1);
+	});
+
+	it("shows every result and no expander by default", () => {
+		const { container } = render(WebSearch, { props: { query: QUERY, results: RESULTS } });
+
+		expect(items(container)).toHaveLength(3);
+		expect(more(container)).toBeNull();
+	});
+
+	it("clamps to maxVisible and offers the rest behind an expander", async () => {
+		const { container } = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS, maxVisible: 1 },
+		});
+
+		expect(items(container)).toHaveLength(1);
+
+		const button = more(container);
+		expect(button?.textContent?.trim()).toBe("Show 2 more");
+		expect(button?.getAttribute("aria-expanded")).toBe("false");
+
+		await fireEvent.click(button!);
+
+		expect(items(container)).toHaveLength(3);
+		expect(more(container)?.textContent?.trim()).toBe("Show less");
+		expect(more(container)?.getAttribute("aria-expanded")).toBe("true");
+
+		await fireEvent.click(more(container)!);
+		expect(items(container)).toHaveLength(1);
+	});
+
+	it("points the expander at the list it controls", () => {
+		const { container } = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS, maxVisible: 2 },
+		});
+
+		const listId = container.querySelector(".ft-websearch-list")?.id;
+		expect(listId).toBeTruthy();
+		expect(more(container)?.getAttribute("aria-controls")).toBe(listId);
+	});
+
+	it("treats a maxVisible of zero or less as no cap at all", () => {
+		const { container } = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS, maxVisible: 0 },
+		});
+		expect(items(container)).toHaveLength(3);
+
+		cleanup();
+
+		const negative = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS, maxVisible: -3 },
+		});
+		expect(items(negative.container)).toHaveLength(3);
+		expect(more(negative.container)).toBeNull();
+	});
+
+	it("keeps the expander honest as results keep landing", async () => {
+		const { container, rerender } = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS.slice(0, 2), maxVisible: 1 },
+		});
+		expect(more(container)?.textContent?.trim()).toBe("Show 1 more");
+
+		await rerender({ query: QUERY, results: RESULTS, maxVisible: 1 });
+		expect(more(container)?.textContent?.trim()).toBe("Show 2 more");
+	});
+
+	it("retires the expansion when the list empties, so the next search starts capped", async () => {
+		const { container, rerender } = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS, maxVisible: 1 },
+		});
+
+		await fireEvent.click(more(container)!);
+		expect(items(container)).toHaveLength(3);
+
+		// A new search wipes the list before its first hits land. The reader asked to
+		// see the rest of a result set that no longer exists.
+		await rerender({ query: QUERY, results: [], maxVisible: 1 });
+		expect(items(container)).toHaveLength(0);
+
+		await rerender({ query: QUERY, results: RESULTS, maxVisible: 1 });
+		expect(items(container)).toHaveLength(1);
+		expect(more(container)?.textContent?.trim()).toBe("Show 2 more");
+		expect(more(container)?.getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("renders the item snippet in place of the built-in row body", () => {
+		const item = createRawSnippet<[SearchResultData, number]>((result, index) => ({
+			render: () => `<span class="custom-row">${index()}: ${result().title}</span>`,
+		}));
+
+		const { container } = render(WebSearch, { props: { query: QUERY, results: RESULTS, item } });
+		const custom = container.querySelectorAll(".custom-row");
+
+		expect(custom).toHaveLength(3);
+		expect(custom[1].textContent).toBe("1: Deriving state without effects");
+		expect(container.querySelector(".ft-websearch-monogram")).toBeNull();
+		// The override owns the body, not the row: the link is still a link.
+		expect(rows(container)[0].tagName).toBe("A");
+	});
+
+	it("exposes a labelled group, overridable through the label prop", () => {
+		const { container } = render(WebSearch, { props: { query: QUERY, results: RESULTS } });
+		expect(root(container).getAttribute("role")).toBe("group");
+		expect(root(container).getAttribute("aria-label")).toBe("Web search");
+
+		cleanup();
+
+		const named = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS, label: "Sources consulted" },
+		});
+		expect(root(named.container).getAttribute("aria-label")).toBe("Sources consulted");
+	});
+
+	it("merges the class prop with the base layout classes", () => {
+		const { container } = render(WebSearch, {
+			props: { query: QUERY, results: RESULTS, class: "mt-4" },
+		});
+		const cls = root(container).className;
+
+		expect(cls).toContain("ft-websearch");
+		expect(cls).toContain("w-full");
+		expect(cls).toContain("mt-4");
+	});
+});

--- a/src/lib/fancy-ui/web-search/index.ts
+++ b/src/lib/fancy-ui/web-search/index.ts
@@ -1,0 +1,4 @@
+import WebSearch from "./WebSearch.svelte";
+import type { WebSearchProps } from "./WebSearch.svelte";
+
+export { WebSearch, type WebSearchProps };

--- a/src/stories/image-generation.stories.svelte
+++ b/src/stories/image-generation.stories.svelte
@@ -1,0 +1,76 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ImageGeneration } from "$lib/fancy-ui/image-generation";
+
+	// Drawn locally so the story has no network dependency in any environment.
+	const artwork = `data:image/svg+xml,${encodeURIComponent(
+		`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'>
+			<defs>
+				<linearGradient id='sky' x1='0' y1='0' x2='0.4' y2='1'>
+					<stop offset='0' stop-color='hsl(258 85% 40%)'/>
+					<stop offset='0.55' stop-color='hsl(318 78% 55%)'/>
+					<stop offset='1' stop-color='hsl(28 95% 62%)'/>
+				</linearGradient>
+			</defs>
+			<rect width='512' height='512' fill='url(#sky)'/>
+			<circle cx='348' cy='174' r='52' fill='hsl(46 100% 76%)'/>
+			<path d='M0 372 120 292 236 356 336 286 512 348 512 512 0 512Z' fill='hsl(266 55% 20%)' opacity='0.85'/>
+			<path d='M0 438 132 384 292 448 512 402 512 512 0 512Z' fill='hsl(266 65% 12%)'/>
+		</svg>`.replace(/\s+/g, " ")
+	)}`;
+
+	const { Story } = defineMeta({
+		title: "AI Chat/ImageGeneration",
+		component: ImageGeneration,
+		tags: ["autodocs"],
+		args: {
+			status: "generating",
+			alt: "a lone barn under a sodium sunset, 35mm, grain",
+			prompt: "a lone barn under a sodium sunset, 35mm, grain",
+			aspectRatio: "1 / 1",
+			errorText: "Generation failed",
+		},
+		argTypes: {
+			status: {
+				control: "select",
+				options: ["idle", "generating", "done", "error"],
+				description: "Which stage of the generation to render",
+			},
+			alt: {
+				control: "text",
+				description: "Describes the image to assistive tech — typically the prompt",
+			},
+			prompt: { control: "text", description: "Muted caption line under the frame" },
+			aspectRatio: {
+				control: "text",
+				description: "CSS aspect-ratio of the frame, holding the layout across every state",
+			},
+			errorText: { control: "text", description: "The failure line shown in the error state" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-72">
+		<ImageGeneration {...args} />
+	</div>
+{/snippet}
+
+<Story name="Idle" {template} args={{ status: "idle" }} />
+
+<Story name="Generating" {template} args={{ status: "generating" }} />
+
+<Story name="Done" {template} args={{ status: "done", src: artwork }} />
+
+<Story
+	name="Error"
+	{template}
+	args={{ status: "error", errorText: "The model returned no image", onRetry: () => {} }}
+/>
+
+<Story
+	name="Wide"
+	{template}
+	args={{ status: "done", src: artwork, aspectRatio: "16 / 9" }}
+	parameters={{ docs: { description: { story: "The frame takes any CSS aspect-ratio." } } }}
+/>

--- a/src/stories/inline-citation.stories.svelte
+++ b/src/stories/inline-citation.stories.svelte
@@ -1,0 +1,41 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { InlineCitation } from "$lib/fancy-ui/inline-citation";
+
+	const source = {
+		id: "s1",
+		title: "Constrained decoding for structured tool calls",
+		url: "https://www.example.com/papers/constrained-decoding",
+		snippet:
+			"Sampling under a grammar removes the parse-and-retry loop entirely: an invalid token is never drawn, so there is nothing to repair downstream.",
+	};
+
+	const { Story } = defineMeta({
+		title: "AI Chat/InlineCitation",
+		component: InlineCitation,
+		tags: ["autodocs"],
+		args: {
+			source,
+			index: 1,
+		},
+		argTypes: {
+			index: { control: "number", description: "The reference number; 3 renders [3]" },
+			href: {
+				control: "text",
+				description: 'Link target; defaults to source.url, "" renders an unlinked marker',
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<p class="max-w-md p-6 text-sm leading-relaxed">
+		Structured output is a decoding constraint rather than a prompting technique<InlineCitation
+			{...args}
+		/>, which is why the guarantee survives a raised temperature. Hover the marker, or tab to it.
+	</p>
+{/snippet}
+
+<Story name="In Paragraph" {template} />
+
+<Story name="Unlinked" {template} args={{ href: "", index: 2 }} />

--- a/src/stories/sources.stories.svelte
+++ b/src/stories/sources.stories.svelte
@@ -1,0 +1,94 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { Sources, SourcesTrigger, SourcesList, SourceCard } from "$lib/fancy-ui/sources";
+	import type { SourceData } from "$lib/fancy-ui/_internals/ai-types.js";
+
+	const sources: SourceData[] = [
+		{
+			id: "s1",
+			title: "Designing citation surfaces for generated answers",
+			url: "https://docs.example.dev/patterns/citations",
+			domain: "docs.example.dev",
+			snippet: "A citation is a promise that the answer can be checked, not a footnote.",
+		},
+		{
+			id: "s2",
+			title: "Retrieval quality and the illusion of grounding",
+			url: "https://research.example.org/papers/grounding",
+			domain: "research.example.org",
+			snippet: "Four plausible sources under a wrong answer make it read as a right one.",
+		},
+		{
+			id: "s3",
+			title: "Why readers glance at sources instead of opening them",
+			url: "https://notes.example.net/reading-citations",
+			domain: "notes.example.net",
+			snippet: "The host name does most of the work; the title does the rest.",
+		},
+		{
+			id: "s4",
+			title: "A field guide to attribution in assistant answers",
+			url: "https://handbook.example.io/attribution",
+			domain: "handbook.example.io",
+			snippet: "Say where it came from before anyone has to ask.",
+		},
+	];
+
+	const { Story } = defineMeta({
+		title: "AI Chat/Sources",
+		component: Sources,
+		tags: ["autodocs"],
+		args: { sources, open: false },
+		argTypes: {
+			sources: { control: "object", description: "The documents backing the answer" },
+			open: { control: "boolean", description: "Whether the list is expanded" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="max-w-xl p-6">
+		<Sources {...args} />
+	</div>
+{/snippet}
+
+{#snippet composed(args: any)}
+	<div class="max-w-xl p-6">
+		<Sources {...args}>
+			<SourcesTrigger label="Checked against 4 papers" />
+			<SourcesList>
+				{#snippet item(source: SourceData, index: number)}
+					<div class="flex items-baseline gap-2 text-xs">
+						<span class="text-muted-foreground tabular-nums">{index + 1}.</span>
+						<a
+							href={source.url}
+							target="_blank"
+							rel="noopener noreferrer nofollow ugc"
+							class="underline underline-offset-2"
+						>
+							{source.title}
+						</a>
+					</div>
+				{/snippet}
+			</SourcesList>
+		</Sources>
+	</div>
+{/snippet}
+
+{#snippet standalone()}
+	<div class="grid max-w-xl gap-2 p-6 sm:grid-cols-2">
+		{#each sources.slice(0, 2) as source (source.id)}
+			<SourceCard {source} />
+		{/each}
+	</div>
+{/snippet}
+
+<Story name="Collapsed" {template} />
+
+<Story name="Open" {template} args={{ open: true }} />
+
+<Story name="Single" {template} args={{ sources: sources.slice(0, 1), open: true }} />
+
+<Story name="CustomItem" template={composed} args={{ open: true }} />
+
+<Story name="CardStandalone" template={standalone} />

--- a/src/stories/web-search.stories.svelte
+++ b/src/stories/web-search.stories.svelte
@@ -1,0 +1,90 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { WebSearch } from "$lib/fancy-ui/web-search";
+	import type { SearchResultData } from "$lib/fancy-ui";
+
+	const QUERY = "postgres connection pool exhausted under load";
+
+	const RESULTS: SearchResultData[] = [
+		{
+			id: "h1",
+			title: "Why your pool runs dry before your database does",
+			url: "https://www.example.dev/posts/pool-exhaustion",
+			snippet:
+				"Connection limits are usually reached by leaked handles rather than by traffic. The give-away is a pool that never recovers after the spike passes.",
+		},
+		{
+			id: "h2",
+			title: "Sizing a connection pool",
+			url: "https://notes.example.org/pool-sizing",
+			snippet:
+				"A pool larger than the server's max_connections turns a queue you can observe into an error you cannot.",
+		},
+		{
+			id: "h3",
+			title: "Tracking down a leaked transaction",
+			url: "https://example.net/guides/leaked-transactions",
+			snippet:
+				"pg_stat_activity tells you which query is holding a connection open and for how long it has been idle in transaction.",
+		},
+		{
+			id: "h4",
+			title: "Backpressure beats a bigger pool",
+			url: "https://blog.example.com/backpressure",
+			snippet: "Queueing at the edge fails a request in milliseconds instead of in thirty seconds.",
+		},
+	];
+
+	const { Story } = defineMeta({
+		title: "AI Chat/WebSearch",
+		component: WebSearch,
+		tags: ["autodocs"],
+		args: {
+			query: QUERY,
+			results: RESULTS,
+			searching: false,
+			maxVisible: 0,
+			label: "Web search",
+		},
+		argTypes: {
+			query: { control: "text", description: "What the agent looked up" },
+			results: { control: "object", description: "Hits found so far, oldest first" },
+			searching: {
+				control: "boolean",
+				description: "Whether the lookup is still running",
+			},
+			maxVisible: {
+				control: "number",
+				description: "Rows shown before the expander takes over; 0 shows every result",
+			},
+			label: { control: "text", description: "Accessible name for the whole block" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-xl">
+		<WebSearch {...args} />
+	</div>
+{/snippet}
+
+<Story name="Complete" {template} />
+
+<!-- Still running, with the first hits already in: the bar sweeps above them. -->
+<Story name="Searching" {template} args={{ results: RESULTS.slice(0, 2), searching: true }} />
+
+<Story name="Nothing found yet" {template} args={{ results: [], searching: true }} />
+
+<Story name="No results" {template} args={{ results: [] }} />
+
+<!-- Supplying onSelect is what turns every row from a link into a button. -->
+<Story
+	name="Clickable"
+	{template}
+	args={{
+		onSelect: (result: SearchResultData, index: number) =>
+			console.log("selected", index, result.title, result.url),
+	}}
+/>
+
+<Story name="Capped with an expander" {template} args={{ maxVisible: 2 }} />


### PR DESCRIPTION
## Summary

Part 5/8 of the AI/chat family (stacks on #185). The `ai-chat` knowledge layer.

| Component | What it does |
|---|---|
| `Sources` (compound) | Citation pill (overlapping domain monograms + count) expanding into scannable source cards; `SourceCard` reusable standalone |
| `InlineCitation` | Numbered in-sentence reference `[n]`; hover/focus reveals a `SourceCard` preview in a floating card (internals `float` action, tooltip pattern: open delay, close grace, Escape) |
| `WebSearch` | Query header + indeterminate scanning bar; results land sequentially without re-keying settled rows; anchor/button/plain rows by context |
| `ImageGeneration` | Fixed-aspect frame across idle → generating (PixelLoader over a drifting dot field) → done (blur-to-sharp) → error (retry); layout never shifts |

## Review passes (Workflow: 2 parallel adversarial reviewers, then fixes)
- **Contracts**: caught a real hydration bug — an image `complete` at mount with `naturalWidth 0` (failed pre-hydration, or viewBox-only SVG) latched the blur forever; now complete-at-mount is decisive. Also: three diverging host-derivation implementations unified into `_internals/host.ts`, expander state re-derived after result resets, SourceCard adopted as the citation preview body (duplication removed).
- **Visual QA (pixel-measured)**: caught two prose defects — a stray whitespace node detaching punctuation from citations, and the citation marker inflating its line box (uneven leading). Both fixed. Sources stagger, search sequencing, un-blur cycle, dark mode, reduced motion all verified frame-level.

## Gates
`check:registry` ✅ (78) · `check:i18n` ✅ · `svelte-check` ✅ 0 errors · `vitest` ✅ 1252/1252 · `build` ✅ · `package` + publint ✅

Next in stack: agents & structured output (agent-plan, subagent-list, approval-card, recommendation-card, artifact-card, ai-data-table).