### PR TITLE
feat(ai): agent activity & structured output — six ai-agents components

### DIFF
--- a/.changeset/ai-agents-structured.md
+++ b/.changeset/ai-agents-structured.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+Add the agent-activity and structured-output surfaces of the AI/chat family: `AgentPlan` (glanceable checklist with done/total count, completion bar, status glyphs, and one level of substeps), `SubagentList` (fan-out panel for parallel workers with per-row status dots, model badges, and progress bars under a self-deriving label), `ApprovalCard` (human-in-the-loop gate whose approve/deny footer swaps for a politely announced verdict line, with a destructive variant), `RecommendationCard` (an agent's proposal with a counted-up confidence figure beside a filling ring, banded by certainty), `ArtifactCard` (a generated document as a tangible object — version navigator, streaming preview behind a fade, and a real Open button), and `AiDataTable` (compact comparison table for structured model output with real table semantics, keyboard-scrollable overflow, and no client-side sorting by design). All six render duplicate model-supplied ids without crashing, follow the shared `--ft-status-*` tokens, and ship with colocated tests, docs examples, and stories.

--- a/src/lib/components/docs/DemoRenderer.svelte
+++ b/src/lib/components/docs/DemoRenderer.svelte
@@ -80,6 +80,12 @@
 		"inline-citation",
 		"web-search",
 		"image-generation",
+		"agent-plan",
+		"subagent-list",
+		"approval-card",
+		"recommendation-card",
+		"artifact-card",
+		"ai-data-table",
 	]);
 </script>
 

--- a/src/lib/components/docs/examples/agent-plan/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/agent-plan/BasicUsage.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { AgentPlan } from "$lib/fancy-ui/agent-plan";
+	import type { PlanStepData, RunStatus } from "$lib/fancy-ui";
+
+	/** How long each step is left running before the next one takes over. */
+	const STEP_MS = 900;
+
+	/**
+	 * The leaves of the plan, in the order the agent works through them. Only these
+	 * advance: the parent below reads its status off the children, the way a real
+	 * plan does — it is running while any of them is, and done when all of them are.
+	 */
+	const LEAVES = [
+		{ id: "plan-read", label: "Read the failing test", detail: "tests/retry.spec.ts" },
+		{ id: "plan-grep", label: "Search for the retry helper" },
+		{ id: "plan-open", label: "Open the module it lives in", detail: "142 lines" },
+		{ id: "plan-fix", label: "Cap the backoff at 30s", detail: "One clamp, one comment" },
+		{ id: "plan-test", label: "Run the suite", detail: "2 specs still failing" },
+		{ id: "plan-report", label: "Summarise what happened" },
+	];
+
+	/**
+	 * Plans go wrong, so the demo does too: this step ends `error` rather than
+	 * `done`, which is the only way the failure glyph and its colour reach the page.
+	 */
+	const FAILING_ID = "plan-test";
+
+	/** Every leaf running once, plus a final frame with the whole plan finished. */
+	const FRAMES = LEAVES.length + 1;
+
+	let stage = $state(FRAMES - 1);
+
+	function leafStatus(index: number, at: number): RunStatus {
+		if (index < at) return LEAVES[index].id === FAILING_ID ? "error" : "done";
+		return index === at ? "running" : "pending";
+	}
+
+	/** A parent is only as finished as its children, and starts when the first one does. */
+	function parentStatus(children: RunStatus[]): RunStatus {
+		if (children.every((status) => status === "done")) return "done";
+		if (children.some((status) => status !== "pending")) return "running";
+		return "pending";
+	}
+
+	const steps: PlanStepData[] = $derived.by(() => {
+		const status = LEAVES.map((_, index) => leafStatus(index, stage));
+		const substeps: PlanStepData[] = [
+			{ ...LEAVES[1], status: status[1] },
+			{ ...LEAVES[2], status: status[2] },
+		];
+
+		return [
+			{ ...LEAVES[0], status: status[0] },
+			{
+				id: "plan-locate",
+				label: "Locate the retry helper",
+				status: parentStatus([status[1], status[2]]),
+				substeps,
+			},
+			{ ...LEAVES[3], status: status[3] },
+			{ ...LEAVES[4], status: status[4] },
+			{ ...LEAVES[5], status: status[5] },
+		];
+	});
+
+	onMount(() => {
+		// A plan that never settles is exactly what reduced motion is asking us not
+		// to run, so it gets the finished checklist and no timer at all.
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+		// The counter lives outside the state it drives, so nothing here reads what
+		// it is about to write.
+		let frame = 0;
+		stage = frame;
+
+		const timer = setInterval(() => {
+			frame = (frame + 1) % FRAMES;
+			stage = frame;
+		}, STEP_MS);
+
+		return () => clearInterval(timer);
+	});
+</script>
+
+<div class="flex w-full max-w-md flex-col gap-3 p-6">
+	<AgentPlan {steps} label="Fix the retry backoff" />
+
+	<p class="text-muted-foreground text-xs">
+		The count and the bar take the two nested checks as steps of their own — seven, not five. The
+		suite ends red, and the count stops one short of the total because of it.
+	</p>
+</div>

--- a/src/lib/components/docs/examples/ai-data-table/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/ai-data-table/BasicUsage.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import { AiDataTable } from "$lib/fancy-ui/ai-data-table";
+	import type { AiDataTableColumn, AiDataTableRow } from "$lib/fancy-ui/ai-data-table";
+
+	// Exactly the shape a model hands back when asked to compare things: five
+	// criteria, four kinds of value, and one cell it could not fill.
+	const columns: AiDataTableColumn[] = [
+		{ key: "option", label: "Deployment" },
+		{ key: "latency", label: "p95 latency (ms)", numeric: true },
+		{ key: "cost", label: "Cost / 1M req", numeric: true },
+		{ key: "selfHosted", label: "Self-hosted", align: "center" },
+		{ key: "sla", label: "SLA" },
+		{ key: "effort", label: "Ops effort" },
+	];
+
+	const rows: AiDataTableRow[] = [
+		{
+			option: "Managed cluster",
+			latency: 42,
+			cost: 18.4,
+			selfHosted: false,
+			sla: "99.95%",
+			effort: "Low",
+		},
+		{
+			option: "Serverless pool",
+			latency: 88,
+			cost: 6.2,
+			selfHosted: false,
+			sla: "99.9%",
+			effort: "None",
+		},
+		{
+			option: "Self-run nodes",
+			latency: 31,
+			cost: 24.9,
+			selfHosted: true,
+			sla: null,
+			effort: "High",
+		},
+	];
+</script>
+
+<div class="flex w-full max-w-2xl flex-col gap-2 p-6">
+	<AiDataTable
+		{columns}
+		{rows}
+		caption="Inference deployments compared on cost, latency and operational load"
+		captionVisible
+		highlightColumn="cost"
+	/>
+
+	<p class="text-muted-foreground mt-2 text-xs">
+		The tinted column is the one the answer turned on. Nothing here sorts or filters — the order is
+		the order the model chose, and changing it would be editing the answer.
+	</p>
+</div>

--- a/src/lib/components/docs/examples/approval-card/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/approval-card/BasicUsage.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { ApprovalCard } from "$lib/fancy-ui/approval-card";
+	import type { ApprovalState } from "$lib/fancy-ui/approval-card";
+
+	// No timer, no loop: the demo only moves when someone actually decides
+	// something, which is the whole point of the component.
+	let branchState = $state<ApprovalState>("pending");
+	let migrationState = $state<ApprovalState>("pending");
+
+	const settled = $derived(
+		[branchState, migrationState].filter((state) => state !== "pending").length
+	);
+
+	function reset() {
+		branchState = "pending";
+		migrationState = "pending";
+	}
+</script>
+
+<div class="flex w-full max-w-xl flex-col gap-3 p-6">
+	<ApprovalCard
+		title="Create branch fix/retry-backoff"
+		description="Branches from develop and pushes an empty commit so CI has something to run."
+		bind:state={branchState}
+	/>
+
+	<ApprovalCard
+		title="Run database migration"
+		description="Adds two columns to invoices and backfills 41,880 rows. There is no down migration."
+		destructive
+		approveLabel="Run migration"
+		denyLabel="Not now"
+		bind:state={migrationState}
+	>
+		<pre
+			class="ft-approval-preview text-foreground/80 overflow-x-auto rounded-md px-2.5 py-2 font-mono text-xs">pnpm db:migrate --env production --yes</pre>
+	</ApprovalCard>
+
+	<p class="text-muted-foreground mt-1 text-xs">
+		{#if settled === 0}
+			Both gates are waiting. Nothing runs until you press something.
+		{:else}
+			{settled} of 2 decided.
+			<button
+				type="button"
+				class="text-foreground underline decoration-dotted underline-offset-2"
+				onclick={reset}
+			>
+				Reset
+			</button>
+		{/if}
+	</p>
+</div>
+
+<style>
+	.ft-approval-preview {
+		background: color-mix(in oklab, currentColor 7%, transparent);
+	}
+</style>

--- a/src/lib/components/docs/examples/artifact-card/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/artifact-card/BasicUsage.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { ArtifactCard } from "$lib/fancy-ui/artifact-card";
+	import type { StreamStatus } from "$lib/fancy-ui";
+
+	/** The two drafts the rig cycles between — the second is a tightened edit of the first. */
+	const DRAFTS = [
+		"Revenue closed the quarter at 4.2M, six percent ahead of plan, and for the first time the mid-market segment outgrew enterprise. Two things drove it: the self-serve trial that shipped in May, which now accounts for a third of new logos, and a pricing change nobody expected much from. Churn is flat. The one number worth arguing about is expansion, which slipped for a second quarter running and is the reason next quarter's forecast is not simply this quarter plus growth.",
+		"Revenue closed the quarter at 4.2M, six percent ahead of plan — the first time mid-market has outgrown enterprise. Two things drove it: the self-serve trial shipped in May, now a third of new logos, and a pricing change nobody expected much from. Churn is flat. Expansion is the number worth arguing about: it slipped for a second quarter running, which is why next quarter's forecast is not this quarter plus growth. Recommendation: hold the pricing, fund the expansion motion.",
+	];
+
+	/** How many characters land per tick, and how often a tick happens. */
+	const CHUNK = 4;
+	const TICK_MS = 22;
+	/** Beat before a draft starts, and how long a finished one is left on screen. */
+	const LEAD_MS = 500;
+	const HOLD_MS = 2600;
+
+	// Nothing has been written before the rig starts, so the server renders the
+	// header alone and the preview region arrives with its first chunk.
+	let version = $state(1);
+	let status = $state<StreamStatus>("idle");
+	let preview = $state("");
+	let opened = $state(false);
+	let copied = $state(false);
+
+	// One timer at a time, so cleanup is a single clearTimeout and the rig can be
+	// stopped mid-draft the moment a reader takes over the navigator.
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	function stop() {
+		clearTimeout(timer);
+		timer = undefined;
+	}
+
+	/** Renders a draft finished and still — what a reader's click, or reduced motion, gets. */
+	function settleOn(n: number) {
+		stop();
+		version = n;
+		preview = DRAFTS[n - 1];
+		status = "done";
+	}
+
+	function writeDraft(n: number) {
+		version = n;
+		status = "streaming";
+		const full = DRAFTS[n - 1];
+		let cut = CHUNK;
+		preview = full.slice(0, cut);
+
+		const tick = () => {
+			cut = Math.min(full.length, cut + CHUNK);
+			preview = full.slice(0, cut);
+			timer = setTimeout(cut < full.length ? tick : finish, TICK_MS);
+		};
+
+		const finish = () => {
+			status = "done";
+			timer = setTimeout(() => writeDraft(n === DRAFTS.length ? 1 : n + 1), HOLD_MS);
+		};
+
+		timer = setTimeout(tick, LEAD_MS);
+	}
+
+	onMount(() => {
+		// A document that rewrites itself forever is exactly what reduced motion is
+		// asking us not to run, so it gets the finished second draft and no timer.
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			settleOn(DRAFTS.length);
+			return;
+		}
+
+		writeDraft(1);
+		return stop;
+	});
+</script>
+
+<div class="flex w-full max-w-xl flex-col gap-2 p-6">
+	<ArtifactCard
+		title="Q3 revenue review"
+		kind="Memo"
+		{version}
+		versionCount={DRAFTS.length}
+		onVersionChange={settleOn}
+		{status}
+		{preview}
+		onOpen={() => (opened = !opened)}
+	>
+		{#snippet actions()}
+			<button
+				type="button"
+				class="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring inline-flex size-6 cursor-pointer items-center justify-center rounded transition-colors focus-visible:ring-1 focus-visible:outline-none"
+				aria-label={copied ? "Copied" : "Copy document"}
+				onclick={() => (copied = !copied)}
+			>
+				{#if copied}
+					<svg
+						class="size-3.5"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2.5"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<path d="m5 13 4 4L19 7" />
+					</svg>
+				{:else}
+					<svg
+						class="size-3.5"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.75"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<rect x="9" y="9" width="11" height="11" rx="2" />
+						<path d="M5 15V5a2 2 0 0 1 2-2h10" />
+					</svg>
+				{/if}
+			</button>
+		{/snippet}
+	</ArtifactCard>
+
+	<p class="text-muted-foreground mt-1 text-xs">
+		{opened
+			? "That would open the document in a side panel — the copy button kept its own click."
+			: "The card is writing itself, then rewriting itself. Click it to open, or use the arrows to settle on a draft."}
+	</p>
+
+	<!-- Still, since a document that failed is the one state the rig above never reaches. -->
+	<ArtifactCard title="Q3 cohort appendix" kind="Spreadsheet" status="error" />
+
+	<p class="text-muted-foreground text-xs">
+		A failure says so in words, in a tinted footer, rather than in the border alone.
+	</p>
+</div>

--- a/src/lib/components/docs/examples/recommendation-card/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/recommendation-card/BasicUsage.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { RecommendationCard } from "$lib/fancy-ui/recommendation-card";
+	import type { RecommendationState } from "$lib/fancy-ui/recommendation-card";
+
+	// Nothing is on a timer here: the demo only moves when you move it, so there
+	// is no rig to hold still for reduced motion.
+	let indexState = $state<RecommendationState>("open");
+	let cacheState = $state<RecommendationState>("open");
+
+	const settled = $derived(indexState !== "open" || cacheState !== "open");
+
+	function reset() {
+		indexState = "open";
+		cacheState = "open";
+	}
+</script>
+
+<div class="flex w-full max-w-xl flex-col gap-3 p-6">
+	<RecommendationCard
+		badge="Suggestion"
+		title="Add an index on orders.customer_id"
+		description="The three slowest queries this week all scanned the whole table."
+		confidence={0.87}
+		acceptLabel="Apply migration"
+		bind:state={indexState}
+	>
+		<code
+			class="bg-foreground/5 text-muted-foreground block rounded-md px-2.5 py-1.5 font-mono text-xs"
+		>
+			CREATE INDEX orders_customer_id_idx ON orders (customer_id);
+		</code>
+	</RecommendationCard>
+
+	<RecommendationCard
+		badge="Speculative"
+		title="Cache the pricing lookup for 60 seconds"
+		description="Prices changed twice last quarter, so staleness is cheap — but the traffic here is modest."
+		confidence={0.42}
+		acceptLabel="Apply patch"
+		dismissLabel="Not now"
+		bind:state={cacheState}
+	/>
+
+	<div class="mt-1 flex items-center justify-between gap-3">
+		<p class="text-muted-foreground text-xs">
+			The ring and the counter agree on one figure; the band shifts colour at 75% and 50%.
+		</p>
+		{#if settled}
+			<button
+				type="button"
+				class="text-muted-foreground hover:text-foreground hover:bg-foreground/5 flex-none rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
+				onclick={reset}
+			>
+				Reset both
+			</button>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/docs/examples/registry.ts
+++ b/src/lib/components/docs/examples/registry.ts
@@ -440,4 +440,10 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 	"inline-citation": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"web-search": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"image-generation": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"agent-plan": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"subagent-list": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"approval-card": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"recommendation-card": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"artifact-card": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"ai-data-table": [{ name: "BasicUsage", title: "Basic Usage" }],
 };

--- a/src/lib/components/docs/examples/subagent-list/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/subagent-list/BasicUsage.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { SubagentList } from "$lib/fancy-ui/subagent-list";
+	import type { SubagentData } from "$lib/fancy-ui";
+
+	/** How often the fan-out redraws. */
+	const TICK_MS = 120;
+	/** How long the finished roster is held before the demo spawns them again. */
+	const HOLD_MS = 2600;
+
+	// One worker per line: when it is spawned, and how long it takes to land. The
+	// whole demo is a function of these, so a frame can be computed from a single
+	// elapsed number rather than from whatever the previous frame happened to be.
+	const script = [
+		{
+			id: "researcher",
+			name: "Researcher",
+			task: "Read the changelog for breaking changes",
+			model: "mini",
+			startAt: 0,
+			durationMs: 3600,
+		},
+		{
+			id: "writer",
+			name: "Writer",
+			task: "Draft the migration note",
+			model: "pro",
+			startAt: 900,
+			durationMs: 5400,
+		},
+		{
+			id: "reviewer",
+			name: "Reviewer",
+			task: "Check every code sample still compiles",
+			model: "pro",
+			startAt: 1800,
+			durationMs: 4200,
+		},
+	];
+
+	const CYCLE_MS = Math.max(...script.map((s) => s.startAt + s.durationMs)) + HOLD_MS;
+
+	/**
+	 * The roster at a given point in the cycle. Pure: nothing here reads the state
+	 * it is about to write, so the tick can never chase its own tail.
+	 */
+	function frame(elapsed: number): SubagentData[] {
+		return script
+			.filter((worker) => elapsed >= worker.startAt)
+			.map(({ id, name, task, model, startAt, durationMs }) => {
+				const ran = elapsed - startAt;
+				return ran >= durationMs
+					? { id, name, task, model, status: "done" as const }
+					: { id, name, task, model, status: "running" as const, progress: ran / durationMs };
+			});
+	}
+
+	let agents = $state<SubagentData[]>(frame(0));
+
+	onMount(() => {
+		// A fan-out that respawns forever is exactly what reduced motion is asking
+		// us not to run, so it gets the finished roster and no timer at all.
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			agents = frame(CYCLE_MS);
+			return;
+		}
+
+		const started = Date.now();
+		const timer = setInterval(() => {
+			agents = frame((Date.now() - started) % CYCLE_MS);
+		}, TICK_MS);
+		return () => clearInterval(timer);
+	});
+</script>
+
+<div class="bg-card w-full max-w-xl rounded-lg border p-5">
+	<p class="text-muted-foreground mb-3 text-xs font-medium tracking-wide uppercase">
+		Parallel workers
+	</p>
+	<SubagentList {agents} />
+	<p class="text-muted-foreground mt-3 text-xs">
+		Each worker arrives when it is spawned and fills its own bar. The list names itself for screen
+		readers as it goes — "3 agents running", then "3 agents finished".
+	</p>
+</div>

--- a/src/lib/fancy-ui/agent-plan/AgentPlan.svelte
+++ b/src/lib/fancy-ui/agent-plan/AgentPlan.svelte
@@ -73,11 +73,30 @@
 	const rows = $derived.by(() => {
 		const out: PlanRow[] = [];
 		const seen = new Map<string, number>();
+		// Every id in the plan, substeps included: a suffixed key has to clear them
+		// as well as the keys already handed out, since a step may genuinely be
+		// called "x#1" while two others are called "x".
+		const ids = new Set<string>();
+		const collectIds = (list: PlanStepData[]) => {
+			for (const step of list) {
+				ids.add(step.id);
+				if (step.substeps) collectIds(step.substeps);
+			}
+		};
+		collectIds(steps);
+		const used = new Set<string>();
 
 		const push = (step: PlanStepData, depth: number) => {
 			const occurrence = seen.get(step.id) ?? 0;
 			seen.set(step.id, occurrence + 1);
-			out.push({ step, key: `${step.id}#${occurrence}`, depth, index: out.length, lastSub: false });
+			let key = `${step.id}#${occurrence}`;
+			let suffix = occurrence;
+			while (ids.has(key) || used.has(key)) {
+				suffix++;
+				key = `${step.id}#${suffix}`;
+			}
+			used.add(key);
+			out.push({ step, key, depth, index: out.length, lastSub: false });
 		};
 
 		for (const step of steps) {

--- a/src/lib/fancy-ui/agent-plan/AgentPlan.svelte
+++ b/src/lib/fancy-ui/agent-plan/AgentPlan.svelte
@@ -1,0 +1,433 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { PlanStepData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for AgentPlan
+	 */
+	export interface AgentPlanProps {
+		/** The plan, in the order the agent means to work through it. Nests via `substeps`. */
+		steps: PlanStepData[];
+		/** Header text, sitting beside the done/total count. */
+		label?: string;
+		/** Whether the thin completion bar shows under the header. */
+		showProgress?: boolean;
+		/** Called when a row is activated; supplying it turns every row into a button. */
+		onSelect?: (step: PlanStepData) => void;
+		/** Replaces the built-in row body, keeping the glyph and the indent. */
+		item?: Snippet<[PlanStepData, number]>;
+		/** Additional CSS classes */
+		class?: string;
+		/** The root element */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { RunStatus } from "../_internals/ai-types.js";
+
+	let {
+		steps,
+		label = "Plan",
+		showProgress = true,
+		onSelect,
+		item,
+		class: className,
+		ref = $bindable(null),
+	}: AgentPlanProps = $props();
+
+	/** Spoken alongside each step, since the glyph says nothing out loud. */
+	const STATUS_LABELS: Record<RunStatus, string> = {
+		pending: "Pending",
+		running: "Running",
+		done: "Completed",
+		error: "Failed",
+		cancelled: "Cancelled",
+	};
+
+	const uid = $props.id();
+	const labelId = `${uid}-label`;
+
+	/** One rendered line: the step itself plus where it sits in the flattened list. */
+	interface PlanRow {
+		step: PlanStepData;
+		/**
+		 * What the `{#each}` is keyed by. The id leads, so a row keeps its DOM node
+		 * across a re-render, but the position is appended: a model that emits the
+		 * same id twice would otherwise crash the block, and a plan that repeats a
+		 * step is a plan, not an error.
+		 */
+		key: string;
+		/** 0 for a top-level step, 1 for anything nested under one. */
+		depth: number;
+		/** Position in visual order, substeps included — what `item` receives. */
+		index: number;
+		/** Last nested row of its group, so the rail can stop rather than run on. */
+		lastSub: boolean;
+	}
+
+	const rows = $derived.by(() => {
+		const out: PlanRow[] = [];
+
+		const push = (step: PlanStepData, depth: number) => {
+			out.push({ step, key: `${step.id}#${out.length}`, depth, index: out.length, lastSub: false });
+		};
+
+		for (const step of steps) {
+			push(step, 0);
+
+			// One level of indent is all the eye can follow at a glance, so anything
+			// deeper is pulled up beside its parent's own children instead of
+			// marching further right — depth-first, so a grandchild still reads
+			// directly under the child it belongs to.
+			const queue = [...(step.substeps ?? [])];
+			while (queue.length > 0) {
+				const sub = queue.shift() as PlanStepData;
+				push(sub, 1);
+				if (sub.substeps && sub.substeps.length > 0) queue.unshift(...sub.substeps);
+			}
+
+			const last = out[out.length - 1];
+			if (last.depth === 1) last.lastSub = true;
+		}
+
+		return out;
+	});
+
+	// Substeps are steps: a plan that finished four of its five checks and both of
+	// the two hiding under one of them is 6/7, not 4/5.
+	const total = $derived(rows.length);
+	const doneCount = $derived(rows.filter((row) => row.step.status === "done").length);
+	const percent = $derived(total === 0 ? 0 : Math.round((doneCount / total) * 1000) / 10);
+
+	// Only the first one: a plan with two things in flight still has one place the
+	// reader's eye — and a screen reader's "current step" — should land.
+	const currentIndex = $derived(rows.findIndex((row) => row.step.status === "running"));
+</script>
+
+{#snippet glyph(status: RunStatus)}
+	<!--
+		Shape carries the status as well as hue — hollow ring, filled dot, tick,
+		cross, dash — so the four states stay apart for anyone who cannot tell the
+		colours apart. The words are in the `sr-only` label beside the step.
+	-->
+	<span
+		class="ft-agentplan-glyph"
+		class:ft-status-pending={status === "pending"}
+		class:ft-status-running={status === "running"}
+		class:ft-status-done={status === "done"}
+		class:ft-status-error={status === "error"}
+		class:ft-status-cancelled={status === "cancelled"}
+		aria-hidden="true"
+	>
+		{#if status === "done"}
+			<svg
+				class="ft-agentplan-icon"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="3"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="m5 13 4 4L19 7" />
+			</svg>
+		{:else if status === "error"}
+			<svg
+				class="ft-agentplan-icon"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="3"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="M6 6l12 12M18 6 6 18" />
+			</svg>
+		{:else if status === "cancelled"}
+			<span class="ft-agentplan-dash"></span>
+		{:else if status === "running"}
+			<span class="ft-agentplan-dot"></span>
+		{:else}
+			<span class="ft-agentplan-ring"></span>
+		{/if}
+	</span>
+{/snippet}
+
+{#snippet rowBody(row: PlanRow)}
+	{@render glyph(row.step.status)}
+
+	{#if item}
+		{@render item(row.step, row.index)}
+	{:else}
+		<span class="ft-agentplan-text min-w-0 flex-1">
+			<!--
+				Muted, never struck through: a finished step is still worth reading,
+				and a checklist of crossed-out lines is harder to scan, not easier.
+			-->
+			<span
+				class="ft-agentplan-step-label block leading-snug"
+				class:text-muted-foreground={row.step.status === "done" || row.step.status === "cancelled"}
+				class:font-medium={row.step.status === "running"}>{row.step.label}</span
+			>
+			<span class="sr-only">{STATUS_LABELS[row.step.status]}</span>
+			{#if row.step.detail}
+				<span
+					class="ft-agentplan-detail text-muted-foreground mt-0.5 block truncate text-xs"
+					title={row.step.detail}>{row.step.detail}</span
+				>
+			{/if}
+		</span>
+	{/if}
+{/snippet}
+
+<div bind:this={ref} class={cn("ft-agentplan w-full text-sm", className)}>
+	<div class="ft-agentplan-header">
+		<div class="flex items-baseline gap-2">
+			<span id={labelId} class="ft-agentplan-label text-foreground truncate font-medium"
+				>{label}</span
+			>
+			<span class="ft-agentplan-count text-muted-foreground ml-auto shrink-0 text-xs tabular-nums"
+				>{doneCount}/{total}</span
+			>
+		</div>
+
+		{#if showProgress}
+			<!-- The count above already says it in words, so the bar is decoration. -->
+			<div class="ft-agentplan-track" aria-hidden="true">
+				<div class="ft-agentplan-bar" style="width: {percent}%"></div>
+			</div>
+		{/if}
+	</div>
+
+	<!--
+		Flat list with an indent class rather than nested lists: `listitem` needs
+		`list` as its parent, and a wrapper per group would put a plain div between
+		them and break the semantics for the sake of a left margin CSS can do.
+	-->
+	<div class="ft-agentplan-list" role="list" aria-labelledby={labelId}>
+		{#each rows as row (row.key)}
+			<div
+				class="ft-agentplan-row"
+				class:ft-agentplan-sub={row.depth === 1}
+				class:ft-agentplan-sub-last={row.lastSub}
+				role="listitem"
+				data-status={row.step.status}
+				aria-current={row.index === currentIndex ? "step" : undefined}
+			>
+				{#if onSelect}
+					<button
+						type="button"
+						class="ft-agentplan-body hover:bg-muted/60 focus-visible:ring-ring flex w-full cursor-pointer items-start gap-2 rounded-md text-left transition-colors focus-visible:ring-1 focus-visible:outline-none"
+						onclick={() => onSelect?.(row.step)}
+					>
+						{@render rowBody(row)}
+					</button>
+				{:else}
+					<div class="ft-agentplan-body flex items-start gap-2 rounded-md">
+						{@render rowBody(row)}
+					</div>
+				{/if}
+			</div>
+		{/each}
+	</div>
+</div>
+
+<style>
+	.ft-agentplan {
+		/* Rail and track are mixes of currentColor, so one value reads correctly on
+		   either theme. The status colours cannot do that — they are ink, and no
+		   single token clears 4.5:1 on both white and near-black — so they are read
+		   at their point of use off the `--ft-status-*` vocabulary this family
+		   shares, whose defaults are `light-dark()` pairs. A glyph is a graphical
+		   object and owes 3:1, which is why the light half of the grey pair is 0.5
+		   rather than 0.55. */
+		--ft-agentplan-rail: color-mix(in oklab, currentColor 16%, transparent);
+		--ft-agentplan-track-bg: color-mix(in oklab, currentColor 12%, transparent);
+
+		/* Geometry shared by the glyph, the indent, and the substep rail, so moving
+		   one moves all three together. */
+		--ft-agentplan-glyph-size: 0.875rem;
+		--ft-agentplan-row-pad: 0.25rem;
+		--ft-agentplan-indent: 1.5rem;
+		/* Centre of a top-level glyph: body padding plus half the glyph. */
+		--ft-agentplan-rail-x: 0.9375rem;
+		/* Where that glyph's centre sits vertically, so the rail can stop on it. */
+		--ft-agentplan-rail-stop: 0.875rem;
+	}
+
+	.ft-agentplan-header {
+		padding: 0 0.5rem 0.375rem;
+	}
+
+	.ft-agentplan-track {
+		margin-top: 0.375rem;
+		height: 0.1875rem;
+		border-radius: 9999px;
+		background: var(--ft-agentplan-track-bg);
+		overflow: hidden;
+	}
+
+	.ft-agentplan-bar {
+		height: 100%;
+		border-radius: inherit;
+		background: var(
+			--ft-agentplan-bar,
+			var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145)))
+		);
+	}
+
+	.ft-agentplan-row {
+		position: relative;
+	}
+
+	.ft-agentplan-sub {
+		padding-left: var(--ft-agentplan-indent);
+	}
+
+	/* Drawn per row rather than once behind the group, so it stretches with the
+	   row it belongs to and needs no height measurement. */
+	.ft-agentplan-sub::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: calc(var(--ft-agentplan-rail-x) - 1px);
+		width: 2px;
+		background: var(--ft-agentplan-rail);
+	}
+
+	/* Stop on the last child's glyph instead of running on into the next
+	   top-level step, which belongs to nobody. */
+	.ft-agentplan-sub-last::before {
+		bottom: auto;
+		height: calc(var(--ft-agentplan-rail-stop) + var(--ft-agentplan-row-pad));
+	}
+
+	.ft-agentplan-body {
+		width: 100%;
+		padding: var(--ft-agentplan-row-pad) 0.5rem;
+	}
+
+	.ft-agentplan-glyph {
+		position: relative;
+		display: inline-flex;
+		flex: none;
+		align-items: center;
+		justify-content: center;
+		width: var(--ft-agentplan-glyph-size);
+		height: var(--ft-agentplan-glyph-size);
+		/* Centres the glyph on the first line of the label rather than its box. */
+		margin-top: calc((1.25rem - var(--ft-agentplan-glyph-size)) / 2);
+	}
+
+	/*
+	 * Each state sets `color` once and every shape inside reads `currentColor`, so
+	 * a consumer retints a status by naming one variable. The component's own
+	 * `--ft-agentplan-*` sits in front of the shared `--ft-status-*`, which sits in
+	 * front of the literal: setting either anywhere up the tree wins without having
+	 * to out-specify these scoped rules.
+	 */
+	.ft-agentplan-glyph.ft-status-pending {
+		color: var(
+			--ft-agentplan-pending,
+			color-mix(
+				in oklab,
+				var(--ft-status-pending, light-dark(oklch(0.5 0.02 260), oklch(0.72 0.02 260))) 70%,
+				transparent
+			)
+		);
+	}
+
+	.ft-agentplan-glyph.ft-status-cancelled {
+		color: var(
+			--ft-agentplan-cancelled,
+			color-mix(
+				in oklab,
+				var(--ft-status-cancelled, light-dark(oklch(0.5 0.02 260), oklch(0.72 0.02 260))) 55%,
+				transparent
+			)
+		);
+	}
+
+	.ft-agentplan-glyph.ft-status-running {
+		color: var(
+			--ft-agentplan-running,
+			var(--ft-status-running, light-dark(oklch(0.5 0.18 265), oklch(0.72 0.15 265)))
+		);
+	}
+
+	.ft-agentplan-glyph.ft-status-done {
+		color: var(
+			--ft-agentplan-done,
+			var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145)))
+		);
+	}
+
+	.ft-agentplan-glyph.ft-status-error {
+		color: var(
+			--ft-agentplan-error,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+	}
+
+	.ft-agentplan-icon {
+		width: 100%;
+		height: 100%;
+	}
+
+	.ft-agentplan-ring {
+		width: 0.625rem;
+		height: 0.625rem;
+		border-radius: 9999px;
+		box-shadow: inset 0 0 0 1.5px currentColor;
+	}
+
+	.ft-agentplan-dot {
+		position: relative;
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 9999px;
+		background: currentColor;
+	}
+
+	.ft-agentplan-dash {
+		width: 0.625rem;
+		height: 2px;
+		border-radius: 9999px;
+		background: currentColor;
+	}
+
+	/*
+	 * Everything that moves lives behind the query, so reduced motion is not a
+	 * degraded variant to keep in sync: the running step is still a filled accent
+	 * dot, it just stops breathing, and the bar lands at its width instead of
+	 * sliding to it.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-agentplan-bar {
+			transition: width 420ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+
+		.ft-agentplan-dot::after {
+			content: "";
+			position: absolute;
+			inset: 0;
+			border-radius: inherit;
+			background: currentColor;
+			animation: ft-agentplan-ping 1.6s cubic-bezier(0, 0, 0.2, 1) infinite;
+		}
+	}
+
+	@keyframes ft-agentplan-ping {
+		from {
+			opacity: 0.55;
+			transform: scale(1);
+		}
+		to {
+			opacity: 0;
+			transform: scale(2.4);
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/agent-plan/AgentPlan.svelte
+++ b/src/lib/fancy-ui/agent-plan/AgentPlan.svelte
@@ -54,9 +54,12 @@
 		step: PlanStepData;
 		/**
 		 * What the `{#each}` is keyed by. The id leads, so a row keeps its DOM node
-		 * across a re-render, but the position is appended: a model that emits the
-		 * same id twice would otherwise crash the block, and a plan that repeats a
-		 * step is a plan, not an error.
+		 * across a re-render, but an occurrence count is appended rather than the
+		 * row's flattened position: a model that emits the same id twice would
+		 * otherwise crash the block, and counting by occurrence rather than
+		 * position means inserting or removing a step elsewhere in the plan does
+		 * not change the key — and so does not remount — a row whose own id never
+		 * changed.
 		 */
 		key: string;
 		/** 0 for a top-level step, 1 for anything nested under one. */
@@ -69,9 +72,12 @@
 
 	const rows = $derived.by(() => {
 		const out: PlanRow[] = [];
+		const seen = new Map<string, number>();
 
 		const push = (step: PlanStepData, depth: number) => {
-			out.push({ step, key: `${step.id}#${out.length}`, depth, index: out.length, lastSub: false });
+			const occurrence = seen.get(step.id) ?? 0;
+			seen.set(step.id, occurrence + 1);
+			out.push({ step, key: `${step.id}#${occurrence}`, depth, index: out.length, lastSub: false });
 		};
 
 		for (const step of steps) {
@@ -159,6 +165,7 @@
 	{@render glyph(row.step.status)}
 
 	{#if item}
+		<span class="sr-only">{STATUS_LABELS[row.step.status]}</span>
 		{@render item(row.step, row.index)}
 	{:else}
 		<span class="ft-agentplan-text min-w-0 flex-1">

--- a/src/lib/fancy-ui/agent-plan/AgentPlan.test.ts
+++ b/src/lib/fancy-ui/agent-plan/AgentPlan.test.ts
@@ -292,6 +292,19 @@ describe("AgentPlan", () => {
 		expect(container.querySelectorAll(".ft-agentplan-glyph")).toHaveLength(5);
 	});
 
+	it("speaks the status of a custom row, since the sr-only label lives only in the default body", () => {
+		const { container } = render(AgentPlan, {
+			props: {
+				steps: [step({ status: "error" })],
+				item: createRawSnippet<[PlanStepData, number]>(() => ({
+					render: () => `<span class="custom-row">mine</span>`,
+				})),
+			},
+		});
+
+		expect(container.querySelector(".sr-only")?.textContent).toBe("Failed");
+	});
+
 	it("renders a plan that repeats an id instead of crashing on it", () => {
 		const steps: PlanStepData[] = [
 			step({ id: "retry", label: "Retry the request", status: "done" }),
@@ -321,6 +334,19 @@ describe("AgentPlan", () => {
 		// Same node, not a remount: an appended step must not replay every entrance.
 		expect(rows(container)[0]).toBe(first);
 		expect(rows(container)).toHaveLength(6);
+	});
+
+	it("keeps a row's key stable when a step is inserted earlier in the plan", async () => {
+		const { container, rerender } = render(AgentPlan, { props: { steps: nested() } });
+		const last = rows(container)[rows(container).length - 1];
+
+		// Inserted at the front rather than appended: keying by flattened position
+		// would shift every row after the insertion point even though none of
+		// their ids changed, tearing them down and rebuilding them for nothing.
+		await rerender({ steps: [step({ id: "s0", label: "Set up the sandbox" }), ...nested()] });
+
+		expect(rows(container)).toHaveLength(6);
+		expect(rows(container)[rows(container).length - 1]).toBe(last);
 	});
 
 	it("merges custom classes onto the root", () => {

--- a/src/lib/fancy-ui/agent-plan/AgentPlan.test.ts
+++ b/src/lib/fancy-ui/agent-plan/AgentPlan.test.ts
@@ -1,0 +1,335 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import AgentPlan from "./AgentPlan.svelte";
+import type { PlanStepData } from "../_internals/ai-types.js";
+
+function step(overrides: Partial<PlanStepData> = {}): PlanStepData {
+	return { id: "s1", label: "Read the failing test", status: "pending", ...overrides };
+}
+
+/** Three top-level steps, the middle one carrying two substeps: five rows, two done. */
+function nested(): PlanStepData[] {
+	return [
+		step({ id: "s1", label: "Read the failing test", status: "done" }),
+		step({
+			id: "s2",
+			label: "Locate the retry helper",
+			status: "running",
+			substeps: [
+				step({ id: "s2a", label: "Search the repo", status: "done" }),
+				step({ id: "s2b", label: "Open the module", status: "running" }),
+			],
+		}),
+		step({ id: "s3", label: "Apply the fix", status: "pending" }),
+	];
+}
+
+function rows(container: HTMLElement): HTMLElement[] {
+	return [...container.querySelectorAll<HTMLElement>('[role="listitem"]')];
+}
+
+function labels(container: HTMLElement): string[] {
+	return [...container.querySelectorAll(".ft-agentplan-step-label")].map(
+		(el) => el.textContent ?? ""
+	);
+}
+
+function count(container: HTMLElement): string {
+	return container.querySelector(".ft-agentplan-count")?.textContent ?? "";
+}
+
+function bar(container: HTMLElement): HTMLElement | null {
+	return container.querySelector(".ft-agentplan-bar");
+}
+
+function glyph(row: HTMLElement): HTMLElement {
+	return row.querySelector(".ft-agentplan-glyph") as HTMLElement;
+}
+
+describe("AgentPlan", () => {
+	afterEach(cleanup);
+
+	it('heads the plan with its label, defaulting to "Plan"', () => {
+		const { container } = render(AgentPlan, { props: { steps: [step()] } });
+
+		expect(container.querySelector(".ft-agentplan-label")?.textContent).toBe("Plan");
+	});
+
+	it("uses the label it is given and names the list with it", () => {
+		const { container } = render(AgentPlan, {
+			props: { steps: [step()], label: "Migration plan" },
+		});
+
+		const heading = container.querySelector(".ft-agentplan-label") as HTMLElement;
+		const list = container.querySelector('[role="list"]') as HTMLElement;
+
+		expect(heading.textContent).toBe("Migration plan");
+		expect(list.getAttribute("aria-labelledby")).toBe(heading.id);
+	});
+
+	it("counts substeps in the n/m total, not just the top-level steps", () => {
+		const { container } = render(AgentPlan, { props: { steps: nested() } });
+
+		expect(count(container)).toBe("2/5");
+		expect(rows(container)).toHaveLength(5);
+	});
+
+	it("recounts when a step finishes", async () => {
+		const { container, rerender } = render(AgentPlan, { props: { steps: nested() } });
+		expect(count(container)).toBe("2/5");
+
+		const finished = nested();
+		finished[2].status = "done";
+		await rerender({ steps: finished });
+
+		expect(count(container)).toBe("3/5");
+	});
+
+	it.each([
+		["pending", "ft-status-pending"],
+		["running", "ft-status-running"],
+		["done", "ft-status-done"],
+		["error", "ft-status-error"],
+		["cancelled", "ft-status-cancelled"],
+	] as const)("marks the glyph for %s", (status, className) => {
+		const { container } = render(AgentPlan, { props: { steps: [step({ status })] } });
+
+		const row = rows(container)[0];
+		expect(glyph(row).classList.contains(className)).toBe(true);
+		expect(glyph(row).getAttribute("aria-hidden")).toBe("true");
+		expect(row.dataset.status).toBe(status);
+	});
+
+	it("names each status out loud, since the glyph is hidden from assistive tech", () => {
+		const { container } = render(AgentPlan, {
+			props: { steps: [step({ status: "error" }), step({ id: "s2", status: "cancelled" })] },
+		});
+
+		expect([...container.querySelectorAll(".sr-only")].map((el) => el.textContent)).toEqual([
+			"Failed",
+			"Cancelled",
+		]);
+	});
+
+	it("indents substeps one level, in visual order under their parent", () => {
+		const { container } = render(AgentPlan, { props: { steps: nested() } });
+		const all = rows(container);
+
+		expect(labels(container)).toEqual([
+			"Read the failing test",
+			"Locate the retry helper",
+			"Search the repo",
+			"Open the module",
+			"Apply the fix",
+		]);
+		expect(all.map((row) => row.classList.contains("ft-agentplan-sub"))).toEqual([
+			false,
+			false,
+			true,
+			true,
+			false,
+		]);
+		// The rail stops on the last child of the group rather than running on.
+		expect(all.map((row) => row.classList.contains("ft-agentplan-sub-last"))).toEqual([
+			false,
+			false,
+			false,
+			true,
+			false,
+		]);
+	});
+
+	it("flattens anything nested deeper than one level instead of indenting further", () => {
+		const steps: PlanStepData[] = [
+			step({
+				id: "s1",
+				label: "Ship it",
+				substeps: [
+					step({
+						id: "s1a",
+						label: "Build",
+						substeps: [step({ id: "s1a1", label: "Compile" })],
+					}),
+					step({ id: "s1b", label: "Publish" }),
+				],
+			}),
+		];
+
+		const { container } = render(AgentPlan, { props: { steps } });
+
+		expect(labels(container)).toEqual(["Ship it", "Build", "Compile", "Publish"]);
+		expect(rows(container).map((row) => row.classList.contains("ft-agentplan-sub"))).toEqual([
+			false,
+			true,
+			true,
+			true,
+		]);
+		expect(count(container)).toBe("0/4");
+	});
+
+	it("marks the first running step as the current one, and only that one", () => {
+		const steps = nested();
+		steps[2].status = "running";
+		const { container } = render(AgentPlan, { props: { steps } });
+
+		const current = rows(container).map((row) => row.getAttribute("aria-current"));
+		expect(current).toEqual([null, "step", null, null, null]);
+	});
+
+	it("moves aria-current onto the substep once the parent is done", async () => {
+		const steps = nested();
+		steps[1].status = "done";
+		const { container } = render(AgentPlan, { props: { steps } });
+
+		expect(rows(container).map((row) => row.getAttribute("aria-current"))).toEqual([
+			null,
+			null,
+			null,
+			"step",
+			null,
+		]);
+	});
+
+	it("marks nothing current when the plan has not started", () => {
+		const { container } = render(AgentPlan, {
+			props: { steps: [step(), step({ id: "s2" })] },
+		});
+
+		expect(rows(container).every((row) => row.getAttribute("aria-current") === null)).toBe(true);
+	});
+
+	it("renders the detail line under the step it belongs to", () => {
+		const { container } = render(AgentPlan, {
+			props: { steps: [step({ detail: "tests/retry.spec.ts" })] },
+		});
+
+		const detail = container.querySelector(".ft-agentplan-detail") as HTMLElement;
+		expect(detail.textContent).toBe("tests/retry.spec.ts");
+		expect(detail.getAttribute("title")).toBe("tests/retry.spec.ts");
+	});
+
+	it("says nothing where there is no detail", () => {
+		const { container } = render(AgentPlan, { props: { steps: [step()] } });
+
+		expect(container.querySelector(".ft-agentplan-detail")).toBeNull();
+	});
+
+	it("mutes a finished step without striking it through", () => {
+		const { container } = render(AgentPlan, {
+			props: { steps: [step({ status: "done" }), step({ id: "s2", status: "running" })] },
+		});
+
+		const [done, running] = [
+			...container.querySelectorAll<HTMLElement>(".ft-agentplan-step-label"),
+		];
+		expect(done.className).toContain("text-muted-foreground");
+		expect(done.className).not.toContain("line-through");
+		expect(running.className).toContain("font-medium");
+	});
+
+	it("sizes the progress bar to the done fraction, substeps included", () => {
+		const { container } = render(AgentPlan, { props: { steps: nested() } });
+
+		expect(bar(container)?.style.width).toBe("40%");
+	});
+
+	it("leaves the bar empty rather than dividing by nothing", () => {
+		const { container } = render(AgentPlan, { props: { steps: [] } });
+
+		expect(count(container)).toBe("0/0");
+		expect(bar(container)?.style.width).toBe("0%");
+		expect(rows(container)).toHaveLength(0);
+	});
+
+	it("drops the bar when progress is turned off, keeping the count", () => {
+		const { container } = render(AgentPlan, {
+			props: { steps: nested(), showProgress: false },
+		});
+
+		expect(container.querySelector(".ft-agentplan-track")).toBeNull();
+		expect(count(container)).toBe("2/5");
+	});
+
+	it("leaves rows inert until onSelect says otherwise", () => {
+		const { container } = render(AgentPlan, { props: { steps: nested() } });
+
+		expect(container.querySelectorAll("button")).toHaveLength(0);
+	});
+
+	it("turns every row into a button when onSelect is supplied", async () => {
+		const onSelect = vi.fn();
+		const { container } = render(AgentPlan, { props: { steps: nested(), onSelect } });
+
+		const buttons = container.querySelectorAll("button");
+		expect(buttons).toHaveLength(5);
+
+		// The third row is the first substep: a nested step reports itself, not its parent.
+		await fireEvent.click(buttons[2]);
+		expect(onSelect).toHaveBeenCalledTimes(1);
+		expect(onSelect.mock.calls[0][0]).toMatchObject({ id: "s2a", label: "Search the repo" });
+	});
+
+	it("lets the item snippet replace the row body, keeping the glyph", () => {
+		const { container } = render(AgentPlan, {
+			props: {
+				steps: nested(),
+				item: createRawSnippet<[PlanStepData, number]>((stepArg, index) => ({
+					render: () =>
+						`<span class="custom-row">${index()}: ${(stepArg() as PlanStepData).label}</span>`,
+				})),
+			},
+		});
+
+		expect([...container.querySelectorAll(".custom-row")].map((el) => el.textContent)).toEqual([
+			"0: Read the failing test",
+			"1: Locate the retry helper",
+			"2: Search the repo",
+			"3: Open the module",
+			"4: Apply the fix",
+		]);
+		expect(container.querySelector(".ft-agentplan-step-label")).toBeNull();
+		expect(container.querySelectorAll(".ft-agentplan-glyph")).toHaveLength(5);
+	});
+
+	it("renders a plan that repeats an id instead of crashing on it", () => {
+		const steps: PlanStepData[] = [
+			step({ id: "retry", label: "Retry the request", status: "done" }),
+			step({ id: "retry", label: "Retry the request", status: "error" }),
+			step({
+				id: "retry",
+				label: "Retry the request",
+				status: "running",
+				substeps: [step({ id: "retry", label: "Back off" })],
+			}),
+		];
+
+		// Keying on the id alone would throw `each_key_duplicate` before a single
+		// row reached the DOM, and the ids here come from a model.
+		const { container } = render(AgentPlan, { props: { steps } });
+
+		expect(rows(container)).toHaveLength(4);
+		expect(count(container)).toBe("1/4");
+	});
+
+	it("keeps the rows already on screen keyed the same when the plan grows", async () => {
+		const { container, rerender } = render(AgentPlan, { props: { steps: nested() } });
+		const first = rows(container)[0];
+
+		await rerender({ steps: [...nested(), step({ id: "s4", label: "Open a PR" })] });
+
+		// Same node, not a remount: an appended step must not replay every entrance.
+		expect(rows(container)[0]).toBe(first);
+		expect(rows(container)).toHaveLength(6);
+	});
+
+	it("merges custom classes onto the root", () => {
+		const { container } = render(AgentPlan, {
+			props: { steps: [step()], class: "my-plan" },
+		});
+		const root = container.firstElementChild as HTMLElement;
+
+		expect(root.className).toContain("my-plan");
+		expect(root.className).toContain("ft-agentplan");
+	});
+});

--- a/src/lib/fancy-ui/agent-plan/AgentPlan.test.ts
+++ b/src/lib/fancy-ui/agent-plan/AgentPlan.test.ts
@@ -358,4 +358,19 @@ describe("AgentPlan", () => {
 		expect(root.className).toContain("my-plan");
 		expect(root.className).toContain("ft-agentplan");
 	});
+
+	it("keeps every key distinct when a raw id looks like a generated suffix", () => {
+		// The second "x" would otherwise be handed the key the third step answers to.
+		const { container } = render(AgentPlan, {
+			props: {
+				steps: [
+					step({ id: "x", label: "First" }),
+					step({ id: "x", label: "Second" }),
+					step({ id: "x#1", label: "Third" }),
+				],
+			},
+		});
+
+		expect(labels(container)).toEqual(["First", "Second", "Third"]);
+	});
 });

--- a/src/lib/fancy-ui/agent-plan/README.md
+++ b/src/lib/fancy-ui/agent-plan/README.md
@@ -1,0 +1,136 @@
+# Agent Plan
+
+What the agent means to do and how far down the list it has got: a header with a done/total count and a thin completion bar, then one row per step with a glyph for its state and its substeps indented under a rail.
+
+## Components
+
+- `AgentPlan` — header, progress bar, and the flattened step list
+
+## Usage
+
+```svelte
+<script>
+	import { AgentPlan } from "fancy-ui-svelte";
+
+	const steps = [
+		{ id: "s1", label: "Read the failing test", status: "done", detail: "tests/retry.spec.ts" },
+		{
+			id: "s2",
+			label: "Locate the retry helper",
+			status: "running",
+			substeps: [
+				{ id: "s2a", label: "Search for retryWithBackoff", status: "done" },
+				{ id: "s2b", label: "Open the module it lives in", status: "running" },
+			],
+		},
+		{ id: "s3", label: "Run the suite", status: "pending" },
+	];
+</script>
+
+<AgentPlan {steps} label="Fix the retry backoff" />
+```
+
+## The data contract
+
+Each entry is a `PlanStepData`, the shape shared by every component in this family — the same objects can flow from a plan tree into a task checklist without translation:
+
+```ts
+interface PlanStepData {
+	id: string;
+	label: string;
+	status: "pending" | "running" | "done" | "error" | "cancelled";
+	detail?: string;
+	substeps?: PlanStepData[];
+}
+```
+
+Only `id`, `label`, and `status` are required. Give each step an `id` that is unique across the whole plan, substeps included: it leads the key each row is tracked by, so unique ids are what keep a row on its own DOM node when the plan changes shape. Repeats are survivable rather than fatal — the position is folded into the key — but two steps sharing an id will trade places rather than move.
+
+## Props
+
+| Prop           | Type                              | Default     | Description                                             |
+| -------------- | --------------------------------- | ----------- | ------------------------------------------------------- |
+| `steps`        | `PlanStepData[]`                  | —           | The plan, in the order it will be worked. Required.     |
+| `label`        | `string`                          | `"Plan"`    | Header text, beside the done/total count                |
+| `showProgress` | `boolean`                         | `true`      | Whether the thin completion bar shows                   |
+| `onSelect`     | `(step: PlanStepData) => void`    | `undefined` | Called when a row is activated; turns rows into buttons |
+| `item`         | `Snippet<[PlanStepData, number]>` | `undefined` | Replaces the row body, keeping the glyph and indent     |
+| `class`        | `string`                          | `undefined` | Additional CSS classes                                  |
+| `ref`          | `HTMLDivElement \| null`          | `null`      | Bindable reference to the root element                  |
+
+## Counting
+
+The count and the bar treat a substep as a step: a plan of five checks with two hiding under one of them is out of seven, not out of five. The fraction is `done / total` — only `done` counts, so a failed or cancelled step holds the bar back rather than quietly completing it.
+
+## Depth
+
+One level of indent is all the eye can follow at a glance, so a plan nested deeper is **flattened, not indented further**: a grandchild renders at the same level as the child it belongs to, immediately below it, keeping reading order intact. Nothing is dropped and everything is still counted.
+
+## The current step
+
+`aria-current="step"` lands on the **first** row whose status is `running`, in visual order. A plan with two things in flight still has one place the reader's eye — and a screen reader's "current step" — should go. Nothing carries it when nothing is running.
+
+## Selectable rows
+
+Pass `onSelect` and every row becomes a `<button>` with hover and focus states; leave it off and rows are plain text with nothing to tab through. A nested row reports itself, not its parent.
+
+## Replacing a row
+
+`item` receives the step and its position in visual order — substeps included, so the fourth line is index `3` whatever its depth:
+
+```svelte
+<AgentPlan {steps}>
+	{#snippet item(step, index)}
+		<span class="flex-1">{index + 1}. {step.label}</span>
+	{/snippet}
+</AgentPlan>
+```
+
+The glyph and the indent stay; only the text block is yours.
+
+## Styling
+
+Colour comes from `--ft-status-*`, the run-status vocabulary shared with `ToolCall`, `ToolTimeline`, `TerminalBlock`, `CodeDiff` and `ChatError`. Set one anywhere up the tree and every component in the family follows:
+
+| Variable                | Default (light / dark)                         | Meaning                      |
+| ----------------------- | ---------------------------------------------- | ---------------------------- |
+| `--ft-status-pending`   | `oklch(0.5 0.02 260)` / `oklch(0.72 0.02 260)` | Queued, nothing has run yet  |
+| `--ft-status-running`   | `oklch(0.5 0.18 265)` / `oklch(0.72 0.15 265)` | In flight                    |
+| `--ft-status-done`      | `oklch(0.5 0.14 145)` / `oklch(0.72 0.15 145)` | Succeeded                    |
+| `--ft-status-error`     | `oklch(0.5 0.19 25)` / `oklch(0.7 0.18 25)`    | Failed                       |
+| `--ft-status-cancelled` | `oklch(0.5 0.02 260)` / `oklch(0.72 0.02 260)` | Abandoned before it finished |
+
+Each default is a `light-dark()` pair, because no single token clears 4.5:1 against both white and near-black. Which half applies is decided by `color-scheme`, so **your theme must declare it**:
+
+```css
+:root {
+	color-scheme: light;
+}
+.dark {
+	color-scheme: dark;
+}
+```
+
+The `--ft-agentplan-*` names below sit in front of the shared ones, for the case where this list alone should differ:
+
+| Variable                   | Default                        | Applies to                          |
+| -------------------------- | ------------------------------ | ----------------------------------- |
+| `--ft-agentplan-pending`   | `--ft-status-pending` at 70%   | Hollow ring                         |
+| `--ft-agentplan-running`   | `--ft-status-running`          | Filled dot and its pulse            |
+| `--ft-agentplan-done`      | `--ft-status-done`             | Tick                                |
+| `--ft-agentplan-error`     | `--ft-status-error`            | Cross                               |
+| `--ft-agentplan-cancelled` | `--ft-status-cancelled` at 55% | Dash                                |
+| `--ft-agentplan-bar`       | `--ft-status-done`             | The progress fill                   |
+| `--ft-agentplan-rail`      | `currentColor` at 16%          | The line beside a group of substeps |
+| `--ft-agentplan-track-bg`  | `currentColor` at 12%          | The unfilled part of the bar        |
+| `--ft-agentplan-indent`    | `1.5rem`                       | How far a substep sits in           |
+
+## Implementation Notes
+
+- Status is carried by shape as well as hue — hollow ring, filled dot, tick, cross, dash — and spelled out in a screen-reader-only label beside each step, so colour is never the only signal.
+- A finished step is muted, never struck through: a checklist of crossed-out lines is harder to scan, not easier.
+- The list is flat in the DOM with an indent class, because `listitem` needs `list` as its parent and a wrapper per group would break that for the sake of a left margin CSS can do. The rail is drawn per row and stops on the last child of its group.
+- The bar is `aria-hidden`: the header already says `4/7` in words.
+- Every animation — the running pulse, the bar sliding to its new width — lives behind `prefers-reduced-motion: no-preference`. Reduced motion gets the same states, instantly.
+- Each row is keyed by its step's `id` with its flattened position appended. The id is what keeps a row on its own DOM node across a re-render; the position is what stops a model that emits the same id twice from crashing the block, and appending a step leaves every existing key untouched.
+- Nothing is scheduled and no DOM is touched at construction time, so the list renders under SSR unchanged.

--- a/src/lib/fancy-ui/agent-plan/index.ts
+++ b/src/lib/fancy-ui/agent-plan/index.ts
@@ -1,0 +1,4 @@
+import AgentPlan from "./AgentPlan.svelte";
+import type { AgentPlanProps } from "./AgentPlan.svelte";
+
+export { AgentPlan, type AgentPlanProps };

--- a/src/lib/fancy-ui/ai-data-table/AiDataTable.svelte
+++ b/src/lib/fancy-ui/ai-data-table/AiDataTable.svelte
@@ -1,0 +1,214 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	/** One column, rendered in the order it appears in the array. */
+	export interface AiDataTableColumn {
+		/** Key looked up on every row. */
+		key: string;
+		/** Header text. */
+		label: string;
+		/** Horizontal alignment. Defaults to right on a numeric column, left otherwise. */
+		align?: "left" | "center" | "right";
+		/** Renders the column with tabular figures, and right-aligns it unless `align` says otherwise. */
+		numeric?: boolean;
+	}
+
+	/** Everything a cell is allowed to hold — the four things a model actually emits. */
+	export type AiDataTableValue = string | number | boolean | null | undefined;
+
+	/** One row, keyed by column key. Missing keys read as empty. */
+	export type AiDataTableRow = Record<string, AiDataTableValue>;
+
+	/**
+	 * Props for AiDataTable
+	 */
+	export interface AiDataTableProps {
+		/** The columns to render, in order. */
+		columns: AiDataTableColumn[];
+		/** The rows to render, in the order the model produced them. */
+		rows: AiDataTableRow[];
+		/** Describes the table for assistive tech. Hidden on screen unless `captionVisible`. */
+		caption?: string;
+		/** Shows `caption` as a muted line above the table. */
+		captionVisible?: boolean;
+		/** Tighter rows, for a table read at a glance rather than studied. */
+		dense?: boolean;
+		/** Key of the column to tint — the recommendation, or whichever criterion decided it. */
+		highlightColumn?: string;
+		/** Replaces the default cell rendering. Receives the raw value and its position. */
+		cell?: Snippet<[unknown, { row: number; key: string }]>;
+		/** Additional CSS classes */
+		class?: string;
+		/** The root element */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let {
+		columns,
+		rows,
+		caption,
+		captionVisible = false,
+		dense = false,
+		highlightColumn,
+		cell,
+		class: className,
+		ref = $bindable(null),
+	}: AiDataTableProps = $props();
+
+	/** Spoken in place of the glyphs, which say nothing out loud. */
+	const TRUE_LABEL = "True";
+	const FALSE_LABEL = "False";
+	const EMPTY_LABEL = "No value";
+
+	/**
+	 * Written out rather than interpolated: Tailwind reads this file as text, and a
+	 * class assembled at runtime is a class it never sees.
+	 */
+	const ALIGN_CLASS = {
+		left: "text-left",
+		center: "text-center",
+		right: "text-right",
+	} as const;
+
+	/** Numbers lean right by default — that is where the eye compares magnitudes. */
+	function alignOf(column: AiDataTableColumn): "left" | "center" | "right" {
+		return column.align ?? (column.numeric ? "right" : "left");
+	}
+</script>
+
+<!--
+	The wrapper is the only thing allowed to scroll sideways: a model asked for
+	nine criteria will produce nine columns, and the page around it must not go on
+	a horizontal rail because of that.
+
+	Which is why it is focusable and named. A scroll container that only answers to
+	a pointer is unreachable for anyone driving the page from the keyboard, so it
+	takes a tab stop and a `region` role to explain what the tab stop is for.
+-->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div
+	bind:this={ref}
+	class={cn("ft-datatable w-full max-w-full overflow-x-auto", className)}
+	tabindex="0"
+	role="region"
+	aria-label={caption ?? "Data table"}
+>
+	<table class="ft-datatable-table w-full border-collapse text-sm" class:ft-datatable-dense={dense}>
+		{#if caption}
+			<caption
+				class={captionVisible
+					? "ft-datatable-caption text-muted-foreground pb-2 text-left text-xs"
+					: "ft-datatable-caption sr-only"}>{caption}</caption
+			>
+		{/if}
+
+		<thead>
+			<tr class="border-border border-b">
+				{#each columns as column, columnIndex (columnIndex)}
+					<th
+						scope="col"
+						class={cn(
+							"text-muted-foreground text-xs font-medium whitespace-nowrap",
+							ALIGN_CLASS[alignOf(column)],
+							column.numeric && "tabular-nums",
+							column.key === highlightColumn && "ft-datatable-highlight"
+						)}>{column.label}</th
+					>
+				{/each}
+			</tr>
+		</thead>
+
+		<tbody>
+			{#each rows as row, rowIndex (rowIndex)}
+				<tr class:ft-datatable-zebra={rowIndex % 2 === 1}>
+					{#each columns as column, columnIndex (columnIndex)}
+						{@const value = row[column.key]}
+						<td
+							class={cn(
+								"align-top",
+								ALIGN_CLASS[alignOf(column)],
+								column.numeric && "tabular-nums",
+								column.key === highlightColumn && "ft-datatable-highlight"
+							)}
+						>
+							{#if cell}
+								{@render cell(value, { row: rowIndex, key: column.key })}
+							{:else if typeof value === "boolean"}
+								{#if value}
+									<svg
+										class="ft-datatable-true inline-block size-3.5 align-[-0.15em]"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="3"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										aria-hidden="true"
+									>
+										<path d="m5 13 4 4L19 7" />
+									</svg>
+									<span class="sr-only">{TRUE_LABEL}</span>
+								{:else}
+									<span class="ft-datatable-false text-muted-foreground" aria-hidden="true">–</span>
+									<span class="sr-only">{FALSE_LABEL}</span>
+								{/if}
+							{:else if value === null || value === undefined || value === ""}
+								<!--
+									An empty string is the third way a model says nothing, alongside
+									`null` and a key it never mentioned, so it reads the same way
+									rather than as a cell the renderer dropped on the floor.
+								-->
+								<span class="ft-datatable-empty text-muted-foreground" aria-hidden="true">—</span>
+								<span class="sr-only">{EMPTY_LABEL}</span>
+							{:else}
+								{value}
+							{/if}
+						</td>
+					{/each}
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>
+
+<style>
+	/*
+	 * Padding lives here rather than on every cell so a consumer can retune the
+	 * whole grid with one custom property instead of restyling each element.
+	 */
+	.ft-datatable-table th,
+	.ft-datatable-table td {
+		padding-block: var(--ft-table-pad-y, 0.5rem);
+		padding-inline: var(--ft-table-pad-x, 0.75rem);
+	}
+
+	.ft-datatable-table.ft-datatable-dense th,
+	.ft-datatable-table.ft-datatable-dense td {
+		padding-block: var(--ft-table-dense-pad-y, 0.25rem);
+	}
+
+	/*
+	 * Zebra sits on the row and the tint on the cell, so the two never fight over
+	 * one background: a tinted cell simply paints over the stripe underneath it.
+	 * Both are mixes of `currentColor`, which is how they stay legible on a light
+	 * page and a dark one without knowing which they are on.
+	 */
+	.ft-datatable-zebra {
+		background: var(--ft-table-zebra, color-mix(in oklab, currentColor 3%, transparent));
+	}
+
+	.ft-datatable-highlight {
+		background: var(--ft-table-highlight, color-mix(in oklab, currentColor 5%, transparent));
+	}
+
+	.ft-datatable-true {
+		color: var(
+			--ft-table-true,
+			var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145)))
+		);
+	}
+</style>

--- a/src/lib/fancy-ui/ai-data-table/AiDataTable.test.ts
+++ b/src/lib/fancy-ui/ai-data-table/AiDataTable.test.ts
@@ -1,0 +1,278 @@
+import { render, cleanup } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect } from "vitest";
+import AiDataTable from "./AiDataTable.svelte";
+import type { AiDataTableColumn, AiDataTableRow } from "./AiDataTable.svelte";
+
+const COLUMNS: AiDataTableColumn[] = [
+	{ key: "option", label: "Option" },
+	{ key: "latency", label: "p95 latency (ms)", numeric: true },
+	{ key: "selfHosted", label: "Self-hosted" },
+	{ key: "sla", label: "SLA" },
+];
+
+const ROWS: AiDataTableRow[] = [
+	{ option: "Managed cluster", latency: 42, selfHosted: false, sla: "99.95%" },
+	{ option: "Serverless pool", latency: 88, selfHosted: false, sla: "99.9%" },
+	{ option: "Self-run nodes", latency: 31, selfHosted: true, sla: null },
+];
+
+function headers(container: HTMLElement): HTMLTableCellElement[] {
+	return [...container.querySelectorAll("thead th")] as HTMLTableCellElement[];
+}
+
+function bodyRows(container: HTMLElement): HTMLTableRowElement[] {
+	return [...container.querySelectorAll("tbody tr")] as HTMLTableRowElement[];
+}
+
+function cellsOf(row: HTMLTableRowElement): HTMLTableCellElement[] {
+	return [...row.querySelectorAll("td")] as HTMLTableCellElement[];
+}
+
+describe("AiDataTable", () => {
+	afterEach(cleanup);
+
+	it("renders one header per column, in order, inside a real table", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: ROWS } });
+
+		expect(container.querySelector("table")).not.toBeNull();
+		expect(headers(container).map((th) => th.textContent)).toEqual([
+			"Option",
+			"p95 latency (ms)",
+			"Self-hosted",
+			"SLA",
+		]);
+	});
+
+	it("scopes every header to its column", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: ROWS } });
+
+		for (const th of headers(container)) {
+			expect(th.getAttribute("scope")).toBe("col");
+		}
+	});
+
+	it("renders one row per record, reading each cell by its column key", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: ROWS } });
+		const rows = bodyRows(container);
+
+		expect(rows).toHaveLength(3);
+		// The boolean cell carries its glyph and the words for it, in that order.
+		expect(cellsOf(rows[0]).map((td) => td.textContent?.trim())).toEqual([
+			"Managed cluster",
+			"42",
+			"– False",
+			"99.95%",
+		]);
+	});
+
+	it("right-aligns numeric columns and gives them tabular figures", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: ROWS } });
+		const latencyHeader = headers(container)[1];
+		const latencyCell = cellsOf(bodyRows(container)[0])[1];
+
+		expect(latencyHeader.className).toContain("text-right");
+		expect(latencyHeader.className).toContain("tabular-nums");
+		expect(latencyCell.className).toContain("text-right");
+		expect(latencyCell.className).toContain("tabular-nums");
+	});
+
+	it("lets an explicit align beat the numeric default, and leaves prose on the left", () => {
+		const { container } = render(AiDataTable, {
+			props: {
+				columns: [
+					{ key: "n", label: "N", numeric: true, align: "center" },
+					{ key: "note", label: "Note" },
+				],
+				rows: [{ n: 1, note: "why" }],
+			},
+		});
+
+		expect(headers(container)[0].className).toContain("text-center");
+		expect(headers(container)[0].className).not.toContain("text-right");
+		expect(headers(container)[1].className).toContain("text-left");
+	});
+
+	it("renders true as a check that says so out loud", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: ROWS } });
+		const cell = cellsOf(bodyRows(container)[2])[2];
+
+		const glyph = cell.querySelector(".ft-datatable-true") as SVGElement;
+		expect(glyph).not.toBeNull();
+		expect(glyph.getAttribute("aria-hidden")).toBe("true");
+		expect(cell.querySelector(".sr-only")?.textContent).toBe("True");
+	});
+
+	it("renders false as a muted dash that says so out loud", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: ROWS } });
+		const cell = cellsOf(bodyRows(container)[0])[2];
+
+		const glyph = cell.querySelector(".ft-datatable-false") as HTMLElement;
+		expect(glyph.textContent).toBe("–");
+		expect(glyph.getAttribute("aria-hidden")).toBe("true");
+		expect(cell.querySelector(".sr-only")?.textContent).toBe("False");
+	});
+
+	it("marks a null cell with an em dash rather than leaving it blank", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: ROWS } });
+		const cell = cellsOf(bodyRows(container)[2])[3];
+
+		const glyph = cell.querySelector(".ft-datatable-empty") as HTMLElement;
+		expect(glyph.textContent).toBe("—");
+		expect(glyph.getAttribute("aria-hidden")).toBe("true");
+		expect(cell.querySelector(".sr-only")?.textContent).toBe("No value");
+	});
+
+	it("reads an empty string as the model saying nothing, like a null", () => {
+		const { container } = render(AiDataTable, {
+			props: { columns: COLUMNS, rows: [{ option: "Managed cluster", sla: "" }] },
+		});
+		const cell = cellsOf(bodyRows(container)[0])[3];
+
+		expect(cell.querySelector(".ft-datatable-empty")?.textContent).toBe("—");
+		expect(cell.querySelector(".sr-only")?.textContent).toBe("No value");
+	});
+
+	it("treats a key the row never mentioned as empty rather than crashing", () => {
+		const { container } = render(AiDataTable, {
+			props: { columns: COLUMNS, rows: [{ option: "Only a name" }] },
+		});
+		const cells = cellsOf(bodyRows(container)[0]);
+
+		expect(cells).toHaveLength(4);
+		expect(cells[1].querySelector(".ft-datatable-empty")?.textContent).toBe("—");
+	});
+
+	it("keeps the caption out of sight but in the accessibility tree by default", () => {
+		const { container } = render(AiDataTable, {
+			props: { columns: COLUMNS, rows: ROWS, caption: "Deployment options" },
+		});
+		const caption = container.querySelector("caption") as HTMLElement;
+
+		expect(caption.textContent).toBe("Deployment options");
+		expect(caption.classList.contains("sr-only")).toBe(true);
+	});
+
+	it("shows the caption as a muted line when asked", () => {
+		const { container } = render(AiDataTable, {
+			props: {
+				columns: COLUMNS,
+				rows: ROWS,
+				caption: "Deployment options",
+				captionVisible: true,
+			},
+		});
+		const caption = container.querySelector("caption") as HTMLElement;
+
+		expect(caption.classList.contains("sr-only")).toBe(false);
+		expect(caption.className).toContain("text-muted-foreground");
+	});
+
+	it("renders no caption element when there is nothing to caption", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: ROWS } });
+
+		expect(container.querySelector("caption")).toBeNull();
+	});
+
+	it("tints one column top to bottom, and only that one", () => {
+		const { container } = render(AiDataTable, {
+			props: { columns: COLUMNS, rows: ROWS, highlightColumn: "latency" },
+		});
+
+		expect(headers(container)[1].classList.contains("ft-datatable-highlight")).toBe(true);
+		expect(headers(container)[0].classList.contains("ft-datatable-highlight")).toBe(false);
+
+		for (const row of bodyRows(container)) {
+			const cells = cellsOf(row);
+			expect(cells[1].classList.contains("ft-datatable-highlight")).toBe(true);
+			expect(cells[3].classList.contains("ft-datatable-highlight")).toBe(false);
+		}
+	});
+
+	it("tints nothing when the highlight key matches no column", () => {
+		const { container } = render(AiDataTable, {
+			props: { columns: COLUMNS, rows: ROWS, highlightColumn: "nope" },
+		});
+
+		expect(container.querySelectorAll(".ft-datatable-highlight")).toHaveLength(0);
+	});
+
+	it("stripes every other row", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: ROWS } });
+		const striped = bodyRows(container).map((tr) => tr.classList.contains("ft-datatable-zebra"));
+
+		expect(striped).toEqual([false, true, false]);
+	});
+
+	it("hands the cell snippet the raw value and where it sits", () => {
+		const { container } = render(AiDataTable, {
+			props: {
+				columns: COLUMNS,
+				rows: ROWS,
+				cell: createRawSnippet<[unknown, { row: number; key: string }]>((value, at) => ({
+					render: () =>
+						`<span class="custom-cell">${at().row}:${at().key}=${String(value())}</span>`,
+				})),
+			},
+		});
+		const cells = cellsOf(bodyRows(container)[1]);
+
+		expect(container.querySelectorAll(".custom-cell")).toHaveLength(12);
+		expect(cells[0].textContent?.trim()).toBe("1:option=Serverless pool");
+		expect(cells[2].textContent?.trim()).toBe("1:selfHosted=false");
+		// The default glyphs step aside entirely rather than doubling up.
+		expect(container.querySelector(".ft-datatable-false")).toBeNull();
+	});
+
+	it("tightens the rows when dense", () => {
+		const { container } = render(AiDataTable, {
+			props: { columns: COLUMNS, rows: ROWS, dense: true },
+		});
+		const table = container.querySelector("table") as HTMLTableElement;
+
+		expect(table.classList.contains("ft-datatable-dense")).toBe(true);
+	});
+
+	it("renders at full width without dense", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: ROWS } });
+		const table = container.querySelector("table") as HTMLTableElement;
+
+		expect(table.classList.contains("ft-datatable-dense")).toBe(false);
+	});
+
+	it("survives a model that returned columns but no rows", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: [] } });
+
+		expect(headers(container)).toHaveLength(4);
+		expect(bodyRows(container)).toHaveLength(0);
+	});
+
+	it("makes the scrolling wrapper reachable from the keyboard, and says what it is", () => {
+		const { container } = render(AiDataTable, {
+			props: { columns: COLUMNS, rows: ROWS, caption: "Deployment options" },
+		});
+		const root = container.firstElementChild as HTMLElement;
+
+		expect(root.getAttribute("tabindex")).toBe("0");
+		expect(root.getAttribute("role")).toBe("region");
+		expect(root.getAttribute("aria-label")).toBe("Deployment options");
+	});
+
+	it("names the scroll region generically when there is no caption to borrow", () => {
+		const { container } = render(AiDataTable, { props: { columns: COLUMNS, rows: ROWS } });
+		const root = container.firstElementChild as HTMLElement;
+
+		expect(root.getAttribute("aria-label")).toBe("Data table");
+	});
+
+	it("merges custom classes onto the scrolling root", () => {
+		const { container } = render(AiDataTable, {
+			props: { columns: COLUMNS, rows: ROWS, class: "my-table" },
+		});
+		const root = container.firstElementChild as HTMLElement;
+
+		expect(root.className).toContain("my-table");
+		expect(root.className).toContain("ft-datatable");
+		expect(root.className).toContain("overflow-x-auto");
+	});
+});

--- a/src/lib/fancy-ui/ai-data-table/README.md
+++ b/src/lib/fancy-ui/ai-data-table/README.md
@@ -1,0 +1,147 @@
+# AI Data Table
+
+A compact comparison table for the structured answer a model just produced: real `<table>` semantics, tabular figures on the numeric columns, check-or-dash glyphs on the booleans, and one column you can tint as the recommendation.
+
+## Components
+
+- `AiDataTable` — the scrolling wrapper, the table, and its default cell rendering
+
+## Usage
+
+```svelte
+<script>
+	import { AiDataTable } from "fancy-ui-svelte";
+
+	const columns = [
+		{ key: "option", label: "Deployment" },
+		{ key: "cost", label: "Cost / 1M req", numeric: true },
+		{ key: "selfHosted", label: "Self-hosted", align: "center" },
+		{ key: "sla", label: "SLA" },
+	];
+
+	const rows = [
+		{ option: "Managed cluster", cost: 18.4, selfHosted: false, sla: "99.95%" },
+		{ option: "Serverless pool", cost: 6.2, selfHosted: false, sla: "99.9%" },
+		{ option: "Self-run nodes", cost: 24.9, selfHosted: true, sla: null },
+	];
+</script>
+
+<AiDataTable {columns} {rows} caption="Deployment options" highlightColumn="cost" />
+```
+
+## It renders the answer, it does not re-open it
+
+**There is no sorting and no filtering, by design.** A model that returns a table has already made two decisions you cannot see: which rows to include, and what order to put them in. "Cheapest first" may be the argument the answer is making. A column header that quietly re-sorts the rows lets a reader take the table apart without the model's reasoning coming with it — and turns a rendered answer into a spreadsheet that no longer says what was said.
+
+So this component renders `rows` in the order it received them, forever. If you need interaction, you need something else above it: sort the array yourself before you pass it, and own the consequences of having done so.
+
+The same rule holds inside a cell. Numbers are printed exactly as they arrived — no rounding, no thousands separators, no currency. `18.4` renders as `18.4`. Formatting is a claim about precision, and it is not this component's claim to make; format the value before it reaches `rows`, or take over the cell with the `cell` snippet.
+
+## The data contract
+
+```ts
+interface AiDataTableColumn {
+	key: string;
+	label: string;
+	align?: "left" | "center" | "right";
+	numeric?: boolean;
+}
+
+type AiDataTableValue = string | number | boolean | null | undefined;
+type AiDataTableRow = Record<string, AiDataTableValue>;
+```
+
+`columns` fixes the order and the header text; each column's `key` is looked up on every row. A key a row never mentions is not an error — it renders as empty, the same as `null`, because a model answering about three options will routinely know four things about two of them.
+
+## Props
+
+| Prop              | Type                                               | Default     | Description                                         |
+| ----------------- | -------------------------------------------------- | ----------- | --------------------------------------------------- |
+| `columns`         | `AiDataTableColumn[]`                              | —           | Columns in render order. Required                   |
+| `rows`            | `AiDataTableRow[]`                                 | —           | Rows in the order the model produced them. Required |
+| `caption`         | `string`                                           | `undefined` | Names the table for assistive tech                  |
+| `captionVisible`  | `boolean`                                          | `false`     | Also shows the caption, as a muted line above       |
+| `dense`           | `boolean`                                          | `false`     | Tighter rows                                        |
+| `highlightColumn` | `string`                                           | `undefined` | Key of the column to tint                           |
+| `cell`            | `Snippet<[unknown, { row: number; key: string }]>` | `undefined` | Replaces the default cell rendering                 |
+| `class`           | `string`                                           | `undefined` | Additional CSS classes                              |
+| `ref`             | `HTMLDivElement \| null`                           | `null`      | Bindable reference to the scrolling root            |
+
+## How a value is rendered
+
+| Value                   | On screen                              | Out loud   |
+| ----------------------- | -------------------------------------- | ---------- |
+| `string` / `number`     | As-is                                  | As-is      |
+| `true`                  | Check glyph, tinted `--ft-status-done` | "True"     |
+| `false`                 | Muted en dash `–`                      | "False"    |
+| `null` / `""` / missing | Muted em dash `—`                      | "No value" |
+
+Every glyph is `aria-hidden` with the words beside it in a screen-reader-only span, so a boolean column is never a colour-and-shape puzzle for anyone who cannot see it. The two dashes differ on purpose: `–` means the model said no, `—` means the model said nothing — and an empty string is the model saying nothing, so it reads as the em dash rather than as a cell that looks dropped.
+
+## Alignment
+
+`numeric: true` does two things: `tabular-nums`, so digits line up in a column instead of wandering, and right alignment, because that is the edge the eye compares magnitudes along. Set `align` to override — a numeric column of ratings reads better centred:
+
+```svelte
+<AiDataTable
+	columns={[
+		{ key: "score", label: "Score", numeric: true, align: "center" },
+		{ key: "name", label: "Model" },
+	]}
+	{rows}
+/>
+```
+
+## Taking over a cell
+
+`cell` replaces the default rendering for **every** cell, receiving the raw value and where it sits. Branch on `key` to keep the defaults everywhere else:
+
+```svelte
+<AiDataTable {columns} {rows}>
+	{#snippet cell(value, { key })}
+		{#if key === "sla" && value === null}
+			<span class="text-muted-foreground italic">not published</span>
+		{:else}
+			{value}
+		{/if}
+	{/snippet}
+</AiDataTable>
+```
+
+## Accessibility
+
+- A real `<table>` with `<thead>`, `<tbody>`, and `scope="col"` on every header — so a screen reader announces the column when it reads a cell, which is the whole reason to use a table rather than a grid of divs.
+- `caption` names the table. It is hidden by default rather than absent, so the name reaches assistive tech without adding a heading nobody asked for; `captionVisible` shows it too.
+- Booleans and empties carry text, never colour alone.
+- The table sits inside an `overflow-x-auto` wrapper, so a nine-column answer scrolls in place instead of putting the whole page on a horizontal rail.
+
+## Styling
+
+| Variable                 | Default              | Applies to                         |
+| ------------------------ | -------------------- | ---------------------------------- |
+| `--ft-table-highlight`   | `currentColor` at 5% | The `highlightColumn` tint         |
+| `--ft-table-zebra`       | `currentColor` at 3% | The stripe on every other row      |
+| `--ft-table-true`        | `--ft-status-done`   | The check glyph                    |
+| `--ft-table-pad-y`       | `0.5rem`             | Vertical cell padding              |
+| `--ft-table-dense-pad-y` | `0.25rem`            | Vertical cell padding when `dense` |
+| `--ft-table-pad-x`       | `0.75rem`            | Horizontal cell padding            |
+
+The check glyph reads `--ft-status-done`, the run-status vocabulary shared with `ToolCall`, `ToolTimeline`, `TerminalBlock`, `CodeDiff` and `ChatError` — retint that one variable and every component in the family follows. Its default is a `light-dark()` pair, since no single green clears 4.5:1 against both white and near-black, so **your theme must declare `color-scheme`**:
+
+```css
+:root {
+	color-scheme: light;
+}
+.dark {
+	color-scheme: dark;
+}
+```
+
+Zebra and highlight are both mixes of `currentColor`, so they stay proportionate on a light page and a dark one without being told which they are on. They are also layered rather than blended: the stripe sits on the row and the tint on the cell, so a highlighted cell in a striped row simply paints over the stripe instead of fighting it for one background.
+
+## Implementation Notes
+
+- Nothing animates. There is no transition to shorten and no motion to suppress, so the component renders identically under `prefers-reduced-motion: reduce`.
+- Nothing is scheduled and no DOM is touched at construction, so it renders unchanged under SSR.
+- Rows and columns are keyed by index, not by `key`, so a model that emits the same column key twice renders a slightly odd table rather than crashing the page.
+- The scrolling wrapper is a focusable `region`, named from `caption` (or "Data table" without one). A wide table that only scrolls under a pointer is unreachable for anyone driving the page from the keyboard; the tab stop is what lets them reach the columns off the right edge, and the role and name are what make the stop explicable when they land on it.

--- a/src/lib/fancy-ui/ai-data-table/index.ts
+++ b/src/lib/fancy-ui/ai-data-table/index.ts
@@ -1,0 +1,15 @@
+import AiDataTable from "./AiDataTable.svelte";
+import type {
+	AiDataTableProps,
+	AiDataTableColumn,
+	AiDataTableRow,
+	AiDataTableValue,
+} from "./AiDataTable.svelte";
+
+export {
+	AiDataTable,
+	type AiDataTableProps,
+	type AiDataTableColumn,
+	type AiDataTableRow,
+	type AiDataTableValue,
+};

--- a/src/lib/fancy-ui/approval-card/ApprovalCard.svelte
+++ b/src/lib/fancy-ui/approval-card/ApprovalCard.svelte
@@ -36,6 +36,7 @@
 </script>
 
 <script lang="ts">
+	import { tick } from "svelte";
 	import { cn } from "$lib/utils.js";
 
 	let {
@@ -63,6 +64,9 @@
 	const isApproved = $derived(state === "approved");
 	const resolvedLabel = $derived(isApproved ? RESOLVED_LABELS.approved : RESOLVED_LABELS.denied);
 
+	/** Where focus lands once the buttons it might have held are gone. */
+	let resolvedRef: HTMLParagraphElement | null = null;
+
 	/**
 	 * The decision is written to `state` before the callback fires, so a consumer
 	 * reading the bound value from inside its own handler already sees the answer.
@@ -73,6 +77,10 @@
 		state = next;
 		if (next === "approved") onApprove?.();
 		else onDeny?.();
+		// The button just pressed is about to leave the DOM along with the rest of
+		// the action group, so focus is moved to the verdict once it has painted —
+		// otherwise the browser drops it back to the document body.
+		tick().then(() => resolvedRef?.focus());
 	}
 </script>
 
@@ -153,7 +161,9 @@
 			</div>
 		{:else}
 			<p
-				class="ft-approval-resolved flex items-center gap-1.5 text-xs font-medium"
+				bind:this={resolvedRef}
+				tabindex="-1"
+				class="ft-approval-resolved focus-visible:ring-ring flex items-center gap-1.5 rounded-md text-xs font-medium focus-visible:ring-1 focus-visible:outline-none"
 				class:ft-approved={isApproved}
 			>
 				<span class="flex-none" aria-hidden="true">

--- a/src/lib/fancy-ui/approval-card/ApprovalCard.svelte
+++ b/src/lib/fancy-ui/approval-card/ApprovalCard.svelte
@@ -1,0 +1,289 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	/** The three states of a human-in-the-loop gate. */
+	export type ApprovalState = "pending" | "approved" | "denied";
+
+	/**
+	 * Props for ApprovalCard
+	 */
+	export interface ApprovalCardProps {
+		/** What the agent is asking permission for, e.g. "Run database migration". */
+		title: string;
+		/** Secondary muted line under the title — the consequence, the blast radius. */
+		description?: string;
+		/** Which side of the gate we are on. Bindable, so the decision is readable from outside. */
+		state?: ApprovalState;
+		/** Marks the action as irreversible: red approve button and a warning tint on the card. */
+		destructive?: boolean;
+		/** Label for the approve button. */
+		approveLabel?: string;
+		/** Label for the deny button. */
+		denyLabel?: string;
+		/** Called when approve is pressed, after `state` has been written. */
+		onApprove?: () => void;
+		/** Called when deny is pressed, after `state` has been written. */
+		onDeny?: () => void;
+		/** The consumer is executing the decision: both buttons go disabled and the card is `aria-busy`. */
+		busy?: boolean;
+		/** The detail region between the header and the footer — a diff, a command preview. */
+		children?: Snippet;
+		/** Additional CSS classes */
+		class?: string;
+		/** The root element */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let {
+		title,
+		description,
+		state = $bindable("pending"),
+		destructive = false,
+		approveLabel = "Approve",
+		denyLabel = "Deny",
+		onApprove,
+		onDeny,
+		busy = false,
+		children,
+		class: className,
+		ref = $bindable(null),
+	}: ApprovalCardProps = $props();
+
+	/** Spoken and shown once the gate is behind us. */
+	const RESOLVED_LABELS = {
+		approved: "Approved",
+		denied: "Denied",
+	} as const;
+
+	const isPending = $derived(state === "pending");
+	const isApproved = $derived(state === "approved");
+	const resolvedLabel = $derived(isApproved ? RESOLVED_LABELS.approved : RESOLVED_LABELS.denied);
+
+	/**
+	 * The decision is written to `state` before the callback fires, so a consumer
+	 * reading the bound value from inside its own handler already sees the answer.
+	 * Re-entry is refused rather than re-announced: a gate resolves once.
+	 */
+	function decide(next: "approved" | "denied") {
+		if (busy || state !== "pending") return;
+		state = next;
+		if (next === "approved") onApprove?.();
+		else onDeny?.();
+	}
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("ft-approval border-border bg-card/50 w-full rounded-lg border p-4 text-sm", className)}
+	class:ft-destructive={destructive}
+	role="group"
+	aria-label={title}
+	aria-busy={busy ? "true" : undefined}
+	data-state={state}
+>
+	<div class="flex items-start gap-2.5">
+		<!--
+			Decorative: the title carries the ask in words. On a destructive gate the
+			shield picks up an alert mark, so "this one is irreversible" is not left
+			to the tint alone.
+		-->
+		<span class="ft-approval-icon mt-0.5 flex-none" aria-hidden="true">
+			<svg
+				class="size-4"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+				{#if destructive}
+					<path d="M12 8v3.5" />
+					<path d="M12 15h.01" />
+				{/if}
+			</svg>
+		</span>
+
+		<div class="min-w-0 flex-1">
+			<p class="ft-approval-title text-foreground font-medium">{title}</p>
+			{#if description}
+				<p class="ft-approval-description text-muted-foreground mt-0.5 text-xs leading-relaxed">
+					{description}
+				</p>
+			{/if}
+		</div>
+	</div>
+
+	{#if children}
+		<div class="ft-approval-detail mt-3 min-w-0">
+			{@render children()}
+		</div>
+	{/if}
+
+	<!--
+		One footer element, mounted from the first render, so the live region exists
+		before the decision lands in it — a region that appears at the same moment as
+		its own text is routinely missed by screen readers.
+	-->
+	<div class="ft-approval-foot mt-3" aria-live="polite">
+		{#if isPending}
+			<div class="ft-approval-actions flex flex-wrap items-center justify-end gap-2">
+				<button
+					type="button"
+					class="ft-approval-deny text-muted-foreground hover:text-foreground hover:bg-foreground/5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:pointer-events-none disabled:opacity-60"
+					disabled={busy}
+					onclick={() => decide("denied")}
+				>
+					{denyLabel}
+				</button>
+				<button
+					type="button"
+					class="ft-approval-approve bg-foreground text-background hover:bg-foreground/90 rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:pointer-events-none disabled:opacity-60"
+					class:ft-destructive={destructive}
+					disabled={busy}
+					onclick={() => decide("approved")}
+				>
+					{approveLabel}
+				</button>
+			</div>
+		{:else}
+			<p
+				class="ft-approval-resolved flex items-center gap-1.5 text-xs font-medium"
+				class:ft-approved={isApproved}
+			>
+				<span class="flex-none" aria-hidden="true">
+					<svg
+						class="size-3.5"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2.5"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						{#if isApproved}
+							<path d="m20 6-11 11-5-5" />
+						{:else}
+							<path d="M18 6 6 18" />
+							<path d="m6 6 12 12" />
+						{/if}
+					</svg>
+				</span>
+				{resolvedLabel}
+			</p>
+		{/if}
+	</div>
+</div>
+
+<style>
+	/*
+	 * Every colour is read at the point of use through two hooks: this card's own
+	 * `--ft-approval-*`, then the `--ft-status-*` vocabulary the whole AI family
+	 * shares, then the literal. Setting either anywhere up the tree retints the
+	 * card without having to win a specificity fight against these scoped rules,
+	 * and the shared one recolours every sibling component at once.
+	 */
+	.ft-approval.ft-destructive {
+		background: var(
+			--ft-approval-danger-bg,
+			color-mix(
+				in oklab,
+				var(
+						--ft-approval-danger,
+						var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+					)
+					6%,
+				transparent
+			)
+		);
+		border-color: var(
+			--ft-approval-danger-border,
+			color-mix(
+				in oklab,
+				var(
+						--ft-approval-danger,
+						var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+					)
+					22%,
+				transparent
+			)
+		);
+	}
+
+	.ft-approval.ft-destructive .ft-approval-icon {
+		color: var(
+			--ft-approval-danger,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+	}
+
+	/*
+	 * Unlayered scoped rules beat Tailwind's layered utilities, so the destructive
+	 * button overrides `bg-foreground` / `text-background` without `!important`.
+	 * Its text flips with the scheme because no single ink clears 4.5:1 against a
+	 * red that is dark on a light page and light on a dark one.
+	 */
+	.ft-approval-approve.ft-destructive {
+		background: var(
+			--ft-approval-danger,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+		color: var(--ft-approval-danger-fg, light-dark(oklch(0.985 0 0), oklch(0.16 0 0)));
+	}
+
+	.ft-approval-approve.ft-destructive:hover:not(:disabled) {
+		background: color-mix(
+			in oklab,
+			var(
+					--ft-approval-danger,
+					var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+				)
+				88%,
+			transparent
+		);
+	}
+
+	/* Denied stays deliberately quiet — a refusal is not a failure. */
+	.ft-approval-resolved {
+		color: var(--ft-approval-denied, color-mix(in oklab, currentColor 65%, transparent));
+	}
+
+	.ft-approval-resolved.ft-approved {
+		color: var(
+			--ft-approval-approved,
+			var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145)))
+		);
+	}
+
+	/*
+	 * The verdict's fade is the whole animation, and it lives behind the query, so
+	 * reduced motion is not a degraded variant to keep in sync: the footer simply
+	 * swaps, with the same colours and the same words.
+	 *
+	 * The footer's height is deliberately left alone. A transition needs the
+	 * specified value to change, and `height: auto` never changes — only the
+	 * content under it does — so an `interpolate-size` rule here would have been
+	 * dead weight rather than a smooth collapse.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-approval-resolved {
+			animation: ft-approval-resolve-in 240ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+	}
+
+	@keyframes ft-approval-resolve-in {
+		from {
+			opacity: 0;
+			transform: translateY(-3px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/approval-card/ApprovalCard.test.ts
+++ b/src/lib/fancy-ui/approval-card/ApprovalCard.test.ts
@@ -1,5 +1,5 @@
 import { render, cleanup, fireEvent } from "@testing-library/svelte";
-import { createRawSnippet } from "svelte";
+import { createRawSnippet, tick } from "svelte";
 import { afterEach, describe, it, expect, vi } from "vitest";
 import ApprovalCard from "./ApprovalCard.svelte";
 import Harness from "./ApprovalCardHarness.test.svelte";
@@ -161,6 +161,15 @@ describe("ApprovalCard", () => {
 
 		expect(root(container).getAttribute("aria-busy")).toBeNull();
 		expect(approve(container).disabled).toBe(false);
+	});
+
+	it("moves focus to the verdict once the buttons that held it are gone", async () => {
+		const { container } = render(ApprovalCard, { props: { title: TITLE } });
+
+		await fireEvent.click(approve(container));
+		await tick();
+
+		expect(document.activeElement).toBe(resolved(container));
 	});
 
 	it("refuses a decision that arrives while busy", async () => {

--- a/src/lib/fancy-ui/approval-card/ApprovalCard.test.ts
+++ b/src/lib/fancy-ui/approval-card/ApprovalCard.test.ts
@@ -1,0 +1,221 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import ApprovalCard from "./ApprovalCard.svelte";
+import Harness from "./ApprovalCardHarness.test.svelte";
+
+const TITLE = "Run database migration";
+
+function root(container: HTMLElement): HTMLElement {
+	return container.querySelector(".ft-approval") as HTMLElement;
+}
+
+function approve(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector(".ft-approval-approve") as HTMLButtonElement;
+}
+
+function deny(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector(".ft-approval-deny") as HTMLButtonElement;
+}
+
+function resolved(container: HTMLElement): HTMLElement | null {
+	return container.querySelector(".ft-approval-resolved");
+}
+
+describe("ApprovalCard", () => {
+	afterEach(cleanup);
+
+	it("names the gate and groups it under that name", () => {
+		const { container } = render(ApprovalCard, { props: { title: TITLE } });
+
+		expect(container.querySelector(".ft-approval-title")?.textContent).toBe(TITLE);
+		expect(root(container).getAttribute("role")).toBe("group");
+		expect(root(container).getAttribute("aria-label")).toBe(TITLE);
+		expect(root(container).dataset.state).toBe("pending");
+	});
+
+	it("shows the description only when there is one", () => {
+		const withDetail = render(ApprovalCard, {
+			props: { title: TITLE, description: "Adds two columns to `invoices`." },
+		});
+		expect(withDetail.container.querySelector(".ft-approval-description")?.textContent).toContain(
+			"Adds two columns"
+		);
+
+		cleanup();
+		const without = render(ApprovalCard, { props: { title: TITLE } });
+		expect(without.container.querySelector(".ft-approval-description")).toBeNull();
+	});
+
+	it("offers both decisions while pending, with the labels it was given", () => {
+		const { container } = render(ApprovalCard, {
+			props: { title: TITLE, approveLabel: "Run it", denyLabel: "Not now" },
+		});
+
+		expect(approve(container).textContent?.trim()).toBe("Run it");
+		expect(deny(container).textContent?.trim()).toBe("Not now");
+		expect(resolved(container)).toBeNull();
+	});
+
+	it("defaults the two labels", () => {
+		const { container } = render(ApprovalCard, { props: { title: TITLE } });
+
+		expect(approve(container).textContent?.trim()).toBe("Approve");
+		expect(deny(container).textContent?.trim()).toBe("Deny");
+	});
+
+	it("fires onApprove and resolves the card", async () => {
+		const onApprove = vi.fn();
+		const onDeny = vi.fn();
+		const { container } = render(ApprovalCard, { props: { title: TITLE, onApprove, onDeny } });
+
+		await fireEvent.click(approve(container));
+
+		expect(onApprove).toHaveBeenCalledTimes(1);
+		expect(onDeny).not.toHaveBeenCalled();
+		expect(root(container).dataset.state).toBe("approved");
+	});
+
+	it("fires onDeny and resolves the card", async () => {
+		const onApprove = vi.fn();
+		const onDeny = vi.fn();
+		const { container } = render(ApprovalCard, { props: { title: TITLE, onApprove, onDeny } });
+
+		await fireEvent.click(deny(container));
+
+		expect(onDeny).toHaveBeenCalledTimes(1);
+		expect(onApprove).not.toHaveBeenCalled();
+		expect(root(container).dataset.state).toBe("denied");
+	});
+
+	it("writes the decision back out through the binding", async () => {
+		const { container, getByTestId } = render(Harness, { props: { title: TITLE } });
+		expect(getByTestId("bound-state").textContent).toBe("pending");
+
+		await fireEvent.click(approve(container));
+		expect(getByTestId("bound-state").textContent).toBe("approved");
+	});
+
+	it("writes a denial back out through the binding too", async () => {
+		const { container, getByTestId } = render(Harness, { props: { title: TITLE } });
+
+		await fireEvent.click(deny(container));
+		expect(getByTestId("bound-state").textContent).toBe("denied");
+	});
+
+	it("follows a state prop driven from outside", async () => {
+		const { container, rerender } = render(ApprovalCard, {
+			props: { title: TITLE, state: "pending" as const },
+		});
+		expect(approve(container)).not.toBeNull();
+
+		await rerender({ title: TITLE, state: "approved" as const });
+		expect(approve(container)).toBeNull();
+		expect(resolved(container)?.textContent?.trim()).toBe("Approved");
+	});
+
+	it("collapses to a quiet approved line, with no buttons left to press", () => {
+		const { container } = render(ApprovalCard, {
+			props: { title: TITLE, state: "approved" as const },
+		});
+
+		expect(resolved(container)?.textContent?.trim()).toBe("Approved");
+		expect(resolved(container)?.classList.contains("ft-approved")).toBe(true);
+		expect(container.querySelectorAll("button")).toHaveLength(0);
+		expect(root(container).dataset.state).toBe("approved");
+	});
+
+	it("collapses to a muted denied line, with no buttons left to press", () => {
+		const { container } = render(ApprovalCard, {
+			props: { title: TITLE, state: "denied" as const },
+		});
+
+		expect(resolved(container)?.textContent?.trim()).toBe("Denied");
+		expect(resolved(container)?.classList.contains("ft-approved")).toBe(false);
+		expect(container.querySelectorAll("button")).toHaveLength(0);
+	});
+
+	it("announces the verdict through a live region that was already there", async () => {
+		const { container } = render(ApprovalCard, { props: { title: TITLE } });
+		const live = container.querySelector('[aria-live="polite"]') as HTMLElement;
+		expect(live).not.toBeNull();
+
+		await fireEvent.click(approve(container));
+
+		// Same element, new contents: a region that appears alongside its own text
+		// is routinely missed.
+		expect(container.querySelector('[aria-live="polite"]')).toBe(live);
+		expect(live.textContent).toContain("Approved");
+	});
+
+	it("disables both buttons and marks the card busy while the consumer works", () => {
+		const { container } = render(ApprovalCard, { props: { title: TITLE, busy: true } });
+
+		expect(approve(container).disabled).toBe(true);
+		expect(deny(container).disabled).toBe(true);
+		expect(root(container).getAttribute("aria-busy")).toBe("true");
+	});
+
+	it("says nothing about busyness when it is not busy", () => {
+		const { container } = render(ApprovalCard, { props: { title: TITLE } });
+
+		expect(root(container).getAttribute("aria-busy")).toBeNull();
+		expect(approve(container).disabled).toBe(false);
+	});
+
+	it("refuses a decision that arrives while busy", async () => {
+		const onApprove = vi.fn();
+		const { container } = render(ApprovalCard, {
+			props: { title: TITLE, busy: true, onApprove },
+		});
+
+		await fireEvent.click(approve(container));
+
+		expect(onApprove).not.toHaveBeenCalled();
+		expect(root(container).dataset.state).toBe("pending");
+	});
+
+	it("marks the approve button and the card destructive", () => {
+		const { container } = render(ApprovalCard, { props: { title: TITLE, destructive: true } });
+
+		expect(approve(container).classList.contains("ft-destructive")).toBe(true);
+		expect(root(container).classList.contains("ft-destructive")).toBe(true);
+		// The tint is not the only signal: the shield picks up an alert mark.
+		expect(container.querySelectorAll(".ft-approval-icon path")).toHaveLength(3);
+	});
+
+	it("leaves both unmarked when the action is ordinary", () => {
+		const { container } = render(ApprovalCard, { props: { title: TITLE } });
+
+		expect(approve(container).classList.contains("ft-destructive")).toBe(false);
+		expect(root(container).classList.contains("ft-destructive")).toBe(false);
+		expect(container.querySelectorAll(".ft-approval-icon path")).toHaveLength(1);
+	});
+
+	it("renders the detail region it is handed", () => {
+		const { container } = render(ApprovalCard, {
+			props: {
+				title: TITLE,
+				children: createRawSnippet(() => ({
+					render: () => `<pre class="preview">pnpm db:migrate --prod</pre>`,
+				})),
+			},
+		});
+
+		const detail = container.querySelector(".ft-approval-detail") as HTMLElement;
+		expect(detail.querySelector(".preview")?.textContent).toBe("pnpm db:migrate --prod");
+	});
+
+	it("leaves out the detail region when there is nothing to put in it", () => {
+		const { container } = render(ApprovalCard, { props: { title: TITLE } });
+
+		expect(container.querySelector(".ft-approval-detail")).toBeNull();
+	});
+
+	it("merges custom classes onto the root", () => {
+		const { container } = render(ApprovalCard, { props: { title: TITLE, class: "my-gate" } });
+
+		expect(root(container).className).toContain("my-gate");
+		expect(root(container).className).toContain("ft-approval");
+	});
+});

--- a/src/lib/fancy-ui/approval-card/ApprovalCardHarness.test.svelte
+++ b/src/lib/fancy-ui/approval-card/ApprovalCardHarness.test.svelte
@@ -1,0 +1,35 @@
+<!--
+  Test-only rig. `bind:` cannot be expressed from a `.ts` test file, so the
+  bindable `state` is bound here and echoed into the DOM, which is the only way
+  to prove the decision travels back out to the consumer rather than merely
+  changing what the card draws. Not exported from index.ts, and not collected by
+  Vitest (the run includes `*.test.ts` only).
+-->
+<script lang="ts">
+	import ApprovalCard from "./ApprovalCard.svelte";
+	import type { ApprovalState } from "./ApprovalCard.svelte";
+
+	interface Props {
+		title: string;
+		description?: string;
+		state?: ApprovalState;
+		destructive?: boolean;
+		busy?: boolean;
+		onApprove?: () => void;
+		onDeny?: () => void;
+	}
+
+	let {
+		title,
+		description,
+		state = $bindable("pending"),
+		destructive = false,
+		busy = false,
+		onApprove,
+		onDeny,
+	}: Props = $props();
+</script>
+
+<ApprovalCard {title} {description} bind:state {destructive} {busy} {onApprove} {onDeny} />
+
+<span data-testid="bound-state">{state}</span>

--- a/src/lib/fancy-ui/approval-card/README.md
+++ b/src/lib/fancy-ui/approval-card/README.md
@@ -1,0 +1,116 @@
+# Approval Card
+
+A human-in-the-loop gate: the agent states what it is about to do, and nothing happens until someone presses a button. Once pressed, the footer collapses to a one-line verdict that stays on screen as the record of who let it through.
+
+## Components
+
+- `ApprovalCard` — the gate: header, optional detail region, and a footer that swaps buttons for a verdict
+
+## Usage
+
+```svelte
+<script>
+	import { ApprovalCard } from "fancy-ui-svelte";
+
+	let state = $state("pending");
+</script>
+
+<ApprovalCard
+	title="Run database migration"
+	description="Adds two columns to `invoices` and backfills 41,880 rows."
+	bind:state
+	onApprove={() => runMigration()}
+	onDeny={() => tellTheAgentNo()}
+/>
+```
+
+## Props
+
+| Prop           | Type                                  | Default     | Description                                                         |
+| -------------- | ------------------------------------- | ----------- | ------------------------------------------------------------------- |
+| `title`        | `string`                              | —           | What permission is being asked for. Required.                       |
+| `description`  | `string`                              | `undefined` | Muted second line — the consequence, the blast radius               |
+| `state`        | `"pending" \| "approved" \| "denied"` | `"pending"` | Which side of the gate we are on. Bindable                          |
+| `destructive`  | `boolean`                             | `false`     | Irreversible: red approve button, warning tint, alert on the shield |
+| `approveLabel` | `string`                              | `"Approve"` | Label for the approve button                                        |
+| `denyLabel`    | `string`                              | `"Deny"`    | Label for the deny button                                           |
+| `onApprove`    | `() => void`                          | `undefined` | Called on approve, after `state` has been written                   |
+| `onDeny`       | `() => void`                          | `undefined` | Called on deny, after `state` has been written                      |
+| `busy`         | `boolean`                             | `false`     | The consumer is executing: both buttons disabled, card `aria-busy`  |
+| `children`     | `Snippet`                             | `undefined` | Detail region between header and footer                             |
+| `class`        | `string`                              | `undefined` | Additional CSS classes                                              |
+| `ref`          | `HTMLDivElement \| null`              | `null`      | Bindable reference to the root element                              |
+
+## The decision contract
+
+A gate resolves once. `state` starts at `"pending"`, the only state in which the buttons exist at all; pressing one writes the answer to `state` **before** the matching callback fires, so a consumer reading the bound value from inside its own handler already sees it. A second press cannot happen — the buttons are gone — and a decision arriving while `busy` is refused outright.
+
+`state` is bindable in both directions. Write `"approved"` to it yourself and the card resolves with no callback fired, which is how you restore a gate that was already answered in a previous session. Write `"pending"` back and the buttons return.
+
+`busy` covers the gap between the press and the work finishing:
+
+```svelte
+<ApprovalCard
+	title="Deploy to production"
+	bind:state
+	{busy}
+	onApprove={async () => {
+		busy = true;
+		await deploy();
+		busy = false;
+	}}
+/>
+```
+
+Because the buttons vanish on the press, `busy` mostly matters for the case where the decision is driven from outside — an optimistic `state` write that has not been confirmed yet still marks the card `aria-busy`, which is what a screen reader needs to know that something is in flight.
+
+## The detail region
+
+`children` renders between the description and the footer, which is where the evidence goes — a command about to be run, a diff about to be applied, a payload about to be posted:
+
+```svelte
+<ApprovalCard title="Publish release" destructive>
+	<pre class="rounded bg-black/5 px-2 py-1 font-mono text-xs">npm publish --access public</pre>
+</ApprovalCard>
+```
+
+## Styling
+
+Colour comes from `--ft-status-*`, the run-status vocabulary shared with `ToolCall`, `ToolTimeline`, `TerminalBlock`, `CodeDiff` and `ChatError`. Set one anywhere up the tree and every component in the family follows:
+
+| Variable            | Default (light / dark)                         | Used for                  |
+| ------------------- | ---------------------------------------------- | ------------------------- |
+| `--ft-status-error` | `oklch(0.5 0.19 25)` / `oklch(0.7 0.18 25)`    | The destructive treatment |
+| `--ft-status-done`  | `oklch(0.5 0.14 145)` / `oklch(0.72 0.15 145)` | The approved verdict line |
+
+Each default is a `light-dark()` pair, because no single token clears 4.5:1 against both white and near-black. Which half applies is decided by `color-scheme`, so **your theme must declare it**:
+
+```css
+:root {
+	color-scheme: light;
+}
+.dark {
+	color-scheme: dark;
+}
+```
+
+Every colour is read at the point of use, so a value you set wins without having to out-specify the component's own scoped rules. The `--ft-approval-*` names sit in front of the shared ones for the case where this card alone should differ:
+
+| Variable                      | Default                    | Applies to                           |
+| ----------------------------- | -------------------------- | ------------------------------------ |
+| `--ft-approval-danger`        | `--ft-status-error`        | Destructive button, shield, and tint |
+| `--ft-approval-danger-fg`     | White / near-black pair    | Text on the destructive button       |
+| `--ft-approval-danger-bg`     | `--ft-approval-danger` 6%  | Card tint when destructive           |
+| `--ft-approval-danger-border` | `--ft-approval-danger` 22% | Card border when destructive         |
+| `--ft-approval-approved`      | `--ft-status-done`         | The "Approved" line                  |
+| `--ft-approval-denied`        | `currentColor` at 65%      | The "Denied" line                    |
+
+## Implementation Notes
+
+- The buttons exist only while `state` is `"pending"`, so a resolved gate leaves nothing focusable behind — no disabled button lingering in the tab order for someone to wonder about.
+- The footer is one element mounted from the first render, carrying `aria-live="polite"`. A live region that appears at the same moment as its own text is routinely missed by screen readers; this one is already listening when the verdict lands in it.
+- `destructive` is never carried by colour alone: the shield gains an alert mark alongside the red, so the warning survives a monochrome rendering.
+- The destructive button's text flips with `color-scheme`, because the same red is dark on a light page (white text, 6.8:1) and light on a dark one (near-black text, 5.7:1).
+- The swap from the button row to the verdict is carried by the verdict's own fade-in, not by an animated height: the footer's height is `auto` before and after, and a transition needs the specified value to change. Nothing is measured and no layout is read back.
+- That fade lives behind `prefers-reduced-motion: no-preference`. Reduced motion gets the same states, the same colours, and the same words, immediately.
+- Nothing is scheduled and no DOM is touched at construction time, so the card renders under SSR unchanged.

--- a/src/lib/fancy-ui/approval-card/index.ts
+++ b/src/lib/fancy-ui/approval-card/index.ts
@@ -1,0 +1,4 @@
+import ApprovalCard from "./ApprovalCard.svelte";
+import type { ApprovalCardProps, ApprovalState } from "./ApprovalCard.svelte";
+
+export { ApprovalCard, type ApprovalCardProps, type ApprovalState };

--- a/src/lib/fancy-ui/artifact-card/ArtifactCard.svelte
+++ b/src/lib/fancy-ui/artifact-card/ArtifactCard.svelte
@@ -1,0 +1,362 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { StreamStatus } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for ArtifactCard
+	 */
+	export interface ArtifactCardProps {
+		/** What the document is called. Required — it is the card's whole identity. */
+		title: string;
+		/** The kind of thing it is, on the muted line under the title. */
+		kind?: string;
+		/** Which revision is on screen, 1-based. Rendered as `v3`. */
+		version?: number;
+		/** How many revisions exist. With `version`, the badge reads `v3/5`. */
+		versionCount?: number;
+		/**
+		 * Asked to show another revision, by 1-based version number. Supplying it
+		 * turns the badge into a navigator; the card holds no version state itself.
+		 */
+		onVersionChange?: (version: number) => void;
+		/** Where the document is in its life: waiting, being written, finished, failed. */
+		status?: StreamStatus;
+		/** The text so far — not the latest delta. Growing it is what streams. */
+		preview?: string;
+		/** Asked to open the document. Supplying it adds an Open button to the header rail. */
+		onOpen?: () => void;
+		/** Buttons for the top-right rail: copy, download, delete. */
+		actions?: Snippet;
+		/** Additional CSS classes */
+		class?: string;
+		/** The root element, bindable. */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import StreamingText from "../streaming-text/StreamingText.svelte";
+
+	let {
+		title,
+		kind = "Document",
+		version,
+		versionCount,
+		onVersionChange,
+		status = "done",
+		preview,
+		onOpen,
+		actions,
+		class: className,
+		ref = $bindable(null),
+	}: ArtifactCardProps = $props();
+
+	/** Spoken beside the title, since the sweep and the tint say nothing out loud. */
+	const STATUS_LABELS = {
+		idle: "Not started",
+		streaming: "Writing",
+		done: "Ready",
+		error: "Failed",
+	} as const;
+
+	/** The footer a failed artifact grows, since no `error` string is carried here. */
+	const ERROR_TEXT = "This document could not be generated.";
+
+	/**
+	 * Anything that has its own activation gets to keep it: a click on the version
+	 * navigator or on an action button must not also count as opening the card.
+	 * The two rails are named alongside the controls themselves, because the gaps
+	 * between their buttons belong to them too — a click that lands beside an arrow,
+	 * or on a disabled one, is aimed at the navigator, not at the document.
+	 */
+	const CONTROL_SELECTOR = "a[href], button, input, select, textarea, [contenteditable='true']";
+	const OPEN_GUARD_SELECTOR = `${CONTROL_SELECTOR}, .ft-artifact-versions, .ft-artifact-actions`;
+
+	const isStreaming = $derived(status === "streaming");
+	const isError = $derived(status === "error");
+
+	const hasPreview = $derived(preview !== undefined && preview !== "");
+	const hasVersion = $derived(version !== undefined);
+	const hasCount = $derived(hasVersion && versionCount !== undefined && versionCount > 0);
+	// A navigator only makes sense when there is somewhere to navigate to *and*
+	// somebody listening; otherwise the same numbers render as a plain badge.
+	const navigable = $derived(hasCount && onVersionChange !== undefined);
+
+	const versionLabel = $derived(
+		hasCount ? `v${version}/${versionCount}` : hasVersion ? `v${version}` : ""
+	);
+	const atFirst = $derived((version ?? 1) <= 1);
+	const atLast = $derived((version ?? 1) >= (versionCount ?? 1));
+
+	function fromControl(event: Event): boolean {
+		const target = event.target;
+		return target instanceof Element && target.closest(OPEN_GUARD_SELECTOR) !== null;
+	}
+
+	/**
+	 * Pointer-only convenience. The keyboard path is the Open button in the header
+	 * rail — a real `<button>`, so `Enter` and `Space` are the browser's job — and
+	 * the card itself stays a plain region rather than an ARIA button, which would
+	 * make its children presentational and swallow the navigator, the actions rail
+	 * and the spoken status.
+	 */
+	function open(event: MouseEvent) {
+		if (fromControl(event)) return;
+		onOpen?.();
+	}
+
+	function step(delta: number) {
+		const current = version ?? 1;
+		const next = current + delta;
+		if (next < 1 || next > (versionCount ?? 1)) return;
+		onVersionChange?.(next);
+	}
+
+	/*
+	 * No `disabled:pointer-events-none`: a disabled button already swallows its own
+	 * clicks, and taking it out of the event flow retargets the click at the card
+	 * behind it — which would open the document from the arrow that refused to move.
+	 */
+	const navButtonClass =
+		"text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring inline-flex size-5 cursor-pointer items-center justify-center rounded transition-colors focus-visible:ring-1 focus-visible:outline-none disabled:opacity-40";
+</script>
+
+<!--
+	The card-wide click is a pointer shortcut for the Open button in the rail, which
+	is where the tab stop and the key handling live. Both warnings are about a
+	keyboard path that exists here, one element over.
+-->
+<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+<div
+	bind:this={ref}
+	class={cn(
+		"ft-artifact border-border bg-card relative w-full overflow-hidden rounded-lg border",
+		onOpen && "hover:border-foreground/25 cursor-pointer transition-colors",
+		className
+	)}
+	data-status={status}
+	onclick={onOpen ? open : undefined}
+>
+	<!--
+		The sweep is parked off its own left edge, so reduced motion — which never
+		starts the animation — simply never sees it.
+	-->
+	{#if isStreaming}
+		<span class="ft-artifact-sweep" aria-hidden="true"></span>
+	{/if}
+
+	<div class="flex items-start gap-2.5 px-3 py-2.5">
+		<span class="ft-artifact-icon text-muted-foreground mt-0.5 flex-none" aria-hidden="true">
+			<svg
+				class="size-4"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="1.75"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="M14 3v5h5" />
+				<path d="M19 8v11a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7z" />
+			</svg>
+		</span>
+
+		<div class="min-w-0 flex-1">
+			<div class="ft-artifact-title text-foreground truncate text-sm font-medium">{title}</div>
+			<div class="ft-artifact-kind text-muted-foreground truncate text-xs">{kind}</div>
+		</div>
+
+		<div class="flex flex-none items-center gap-1">
+			{#if navigable}
+				<div
+					class="ft-artifact-versions text-muted-foreground flex items-center gap-0.5 text-xs"
+					role="group"
+					aria-label="Document versions"
+				>
+					<button
+						type="button"
+						class={navButtonClass}
+						aria-label="Previous version"
+						disabled={atFirst}
+						onclick={() => step(-1)}
+					>
+						<svg
+							class="size-3"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2.5"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<path d="m15 18-6-6 6-6" />
+						</svg>
+					</button>
+					<span class="ft-artifact-version tabular-nums">{versionLabel}</span>
+					<button
+						type="button"
+						class={navButtonClass}
+						aria-label="Next version"
+						disabled={atLast}
+						onclick={() => step(1)}
+					>
+						<svg
+							class="size-3"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2.5"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<path d="m9 6 6 6-6 6" />
+						</svg>
+					</button>
+				</div>
+			{:else if hasVersion}
+				<span class="ft-artifact-version text-muted-foreground text-xs tabular-nums"
+					>{versionLabel}</span
+				>
+			{/if}
+
+			{#if actions}
+				<div class="ft-artifact-actions flex items-center gap-1">{@render actions()}</div>
+			{/if}
+
+			{#if onOpen}
+				<!--
+					The visible affordance and the operable one are the same element: a
+					real button, so it takes a tab stop and handles Enter and Space on the
+					browser's terms, and it names the document rather than saying "Open"
+					into a list of identical cards.
+				-->
+				<button
+					type="button"
+					class="ft-artifact-open text-muted-foreground hover:text-foreground focus-visible:ring-ring ml-0.5 inline-flex cursor-pointer items-center gap-1 rounded text-xs transition-colors focus-visible:ring-1 focus-visible:outline-none"
+					aria-label="Open {title}"
+					onclick={() => onOpen?.()}
+				>
+					Open
+					<svg
+						class="size-3"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2.5"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<path d="M5 12h14" />
+						<path d="m12 5 7 7-7 7" />
+					</svg>
+				</button>
+			{/if}
+		</div>
+	</div>
+
+	<span class="sr-only">{STATUS_LABELS[status]}</span>
+
+	{#if hasPreview}
+		<div class="ft-artifact-preview border-border border-t px-3 py-3 text-sm">
+			<div class="ft-artifact-clamp">
+				<StreamingText text={preview ?? ""} streaming={isStreaming} />
+			</div>
+		</div>
+	{/if}
+
+	{#if isError}
+		<p class="ft-artifact-error border-border border-t px-3 py-2 text-xs">{ERROR_TEXT}</p>
+	{/if}
+</div>
+
+<style>
+	/*
+	 * Both colours are read at the point of use through the component's own
+	 * `--ft-artifact-*` hook, then the `--ft-status-*` vocabulary the whole AI
+	 * family shares, then the literal. Setting either anywhere up the tree retints
+	 * the card without having to out-specify these scoped rules.
+	 */
+	.ft-artifact-error {
+		color: var(
+			--ft-artifact-error,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+		background: color-mix(
+			in oklab,
+			var(
+					--ft-artifact-error,
+					var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+				)
+				7%,
+			transparent
+		);
+	}
+
+	.ft-artifact-preview {
+		background: var(--ft-artifact-preview-bg, color-mix(in oklab, currentColor 4%, transparent));
+	}
+
+	/*
+	 * A teaser, not the document: six lines of it, with the last one dissolving so
+	 * the cut never reads as the end of the text.
+	 */
+	.ft-artifact-clamp {
+		max-height: var(--ft-artifact-preview-height, 9rem);
+		overflow: hidden;
+		line-height: 1.5;
+		-webkit-mask-image: linear-gradient(to bottom, #000 72%, transparent 100%);
+		mask-image: linear-gradient(to bottom, #000 72%, transparent 100%);
+	}
+
+	.ft-artifact-sweep {
+		position: absolute;
+		inset-inline: 0;
+		inset-block-start: 0;
+		block-size: 2px;
+		overflow: hidden;
+		pointer-events: none;
+	}
+
+	.ft-artifact-sweep::after {
+		content: "";
+		position: absolute;
+		inset-block: 0;
+		inline-size: 45%;
+		/* Parked off the left edge: with no animation running, nothing shows. */
+		transform: translateX(-110%);
+		background: linear-gradient(
+			90deg,
+			transparent,
+			var(
+				--ft-artifact-running,
+				var(--ft-status-running, light-dark(oklch(0.5 0.18 265), oklch(0.72 0.15 265)))
+			),
+			transparent
+		);
+	}
+
+	/*
+	 * The sweep is the only thing that moves, and it lives entirely behind the
+	 * query: reduced motion gets the same card with a still top edge, and the
+	 * cursor in the preview stops blinking on StreamingText's own terms.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-artifact-sweep::after {
+			animation: ft-artifact-sweep var(--ft-artifact-sweep-duration, 1.9s) linear infinite;
+		}
+
+		/* 45% of the card wide, so 240% of itself is one full pass and a short beat. */
+		@keyframes ft-artifact-sweep {
+			from {
+				transform: translateX(-110%);
+			}
+			to {
+				transform: translateX(240%);
+			}
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/artifact-card/ArtifactCard.test.ts
+++ b/src/lib/fancy-ui/artifact-card/ArtifactCard.test.ts
@@ -1,0 +1,280 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import ArtifactCard from "./ArtifactCard.svelte";
+
+function root(container: HTMLElement): HTMLElement {
+	return container.firstElementChild as HTMLElement;
+}
+
+function nav(container: HTMLElement, label: string): HTMLButtonElement {
+	return container.querySelector(`button[aria-label="${label}"]`) as HTMLButtonElement;
+}
+
+function openCue(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector(".ft-artifact-open") as HTMLButtonElement;
+}
+
+describe("ArtifactCard", () => {
+	afterEach(() => {
+		cleanup();
+		vi.useRealTimers();
+	});
+
+	it("renders the title and falls back to a generic kind", () => {
+		const { container } = render(ArtifactCard, { props: { title: "Q3 revenue memo" } });
+
+		expect(container.querySelector(".ft-artifact-title")?.textContent).toBe("Q3 revenue memo");
+		expect(container.querySelector(".ft-artifact-kind")?.textContent).toBe("Document");
+	});
+
+	it("renders the kind it is given", () => {
+		const { container } = render(ArtifactCard, {
+			props: { title: "migrate.sql", kind: "SQL migration" },
+		});
+
+		expect(container.querySelector(".ft-artifact-kind")?.textContent).toBe("SQL migration");
+	});
+
+	it("names the status out loud, since the sweep and the tint are silent", async () => {
+		const { container, rerender } = render(ArtifactCard, {
+			props: { title: "Draft", status: "streaming" as const },
+		});
+
+		expect(container.querySelector(".sr-only")?.textContent).toBe("Writing");
+
+		await rerender({ status: "done" });
+		expect(container.querySelector(".sr-only")?.textContent).toBe("Ready");
+	});
+
+	it("shows a bare version badge when there is no count", () => {
+		const { container } = render(ArtifactCard, { props: { title: "Memo", version: 3 } });
+
+		expect(container.querySelector(".ft-artifact-version")?.textContent).toBe("v3");
+		expect(nav(container, "Previous version")).toBeNull();
+	});
+
+	it("shows the count without a navigator when nobody is listening for a change", () => {
+		const { container } = render(ArtifactCard, {
+			props: { title: "Memo", version: 3, versionCount: 5 },
+		});
+
+		expect(container.querySelector(".ft-artifact-version")?.textContent).toBe("v3/5");
+		expect(nav(container, "Next version")).toBeNull();
+	});
+
+	it("turns the badge into a navigator once a change handler exists", () => {
+		const { container } = render(ArtifactCard, {
+			props: { title: "Memo", version: 3, versionCount: 5, onVersionChange: vi.fn() },
+		});
+
+		expect(container.querySelector(".ft-artifact-version")?.textContent).toBe("v3/5");
+		expect(container.querySelector('[role="group"]')?.getAttribute("aria-label")).toBe(
+			"Document versions"
+		);
+	});
+
+	it("asks for the neighbouring version by 1-based number", async () => {
+		const onVersionChange = vi.fn();
+		const { container } = render(ArtifactCard, {
+			props: { title: "Memo", version: 3, versionCount: 5, onVersionChange },
+		});
+
+		await fireEvent.click(nav(container, "Previous version"));
+		expect(onVersionChange).toHaveBeenLastCalledWith(2);
+
+		await fireEvent.click(nav(container, "Next version"));
+		expect(onVersionChange).toHaveBeenLastCalledWith(4);
+		expect(onVersionChange).toHaveBeenCalledTimes(2);
+	});
+
+	it("disables the arrow that would run off the end", async () => {
+		const onVersionChange = vi.fn();
+		const { container, rerender } = render(ArtifactCard, {
+			props: { title: "Memo", version: 1, versionCount: 5, onVersionChange },
+		});
+
+		expect(nav(container, "Previous version").disabled).toBe(true);
+		expect(nav(container, "Next version").disabled).toBe(false);
+
+		await rerender({ version: 5 });
+		expect(nav(container, "Previous version").disabled).toBe(false);
+		expect(nav(container, "Next version").disabled).toBe(true);
+
+		// Nothing escapes past a bound even if the click lands anyway.
+		await fireEvent.click(nav(container, "Next version"));
+		expect(onVersionChange).not.toHaveBeenCalled();
+	});
+
+	it("streams the preview, tinting only what just arrived", async () => {
+		vi.useFakeTimers();
+		const { container, rerender } = render(ArtifactCard, {
+			props: { title: "Memo", status: "streaming" as const, preview: "The quarter" },
+		});
+
+		expect(container.querySelector(".ft-artifact-preview")?.textContent).toContain("The quarter");
+		expect(container.querySelector(".ft-fresh")).toBeFalsy();
+
+		await rerender({ preview: "The quarter closed" });
+		expect(container.querySelector(".ft-fresh")?.textContent).toBe(" closed");
+		expect(container.querySelector(".ft-artifact-preview")?.textContent).toContain(
+			"The quarter closed"
+		);
+	});
+
+	it("trails a cursor only while the document is being written", async () => {
+		const { container, rerender } = render(ArtifactCard, {
+			props: { title: "Memo", status: "streaming" as const, preview: "Half a" },
+		});
+
+		expect(container.querySelector(".ft-streaming-cursor")).toBeTruthy();
+
+		await rerender({ status: "done" });
+		expect(container.querySelector(".ft-streaming-cursor")).toBeFalsy();
+	});
+
+	it("omits the preview region when nothing has been written yet", () => {
+		const { container } = render(ArtifactCard, {
+			props: { title: "Memo", status: "idle" as const },
+		});
+
+		expect(container.querySelector(".ft-artifact-preview")).toBeNull();
+	});
+
+	it("runs the top sweep only while streaming", async () => {
+		const { container, rerender } = render(ArtifactCard, {
+			props: { title: "Memo", status: "streaming" as const },
+		});
+
+		expect(container.querySelector(".ft-artifact-sweep")).toBeTruthy();
+
+		await rerender({ status: "done" });
+		expect(container.querySelector(".ft-artifact-sweep")).toBeNull();
+	});
+
+	it("stays inert until an open handler arrives", () => {
+		const { container } = render(ArtifactCard, { props: { title: "Memo" } });
+
+		expect(root(container).getAttribute("role")).toBeNull();
+		expect(root(container).getAttribute("tabindex")).toBeNull();
+		expect(container.querySelector(".ft-artifact-open")).toBeNull();
+	});
+
+	it("grows a real Open button, named after the document, rather than an ARIA card", async () => {
+		const onOpen = vi.fn();
+		const { container } = render(ArtifactCard, { props: { title: "Q3 memo", onOpen } });
+
+		// The root stays a plain region: an ARIA button would make its children
+		// presentational and erase the navigator, the actions rail and the status.
+		expect(root(container).getAttribute("role")).toBeNull();
+		expect(root(container).getAttribute("tabindex")).toBeNull();
+		expect(root(container).getAttribute("aria-label")).toBeNull();
+
+		const openButton = openCue(container);
+		expect(openButton.tagName).toBe("BUTTON");
+		expect(openButton.getAttribute("aria-label")).toBe("Open Q3 memo");
+		expect(openButton.textContent).toContain("Open");
+
+		await fireEvent.click(openButton);
+		expect(onOpen).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the card-wide click as a pointer shortcut, and only a pointer one", async () => {
+		const onOpen = vi.fn();
+		const { container } = render(ArtifactCard, { props: { title: "Q3 memo", onOpen } });
+
+		await fireEvent.click(container.querySelector(".ft-artifact-title") as HTMLElement);
+		expect(onOpen).toHaveBeenCalledTimes(1);
+
+		// Keys on the root do nothing — the button one element over is the keyboard path.
+		await fireEvent.keyDown(root(container), { key: "Enter" });
+		await fireEvent.keyDown(root(container), { key: " " });
+		expect(onOpen).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the status label and the version navigator out of any ARIA button", () => {
+		const { container } = render(ArtifactCard, {
+			props: {
+				title: "Memo",
+				status: "streaming" as const,
+				version: 2,
+				versionCount: 4,
+				onVersionChange: vi.fn(),
+				onOpen: vi.fn(),
+			},
+		});
+
+		expect(root(container).getAttribute("role")).toBeNull();
+		expect(container.querySelector(".sr-only")?.textContent).toBe("Writing");
+		expect(container.querySelector('[role="group"]')?.getAttribute("aria-label")).toBe(
+			"Document versions"
+		);
+	});
+
+	it("lets the version arrows do their own job without opening the document", async () => {
+		const onOpen = vi.fn();
+		const onVersionChange = vi.fn();
+		const { container } = render(ArtifactCard, {
+			props: { title: "Memo", version: 2, versionCount: 4, onVersionChange, onOpen },
+		});
+
+		await fireEvent.click(nav(container, "Next version"));
+		expect(onVersionChange).toHaveBeenCalledWith(3);
+		expect(onOpen).not.toHaveBeenCalled();
+	});
+
+	it("does not open the document from the navigator's own gaps", async () => {
+		const onOpen = vi.fn();
+		const { container } = render(ArtifactCard, {
+			props: { title: "Memo", version: 1, versionCount: 4, onVersionChange: vi.fn(), onOpen },
+		});
+
+		// A disabled arrow retargets its click at whatever is underneath, and the
+		// space between the arrows belongs to the navigator either way.
+		await fireEvent.click(container.querySelector(".ft-artifact-versions") as HTMLElement);
+		expect(onOpen).not.toHaveBeenCalled();
+	});
+
+	it("renders the actions rail, and its buttons do not open the card", async () => {
+		const onOpen = vi.fn();
+		const { container } = render(ArtifactCard, {
+			props: {
+				title: "Memo",
+				onOpen,
+				actions: createRawSnippet(() => ({
+					render: () => `<button type="button" class="custom-action">Copy</button>`,
+				})),
+			},
+		});
+
+		const action = container.querySelector(".custom-action") as HTMLButtonElement;
+		expect(action).not.toBeNull();
+		expect(container.querySelector(".ft-artifact-actions")?.contains(action)).toBe(true);
+
+		await fireEvent.click(action);
+		expect(onOpen).not.toHaveBeenCalled();
+	});
+
+	it("grows a tinted footer when the document failed, and drops it when it did not", async () => {
+		const { container, rerender } = render(ArtifactCard, {
+			props: { title: "Memo", status: "error" as const },
+		});
+
+		expect(container.querySelector(".ft-artifact-error")?.textContent).toBe(
+			"This document could not be generated."
+		);
+		expect(root(container).dataset.status).toBe("error");
+
+		await rerender({ status: "done" });
+		expect(container.querySelector(".ft-artifact-error")).toBeNull();
+	});
+
+	it("merges custom classes onto the root", () => {
+		const { container } = render(ArtifactCard, {
+			props: { title: "Memo", class: "my-card" },
+		});
+
+		expect(root(container).className).toContain("ft-artifact");
+		expect(root(container).className).toContain("my-card");
+	});
+});

--- a/src/lib/fancy-ui/artifact-card/README.md
+++ b/src/lib/fancy-ui/artifact-card/README.md
@@ -1,0 +1,124 @@
+# ArtifactCard
+
+A generated document, rendered as a thing rather than as a wall of text: a title, what kind of thing it is, which draft you are looking at, and six lines of the document itself dissolving into the card's edge.
+
+It is the surface a model writes _into_. While the text arrives the top edge sweeps and a cursor trails the last character; when it lands the card sits still with a version number you can page through.
+
+## Components
+
+- `ArtifactCard` — the whole card: header, version navigator, preview, error footer
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { ArtifactCard } from "fancy-ui-svelte";
+
+	let preview = $state("");
+	let status = $state<"idle" | "streaming" | "done" | "error">("idle");
+	let version = $state(1);
+</script>
+
+<ArtifactCard
+	title="Q3 revenue review"
+	kind="Memo"
+	{status}
+	{preview}
+	{version}
+	versionCount={3}
+	onVersionChange={(next) => (version = next)}
+	onOpen={() => openInSidePanel()}
+/>
+```
+
+## Props
+
+| Prop              | Type                                         | Default      | Description                                                                    |
+| ----------------- | -------------------------------------------- | ------------ | ------------------------------------------------------------------------------ |
+| `title`           | `string`                                     | —            | What the document is called. Required                                          |
+| `kind`            | `string`                                     | `"Document"` | The kind of thing it is, on the muted line under the title                     |
+| `version`         | `number`                                     | `undefined`  | Which revision is on screen, 1-based. Renders as `v3`                          |
+| `versionCount`    | `number`                                     | `undefined`  | How many revisions exist. With `version`, the badge reads `v3/5`               |
+| `onVersionChange` | `(version: number) => void`                  | `undefined`  | Asked for another revision by 1-based number; turns the badge into a navigator |
+| `status`          | `"idle" \| "streaming" \| "done" \| "error"` | `"done"`     | Where the document is in its life                                              |
+| `preview`         | `string`                                     | `undefined`  | The text so far — not the latest delta                                         |
+| `onOpen`          | `() => void`                                 | `undefined`  | Asked to open the document; makes the whole card activatable                   |
+| `actions`         | `Snippet`                                    | `undefined`  | Buttons for the top-right rail: copy, download, delete                         |
+| `class`           | `string`                                     | `undefined`  | Additional CSS classes                                                         |
+| `ref`             | `HTMLDivElement \| null`                     | `null`       | Bindable reference to the root element                                         |
+
+## Streaming the preview
+
+`preview` is the accumulated text, not the newest chunk. Reassign it with a longer string as tokens arrive and the growth is what animates — the card hands it to `StreamingText`, which tints each new chunk as it lands and trails a cursor for as long as `status` is `"streaming"`.
+
+```svelte
+<script lang="ts">
+	let preview = $state("");
+	let status = $state<"idle" | "streaming" | "done" | "error">("idle");
+
+	async function write(stream: AsyncIterable<string>) {
+		status = "streaming";
+		for await (const chunk of stream) preview += chunk;
+		status = "done";
+	}
+</script>
+
+<ArtifactCard title="Q3 revenue review" {preview} {status} />
+```
+
+The preview is a teaser, capped at roughly six lines with the last one dissolving, so a cut never reads as the end of the document. `--ft-artifact-preview-height` moves the cap. Leave `preview` unset and the region is not rendered at all, which is what an `"idle"` artifact should look like: a title and nothing claimed yet.
+
+## Versions
+
+The card holds no version state. It renders what `version` says and asks for a different number through `onVersionChange`:
+
+- `version` alone → a static `v3` badge.
+- `version` + `versionCount` → a static `v3/5` badge.
+- all three → arrows either side of `v3/5`, each disabled at its bound, each labelled for screen readers.
+
+`onVersionChange` receives a 1-based number and never one outside `1…versionCount`, so a handler can index straight into an array of drafts without clamping first.
+
+## Opening
+
+Pass `onOpen` and an `Open →` button appears in the header rail. That button is the affordance: it takes a tab stop, it is named `Open <title>` so a list of cards does not read as a column of identical "Open"s, and `Enter` and `Space` work on it because it is a real `<button>`. Without `onOpen` the card is an inert region.
+
+A click anywhere else on the card opens it too, as a pointer shortcut. That is all it is — the card root carries no `role`, no `tabindex` and no key handling, because an ARIA button makes everything inside it presentational, which would erase the version navigator, the actions rail and the spoken status from the accessibility tree.
+
+Controls inside the card keep their own activation — a click on a version arrow, or on anything you put in `actions`, does not also open the document. Both rails are guarded whole, so the gaps between their buttons, and a disabled arrow that retargets its click, are safe too.
+
+## Styling
+
+Colour comes from `--ft-status-*`, the run-status vocabulary shared with `ToolCall`, `ToolTimeline`, `TerminalBlock`, `CodeDiff` and `ChatError`. Set one anywhere up the tree and every component in the family follows:
+
+| Variable              | Default (light / dark)                         | Applies to               |
+| --------------------- | ---------------------------------------------- | ------------------------ |
+| `--ft-status-running` | `oklch(0.5 0.18 265)` / `oklch(0.72 0.15 265)` | The sweep, while writing |
+| `--ft-status-error`   | `oklch(0.5 0.19 25)` / `oklch(0.7 0.18 25)`    | The failure footer       |
+
+Each default is a `light-dark()` pair, because no single token clears 4.5:1 against both white and near-black. Which half applies is decided by `color-scheme`, so **your theme must declare it**:
+
+```css
+:root {
+	color-scheme: light;
+}
+.dark {
+	color-scheme: dark;
+}
+```
+
+The card's own hooks sit in front of the shared ones, for the case where this surface alone should differ:
+
+| Variable                       | Default               | Applies to                          |
+| ------------------------------ | --------------------- | ----------------------------------- |
+| `--ft-artifact-running`        | `--ft-status-running` | The streaming sweep on the top edge |
+| `--ft-artifact-error`          | `--ft-status-error`   | The failure footer, text and tint   |
+| `--ft-artifact-preview-bg`     | `currentColor` at 4%  | Background behind the preview       |
+| `--ft-artifact-preview-height` | `9rem`                | Where the preview is cut off        |
+| `--ft-artifact-sweep-duration` | `1.9s`                | One pass of the sweep               |
+
+## Implementation Notes
+
+- Status is never carried by colour alone: a failure says so in words in the footer, and an `sr-only` label beside the header names all four states ("Not started" / "Writing" / "Ready" / "Failed"). That label, the version navigator and the actions rail all stay readable because the root is never given a `role` — an ARIA button would flatten them into its own name.
+- The sweep is a single gradient bar parked off the card's left edge, moved only by an animation that lives entirely inside `prefers-reduced-motion: no-preference`. Reduced motion therefore never sees it — there is no fallback to shorten, because the still state _is_ the parked one.
+- The preview's fade is a `mask-image` on the clipping box, so it works over any background the card is sitting on.
+- Nothing is scheduled and no DOM is touched at construction time, so the card renders under SSR unchanged.

--- a/src/lib/fancy-ui/artifact-card/index.ts
+++ b/src/lib/fancy-ui/artifact-card/index.ts
@@ -1,0 +1,4 @@
+import ArtifactCard from "./ArtifactCard.svelte";
+import type { ArtifactCardProps } from "./ArtifactCard.svelte";
+
+export { ArtifactCard, type ArtifactCardProps };

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -83,6 +83,12 @@ export * from "./sources/index.js";
 export * from "./inline-citation/index.js";
 export * from "./web-search/index.js";
 export * from "./image-generation/index.js";
+export * from "./agent-plan/index.js";
+export * from "./subagent-list/index.js";
+export * from "./approval-card/index.js";
+export * from "./recommendation-card/index.js";
+export * from "./artifact-card/index.js";
+export * from "./ai-data-table/index.js";
 
 // =============================================================================
 // Registry

--- a/src/lib/fancy-ui/recommendation-card/README.md
+++ b/src/lib/fancy-ui/recommendation-card/README.md
@@ -1,0 +1,106 @@
+# Recommendation Card
+
+An agent's proposal, waiting for an answer: a kicker, the recommendation itself, how sure the agent is — counted up beside a ring that fills to match — and two buttons. Answer it and the buttons collapse into one quiet line.
+
+## Components
+
+- `RecommendationCard` — the whole card: header, confidence, detail region, footer
+
+## Usage
+
+```svelte
+<script>
+	import { RecommendationCard } from "fancy-ui-svelte";
+
+	let state = $state("open");
+</script>
+
+<RecommendationCard
+	badge="Suggestion"
+	title="Add an index on orders.customer_id"
+	description="The three slowest queries this week all scanned the whole table."
+	confidence={0.87}
+	bind:state
+	onAccept={() => runMigration()}
+/>
+```
+
+## Props
+
+| Prop           | Type                                  | Default     | Description                                               |
+| -------------- | ------------------------------------- | ----------- | --------------------------------------------------------- |
+| `title`        | `string`                              | —           | What the agent is proposing. Required.                    |
+| `description`  | `string`                              | `undefined` | Secondary muted line — the reasoning, the expected effect |
+| `confidence`   | `number`                              | `undefined` | How sure the agent is, 0–1. Omitted, the block disappears |
+| `acceptLabel`  | `string`                              | `"Apply"`   | Label for the confirm button                              |
+| `dismissLabel` | `string`                              | `"Dismiss"` | Label for the decline button                              |
+| `onAccept`     | `() => void`                          | `undefined` | Called on acceptance, after `state` has been written      |
+| `onDismiss`    | `() => void`                          | `undefined` | Called on dismissal, after `state` has been written       |
+| `state`        | `"open" \| "accepted" \| "dismissed"` | `"open"`    | Where the recommendation stands. Bindable                 |
+| `badge`        | `string`                              | `undefined` | Small kicker above the title, e.g. `"Suggestion"`         |
+| `children`     | `Snippet`                             | `undefined` | Detail region between the header and the footer           |
+| `class`        | `string`                              | `undefined` | Additional CSS classes                                    |
+| `ref`          | `HTMLDivElement \| null`              | `null`      | Bindable reference to the root element                    |
+
+## Reading the confidence
+
+`confidence` is a fraction, not a percentage: `0.87` renders as **87%**. The number counts up, and the ring beside it fills to the same fraction, so the figure is legible at a glance and exactly at a read.
+
+The colour comes from three bands, borrowed from the run-status vocabulary the rest of the AI family speaks:
+
+| Confidence | Band                  | Reads as             |
+| ---------- | --------------------- | -------------------- |
+| `>= 0.75`  | `--ft-status-done`    | Act on it            |
+| `>= 0.5`   | `--ft-status-running` | Worth a look         |
+| `< 0.5`    | `--ft-status-pending` | A guess, and says so |
+
+Colour is never the only signal: the arc's length carries the same fraction, and the percentage is written out beside it. The counter and the ring are both `aria-hidden`, with one `role="img"` label — `"Confidence 87%"` — spoken over the pair, because a number mid-count is not worth announcing.
+
+Omit `confidence` and the block disappears entirely rather than reading as zero. A value outside 0–1 is clamped; `NaN` and `Infinity` are treated as "not reported".
+
+## The answer
+
+`state` starts at `"open"` and moves once. Pressing a button writes it **before** the matching callback fires, so a consumer reading the bound value from inside its own handler already sees the answer. A card that has resolved refuses to resolve again.
+
+Both buttons then collapse into a single line — a check and "Applied", or a cross and "Dismissed" — inside a `polite` live region that has been mounted since the first render, so the outcome is announced rather than silently swapped in. Drive `state` from outside and the card follows: setting it to `"accepted"` renders the resolved line without any callback firing.
+
+## Styling
+
+Colour comes from `--ft-status-*`, the run-status vocabulary shared with `ToolCall`, `ApprovalCard`, `ToolTimeline`, `TerminalBlock` and `ChatError`. Set one anywhere up the tree and every component in the family follows:
+
+| Variable              | Default (light / dark)                         | Used here for           |
+| --------------------- | ---------------------------------------------- | ----------------------- |
+| `--ft-status-done`    | `oklch(0.5 0.14 145)` / `oklch(0.72 0.15 145)` | High band, applied line |
+| `--ft-status-running` | `oklch(0.5 0.18 265)` / `oklch(0.72 0.15 265)` | Middle band             |
+| `--ft-status-pending` | `oklch(0.5 0.02 260)` / `oklch(0.72 0.02 260)` | Low band                |
+
+Each default is a `light-dark()` pair, because no single token clears 4.5:1 against both white and near-black. Which half applies is decided by `color-scheme`, so **your theme must declare it**:
+
+```css
+:root {
+	color-scheme: light;
+}
+.dark {
+	color-scheme: dark;
+}
+```
+
+Every colour is read at the point of use, so a value set by a consumer wins without having to out-specify the component's own scoped rules. The `--ft-rec-*` names sit in front of the shared ones for the case where this card alone should differ:
+
+| Variable             | Default               | Applies to                    |
+| -------------------- | --------------------- | ----------------------------- |
+| `--ft-rec-high`      | `--ft-status-done`    | Ring at 75% and above         |
+| `--ft-rec-medium`    | `--ft-status-running` | Ring between 50% and 75%      |
+| `--ft-rec-low`       | `--ft-status-pending` | Ring below 50%                |
+| `--ft-rec-track`     | `currentColor` at 15% | The unfilled part of the ring |
+| `--ft-rec-accepted`  | `--ft-status-done`    | The applied line              |
+| `--ft-rec-dismissed` | `currentColor` at 65% | The dismissed line            |
+| `--ft-rec-ring-size` | `1.75rem`             | Diameter of the donut         |
+
+## Implementation Notes
+
+- The ring is one SVG circle with a `stroke-dasharray` of its own circumference and a `stroke-dashoffset` carrying the fraction — no arc maths, no measuring. It starts empty and its target is written two animation frames later, because a transition never runs from a value the browser has not painted yet: `onMount` alone still lands inside the mounting frame, so the fill would be the first thing drawn and there would be nothing to animate between. Under reduced motion the target is written immediately instead, so there is no empty frame to notice.
+- The percentage is a `NumberTicker`. Its duration is collapsed under `prefers-reduced-motion: reduce`, so the figure lands immediately instead of counting; the ring's transition sits behind `prefers-reduced-motion: no-preference` alongside it.
+- The footer element is mounted from the first render and marked `aria-live="polite"`, so the region exists before the outcome lands in it — a live region that appears at the same moment as its own text is routinely missed by screen readers.
+- The `state` prop is renamed on the way in (`state: current`): a binding called `state` in scope turns every `$state(...)` in the file into a store subscription. The prop is still `state` from outside.
+- Nothing is scheduled and no DOM is touched at construction time, so the card renders under SSR unchanged; the ring simply arrives empty and fills on hydration.

--- a/src/lib/fancy-ui/recommendation-card/RecommendationCard.svelte
+++ b/src/lib/fancy-ui/recommendation-card/RecommendationCard.svelte
@@ -39,7 +39,7 @@
 </script>
 
 <script lang="ts">
-	import { onMount } from "svelte";
+	import { onMount, tick } from "svelte";
 	import { cn } from "$lib/utils.js";
 	import NumberTicker from "../number-ticker/NumberTicker.svelte";
 
@@ -91,6 +91,9 @@
 	let filled = $state(false);
 	let reduced = $state(false);
 
+	/** Where focus lands once the buttons it might have held are gone. */
+	let resolvedRef: HTMLParagraphElement | null = null;
+
 	// The ring starts empty and fills once the target is written, so its sweep runs
 	// from a known origin — a transition never animates from a value the browser
 	// has not painted yet.
@@ -139,6 +142,10 @@
 		current = next;
 		if (next === "accepted") onAccept?.();
 		else onDismiss?.();
+		// The button just pressed is about to leave the DOM along with the rest of
+		// the action group, so focus is moved to the verdict once it has painted —
+		// otherwise the browser drops it back to the document body.
+		tick().then(() => resolvedRef?.focus());
 	}
 </script>
 
@@ -251,7 +258,9 @@
 			</div>
 		{:else}
 			<p
-				class="ft-rec-resolved flex items-center gap-1.5 text-xs font-medium"
+				bind:this={resolvedRef}
+				tabindex="-1"
+				class="ft-rec-resolved focus-visible:ring-ring flex items-center gap-1.5 rounded-md text-xs font-medium focus-visible:ring-1 focus-visible:outline-none"
 				class:ft-accepted={current === "accepted"}
 			>
 				<span class="flex-none" aria-hidden="true">

--- a/src/lib/fancy-ui/recommendation-card/RecommendationCard.svelte
+++ b/src/lib/fancy-ui/recommendation-card/RecommendationCard.svelte
@@ -1,0 +1,366 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	/** Where a proposal stands: still on the table, taken up, or waved off. */
+	export type RecommendationState = "open" | "accepted" | "dismissed";
+
+	/**
+	 * Props for RecommendationCard
+	 */
+	export interface RecommendationCardProps {
+		/** What the agent is proposing, e.g. "Add an index on orders.customer_id". */
+		title: string;
+		/** Secondary muted line under the title — the reasoning, the expected effect. */
+		description?: string;
+		/**
+		 * How sure the agent is, from 0 to 1. Omitted, the whole confidence block
+		 * disappears rather than reading as zero. Out-of-range numbers are clamped.
+		 */
+		confidence?: number;
+		/** Label for the confirm button. */
+		acceptLabel?: string;
+		/** Label for the decline button. */
+		dismissLabel?: string;
+		/** Called when the recommendation is accepted, after `state` has been written. */
+		onAccept?: () => void;
+		/** Called when the recommendation is dismissed, after `state` has been written. */
+		onDismiss?: () => void;
+		/** Where the recommendation stands. Bindable, so the answer is readable from outside. */
+		state?: RecommendationState;
+		/** Small kicker above the title, e.g. "Suggestion". */
+		badge?: string;
+		/** The detail region between the header and the footer — a snippet of the change. */
+		children?: Snippet;
+		/** Additional CSS classes */
+		class?: string;
+		/** The root element */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import NumberTicker from "../number-ticker/NumberTicker.svelte";
+
+	// `state` is renamed on the way in: a binding of that name in scope would turn
+	// every `$state(...)` below into a store subscription, which is a compile-time
+	// ambiguity Svelte resolves in the store's favour. The prop is still `state`.
+	let {
+		title,
+		description,
+		confidence,
+		acceptLabel = "Apply",
+		dismissLabel = "Dismiss",
+		onAccept,
+		onDismiss,
+		state: current = $bindable("open"),
+		badge,
+		children,
+		class: className,
+		ref = $bindable(null),
+	}: RecommendationCardProps = $props();
+
+	/** Shown and spoken once the proposal is behind us. */
+	const RESOLVED_LABELS = {
+		accepted: "Applied",
+		dismissed: "Dismissed",
+	} as const;
+
+	/** How long the percentage takes to count up, before the reduced-motion clamp. */
+	const TICKER_MS = 900;
+
+	/** Ring geometry. The radius picks the circumference the dash array runs on. */
+	const RING_R = 13;
+	const RING_C = 2 * Math.PI * RING_R;
+
+	const isOpen = $derived(current === "open");
+	const resolvedLabel = $derived(
+		current === "accepted" ? RESOLVED_LABELS.accepted : RESOLVED_LABELS.dismissed
+	);
+
+	// A missing confidence is not a confidence of zero: the block only exists for
+	// a real number, so `NaN` and `Infinity` are treated as "not reported".
+	const hasConfidence = $derived(typeof confidence === "number" && Number.isFinite(confidence));
+	const fraction = $derived(hasConfidence ? Math.min(1, Math.max(0, confidence as number)) : 0);
+	const percent = $derived(Math.round(fraction * 100));
+
+	/** Three bands, borrowing the run-status vocabulary the AI family already shares. */
+	const band = $derived(fraction >= 0.75 ? "done" : fraction >= 0.5 ? "running" : "pending");
+
+	let filled = $state(false);
+	let reduced = $state(false);
+
+	// The ring starts empty and fills once the target is written, so its sweep runs
+	// from a known origin — a transition never animates from a value the browser
+	// has not painted yet.
+	const sweep = $derived(filled ? fraction : 0);
+	const ringOffset = $derived(RING_C * (1 - sweep));
+
+	// The counter is JS-driven, so reduced motion is honoured by collapsing its
+	// duration rather than by a media query: it lands on the number immediately.
+	const tickerMs = $derived(Math.max(0.01, reduced ? 0 : TICKER_MS));
+
+	onMount(() => {
+		reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+		// Reduced motion wants the settled arc, not a fast one: write it in the same
+		// breath so there is never a frame of empty ring to notice.
+		if (reduced) {
+			filled = true;
+			return;
+		}
+
+		// `onMount` still runs inside the frame that mounted the card, so setting the
+		// target here would land in the same paint as the empty ring and the browser
+		// would have nothing to transition between. Two frames out is the guarantee:
+		// the first callback can still belong to the mounting frame, the second
+		// cannot, so the empty ring is on screen before the target is written.
+		let second = 0;
+		const first = requestAnimationFrame(() => {
+			second = requestAnimationFrame(() => {
+				filled = true;
+			});
+		});
+
+		return () => {
+			cancelAnimationFrame(first);
+			cancelAnimationFrame(second);
+		};
+	});
+
+	/**
+	 * The answer is written to `state` before the callback fires, so a consumer
+	 * reading the bound value from inside its own handler already sees it.
+	 * Re-entry is refused rather than re-announced: a proposal resolves once.
+	 */
+	function decide(next: "accepted" | "dismissed") {
+		if (current !== "open") return;
+		current = next;
+		if (next === "accepted") onAccept?.();
+		else onDismiss?.();
+	}
+</script>
+
+<div
+	bind:this={ref}
+	class={cn(
+		"ft-rec border-border w-full rounded-lg border p-4 text-sm",
+		isOpen && "bg-card/50",
+		className
+	)}
+	role="group"
+	aria-label={title}
+	data-state={current}
+>
+	<div class="flex items-start gap-3">
+		<div class="min-w-0 flex-1">
+			{#if badge}
+				<p class="ft-rec-badge text-muted-foreground mb-1 text-[0.6875rem] font-medium uppercase">
+					{badge}
+				</p>
+			{/if}
+			<p class="ft-rec-title text-foreground font-medium">{title}</p>
+			{#if description}
+				<p class="ft-rec-description text-muted-foreground mt-0.5 text-xs leading-relaxed">
+					{description}
+				</p>
+			{/if}
+		</div>
+
+		{#if hasConfidence}
+			<!--
+				One label for the pair: the counter is mid-animation for most of its
+				life and the ring says nothing out loud, so assistive tech is given the
+				settled figure once and both halves are hidden behind it.
+			-->
+			<div
+				class="ft-rec-confidence flex flex-none items-center gap-2"
+				role="img"
+				aria-label="Confidence {percent}%"
+				data-band={band}
+			>
+				<span
+					class="ft-rec-percent text-foreground text-xs font-medium tabular-nums"
+					aria-hidden="true"
+				>
+					<NumberTicker
+						value={percent}
+						duration={tickerMs}
+						class="text-inherit dark:text-inherit"
+					/>%
+				</span>
+
+				<svg class="ft-rec-ring" viewBox="0 0 32 32" aria-hidden="true">
+					<circle
+						class="ft-rec-ring-track"
+						cx="16"
+						cy="16"
+						r={RING_R}
+						fill="none"
+						stroke-width="3"
+					/>
+					<circle
+						class="ft-rec-ring-value"
+						class:ft-status-done={band === "done"}
+						class:ft-status-running={band === "running"}
+						class:ft-status-pending={band === "pending"}
+						cx="16"
+						cy="16"
+						r={RING_R}
+						fill="none"
+						stroke-width="3"
+						stroke-linecap="round"
+						stroke-dasharray={RING_C}
+						stroke-dashoffset={ringOffset}
+						transform="rotate(-90 16 16)"
+					/>
+				</svg>
+			</div>
+		{/if}
+	</div>
+
+	{#if children}
+		<div class="ft-rec-detail mt-3 min-w-0">
+			{@render children()}
+		</div>
+	{/if}
+
+	<!--
+		One footer element, mounted from the first render, so the live region exists
+		before the outcome lands in it — a region that appears at the same moment as
+		its own text is routinely missed by screen readers.
+	-->
+	<div class="ft-rec-foot mt-3" aria-live="polite">
+		{#if isOpen}
+			<div class="ft-rec-actions flex flex-wrap items-center justify-end gap-2">
+				<button
+					type="button"
+					class="ft-rec-dismiss text-muted-foreground hover:text-foreground hover:bg-foreground/5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
+					onclick={() => decide("dismissed")}
+				>
+					{dismissLabel}
+				</button>
+				<button
+					type="button"
+					class="ft-rec-accept bg-foreground text-background hover:bg-foreground/90 rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
+					onclick={() => decide("accepted")}
+				>
+					{acceptLabel}
+				</button>
+			</div>
+		{:else}
+			<p
+				class="ft-rec-resolved flex items-center gap-1.5 text-xs font-medium"
+				class:ft-accepted={current === "accepted"}
+			>
+				<span class="flex-none" aria-hidden="true">
+					<svg
+						class="size-3.5"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2.5"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						{#if current === "accepted"}
+							<path d="m20 6-11 11-5-5" />
+						{:else}
+							<path d="M18 6 6 18" />
+							<path d="m6 6 12 12" />
+						{/if}
+					</svg>
+				</span>
+				{resolvedLabel}
+			</p>
+		{/if}
+	</div>
+</div>
+
+<style>
+	/*
+	 * Every colour is read at the point of use through two hooks: this card's own
+	 * `--ft-rec-*`, then the `--ft-status-*` vocabulary the whole AI family shares,
+	 * then the literal. Setting either anywhere up the tree retints the card
+	 * without having to win a specificity fight against these scoped rules, and
+	 * the shared one recolours every sibling component at once.
+	 */
+	.ft-rec-badge {
+		letter-spacing: 0.08em;
+	}
+
+	.ft-rec-ring {
+		width: var(--ft-rec-ring-size, 1.75rem);
+		height: var(--ft-rec-ring-size, 1.75rem);
+	}
+
+	.ft-rec-ring-track {
+		stroke: var(--ft-rec-track, color-mix(in oklab, currentColor 15%, transparent));
+	}
+
+	/*
+	 * The band is carried by the arc's length as much as by its hue — a quarter
+	 * ring and a full ring are told apart without seeing colour at all, and the
+	 * figure beside it says the number in words either way.
+	 */
+	.ft-rec-ring-value.ft-status-done {
+		stroke: var(
+			--ft-rec-high,
+			var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145)))
+		);
+	}
+
+	.ft-rec-ring-value.ft-status-running {
+		stroke: var(
+			--ft-rec-medium,
+			var(--ft-status-running, light-dark(oklch(0.5 0.18 265), oklch(0.72 0.15 265)))
+		);
+	}
+
+	.ft-rec-ring-value.ft-status-pending {
+		stroke: var(
+			--ft-rec-low,
+			var(--ft-status-pending, light-dark(oklch(0.5 0.02 260), oklch(0.72 0.02 260)))
+		);
+	}
+
+	/* A dismissal is not a failure, so it stays deliberately quiet. */
+	.ft-rec-resolved {
+		color: var(--ft-rec-dismissed, color-mix(in oklab, currentColor 65%, transparent));
+	}
+
+	.ft-rec-resolved.ft-accepted {
+		color: var(
+			--ft-rec-accepted,
+			var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145)))
+		);
+	}
+
+	/*
+	 * Both moving parts live behind the query, so reduced motion is not a degraded
+	 * variant to keep in sync: the ring is drawn at its final length and the
+	 * footer simply swaps, with the same colours and the same words. The counter
+	 * is JS-driven and collapses its own duration alongside.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-rec-ring-value {
+			transition: stroke-dashoffset 700ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+
+		.ft-rec-resolved {
+			animation: ft-rec-resolve-in 240ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+	}
+
+	@keyframes ft-rec-resolve-in {
+		from {
+			opacity: 0;
+			transform: translateY(-3px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/recommendation-card/RecommendationCard.test.ts
+++ b/src/lib/fancy-ui/recommendation-card/RecommendationCard.test.ts
@@ -235,6 +235,15 @@ describe("RecommendationCard", () => {
 		expect(root(container).dataset.state).toBe("dismissed");
 	});
 
+	it("moves focus to the verdict once the buttons that held it are gone", async () => {
+		const { container } = render(RecommendationCard, { props: { title: TITLE } });
+
+		await fireEvent.click(accept(container));
+		await tick();
+
+		expect(document.activeElement).toBe(resolved(container));
+	});
+
 	it("writes an acceptance back out through the binding", async () => {
 		const { container, getByTestId } = render(Harness, { props: { title: TITLE } });
 		expect(getByTestId("bound-state").textContent).toBe("open");

--- a/src/lib/fancy-ui/recommendation-card/RecommendationCard.test.ts
+++ b/src/lib/fancy-ui/recommendation-card/RecommendationCard.test.ts
@@ -1,0 +1,323 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet, tick } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import RecommendationCard from "./RecommendationCard.svelte";
+import Harness from "./RecommendationCardHarness.test.svelte";
+
+const TITLE = "Add an index on orders.customer_id";
+
+function root(container: HTMLElement): HTMLElement {
+	return container.querySelector(".ft-rec") as HTMLElement;
+}
+
+function accept(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector(".ft-rec-accept") as HTMLButtonElement;
+}
+
+function dismiss(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector(".ft-rec-dismiss") as HTMLButtonElement;
+}
+
+function resolved(container: HTMLElement): HTMLElement | null {
+	return container.querySelector(".ft-rec-resolved");
+}
+
+function confidence(container: HTMLElement): HTMLElement | null {
+	return container.querySelector(".ft-rec-confidence");
+}
+
+function ring(container: HTMLElement): SVGCircleElement | null {
+	return container.querySelector(".ft-rec-ring-value");
+}
+
+function offset(container: HTMLElement): number {
+	return Number((ring(container) as SVGCircleElement).getAttribute("stroke-dashoffset"));
+}
+
+/** The circumference the dash array runs on — the offset of a ring drawn empty. */
+const RING_C = 2 * Math.PI * 13;
+
+/**
+ * Two real frames, then a Svelte flush: what the ring waits for before it writes
+ * its target, so the empty state reaches the screen first.
+ */
+async function settle(): Promise<void> {
+	await new Promise<void>((resolve) =>
+		requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+	);
+	await tick();
+}
+
+describe("RecommendationCard", () => {
+	afterEach(cleanup);
+
+	it("renders the proposal and names the group after it", () => {
+		const { container } = render(RecommendationCard, { props: { title: TITLE } });
+
+		expect(container.querySelector(".ft-rec-title")?.textContent).toBe(TITLE);
+		expect(root(container).getAttribute("role")).toBe("group");
+		expect(root(container).getAttribute("aria-label")).toBe(TITLE);
+		expect(root(container).dataset.state).toBe("open");
+	});
+
+	it("renders the description under the title", () => {
+		const { container } = render(RecommendationCard, {
+			props: { title: TITLE, description: "The last three slow queries scanned the whole table." },
+		});
+
+		expect(container.querySelector(".ft-rec-description")?.textContent?.trim()).toBe(
+			"The last three slow queries scanned the whole table."
+		);
+	});
+
+	it("leaves the description line out when there is none", () => {
+		const { container } = render(RecommendationCard, { props: { title: TITLE } });
+
+		expect(container.querySelector(".ft-rec-description")).toBeNull();
+	});
+
+	it("renders the badge as a kicker above the title", () => {
+		const { container } = render(RecommendationCard, {
+			props: { title: TITLE, badge: "Suggestion" },
+		});
+
+		expect(container.querySelector(".ft-rec-badge")?.textContent?.trim()).toBe("Suggestion");
+	});
+
+	it("leaves the kicker out when there is no badge", () => {
+		const { container } = render(RecommendationCard, { props: { title: TITLE } });
+
+		expect(container.querySelector(".ft-rec-badge")).toBeNull();
+	});
+
+	it.each([
+		[0.8, 80, "ft-status-done"],
+		[0.6, 60, "ft-status-running"],
+		[0.3, 30, "ft-status-pending"],
+	])("reports %s as a percentage in the %s band", (value, percent, className) => {
+		const { container } = render(RecommendationCard, {
+			props: { title: TITLE, confidence: value },
+		});
+
+		const block = confidence(container) as HTMLElement;
+		expect(block.getAttribute("aria-label")).toBe(`Confidence ${percent}%`);
+		expect(block.dataset.band).toBe(className.replace("ft-status-", ""));
+		expect(block.textContent).toContain("%");
+		expect(ring(container)?.classList.contains(className)).toBe(true);
+	});
+
+	it("drops the whole confidence block when none was reported", () => {
+		const { container } = render(RecommendationCard, { props: { title: TITLE } });
+
+		expect(confidence(container)).toBeNull();
+		expect(ring(container)).toBeNull();
+		expect(root(container).textContent).not.toContain("%");
+	});
+
+	it("treats a confidence that is not a real number as no confidence at all", () => {
+		const { container } = render(RecommendationCard, {
+			props: { title: TITLE, confidence: Number.NaN },
+		});
+
+		expect(confidence(container)).toBeNull();
+	});
+
+	it.each([
+		[1.4, 100, "ft-status-done"],
+		[-0.5, 0, "ft-status-pending"],
+	])("clamps a confidence of %s into range", (value, percent, className) => {
+		const { container } = render(RecommendationCard, {
+			props: { title: TITLE, confidence: value },
+		});
+
+		expect(confidence(container)?.getAttribute("aria-label")).toBe(`Confidence ${percent}%`);
+		expect(ring(container)?.classList.contains(className)).toBe(true);
+	});
+
+	it("paints the ring empty first, so the fill has somewhere to run from", async () => {
+		const { container } = render(RecommendationCard, {
+			props: { title: TITLE, confidence: 0.8 },
+		});
+
+		// A transition never animates from a value the browser has not painted, so
+		// the settled arc must not be the first thing on screen.
+		await tick();
+		expect(offset(container)).toBeCloseTo(RING_C, 5);
+
+		await settle();
+		expect(offset(container)).toBeCloseTo(RING_C * 0.2, 5);
+	});
+
+	it("sweeps more of the ring for a higher confidence", async () => {
+		const high = render(RecommendationCard, { props: { title: TITLE, confidence: 0.8 } });
+		const low = render(RecommendationCard, { props: { title: TITLE, confidence: 0.3 } });
+		await settle();
+
+		const arc = (container: HTMLElement) => {
+			const circle = ring(container) as SVGCircleElement;
+			const length = Number(circle.getAttribute("stroke-dasharray"));
+			const gap = Number(circle.getAttribute("stroke-dashoffset"));
+			return { length, drawn: length - gap };
+		};
+
+		const highArc = arc(high.container);
+		const lowArc = arc(low.container);
+
+		expect(highArc.length).toBeGreaterThan(0);
+		expect(highArc.drawn).toBeGreaterThan(lowArc.drawn);
+		expect(highArc.drawn).toBeLessThan(highArc.length);
+		expect(highArc.drawn / highArc.length).toBeCloseTo(0.8, 2);
+	});
+
+	it("skips the empty frame entirely under reduced motion", async () => {
+		const real = window.matchMedia;
+		window.matchMedia = ((query: string) => ({
+			...real(query),
+			matches: true,
+		})) as typeof window.matchMedia;
+
+		try {
+			const { container } = render(RecommendationCard, {
+				props: { title: TITLE, confidence: 0.8 },
+			});
+			await tick();
+
+			// No frame of empty ring to notice: the settled arc is the first one drawn.
+			expect(offset(container)).toBeCloseTo(RING_C * 0.2, 5);
+		} finally {
+			window.matchMedia = real;
+		}
+	});
+
+	it("hides the counter and the ring behind the one spoken figure", () => {
+		const { container } = render(RecommendationCard, {
+			props: { title: TITLE, confidence: 0.87 },
+		});
+
+		expect(confidence(container)?.getAttribute("role")).toBe("img");
+		expect(container.querySelector(".ft-rec-percent")?.getAttribute("aria-hidden")).toBe("true");
+		expect(container.querySelector(".ft-rec-ring")?.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it("labels the buttons, with the defaults left to speak for themselves", () => {
+		const { container } = render(RecommendationCard, { props: { title: TITLE } });
+
+		expect(accept(container).textContent?.trim()).toBe("Apply");
+		expect(dismiss(container).textContent?.trim()).toBe("Dismiss");
+	});
+
+	it("takes custom labels for both buttons", () => {
+		const { container } = render(RecommendationCard, {
+			props: { title: TITLE, acceptLabel: "Apply patch", dismissLabel: "Not now" },
+		});
+
+		expect(accept(container).textContent?.trim()).toBe("Apply patch");
+		expect(dismiss(container).textContent?.trim()).toBe("Not now");
+	});
+
+	it("calls onAccept and marks the card accepted", async () => {
+		const onAccept = vi.fn();
+		const { container } = render(RecommendationCard, { props: { title: TITLE, onAccept } });
+
+		await fireEvent.click(accept(container));
+
+		expect(onAccept).toHaveBeenCalledTimes(1);
+		expect(root(container).dataset.state).toBe("accepted");
+	});
+
+	it("calls onDismiss and marks the card dismissed", async () => {
+		const onDismiss = vi.fn();
+		const { container } = render(RecommendationCard, { props: { title: TITLE, onDismiss } });
+
+		await fireEvent.click(dismiss(container));
+
+		expect(onDismiss).toHaveBeenCalledTimes(1);
+		expect(root(container).dataset.state).toBe("dismissed");
+	});
+
+	it("writes an acceptance back out through the binding", async () => {
+		const { container, getByTestId } = render(Harness, { props: { title: TITLE } });
+		expect(getByTestId("bound-state").textContent).toBe("open");
+
+		await fireEvent.click(accept(container));
+		expect(getByTestId("bound-state").textContent).toBe("accepted");
+	});
+
+	it("writes a dismissal back out through the binding too", async () => {
+		const { container, getByTestId } = render(Harness, { props: { title: TITLE } });
+
+		await fireEvent.click(dismiss(container));
+		expect(getByTestId("bound-state").textContent).toBe("dismissed");
+	});
+
+	it("collapses to a quiet applied line, with no buttons left to press", () => {
+		const { container } = render(RecommendationCard, {
+			props: { title: TITLE, state: "accepted" as const },
+		});
+
+		expect(accept(container)).toBeNull();
+		expect(dismiss(container)).toBeNull();
+		expect(resolved(container)?.textContent?.trim()).toBe("Applied");
+		expect(resolved(container)?.classList.contains("ft-accepted")).toBe(true);
+	});
+
+	it("collapses to an even quieter dismissed line", () => {
+		const { container } = render(RecommendationCard, {
+			props: { title: TITLE, state: "dismissed" as const },
+		});
+
+		expect(accept(container)).toBeNull();
+		expect(resolved(container)?.textContent?.trim()).toBe("Dismissed");
+		expect(resolved(container)?.classList.contains("ft-accepted")).toBe(false);
+	});
+
+	it("follows a state prop driven from outside", async () => {
+		const { container, rerender } = render(RecommendationCard, {
+			props: { title: TITLE, state: "open" as const },
+		});
+		expect(accept(container)).not.toBeNull();
+
+		await rerender({ title: TITLE, state: "accepted" as const });
+		expect(accept(container)).toBeNull();
+		expect(resolved(container)?.textContent?.trim()).toBe("Applied");
+	});
+
+	it("keeps the footer live from the first render, before there is an outcome in it", async () => {
+		const { container } = render(RecommendationCard, { props: { title: TITLE } });
+		const foot = container.querySelector(".ft-rec-foot") as HTMLElement;
+
+		expect(foot.getAttribute("aria-live")).toBe("polite");
+		expect(resolved(container)).toBeNull();
+
+		await fireEvent.click(accept(container));
+
+		// Same element, new content: the region was mounted before the answer landed.
+		expect(container.querySelector(".ft-rec-foot")).toBe(foot);
+		expect(resolved(container)?.textContent?.trim()).toBe("Applied");
+	});
+
+	it("renders the children snippet as the detail region", () => {
+		const { container } = render(RecommendationCard, {
+			props: {
+				title: TITLE,
+				children: createRawSnippet(() => ({
+					render: () => `<code class="detail">CREATE INDEX ON orders (customer_id)</code>`,
+				})),
+			},
+		});
+
+		expect(container.querySelector(".ft-rec-detail .detail")?.textContent).toBe(
+			"CREATE INDEX ON orders (customer_id)"
+		);
+	});
+
+	it("merges an extra class onto the root without losing its own", () => {
+		const { container } = render(RecommendationCard, {
+			props: { title: TITLE, class: "my-8 border-dashed" },
+		});
+
+		expect(root(container).classList.contains("my-8")).toBe(true);
+		expect(root(container).classList.contains("border-dashed")).toBe(true);
+		expect(root(container).classList.contains("ft-rec")).toBe(true);
+	});
+});

--- a/src/lib/fancy-ui/recommendation-card/RecommendationCardHarness.test.svelte
+++ b/src/lib/fancy-ui/recommendation-card/RecommendationCardHarness.test.svelte
@@ -1,0 +1,33 @@
+<!--
+  Test-only rig. `bind:` cannot be expressed from a `.ts` test file, so the
+  bindable `state` is bound here and echoed into the DOM, which is the only way
+  to prove the answer travels back out to the consumer rather than merely
+  changing what the card draws. Not exported from index.ts, and not collected by
+  Vitest (the run includes `*.test.ts` only).
+-->
+<script lang="ts">
+	import RecommendationCard from "./RecommendationCard.svelte";
+	import type { RecommendationState } from "./RecommendationCard.svelte";
+
+	interface Props {
+		title: string;
+		description?: string;
+		confidence?: number;
+		state?: RecommendationState;
+		onAccept?: () => void;
+		onDismiss?: () => void;
+	}
+
+	let {
+		title,
+		description,
+		confidence,
+		state = $bindable("open"),
+		onAccept,
+		onDismiss,
+	}: Props = $props();
+</script>
+
+<RecommendationCard {title} {description} {confidence} bind:state {onAccept} {onDismiss} />
+
+<span data-testid="bound-state">{state}</span>

--- a/src/lib/fancy-ui/recommendation-card/index.ts
+++ b/src/lib/fancy-ui/recommendation-card/index.ts
@@ -1,0 +1,4 @@
+import RecommendationCard from "./RecommendationCard.svelte";
+import type { RecommendationCardProps, RecommendationState } from "./RecommendationCard.svelte";
+
+export { RecommendationCard, type RecommendationCardProps, type RecommendationState };

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -3339,6 +3339,360 @@ export const registry: Record<string, ComponentMeta> = {
 			},
 		],
 	},
+	"agent-plan": {
+		name: "AgentPlan",
+		slug: "agent-plan",
+		description:
+			"Glanceable checklist of an agent's plan: a done/total count and completion bar over one row per step, with a status glyph, an optional detail line, and substeps indented under a rail",
+		category: "ai-agents",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "agents", "plan", "checklist", "progress"],
+		props: [
+			{
+				name: "steps",
+				type: "PlanStepData[]",
+				description:
+					"The plan, in the order the agent means to work through it; nests one level via substeps",
+				required: true,
+			},
+			{
+				name: "label",
+				type: "string",
+				default: '"Plan"',
+				description: "Header text, sitting beside the done/total count",
+			},
+			{
+				name: "showProgress",
+				type: "boolean",
+				default: "true",
+				description:
+					"Whether the thin completion bar shows under the header; its fraction counts substeps as steps",
+			},
+			{
+				name: "onSelect",
+				type: "(step: PlanStepData) => void",
+				description: "Called when a row is activated; supplying it turns every row into a button",
+			},
+		],
+		slots: [
+			{
+				name: "item",
+				description:
+					"Replaces the built-in row body, keeping the glyph and the indent; receives the step and its position in visual order",
+			},
+		],
+	},
+	"subagent-list": {
+		name: "SubagentList",
+		slug: "subagent-list",
+		description:
+			"Fan-out panel for parallel workers: one row per delegated agent with its status dot, model badge, task, and its own progress bar",
+		category: "ai-agents",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "agents", "parallel", "progress", "workers"],
+		props: [
+			{
+				name: "agents",
+				type: "SubagentData[]",
+				description:
+					"The delegated workers, in the order they were spawned: id, name, task, status, and optionally progress and model",
+				required: true,
+			},
+			{
+				name: "label",
+				type: "string",
+				description:
+					'Accessible name for the list. Left unset it is derived from the statuses — "2 agents running" while anything runs, "3 agents finished" once the last one lands',
+			},
+			{
+				name: "onSelect",
+				type: "(agent: SubagentData, index: number) => void",
+				description: "Called when a row is activated; supplying it turns every row into a button",
+			},
+			{
+				name: "compact",
+				type: "boolean",
+				default: "false",
+				description: "Tighter rows with the task line dropped",
+			},
+		],
+		slots: [
+			{
+				name: "item",
+				description: "Replaces the built-in row body, keeping the status dot",
+			},
+		],
+	},
+	"approval-card": {
+		name: "ApprovalCard",
+		slug: "approval-card",
+		description:
+			"A human-in-the-loop gate before a side effect: the agent states what it is about to do, and the footer swaps its approve and deny buttons for a one-line verdict once someone decides",
+		category: "ai-agents",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "agents", "approval", "human-in-the-loop", "gate"],
+		props: [
+			{
+				name: "title",
+				type: "string",
+				description: 'What permission is being asked for, e.g. "Run database migration"',
+				required: true,
+			},
+			{
+				name: "description",
+				type: "string",
+				description: "Muted second line under the title — the consequence, the blast radius",
+			},
+			{
+				name: "state",
+				type: '"pending" | "approved" | "denied"',
+				default: '"pending"',
+				description:
+					"Which side of the gate we are on (bindable). Buttons exist only while pending; writing a resolved value from outside settles the card without firing a callback",
+			},
+			{
+				name: "destructive",
+				type: "boolean",
+				default: "false",
+				description:
+					"Marks the action as irreversible: red approve button, a warning tint on the card, and an alert mark on the shield so the warning is not carried by colour alone",
+			},
+			{
+				name: "approveLabel",
+				type: "string",
+				default: '"Approve"',
+				description: "Label for the approve button",
+			},
+			{
+				name: "denyLabel",
+				type: "string",
+				default: '"Deny"',
+				description: "Label for the deny button",
+			},
+			{
+				name: "onApprove",
+				type: "() => void",
+				description: "Called when approve is pressed, after state has been written",
+			},
+			{
+				name: "onDeny",
+				type: "() => void",
+				description: "Called when deny is pressed, after state has been written",
+			},
+			{
+				name: "busy",
+				type: "boolean",
+				default: "false",
+				description:
+					"The consumer is executing the decision: both buttons go disabled and the card is marked aria-busy",
+			},
+		],
+		slots: [
+			{
+				name: "children",
+				description:
+					"Detail region between the header and the footer — a diff, a command preview, the payload about to be posted",
+			},
+		],
+	},
+	"recommendation-card": {
+		name: "RecommendationCard",
+		slug: "recommendation-card",
+		description:
+			"An agent's proposal awaiting an answer: a kicker, the recommendation, a confidence figure counted up beside a ring that fills to match, and two buttons that collapse into one quiet resolved line",
+		category: "ai-agents",
+		status: "done",
+		dependencies: ["number-ticker"],
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "agents", "recommendation", "confidence"],
+		props: [
+			{
+				name: "title",
+				type: "string",
+				description: 'What the agent is proposing, e.g. "Add an index on orders.customer_id"',
+				required: true,
+			},
+			{
+				name: "description",
+				type: "string",
+				description: "Secondary muted line under the title — the reasoning, the expected effect",
+			},
+			{
+				name: "confidence",
+				type: "number",
+				description:
+					"How sure the agent is, from 0 to 1. Omitted, the whole confidence block disappears rather than reading as zero; out-of-range numbers are clamped and the band shifts colour at 0.75 and 0.5",
+			},
+			{
+				name: "acceptLabel",
+				type: "string",
+				default: '"Apply"',
+				description: "Label for the confirm button",
+			},
+			{
+				name: "dismissLabel",
+				type: "string",
+				default: '"Dismiss"',
+				description: "Label for the decline button",
+			},
+			{
+				name: "onAccept",
+				type: "() => void",
+				description: "Called when the recommendation is accepted, after `state` has been written",
+			},
+			{
+				name: "onDismiss",
+				type: "() => void",
+				description: "Called when the recommendation is dismissed, after `state` has been written",
+			},
+			{
+				name: "state",
+				type: '"open" | "accepted" | "dismissed"',
+				default: '"open"',
+				description:
+					"Where the recommendation stands (bindable). Resolving swaps the buttons for a quiet line inside a polite live region; a resolved card refuses to resolve again",
+			},
+			{
+				name: "badge",
+				type: "string",
+				description: 'Small kicker above the title, e.g. "Suggestion"',
+			},
+		],
+		slots: [
+			{
+				name: "children",
+				description:
+					"The detail region between the header and the footer — a snippet of the change being proposed",
+			},
+		],
+	},
+	"artifact-card": {
+		name: "ArtifactCard",
+		slug: "artifact-card",
+		description:
+			"A generated document as a tangible object: title, kind, a version navigator, and the first six lines of the text itself streaming in behind a fade",
+		category: "ai-agents",
+		status: "done",
+		dependencies: ["streaming-text"],
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "agents", "artifact", "document", "versioned", "streaming"],
+		props: [
+			{
+				name: "title",
+				type: "string",
+				description: "What the document is called",
+				required: true,
+			},
+			{
+				name: "kind",
+				type: "string",
+				default: '"Document"',
+				description: "The kind of thing it is, on the muted line under the title",
+			},
+			{
+				name: "version",
+				type: "number",
+				description: "Which revision is on screen, 1-based; rendered as v3",
+			},
+			{
+				name: "versionCount",
+				type: "number",
+				description: "How many revisions exist; with version the badge reads v3/5",
+			},
+			{
+				name: "onVersionChange",
+				type: "(version: number) => void",
+				description:
+					"Asked for another revision by 1-based number, never one outside its bounds; supplying it turns the badge into a navigator",
+			},
+			{
+				name: "status",
+				type: '"idle" | "streaming" | "done" | "error"',
+				default: '"done"',
+				description:
+					"Where the document is in its life; streaming sweeps the top edge and trails a cursor, error grows a tinted footer",
+			},
+			{
+				name: "preview",
+				type: "string",
+				description:
+					"The text so far, not the latest delta; clamped to roughly six lines behind a bottom fade",
+			},
+			{
+				name: "onOpen",
+				type: "() => void",
+				description:
+					"Asked to open the document; supplying it makes the whole card activatable by click, Enter, or Space",
+			},
+		],
+		slots: [
+			{
+				name: "actions",
+				description:
+					"Buttons for the top-right rail; each keeps its own click, without opening the card",
+			},
+		],
+	},
+	"ai-data-table": {
+		name: "AiDataTable",
+		slug: "ai-data-table",
+		description:
+			"Compact comparison table for a model's structured answer: real table semantics, tabular numeric columns, check-or-dash booleans, and one tintable column — rendered in the order it arrived, with no sorting",
+		category: "ai-agents",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "agents", "table", "comparison", "structured-output"],
+		props: [
+			{
+				name: "columns",
+				type: "AiDataTableColumn[]",
+				description:
+					"Columns in render order: key, label, and optional align / numeric. A numeric column gets tabular figures and right alignment",
+				required: true,
+			},
+			{
+				name: "rows",
+				type: "AiDataTableRow[]",
+				description:
+					"Rows keyed by column key, in the order the model produced them; a missing key renders as empty",
+				required: true,
+			},
+			{
+				name: "caption",
+				type: "string",
+				description:
+					"Names the table for assistive tech; rendered in a visually-hidden <caption> unless captionVisible",
+			},
+			{
+				name: "captionVisible",
+				type: "boolean",
+				default: "false",
+				description: "Also shows the caption, as a muted line above the table",
+			},
+			{
+				name: "dense",
+				type: "boolean",
+				default: "false",
+				description: "Tighter rows, for a table read at a glance rather than studied",
+			},
+			{
+				name: "highlightColumn",
+				type: "string",
+				description:
+					"Key of the column to tint — the recommendation, or whichever criterion decided it",
+			},
+		],
+		slots: [
+			{
+				name: "cell",
+				description:
+					"Replaces the default rendering of every cell; receives the raw value and { row, key }",
+			},
+		],
+	},
 };
 
 // =============================================================================

--- a/src/lib/fancy-ui/subagent-list/README.md
+++ b/src/lib/fancy-ui/subagent-list/README.md
@@ -1,0 +1,153 @@
+# SubagentList
+
+The fan-out panel: one row per delegated worker, each with its own status dot, the task it was handed, and how far along it is. This is what you put under an orchestrator's answer while it waits for its workers — a list the reader scans for "who is still out there", not a feature they interact with.
+
+## Components
+
+- `SubagentList` — the whole list; there are no sub-parts to assemble
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { SubagentList } from "fancy-ui-svelte";
+	import type { SubagentData } from "fancy-ui-svelte";
+
+	const agents: SubagentData[] = [
+		{
+			id: "researcher",
+			name: "Researcher",
+			task: "Read the changelog for breaking changes",
+			status: "running",
+			progress: 0.62,
+			model: "mini",
+		},
+		{
+			id: "writer",
+			name: "Writer",
+			task: "Draft the migration note",
+			status: "done",
+			model: "pro",
+		},
+	];
+</script>
+
+<SubagentList {agents} />
+```
+
+```svelte
+<!-- Tighter rows for a sidebar, and rows that open the worker's transcript -->
+<SubagentList {agents} compact onSelect={(agent, index) => open(agent, index)} />
+```
+
+```svelte
+<!-- Own the row body outright; the status dot stays -->
+<SubagentList {agents}>
+	{#snippet item(agent, index)}
+		<span class="flex-1">{index + 1}. {agent.name}</span>
+	{/snippet}
+</SubagentList>
+```
+
+## The data contract
+
+Each entry is a `SubagentData` from the shared AI data model, so the same object can come straight off an orchestrator's fan-out without translation:
+
+```ts
+interface SubagentData {
+	id: string;
+	name: string;
+	task: string;
+	status: "pending" | "running" | "done" | "error" | "cancelled";
+	progress?: number; // 0–1
+	model?: string;
+}
+```
+
+Only `id`, `name`, `task` and `status` are required. `progress` and `model` render when they arrive: send the row without them while the worker is queued, then the same row with a fraction once it starts reporting.
+
+## Props
+
+| Prop       | Type                                           | Default     | Description                                                          |
+| ---------- | ---------------------------------------------- | ----------- | -------------------------------------------------------------------- |
+| `agents`   | `SubagentData[]`                               | —           | The delegated workers, in the order they were spawned (required)     |
+| `label`    | `string`                                       | `undefined` | Accessible name for the list; derived from the statuses when unset   |
+| `onSelect` | `(agent: SubagentData, index: number) => void` | `undefined` | Called when a row is activated; supplying it turns rows into buttons |
+| `compact`  | `boolean`                                      | `false`     | Tighter rows with the task line dropped                              |
+| `class`    | `string`                                       | `undefined` | Additional CSS classes                                               |
+| `ref`      | `HTMLDivElement \| null`                       | `null`      | Bindable reference to the root element                               |
+
+## Snippets
+
+| Snippet | Args                           | Description                                     |
+| ------- | ------------------------------ | ----------------------------------------------- |
+| `item`  | `(agent: SubagentData, index)` | Replaces the built-in row body, keeping the dot |
+
+## The row
+
+- **Status dot** — filled for running, done and error; hollow for pending and cancelled. Colour comes from the `--ft-status-*` vocabulary this family shares, and a running dot breathes.
+- **Name** — emphasised, truncating on overflow with the full string in a `title`.
+- **Model badge** — a tiny muted monospace pill, rendered only for the workers that name a model, so a homogeneous fan-out stays quiet.
+- **Task** — a muted second line, dropped entirely in `compact` mode.
+- **Progress or a word** — a thin bar for a running worker that reported a `progress`, otherwise the status in words (`pending`, `running`, `done`, `error`, `cancelled`).
+
+## The derived label
+
+Left unset, `label` is computed from the statuses, because the one number a fan-out is read for is how many workers are still out there:
+
+| State                              | Accessible name       |
+| ---------------------------------- | --------------------- |
+| Anything running                   | `"2 agents running"`  |
+| Nothing running, all settled       | `"3 agents finished"` |
+| Nothing running, some still queued | `"3 agents"`          |
+| No agents at all                   | `"No agents"`         |
+
+"Settled" covers `error` and `cancelled` as well as `done` — a worker that failed is no longer out there. The count is the running tally in the first row of that table and the headcount everywhere else, and singular reads as `"1 agent running"`. Pass `label` and it wins outright, unchanged.
+
+The label is the list's accessible name only; it is not rendered. Put your own heading above the list if you want the count on screen.
+
+## Implementation notes
+
+- Rows are a real `<ul>` / `<li>` list, with `role="list"` stated rather than left implicit — `list-style: none` strips list semantics in Safari, and the count of workers is exactly what assistive tech should report here.
+- The `{#each}` is keyed by `agent.id` with the row's position appended. The id is what makes a newly spawned worker mount as a fresh node and play the entrance by itself, while the rows already on screen keep their DOM nodes and stay put — keying on position alone would animate the wrong row. The position is folded in because the ids come from a model: a repeated one would otherwise crash the block, and appending a worker leaves every existing key untouched.
+- A running row with a progress bar has no visible caption to speak for it, and `progressbar` is children-presentational, so neither its label nor its value reaches the name of the button around it. Those rows carry the status and the percentage in a screen-reader-only span instead — "Running, 62%".
+- **A bar is a claim that something is moving**, so only a running worker that reported a number gets one. A finished row with a stale `progress: 1` left on it shows `done` in words, not a full bar.
+- `progress` is clamped into `0–1` at the point of use: a worker reporting `1.4` fills the track rather than overrunning it, and a negative number empties it.
+- The bar is a real `role="progressbar"` with `aria-valuenow` in whole percent, named "Running" — so the status is never carried by colour alone. Rows without a bar say their status in visible words instead, which is why there is no screen-reader-only duplicate on a default row. Replace the body with `item` and that duplicate reappears, since your markup cannot be asked to speak the status for us.
+- `onSelect` alone decides the row element: with it, each row is a `<button type="button">` with hover and focus-visible affordances; without it, a plain span with no tab stop and no pointer cursor. There is no "clickable" prop to keep in sync with the handler.
+- Every animation — the entrance, the bar's width transition, the running pulse — lives inside `@media (prefers-reduced-motion: no-preference)`. Reduced motion is therefore not a degraded variant to keep in sync: with those rules gone a new worker appears at its final position, the bar jumps to its width, and a running dot is still a filled accent dot.
+- `ft-subagents-compact` is applied with a `class:` directive rather than through `cn()`, so the compiler can see the class is used and does not prune its scoped rule.
+- Nothing is scheduled and no DOM is touched at construction time, so the list renders under SSR unchanged.
+
+## Styling
+
+Colour comes from `--ft-status-*`, the run-status vocabulary shared with `ToolCall`, `ToolTimeline`, `TerminalBlock`, `CodeDiff` and `ChatError`. Set one anywhere up the tree and every component in the family follows:
+
+| Variable                | Default (light / dark)                         | Meaning                      |
+| ----------------------- | ---------------------------------------------- | ---------------------------- |
+| `--ft-status-pending`   | `oklch(0.5 0.02 260)` / `oklch(0.72 0.02 260)` | Queued, nothing has run yet  |
+| `--ft-status-running`   | `oklch(0.5 0.18 265)` / `oklch(0.72 0.15 265)` | In flight                    |
+| `--ft-status-done`      | `oklch(0.5 0.14 145)` / `oklch(0.72 0.15 145)` | Succeeded                    |
+| `--ft-status-error`     | `oklch(0.5 0.19 25)` / `oklch(0.7 0.18 25)`    | Failed                       |
+| `--ft-status-cancelled` | `oklch(0.5 0.02 260)` / `oklch(0.72 0.02 260)` | Abandoned before it finished |
+
+Each default is a `light-dark()` pair, because no single token clears 4.5:1 against both white and near-black. Which half applies is decided by `color-scheme`, so **your theme must declare it** — see the [ToolCall README](../tool-call/README.md#styling) for the full explanation.
+
+The `--ft-subagents-*` names sit in front of the shared ones, for the case where this list alone should differ:
+
+| Variable                        | Default                          | Controls                           |
+| ------------------------------- | -------------------------------- | ---------------------------------- |
+| `--ft-subagents-pending`        | `--ft-status-pending` at 55%     | Hollow dot, pending                |
+| `--ft-subagents-running`        | `--ft-status-running`            | Dot and its pulse, running         |
+| `--ft-subagents-done`           | `--ft-status-done`               | Dot, finished                      |
+| `--ft-subagents-error`          | `--ft-status-error`              | Dot, failed                        |
+| `--ft-subagents-cancelled`      | `--ft-status-cancelled` at 40%   | Hollow dot, cancelled              |
+| `--ft-subagents-bar`            | `--ft-status-running`            | Progress fill                      |
+| `--ft-subagents-track`          | `currentColor` at 14%            | Progress track                     |
+| `--ft-subagents-track-width`    | `3.5rem`                         | Track length                       |
+| `--ft-subagents-track-height`   | `0.25rem`                        | Track thickness                    |
+| `--ft-subagents-badge-bg`       | `currentColor` at 8%             | Model badge background             |
+| `--ft-subagents-dot-size`       | `0.5rem`                         | Dot diameter                       |
+| `--ft-subagents-row-pad`        | `0.375rem` (`0.1875rem` compact) | Vertical row padding               |
+| `--ft-subagents-enter-duration` | `320ms`                          | Row entrance duration              |
+| `--ft-subagents-fill-duration`  | `320ms`                          | How long the bar takes to catch up |

--- a/src/lib/fancy-ui/subagent-list/SubagentList.svelte
+++ b/src/lib/fancy-ui/subagent-list/SubagentList.svelte
@@ -1,0 +1,401 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { SubagentData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for SubagentList
+	 */
+	export interface SubagentListProps {
+		/** The delegated workers, in the order they were spawned */
+		agents: SubagentData[];
+		/**
+		 * Accessible name for the list. Left undefined it is derived from the
+		 * statuses — "3 agents running", then "3 agents finished".
+		 */
+		label?: string;
+		/** Called when a row is activated; supplying it turns every row into a button */
+		onSelect?: (agent: SubagentData, index: number) => void;
+		/** Replaces the built-in row body, keeping the status dot */
+		item?: Snippet<[SubagentData, number]>;
+		/** Tighter rows with the task line dropped */
+		compact?: boolean;
+		/** Additional CSS classes */
+		class?: string;
+		/** The root element */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { RunStatus } from "../_internals/ai-types.js";
+
+	let {
+		agents,
+		label,
+		onSelect,
+		item,
+		compact = false,
+		class: className,
+		ref = $bindable(null),
+	}: SubagentListProps = $props();
+
+	/** The small caption a row shows in place of a progress bar. */
+	const STATUS_WORDS: Record<RunStatus, string> = {
+		pending: "pending",
+		running: "running",
+		done: "done",
+		error: "error",
+		cancelled: "cancelled",
+	};
+
+	/**
+	 * The spoken form, rendered wherever the row has no visible caption to speak
+	 * for it: under a replaced body, and beside the progress bar. A `progressbar`
+	 * is children-presentational, so its own name and value are dropped from the
+	 * name of a selectable row's button — without these words a running row would
+	 * be a name and nothing else.
+	 */
+	const STATUS_LABELS: Record<RunStatus, string> = {
+		pending: "Pending",
+		running: "Running",
+		done: "Completed",
+		error: "Failed",
+		cancelled: "Cancelled",
+	};
+
+	function isFinished(status: RunStatus): boolean {
+		return status === "done" || status === "error" || status === "cancelled";
+	}
+
+	const runningCount = $derived(agents.filter((agent) => agent.status === "running").length);
+	const allFinished = $derived(
+		agents.length > 0 && agents.every((agent) => isFinished(agent.status))
+	);
+
+	/**
+	 * A fan-out is read for one number: how many workers are still out there. So
+	 * the running count leads while anything runs, and gives way to the total once
+	 * the last one lands. Anything in between — queued, nothing started — is just
+	 * the headcount, since "0 agents running" tells the reader nothing they want.
+	 */
+	const autoLabel = $derived.by(() => {
+		const total = agents.length;
+		if (total === 0) return "No agents";
+		if (runningCount > 0) return `${runningCount} ${noun(runningCount)} running`;
+		if (allFinished) return `${total} ${noun(total)} finished`;
+		return `${total} ${noun(total)}`;
+	});
+
+	const listLabel = $derived(label ?? autoLabel);
+
+	function noun(count: number): string {
+		return count === 1 ? "agent" : "agents";
+	}
+
+	/**
+	 * A bar is a claim that something is moving, so only a running agent that
+	 * reported a number gets one. Everything else — queued, finished, or running
+	 * blind — says where it stands in words instead.
+	 */
+	function showsProgress(agent: SubagentData): boolean {
+		return agent.status === "running" && agent.progress != null && Number.isFinite(agent.progress);
+	}
+
+	/** Clamped, because a worker reporting 1.4 should fill the track, not overrun it. */
+	function percent(progress: number | undefined): number {
+		return Math.round(Math.min(1, Math.max(0, progress ?? 0)) * 100);
+	}
+</script>
+
+<!--
+	`ft-subagents-compact` rides a `class:` directive rather than `cn()` so the
+	compiler can see the class is used and keeps its scoped rule.
+-->
+<div
+	bind:this={ref}
+	class={cn("ft-subagents w-full text-sm", className)}
+	class:ft-subagents-compact={compact}
+>
+	<!--
+		`role="list"` is stated rather than left implicit: `list-style: none` strips
+		list semantics in Safari, and the count of workers is the point of this list.
+	-->
+	<ul class="ft-subagents-list" role="list" aria-label={listLabel}>
+		<!--
+			Keyed by id so a newly spawned worker mounts as a fresh node and plays the
+			entrance on its own, while the rows already on screen keep their DOM nodes
+			and stay put. The position is appended because the ids come from a model:
+			a repeated one would otherwise crash the block, and appending leaves the
+			keys of the rows already on screen untouched when a worker is added.
+		-->
+		{#each agents as agent, index (`${agent.id}#${index}`)}
+			<li class="ft-subagents-row">
+				{#snippet body()}
+					<!--
+						Filled versus hollow, not just hue: the five states stay apart for
+						anyone who cannot tell the colours apart, and the row says which
+						one it is in words beside it.
+					-->
+					<span
+						class="ft-subagents-dot"
+						class:ft-status-pending={agent.status === "pending"}
+						class:ft-status-running={agent.status === "running"}
+						class:ft-status-done={agent.status === "done"}
+						class:ft-status-error={agent.status === "error"}
+						class:ft-status-cancelled={agent.status === "cancelled"}
+						aria-hidden="true"
+					></span>
+
+					{#if item}
+						<span class="sr-only">{STATUS_LABELS[agent.status]}</span>
+						{@render item(agent, index)}
+					{:else}
+						<span class="ft-subagents-main min-w-0 flex-1">
+							<span class="flex min-w-0 items-baseline gap-1.5">
+								<span class="ft-subagents-name truncate font-medium" title={agent.name}
+									>{agent.name}</span
+								>
+								{#if agent.model}
+									<!--
+										`text-foreground/70` rather than `text-muted-foreground`: at
+										10px the badge is not large text, so it owes 4.5:1, and the
+										muted token only reaches 4.33:1 on a light page. Seventy
+										percent of the foreground clears it on both themes.
+									-->
+									<span class="ft-subagents-model text-foreground/70 shrink-0 font-mono"
+										>{agent.model}</span
+									>
+								{/if}
+							</span>
+							{#if !compact && agent.task}
+								<span
+									class="ft-subagents-task text-muted-foreground mt-0.5 block truncate"
+									title={agent.task}>{agent.task}</span
+								>
+							{/if}
+						</span>
+
+						<span class="ft-subagents-meta flex shrink-0 items-center">
+							{#if showsProgress(agent)}
+								{@const value = percent(agent.progress)}
+								<span class="sr-only">{STATUS_LABELS[agent.status]}, {value}%</span>
+								<span
+									class="ft-subagents-progress"
+									role="progressbar"
+									aria-label={STATUS_LABELS.running}
+									aria-valuemin="0"
+									aria-valuemax="100"
+									aria-valuenow={value}
+								>
+									<span class="ft-subagents-progress-fill" style="width: {value}%"></span>
+								</span>
+							{:else}
+								<span class="ft-subagents-state text-muted-foreground"
+									>{STATUS_WORDS[agent.status]}</span
+								>
+							{/if}
+						</span>
+					{/if}
+				{/snippet}
+
+				{#if onSelect}
+					<button
+						type="button"
+						class="ft-subagents-body hover:bg-muted/60 focus-visible:ring-ring flex w-full cursor-pointer items-start gap-2.5 rounded-md text-left transition-colors focus-visible:ring-1 focus-visible:outline-none"
+						onclick={() => onSelect?.(agent, index)}
+					>
+						{@render body()}
+					</button>
+				{:else}
+					<span class="ft-subagents-body flex w-full items-start gap-2.5 rounded-md">
+						{@render body()}
+					</span>
+				{/if}
+			</li>
+		{/each}
+	</ul>
+</div>
+
+<style>
+	.ft-subagents {
+		/* Track and badge are mixes of currentColor, so one set of values reads
+		   correctly in both themes. The dot and the bar fill cannot do that — they
+		   are the status vocabulary — so they are read at their point of use off the
+		   shared `--ft-status-*` names, whose defaults are `light-dark()` pairs. A
+		   dot is a graphical object and owes 3:1, which is why the light half of the
+		   grey pair is 0.5 rather than 0.55. */
+		--ft-subagents-row-pad: 0.375rem;
+		--ft-subagents-dot-size: 0.5rem;
+		--ft-subagents-track: color-mix(in oklab, currentColor 14%, transparent);
+		--ft-subagents-track-width: 3.5rem;
+		--ft-subagents-track-height: 0.25rem;
+		--ft-subagents-badge-bg: color-mix(in oklab, currentColor 8%, transparent);
+		--ft-subagents-enter-duration: 320ms;
+		--ft-subagents-fill-duration: 320ms;
+	}
+
+	.ft-subagents-compact {
+		--ft-subagents-row-pad: 0.1875rem;
+	}
+
+	.ft-subagents-list {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.ft-subagents-body {
+		padding: var(--ft-subagents-row-pad) 0.5rem;
+	}
+
+	.ft-subagents-dot {
+		position: relative;
+		display: inline-block;
+		flex: none;
+		/* Half a 1.25rem line box minus half the dot: the dot sits on the middle of
+		   the name, not of the two-line row. */
+		margin-top: calc((1.25rem - var(--ft-subagents-dot-size)) / 2);
+		width: var(--ft-subagents-dot-size);
+		height: var(--ft-subagents-dot-size);
+		border-radius: 9999px;
+	}
+
+	/* Hollow: nothing has happened yet, or nothing ever will. */
+	.ft-subagents-dot.ft-status-pending {
+		box-shadow: inset 0 0 0 1.5px
+			var(
+				--ft-subagents-pending,
+				color-mix(
+					in oklab,
+					var(--ft-status-pending, light-dark(oklch(0.5 0.02 260), oklch(0.72 0.02 260))) 55%,
+					transparent
+				)
+			);
+	}
+
+	.ft-subagents-dot.ft-status-cancelled {
+		box-shadow: inset 0 0 0 1.5px
+			var(
+				--ft-subagents-cancelled,
+				color-mix(
+					in oklab,
+					var(--ft-status-cancelled, light-dark(oklch(0.5 0.02 260), oklch(0.72 0.02 260))) 40%,
+					transparent
+				)
+			);
+	}
+
+	.ft-subagents-dot.ft-status-running {
+		background: var(
+			--ft-subagents-running,
+			var(--ft-status-running, light-dark(oklch(0.5 0.18 265), oklch(0.72 0.15 265)))
+		);
+	}
+
+	.ft-subagents-dot.ft-status-done {
+		background: var(
+			--ft-subagents-done,
+			var(--ft-status-done, light-dark(oklch(0.5 0.14 145), oklch(0.72 0.15 145)))
+		);
+	}
+
+	.ft-subagents-dot.ft-status-error {
+		background: var(
+			--ft-subagents-error,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+	}
+
+	.ft-subagents-model {
+		border-radius: 0.25rem;
+		background: var(--ft-subagents-badge-bg);
+		padding: 0 0.25rem;
+		font-size: 0.625rem;
+		line-height: 1rem;
+	}
+
+	.ft-subagents-task {
+		font-size: 0.75rem;
+		line-height: 1.25;
+	}
+
+	.ft-subagents-meta {
+		/* Matches the name's line box, so the caption and the bar both land on the
+		   first line rather than in the middle of a two-line row. */
+		min-height: 1.25rem;
+		margin-left: auto;
+	}
+
+	.ft-subagents-state {
+		font-size: 0.75rem;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.ft-subagents-progress {
+		display: block;
+		width: var(--ft-subagents-track-width);
+		height: var(--ft-subagents-track-height);
+		overflow: hidden;
+		border-radius: 9999px;
+		background: var(--ft-subagents-track);
+	}
+
+	.ft-subagents-progress-fill {
+		display: block;
+		height: 100%;
+		border-radius: inherit;
+		background: var(
+			--ft-subagents-bar,
+			var(--ft-status-running, light-dark(oklch(0.5 0.18 265), oklch(0.72 0.15 265)))
+		);
+	}
+
+	/*
+	 * Everything that moves lives behind the query, so reduced motion is not a
+	 * degraded variant to keep in sync: with these rules gone a new worker simply
+	 * appears at its final position, the bar jumps to its width, and a running dot
+	 * is still a filled accent dot — it just stops breathing.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-subagents-row {
+			animation: ft-subagents-enter var(--ft-subagents-enter-duration) cubic-bezier(0.16, 1, 0.3, 1)
+				both;
+		}
+
+		.ft-subagents-progress-fill {
+			transition: width var(--ft-subagents-fill-duration) cubic-bezier(0.4, 0, 0.2, 1);
+		}
+
+		.ft-subagents-dot.ft-status-running::after {
+			content: "";
+			position: absolute;
+			inset: 0;
+			border-radius: inherit;
+			background: inherit;
+			animation: ft-subagents-ping 1.6s cubic-bezier(0, 0, 0.2, 1) infinite;
+		}
+	}
+
+	@keyframes ft-subagents-enter {
+		from {
+			opacity: 0;
+			transform: translateY(-0.25rem);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+
+	@keyframes ft-subagents-ping {
+		from {
+			opacity: 0.55;
+			transform: scale(1);
+		}
+		to {
+			opacity: 0;
+			transform: scale(2.4);
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/subagent-list/SubagentList.svelte
+++ b/src/lib/fancy-ui/subagent-list/SubagentList.svelte
@@ -106,6 +106,33 @@
 	function percent(progress: number | undefined): number {
 		return Math.round(Math.min(1, Math.max(0, progress ?? 0)) * 100);
 	}
+
+	/**
+	 * The first worker under an id keeps that id as its key, so a row survives a
+	 * reorder with its DOM node intact; only a repeat is suffixed, and by
+	 * occurrence rather than position, which would rename every row below an
+	 * insertion. The suffix also clears the ids actually in the list, since a
+	 * worker may genuinely be called "x#1" while two others are called "x".
+	 */
+	const rows = $derived.by(() => {
+		const ids = new Set(agents.map((agent) => agent.id));
+		const seen = new Map<string, number>();
+		const used = new Set<string>();
+		return agents.map((agent, index) => {
+			const occurrence = seen.get(agent.id) ?? 0;
+			seen.set(agent.id, occurrence + 1);
+			let key = agent.id;
+			if (occurrence > 0) {
+				let suffix = occurrence;
+				do {
+					key = `${agent.id}#${suffix}`;
+					suffix++;
+				} while (ids.has(key) || used.has(key));
+			}
+			used.add(key);
+			return { agent, index, key };
+		});
+	});
 </script>
 
 <!--
@@ -125,11 +152,11 @@
 		<!--
 			Keyed by id so a newly spawned worker mounts as a fresh node and plays the
 			entrance on its own, while the rows already on screen keep their DOM nodes
-			and stay put. The position is appended because the ids come from a model:
-			a repeated one would otherwise crash the block, and appending leaves the
-			keys of the rows already on screen untouched when a worker is added.
+			and stay put. The ids come from a model, so a repeat has to be
+			disambiguated or the block would crash — see `rows` for how, and why it
+			counts occurrences rather than positions.
 		-->
-		{#each agents as agent, index (`${agent.id}#${index}`)}
+		{#each rows as { agent, index, key } (key)}
 			<li class="ft-subagents-row">
 				{#snippet body()}
 					<!--

--- a/src/lib/fancy-ui/subagent-list/SubagentList.svelte
+++ b/src/lib/fancy-ui/subagent-list/SubagentList.svelte
@@ -179,7 +179,17 @@
 						<span class="ft-subagents-meta flex shrink-0 items-center">
 							{#if showsProgress(agent)}
 								{@const value = percent(agent.progress)}
-								<span class="sr-only">{STATUS_LABELS[agent.status]}, {value}%</span>
+								{#if onSelect}
+									<!--
+										Only needed inside the selectable row's button: a `progressbar`
+										is a range role, so its own value feeds the button's accessible
+										name instead of being announced on its own, and these words are
+										what makes that name legible. A standalone row keeps the
+										`progressbar` as its own object, independently announced with
+										its label and value — this text would only repeat it.
+									-->
+									<span class="sr-only">{STATUS_LABELS[agent.status]}, {value}%</span>
+								{/if}
 								<span
 									class="ft-subagents-progress"
 									role="progressbar"

--- a/src/lib/fancy-ui/subagent-list/SubagentList.test.ts
+++ b/src/lib/fancy-ui/subagent-list/SubagentList.test.ts
@@ -294,6 +294,18 @@ describe("SubagentList", () => {
 		expect(row.textContent).toContain("62%");
 	});
 
+	it("does not repeat the progress bar's own announcement on a non-selectable row", () => {
+		const { container } = render(SubagentList, {
+			props: { agents: [agent({ status: "running", progress: 0.62 })] },
+		});
+
+		// Outside a button the progress bar is its own object, independently
+		// announced with its label and value — this text would only echo it.
+		expect(container.querySelector(".sr-only")).toBeNull();
+		expect(bar(container)?.getAttribute("aria-label")).toBe("Running");
+		expect(bar(container)?.getAttribute("aria-valuenow")).toBe("62");
+	});
+
 	it("renders a fan-out that repeats an id instead of crashing on it", () => {
 		// Keying on the id alone would throw `each_key_duplicate` before a single row
 		// reached the DOM, and the ids here come from a model.

--- a/src/lib/fancy-ui/subagent-list/SubagentList.test.ts
+++ b/src/lib/fancy-ui/subagent-list/SubagentList.test.ts
@@ -343,4 +343,36 @@ describe("SubagentList", () => {
 		expect(root.className).toContain("my-fanout");
 		expect(root.className).toContain("ft-subagents");
 	});
+
+	it("keeps a row's key across an insertion above it, and survives colliding ids", async () => {
+		// Positional keys renamed every row below an insertion, throwing away the
+		// DOM nodes — and their entrance animations — of rows that never moved.
+		const { container, rerender } = render(SubagentList, {
+			props: { agents: [agent({ id: "a", name: "Alpha" }), agent({ id: "b", name: "Bravo" })] },
+		});
+		const last = container.querySelectorAll(".ft-subagents-row")[1];
+
+		await rerender({
+			agents: [
+				agent({ id: "z", name: "Zulu" }),
+				agent({ id: "a", name: "Alpha" }),
+				agent({ id: "b", name: "Bravo" }),
+			],
+		});
+		expect(container.querySelectorAll(".ft-subagents-row")[2]).toBe(last);
+
+		cleanup();
+		const collision = render(SubagentList, {
+			props: {
+				agents: [
+					agent({ id: "x", name: "First" }),
+					agent({ id: "x", name: "Second" }),
+					agent({ id: "x#1", name: "Third" }),
+				],
+			},
+		});
+		expect(
+			[...collision.container.querySelectorAll(".ft-subagents-name")].map((el) => el.textContent)
+		).toEqual(["First", "Second", "Third"]);
+	});
 });

--- a/src/lib/fancy-ui/subagent-list/SubagentList.test.ts
+++ b/src/lib/fancy-ui/subagent-list/SubagentList.test.ts
@@ -1,0 +1,334 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import SubagentList from "./SubagentList.svelte";
+import type { SubagentData } from "../_internals/ai-types.js";
+
+const agents: SubagentData[] = [
+	{
+		id: "a",
+		name: "Researcher",
+		task: "Read the changelog for breaking changes",
+		status: "running",
+		progress: 0.42,
+		model: "mini",
+	},
+	{ id: "b", name: "Writer", task: "Draft the migration note", status: "done" },
+	{ id: "c", name: "Reviewer", task: "Check the code samples", status: "pending" },
+];
+
+function agent(overrides: Partial<SubagentData> = {}): SubagentData {
+	return {
+		id: "a",
+		name: "Researcher",
+		task: "Read the changelog",
+		status: "running",
+		...overrides,
+	};
+}
+
+function rows(container: HTMLElement): HTMLElement[] {
+	return [...container.querySelectorAll<HTMLElement>(".ft-subagents-row")];
+}
+
+function list(container: HTMLElement): HTMLElement {
+	return container.querySelector('[role="list"]') as HTMLElement;
+}
+
+function bar(container: HTMLElement): HTMLElement | null {
+	return container.querySelector('[role="progressbar"]');
+}
+
+function states(container: HTMLElement): string[] {
+	return [...container.querySelectorAll(".ft-subagents-state")].map((el) => el.textContent ?? "");
+}
+
+describe("SubagentList", () => {
+	afterEach(cleanup);
+
+	it("renders one row per agent", () => {
+		const { container } = render(SubagentList, { props: { agents } });
+
+		expect(rows(container)).toHaveLength(3);
+		expect(container.querySelectorAll('[role="list"] > li')).toHaveLength(3);
+	});
+
+	it("renders each agent's name", () => {
+		const { container } = render(SubagentList, { props: { agents } });
+		const names = [...container.querySelectorAll(".ft-subagents-name")].map((el) => el.textContent);
+
+		expect(names).toEqual(["Researcher", "Writer", "Reviewer"]);
+	});
+
+	it("names the list by how many workers are still running", () => {
+		const { container } = render(SubagentList, {
+			props: {
+				agents: [
+					agent({ id: "a", status: "running" }),
+					agent({ id: "b", status: "running" }),
+					agent({ id: "c", status: "pending" }),
+				],
+			},
+		});
+
+		expect(list(container).getAttribute("aria-label")).toBe("2 agents running");
+	});
+
+	it("drops the plural for a single running worker", () => {
+		const { container } = render(SubagentList, {
+			props: { agents: [agent({ status: "running" }), agent({ id: "b", status: "done" })] },
+		});
+
+		expect(list(container).getAttribute("aria-label")).toBe("1 agent running");
+	});
+
+	it("switches the derived label to the total once the last worker lands", () => {
+		const { container } = render(SubagentList, {
+			props: {
+				agents: [
+					agent({ id: "a", status: "done" }),
+					agent({ id: "b", status: "done" }),
+					agent({ id: "c", status: "done" }),
+				],
+			},
+		});
+
+		expect(list(container).getAttribute("aria-label")).toBe("3 agents finished");
+	});
+
+	it("counts a failed or abandoned worker as finished too", () => {
+		const { container } = render(SubagentList, {
+			props: {
+				agents: [agent({ id: "a", status: "error" }), agent({ id: "b", status: "cancelled" })],
+			},
+		});
+
+		expect(list(container).getAttribute("aria-label")).toBe("2 agents finished");
+	});
+
+	it("falls back to the headcount when nothing has started yet", () => {
+		const { container } = render(SubagentList, {
+			props: {
+				agents: [agent({ id: "a", status: "pending" }), agent({ id: "b", status: "done" })],
+			},
+		});
+
+		expect(list(container).getAttribute("aria-label")).toBe("2 agents");
+	});
+
+	it("still names an empty list", () => {
+		const { container } = render(SubagentList, { props: { agents: [] } });
+
+		expect(list(container).getAttribute("aria-label")).toBe("No agents");
+		expect(rows(container)).toHaveLength(0);
+	});
+
+	it("lets an explicit label win over the derived one", () => {
+		const { container } = render(SubagentList, { props: { agents, label: "Research fan-out" } });
+
+		expect(list(container).getAttribute("aria-label")).toBe("Research fan-out");
+	});
+
+	it.each([
+		["pending", "ft-status-pending"],
+		["running", "ft-status-running"],
+		["done", "ft-status-done"],
+		["error", "ft-status-error"],
+		["cancelled", "ft-status-cancelled"],
+	] as const)("marks the status dot for %s", (status, className) => {
+		const { container } = render(SubagentList, { props: { agents: [agent({ status })] } });
+		const dot = container.querySelector(".ft-subagents-dot") as HTMLElement;
+
+		expect(dot.classList.contains(className)).toBe(true);
+		expect(dot.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it("renders the model badge only for the agents that name a model", () => {
+		const { container } = render(SubagentList, { props: { agents } });
+		const badges = container.querySelectorAll(".ft-subagents-model");
+
+		expect(badges).toHaveLength(1);
+		expect(badges[0].textContent).toBe("mini");
+	});
+
+	it("draws the progress bar at the reported fraction", () => {
+		const { container } = render(SubagentList, {
+			props: { agents: [agent({ status: "running", progress: 0.42 })] },
+		});
+		const track = bar(container) as HTMLElement;
+		const fill = track.querySelector(".ft-subagents-progress-fill") as HTMLElement;
+
+		expect(fill.style.width).toBe("42%");
+		expect(track.getAttribute("aria-valuenow")).toBe("42");
+		expect(track.getAttribute("aria-valuemin")).toBe("0");
+		expect(track.getAttribute("aria-valuemax")).toBe("100");
+		expect(track.getAttribute("aria-label")).toBe("Running");
+	});
+
+	it.each([
+		[-0.5, "0%"],
+		[1.4, "100%"],
+	])("clamps a progress of %s into the track", (progress, expected) => {
+		const { container } = render(SubagentList, {
+			props: { agents: [agent({ status: "running", progress })] },
+		});
+		const fill = container.querySelector(".ft-subagents-progress-fill") as HTMLElement;
+
+		expect(fill.style.width).toBe(expected);
+	});
+
+	it("shows the status word instead when a running worker reports no progress", () => {
+		const { container } = render(SubagentList, {
+			props: { agents: [agent({ status: "running" })] },
+		});
+
+		expect(bar(container)).toBeNull();
+		expect(states(container)).toEqual(["running"]);
+	});
+
+	it("keeps the bar off a finished worker even when it left a progress value behind", () => {
+		const { container } = render(SubagentList, {
+			props: { agents: [agent({ status: "done", progress: 1 })] },
+		});
+
+		expect(bar(container)).toBeNull();
+		expect(states(container)).toEqual(["done"]);
+	});
+
+	it.each([
+		["pending", "pending"],
+		["done", "done"],
+		["error", "error"],
+		["cancelled", "cancelled"],
+	] as const)("captions a %s worker in words", (status, word) => {
+		const { container } = render(SubagentList, { props: { agents: [agent({ status })] } });
+
+		expect(states(container)).toEqual([word]);
+	});
+
+	it("renders the task line by default, with the full text kept in a title", () => {
+		const { container } = render(SubagentList, { props: { agents } });
+		const tasks = [...container.querySelectorAll(".ft-subagents-task")];
+
+		expect(tasks).toHaveLength(3);
+		expect(tasks[0].textContent).toBe("Read the changelog for breaking changes");
+		expect(tasks[0].getAttribute("title")).toBe("Read the changelog for breaking changes");
+	});
+
+	it("drops the task line in compact mode, keeping the name and the status", () => {
+		const { container } = render(SubagentList, { props: { agents, compact: true } });
+
+		expect(container.querySelectorAll(".ft-subagents-task")).toHaveLength(0);
+		expect(container.querySelectorAll(".ft-subagents-name")).toHaveLength(3);
+		expect(bar(container)).not.toBeNull();
+		expect((container.firstElementChild as HTMLElement).className).toContain(
+			"ft-subagents-compact"
+		);
+	});
+
+	it("leaves the rows inert without onSelect", () => {
+		const { container } = render(SubagentList, { props: { agents } });
+
+		expect(container.querySelectorAll("button")).toHaveLength(0);
+	});
+
+	it("turns every row into a button that reports the agent and its index", async () => {
+		const onSelect = vi.fn();
+		const { container } = render(SubagentList, { props: { agents, onSelect } });
+		const buttons = container.querySelectorAll("button");
+
+		expect(buttons).toHaveLength(3);
+
+		await fireEvent.click(buttons[1]);
+		expect(onSelect).toHaveBeenCalledTimes(1);
+		expect(onSelect).toHaveBeenLastCalledWith(agents[1], 1);
+	});
+
+	it("lets the item snippet replace the row body, keeping the status dot", () => {
+		const { container } = render(SubagentList, {
+			props: {
+				agents,
+				item: createRawSnippet<[SubagentData, number]>((data, index) => ({
+					render: () => `<span class="custom-row">${index()}: ${data().name}</span>`,
+				})),
+			},
+		});
+		const custom = [...container.querySelectorAll(".custom-row")].map((el) => el.textContent);
+
+		expect(custom).toEqual(["0: Researcher", "1: Writer", "2: Reviewer"]);
+		expect(container.querySelectorAll(".ft-subagents-name")).toHaveLength(0);
+		expect(container.querySelectorAll(".ft-subagents-dot")).toHaveLength(3);
+	});
+
+	it("speaks the status of a replaced row, since the dot is hidden from assistive tech", () => {
+		const { container } = render(SubagentList, {
+			props: {
+				agents: [agent({ status: "error" })],
+				item: createRawSnippet<[SubagentData, number]>(() => ({
+					render: () => `<span class="custom-row">mine</span>`,
+				})),
+			},
+		});
+
+		expect(container.querySelector(".sr-only")?.textContent).toBe("Failed");
+	});
+
+	it("says nothing twice on a row that already captions itself", () => {
+		const { container } = render(SubagentList, {
+			props: { agents: [agent({ status: "done" }), agent({ id: "b", status: "pending" })] },
+		});
+
+		expect(container.querySelector(".sr-only")).toBeNull();
+		expect(states(container)).toEqual(["done", "pending"]);
+	});
+
+	it("speaks the status of a row whose caption was replaced by a progress bar", () => {
+		const { container } = render(SubagentList, {
+			props: { agents: [agent({ status: "running", progress: 0.62 })], onSelect: vi.fn() },
+		});
+		const row = container.querySelector("button") as HTMLButtonElement;
+
+		// A `progressbar` is children-presentational, so neither its own label nor
+		// its value reaches the name of the button around it.
+		expect(row.textContent).toContain("Running");
+		expect(row.textContent).toContain("62%");
+	});
+
+	it("renders a fan-out that repeats an id instead of crashing on it", () => {
+		// Keying on the id alone would throw `each_key_duplicate` before a single row
+		// reached the DOM, and the ids here come from a model.
+		const { container } = render(SubagentList, {
+			props: {
+				agents: [
+					agent({ id: "worker", name: "Researcher" }),
+					agent({ id: "worker", name: "Writer", status: "done" }),
+					agent({ id: "worker", name: "Reviewer", status: "pending" }),
+				],
+			},
+		});
+
+		expect(rows(container)).toHaveLength(3);
+		expect(
+			[...container.querySelectorAll(".ft-subagents-name")].map((el) => el.textContent)
+		).toEqual(["Researcher", "Writer", "Reviewer"]);
+	});
+
+	it("keeps the rows already on screen keyed the same when a worker is spawned", async () => {
+		const { container, rerender } = render(SubagentList, { props: { agents } });
+		const first = rows(container)[0];
+
+		await rerender({ agents: [...agents, agent({ id: "d", name: "Auditor" })] });
+
+		// Same node, not a remount: an appended worker must not replay every entrance.
+		expect(rows(container)[0]).toBe(first);
+		expect(rows(container)).toHaveLength(4);
+	});
+
+	it("merges custom classes onto the root", () => {
+		const { container } = render(SubagentList, { props: { agents, class: "my-fanout" } });
+		const root = container.firstElementChild as HTMLElement;
+
+		expect(root.className).toContain("my-fanout");
+		expect(root.className).toContain("ft-subagents");
+	});
+});

--- a/src/lib/fancy-ui/subagent-list/index.ts
+++ b/src/lib/fancy-ui/subagent-list/index.ts
@@ -1,0 +1,4 @@
+import SubagentList from "./SubagentList.svelte";
+import type { SubagentListProps } from "./SubagentList.svelte";
+
+export { SubagentList, type SubagentListProps };

--- a/src/lib/fancy-ui/tool-call/README.md
+++ b/src/lib/fancy-ui/tool-call/README.md
@@ -92,15 +92,17 @@ An `error` on the call is shown in the result section whatever the snippets do, 
 
 Colour comes from `--ft-status-*`, the run-status vocabulary shared with `ToolTimeline`, `TerminalBlock`, `CodeDiff` and `ChatError`. Set one of them anywhere up the tree and every component in the family follows:
 
-| Variable                | Default (light / dark)                          | Meaning                      |
-| ----------------------- | ----------------------------------------------- | ---------------------------- |
-| `--ft-status-pending`   | `oklch(0.55 0.02 260)` / `oklch(0.72 0.02 260)` | Queued, nothing has run yet  |
-| `--ft-status-running`   | `oklch(0.5 0.18 265)` / `oklch(0.72 0.15 265)`  | In flight                    |
-| `--ft-status-done`      | `oklch(0.5 0.14 145)` / `oklch(0.72 0.15 145)`  | Succeeded                    |
-| `--ft-status-error`     | `oklch(0.5 0.19 25)` / `oklch(0.7 0.18 25)`     | Failed                       |
-| `--ft-status-cancelled` | `oklch(0.55 0.02 260)` / `oklch(0.72 0.02 260)` | Abandoned before it finished |
+| Variable                | Default (light / dark)                         | Meaning                      |
+| ----------------------- | ---------------------------------------------- | ---------------------------- |
+| `--ft-status-pending`   | `oklch(0.5 0.02 260)` / `oklch(0.72 0.02 260)` | Queued, nothing has run yet  |
+| `--ft-status-running`   | `oklch(0.5 0.18 265)` / `oklch(0.72 0.15 265)` | In flight                    |
+| `--ft-status-done`      | `oklch(0.5 0.14 145)` / `oklch(0.72 0.15 145)` | Succeeded                    |
+| `--ft-status-error`     | `oklch(0.5 0.19 25)` / `oklch(0.7 0.18 25)`    | Failed                       |
+| `--ft-status-cancelled` | `oklch(0.5 0.02 260)` / `oklch(0.72 0.02 260)` | Abandoned before it finished |
 
-Each default is a `light-dark()` pair, because no single token clears 4.5:1 against both white and near-black — the light half is tuned for a light page and the dark half for a dark one. Which half applies is decided by `color-scheme`, so **your theme must declare it**:
+Each default is a `light-dark()` pair, because no single token clears 4.5:1 against both white and near-black — the light half is tuned for a light page and the dark half for a dark one. The greys carrying `pending` and `cancelled` are 0.5 rather than a softer 0.55 on the light side: they mostly paint dots, rings and dashes, which are graphical objects and owe 3:1 of their own, and 0.55 did not clear it.
+
+Which half applies is decided by `color-scheme`, so **your theme must declare it**:
 
 ```css
 :root {

--- a/src/lib/fancy-ui/tool-call/ToolCall.svelte
+++ b/src/lib/fancy-ui/tool-call/ToolCall.svelte
@@ -308,7 +308,7 @@
 				--ft-toolcall-pending,
 				color-mix(
 					in oklab,
-					var(--ft-status-pending, light-dark(oklch(0.55 0.02 260), oklch(0.72 0.02 260))) 55%,
+					var(--ft-status-pending, light-dark(oklch(0.5 0.02 260), oklch(0.72 0.02 260))) 55%,
 					transparent
 				)
 			);
@@ -320,7 +320,7 @@
 				--ft-toolcall-cancelled,
 				color-mix(
 					in oklab,
-					var(--ft-status-cancelled, light-dark(oklch(0.55 0.02 260), oklch(0.72 0.02 260))) 40%,
+					var(--ft-status-cancelled, light-dark(oklch(0.5 0.02 260), oklch(0.72 0.02 260))) 40%,
 					transparent
 				)
 			);

--- a/src/stories/agent-plan.stories.svelte
+++ b/src/stories/agent-plan.stories.svelte
@@ -1,0 +1,103 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { AgentPlan } from "$lib/fancy-ui/agent-plan";
+	import type { PlanStepData } from "$lib/fancy-ui";
+
+	const IN_PROGRESS: PlanStepData[] = [
+		{
+			id: "s1",
+			label: "Read the failing test",
+			status: "done",
+			detail: "tests/retry.spec.ts",
+		},
+		{
+			id: "s2",
+			label: "Locate the retry helper",
+			status: "running",
+			substeps: [
+				{ id: "s2a", label: "Search for retryWithBackoff", status: "done" },
+				{ id: "s2b", label: "Open the module it lives in", status: "running", detail: "142 lines" },
+			],
+		},
+		{ id: "s3", label: "Cap the backoff at 30s", status: "pending" },
+		{ id: "s4", label: "Run the suite", status: "pending" },
+		{ id: "s5", label: "Summarise the change", status: "pending" },
+	];
+
+	const COMPLETE: PlanStepData[] = IN_PROGRESS.map((step) => ({
+		...step,
+		status: "done",
+		substeps: step.substeps?.map((sub) => ({ ...sub, status: "done" as const })),
+	}));
+
+	const WITH_ERROR: PlanStepData[] = [
+		{ id: "e1", label: "Read the failing test", status: "done" },
+		{
+			id: "e2",
+			label: "Locate the retry helper",
+			status: "done",
+			substeps: [
+				{ id: "e2a", label: "Search for retryWithBackoff", status: "done" },
+				{ id: "e2b", label: "Open the module it lives in", status: "done" },
+			],
+		},
+		{ id: "e3", label: "Cap the backoff at 30s", status: "done" },
+		{
+			id: "e4",
+			label: "Run the suite",
+			status: "error",
+			detail: "2 failed — retry.spec.ts:41, queue.spec.ts:12",
+		},
+		{ id: "e5", label: "Summarise the change", status: "cancelled" },
+	];
+
+	const { Story } = defineMeta({
+		title: "AI Agents/AgentPlan",
+		component: AgentPlan,
+		tags: ["autodocs"],
+		args: {
+			steps: IN_PROGRESS,
+			label: "Fix the retry backoff",
+		},
+		argTypes: {
+			steps: {
+				control: "object",
+				description: "The plan, in the order the agent means to work through it",
+			},
+			label: { control: "text", description: "Header text, beside the done/total count" },
+			showProgress: { control: "boolean", description: "Thin completion bar under the header" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-md p-6">
+		<AgentPlan {...args} />
+	</div>
+{/snippet}
+
+<Story name="In Progress" {template} />
+
+<Story name="Complete" {template} args={{ steps: COMPLETE }} />
+
+<Story name="With Error" {template} args={{ steps: WITH_ERROR }} />
+
+<Story
+	name="Not Started"
+	{template}
+	args={{
+		steps: IN_PROGRESS.map((s) => ({
+			...s,
+			status: "pending",
+			substeps: s.substeps?.map((sub) => ({ ...sub, status: "pending" })),
+		})),
+	}}
+/>
+
+<Story name="Without Progress Bar" {template} args={{ showProgress: false }} />
+
+<Story
+	name="Selectable Rows"
+	{template}
+	args={{ onSelect: (step: PlanStepData) => console.log(step.id) }}
+/>

--- a/src/stories/ai-data-table.stories.svelte
+++ b/src/stories/ai-data-table.stories.svelte
@@ -1,0 +1,119 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { AiDataTable } from "$lib/fancy-ui/ai-data-table";
+	import type { AiDataTableColumn, AiDataTableRow } from "$lib/fancy-ui/ai-data-table";
+
+	const COLUMNS: AiDataTableColumn[] = [
+		{ key: "option", label: "Deployment" },
+		{ key: "latency", label: "p95 latency (ms)", numeric: true },
+		{ key: "cost", label: "Cost / 1M req", numeric: true },
+		{ key: "selfHosted", label: "Self-hosted", align: "center" },
+		{ key: "sla", label: "SLA" },
+		{ key: "effort", label: "Ops effort" },
+	];
+
+	const ROWS: AiDataTableRow[] = [
+		{
+			option: "Managed cluster",
+			latency: 42,
+			cost: 18.4,
+			selfHosted: false,
+			sla: "99.95%",
+			effort: "Low",
+		},
+		{
+			option: "Serverless pool",
+			latency: 88,
+			cost: 6.2,
+			selfHosted: false,
+			sla: "99.9%",
+			effort: "None",
+		},
+		{
+			option: "Self-run nodes",
+			latency: 31,
+			cost: 24.9,
+			selfHosted: true,
+			sla: null,
+			effort: "High",
+		},
+	];
+
+	const { Story } = defineMeta({
+		title: "AI Agents/AiDataTable",
+		component: AiDataTable,
+		tags: ["autodocs"],
+		args: {
+			columns: COLUMNS,
+			rows: ROWS,
+		},
+		argTypes: {
+			columns: {
+				control: "object",
+				description: "The columns to render, in order",
+			},
+			rows: {
+				control: "object",
+				description: "The rows to render, in the order the model produced them",
+			},
+			caption: {
+				control: "text",
+				description: "Describes the table for assistive tech; hidden unless captionVisible",
+			},
+			captionVisible: {
+				control: "boolean",
+				description: "Shows the caption as a muted line above the table",
+			},
+			dense: {
+				control: "boolean",
+				description: "Tighter rows, for a table read at a glance",
+			},
+			highlightColumn: {
+				control: "text",
+				description: "Key of the column to tint",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-2xl p-6">
+		<AiDataTable {...args} />
+	</div>
+{/snippet}
+
+<Story name="Default" {template} />
+
+<Story name="Dense" {template} args={{ dense: true }} />
+
+<Story name="Highlighted" {template} args={{ highlightColumn: "cost" }} />
+
+<Story
+	name="With Caption"
+	{template}
+	args={{
+		caption: "Inference deployments compared on cost, latency and operational load",
+		captionVisible: true,
+		highlightColumn: "cost",
+	}}
+/>
+
+<Story
+	name="Many Columns"
+	{template}
+	args={{
+		columns: [
+			...COLUMNS,
+			{ key: "region", label: "Primary region" },
+			{ key: "gpu", label: "GPU pinned", align: "center" },
+			{ key: "quota", label: "Req/s quota", numeric: true },
+		],
+		rows: ROWS.map((row, i) => ({
+			...row,
+			region: ["eu-west-1", "us-east-1", "on-prem"][i],
+			gpu: [false, false, true][i],
+			quota: [1200, 400, 2500][i],
+		})),
+		highlightColumn: "cost",
+	}}
+/>

--- a/src/stories/approval-card.stories.svelte
+++ b/src/stories/approval-card.stories.svelte
@@ -1,0 +1,58 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ApprovalCard } from "$lib/fancy-ui/approval-card";
+
+	const { Story } = defineMeta({
+		title: "AI Agents/ApprovalCard",
+		component: ApprovalCard,
+		tags: ["autodocs"],
+		args: {
+			title: "Create branch fix/retry-backoff",
+			description: "Branches from develop and pushes an empty commit so CI has something to run.",
+		},
+		argTypes: {
+			title: { control: "text", description: "What permission is being asked for" },
+			description: { control: "text", description: "Muted second line — the consequence" },
+			state: {
+				control: "select",
+				options: ["pending", "approved", "denied"],
+				description: "Which side of the gate we are on (bindable)",
+			},
+			destructive: {
+				control: "boolean",
+				description: "Irreversible: red approve button, warning tint, alert on the shield",
+			},
+			busy: {
+				control: "boolean",
+				description: "The consumer is executing: both buttons disabled, card aria-busy",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-xl p-6">
+		<ApprovalCard {...args} />
+	</div>
+{/snippet}
+
+<Story name="Pending" {template} />
+
+<Story
+	name="Destructive"
+	{template}
+	args={{
+		title: "Run database migration",
+		description:
+			"Adds two columns to invoices and backfills 41,880 rows. There is no down migration.",
+		destructive: true,
+		approveLabel: "Run migration",
+		denyLabel: "Not now",
+	}}
+/>
+
+<Story name="Approved" {template} args={{ state: "approved" }} />
+
+<Story name="Denied" {template} args={{ state: "denied" }} />
+
+<Story name="Busy" {template} args={{ busy: true }} />

--- a/src/stories/artifact-card.stories.svelte
+++ b/src/stories/artifact-card.stories.svelte
@@ -1,0 +1,59 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ArtifactCard } from "$lib/fancy-ui/artifact-card";
+
+	const PREVIEW =
+		"Revenue closed the quarter at 4.2M, six percent ahead of plan, and for the first time the mid-market segment outgrew enterprise. Two things drove it: the self-serve trial that shipped in May, which now accounts for a third of new logos, and a pricing change nobody expected much from. Churn is flat. The one number worth arguing about is expansion, which slipped for a second quarter running.";
+
+	const { Story } = defineMeta({
+		title: "AI Agents/ArtifactCard",
+		component: ArtifactCard,
+		tags: ["autodocs"],
+		args: {
+			title: "Q3 revenue review",
+			kind: "Memo",
+			status: "done",
+			preview: PREVIEW,
+		},
+		argTypes: {
+			title: { control: "text", description: "What the document is called" },
+			kind: { control: "text", description: "The kind of thing it is, on the muted line" },
+			status: {
+				control: "select",
+				options: ["idle", "streaming", "done", "error"],
+				description: "Where the document is in its life",
+			},
+			preview: { control: "text", description: "The text so far — growing it is what streams" },
+			version: { control: "number", description: "Which revision is on screen, 1-based" },
+			versionCount: { control: "number", description: "How many revisions exist" },
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-xl p-6">
+		<ArtifactCard {...args} />
+	</div>
+{/snippet}
+
+<Story name="Done" {template} />
+
+<Story name="Streaming" {template} args={{ status: "streaming", preview: PREVIEW.slice(0, 190) }} />
+
+<Story name="Error" {template} args={{ status: "error", preview: PREVIEW.slice(0, 90) }} />
+
+<Story name="Idle" {template} args={{ status: "idle", preview: undefined }} />
+
+<Story
+	name="With Versions"
+	{template}
+	args={{ version: 3, versionCount: 5, onVersionChange: () => {} }}
+/>
+
+<Story name="Version Badge Only" {template} args={{ version: 2 }} />
+
+<Story
+	name="Openable"
+	{template}
+	args={{ version: 3, versionCount: 5, onVersionChange: () => {}, onOpen: () => {} }}
+/>

--- a/src/stories/recommendation-card.stories.svelte
+++ b/src/stories/recommendation-card.stories.svelte
@@ -1,0 +1,51 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { RecommendationCard } from "$lib/fancy-ui/recommendation-card";
+
+	const { Story } = defineMeta({
+		title: "AI Agents/RecommendationCard",
+		component: RecommendationCard,
+		tags: ["autodocs"],
+		args: {
+			badge: "Suggestion",
+			title: "Add an index on orders.customer_id",
+			description: "The three slowest queries this week all scanned the whole table.",
+		},
+		argTypes: {
+			confidence: {
+				control: { type: "range", min: 0, max: 1, step: 0.01 },
+				description: "How sure the agent is, 0–1; omitted, the confidence block disappears",
+			},
+			state: {
+				control: "select",
+				options: ["open", "accepted", "dismissed"],
+				description: "Where the recommendation stands (bindable)",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-xl p-6">
+		<RecommendationCard {...args} />
+	</div>
+{/snippet}
+
+<Story name="Open" {template} />
+
+<Story name="High Confidence" {template} args={{ confidence: 0.87 }} />
+
+<Story
+	name="Low Confidence"
+	{template}
+	args={{
+		badge: "Speculative",
+		title: "Cache the pricing lookup for 60 seconds",
+		description: "Prices changed twice last quarter, but the traffic here is modest.",
+		confidence: 0.42,
+		acceptLabel: "Apply patch",
+		dismissLabel: "Not now",
+	}}
+/>
+
+<Story name="Accepted" {template} args={{ confidence: 0.87, state: "accepted" }} />

--- a/src/stories/subagent-list.stories.svelte
+++ b/src/stories/subagent-list.stories.svelte
@@ -1,0 +1,102 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { SubagentList } from "$lib/fancy-ui/subagent-list";
+	import type { SubagentData } from "$lib/fancy-ui";
+
+	const RUNNING: SubagentData[] = [
+		{
+			id: "researcher",
+			name: "Researcher",
+			task: "Read the changelog for breaking changes",
+			status: "running",
+			progress: 0.62,
+			model: "mini",
+		},
+		{
+			id: "writer",
+			name: "Writer",
+			task: "Draft the migration note",
+			status: "running",
+			progress: 0.28,
+			model: "pro",
+		},
+		{
+			id: "reviewer",
+			name: "Reviewer",
+			task: "Check every code sample still compiles",
+			status: "running",
+			progress: 0.05,
+			model: "pro",
+		},
+	];
+
+	const MIXED: SubagentData[] = [
+		{
+			id: "researcher",
+			name: "Researcher",
+			task: "Read the changelog for breaking changes",
+			status: "done",
+			model: "mini",
+		},
+		{
+			id: "writer",
+			name: "Writer",
+			task: "Draft the migration note",
+			status: "running",
+			progress: 0.44,
+			model: "pro",
+		},
+		{
+			id: "reviewer",
+			name: "Reviewer",
+			task: "Check every code sample still compiles",
+			status: "error",
+			model: "pro",
+		},
+		{ id: "publisher", name: "Publisher", task: "Open the pull request", status: "pending" },
+		{ id: "notifier", name: "Notifier", task: "Post the summary", status: "cancelled" },
+	];
+
+	const { Story } = defineMeta({
+		title: "AI Agents/SubagentList",
+		component: SubagentList,
+		tags: ["autodocs"],
+		args: {
+			agents: RUNNING,
+		},
+		argTypes: {
+			agents: {
+				control: "object",
+				description: "The delegated workers, in the order they were spawned",
+			},
+			label: {
+				control: "text",
+				description: "Accessible name for the list; derived from the statuses when left unset",
+			},
+			compact: {
+				control: "boolean",
+				description: "Tighter rows with the task line dropped",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-xl p-6">
+		<SubagentList {...args} />
+	</div>
+{/snippet}
+
+<Story name="Running" {template} />
+
+<Story name="Mixed" {template} args={{ agents: MIXED }} />
+
+<Story name="Compact" {template} args={{ agents: MIXED, compact: true }} />
+
+<Story
+	name="Finished"
+	{template}
+	args={{ agents: MIXED.map((agent) => ({ ...agent, status: "done", progress: undefined })) }}
+/>
+
+<Story name="Selectable" {template} args={{ agents: MIXED, onSelect: () => {} }} />


### PR DESCRIPTION
## Summary

Part 6/8 of the AI/chat family (stacks on #186). Built by a 6-agent Workflow, reviewed by a 2-agent adversarial Workflow, fixed, re-verified.

| Component | What it does |
|---|---|
| `AgentPlan` | Glanceable checklist: n/m count + completion bar, status glyphs, one level of substeps under a rail, `aria-current` on the running step |
| `SubagentList` | Parallel workers: status dot, model badge, task line, per-row progress bar; label self-derives ("2 agents running" → "3 agents finished") |
| `ApprovalCard` | Human-in-the-loop gate: approve/deny footer swaps for a verdict line inside a pre-existing polite live region; `destructive` variant; `busy` state |
| `RecommendationCard` | Proposal + confidence: NumberTicker % beside a filling SVG ring, banded at 0.75/0.5 |
| `ArtifactCard` | Generated document as an object: version navigator ‹ v3/5 ›, streaming preview behind a fade, real Open button + pointer-only card click |
| `AiDataTable` | Comparison table for model output: real table semantics, tabular numerics, boolean glyphs, highlighted column, keyboard-scrollable wrapper, **no sorting by design** |

## Review rounds (all findings fixed)
- **Contracts**: disabled version arrows opening the card through click retargeting; container `role=button` erasing every nested control from the a11y tree (children-presentational); model-supplied duplicate ids crashing keyed eachs — now collision-proof keys; empty-string cells rendering blank; scrollable region not keyboard-reachable; dead height transition removed.
- **Visual (pixel-measured)**: confidence ring rendering settled on first frame (paint-then-fill via double rAF); badge text 4.33:1 → AA; pending/cancelled light tokens lifted to the 3:1 non-text floor repo-wide; error states added to docs demos.

## Gates
`check:registry` ✅ (84) · `check:i18n` ✅ · `svelte-check` ✅ 0 errors · `vitest` ✅ 1406/1406 (154 in wave) · `build` ✅ · `package` + publint ✅

Next in stack: composer (compound, 8 exports) + voice-input + context-ring.