### PR TITLE
feat(ai): input layer — Composer compound, VoiceInput, ContextRing

### DIFF
--- a/.changeset/ai-composer.md
+++ b/.changeset/ai-composer.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+Add the input layer of the AI/chat family: the `Composer` compound — a root that owns the draft plus seven parts reading it through a shared context (`ComposerInput` with auto-grow and Enter/Shift+Enter, `ComposerSubmit` that becomes a stop button while streaming, `ComposerToolbar`, `ComposerModelPicker`, `ComposerAttachments`/`ComposerAttachment` chips with upload progress, and `ComposerCommandMenu`, one caret-anchored completion primitive mountable twice for slash commands and @ mentions, with a single source of truth for trigger-token arithmetic) — alongside `VoiceInput` (a mic button opening into a canvas waveform panel fed by consumer-supplied amplitude levels, never touching the microphone itself) and `ContextRing` (context-window usage as a compact donut with warn/critical bands and an optional breakdown popover). The internals `float` action now goes out of flow before measuring its anchor, fixing sibling-anchored popover placement everywhere it is used.

--- a/src/lib/components/docs/DemoRenderer.svelte
+++ b/src/lib/components/docs/DemoRenderer.svelte
@@ -86,6 +86,9 @@
 		"recommendation-card",
 		"artifact-card",
 		"ai-data-table",
+		"composer",
+		"voice-input",
+		"context-ring",
 	]);
 </script>
 

--- a/src/lib/components/docs/examples/composer/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/composer/BasicUsage.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { Composer } from "$lib/fancy-ui/composer";
+
+	/** What the rig types when nobody has taken the keyboard yet. */
+	const QUESTION = "Why did the deploy stall?";
+
+	/** Between keystrokes while the rig types. */
+	const KEY_MS = 55;
+	/** The beat between the last keystroke and the send. */
+	const SEND_MS = 520;
+	/** Before the first word of a reply, and between the words after it. */
+	const REPLY_MS = 380;
+	const WORD_MS = 32;
+	/** How long a finished answer sits there before the rig starts over. */
+	const READ_MS = 3200;
+
+	let draft = $state("");
+	let reply = $state("");
+	let streaming = $state(false);
+
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	let typed = 0;
+	/** True while the rig owns the composer. A person touching it takes it back. */
+	let driving = false;
+	let reduced = false;
+
+	/**
+	 * The fake model. It answers the prompt it was handed and nothing is behind it
+	 * — which is the honest thing for a docs page to demonstrate.
+	 */
+	function sentenceFor(prompt: string): string {
+		return `You asked: “${prompt}” — and nothing is wired up behind this composer. The reply is on a timer, arriving one word at a time so the send button has something to turn into.`;
+	}
+
+	function answer(prompt: string) {
+		clearTimeout(timer);
+		const words = sentenceFor(prompt).split(" ");
+
+		// Reduced motion gets the finished answer: a reply that types itself is the
+		// motion this setting is asking us not to run.
+		if (reduced) {
+			reply = words.join(" ");
+			streaming = false;
+			return;
+		}
+
+		reply = "";
+		streaming = true;
+		let i = 0;
+
+		function chunk() {
+			if (i < words.length) {
+				reply = i === 0 ? words[0] : `${reply} ${words[i]}`;
+				i += 1;
+				timer = setTimeout(chunk, WORD_MS);
+				return;
+			}
+			streaming = false;
+			if (driving) timer = setTimeout(restart, READ_MS);
+		}
+
+		timer = setTimeout(chunk, REPLY_MS);
+	}
+
+	/** The composer clears its own text on a successful send; the reply is ours. */
+	function send(payload: { text: string }) {
+		answer(payload.text);
+	}
+
+	/** What the stop button does here: drop the rest of the sentence and stand down. */
+	function halt() {
+		clearTimeout(timer);
+		streaming = false;
+		if (driving) timer = setTimeout(restart, READ_MS);
+	}
+
+	function typeNext() {
+		if (typed < QUESTION.length) {
+			typed += 1;
+			draft = QUESTION.slice(0, typed);
+			timer = setTimeout(typeNext, KEY_MS);
+			return;
+		}
+		timer = setTimeout(() => {
+			const text = draft.trim();
+			draft = "";
+			answer(text);
+		}, SEND_MS);
+	}
+
+	function restart() {
+		reply = "";
+		draft = "";
+		typed = 0;
+		timer = setTimeout(typeNext, KEY_MS);
+	}
+
+	/** The demo is yours the moment you reach for it, and the rig does not fight you. */
+	function handOver() {
+		if (!driving) return;
+		driving = false;
+		clearTimeout(timer);
+	}
+
+	onMount(() => {
+		reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+		// Nothing loops under reduced motion: one answered question, already there,
+		// and an empty composer waiting for a real one.
+		if (reduced) {
+			reply = sentenceFor(QUESTION);
+			return;
+		}
+
+		driving = true;
+		timer = setTimeout(typeNext, READ_MS / 4);
+		return () => {
+			driving = false;
+			clearTimeout(timer);
+		};
+	});
+</script>
+
+<!-- Capture, so the hand-over happens before the composer's own handlers run. -->
+<div
+	class="flex w-full max-w-xl flex-col gap-3 p-6"
+	onpointerdowncapture={handOver}
+	onkeydowncapture={handOver}
+>
+	{#if reply}
+		<div class="bg-muted text-foreground mr-auto max-w-[90%] rounded-2xl rounded-bl-sm px-4 py-3">
+			<p class="text-sm leading-relaxed">{reply}</p>
+		</div>
+	{/if}
+
+	<Composer
+		bind:value={draft}
+		{streaming}
+		placeholder="Ask anything"
+		onSubmit={send}
+		onStop={halt}
+	/>
+
+	<p class="text-muted-foreground text-xs">
+		Enter sends, Shift+Enter adds a line. While the reply streams the send button becomes a stop
+		button, and the composer refuses to send again until it lands.
+	</p>
+</div>

--- a/src/lib/components/docs/examples/composer/FullComposer.svelte
+++ b/src/lib/components/docs/examples/composer/FullComposer.svelte
@@ -71,9 +71,19 @@
 	let timers: ReturnType<typeof setTimeout>[] = [];
 	let reduced = false;
 
+	/** Just the reply in flight, so stopping it leaves the rest of the demo alone. */
+	let replyTimers: ReturnType<typeof setTimeout>[] = [];
+
 	/** Every timer in this file goes through here, so unmount can take them all back. */
 	function later(fn: () => void, ms: number) {
 		timers.push(setTimeout(fn, ms));
+	}
+
+	/** A reply's own timer: tracked twice, so `halt` can cancel it and unmount still can. */
+	function laterReply(fn: () => void, ms: number) {
+		const timer = setTimeout(fn, ms);
+		timers.push(timer);
+		replyTimers.push(timer);
 	}
 
 	// -------------------------------------------------------------------------
@@ -173,10 +183,10 @@
 				turn.id === id ? { ...turn, text: turn.text === "" ? word : `${turn.text} ${word}` } : turn
 			);
 			i += 1;
-			later(chunk, WORD_MS);
+			laterReply(chunk, WORD_MS);
 		}
 
-		later(chunk, REPLY_MS);
+		laterReply(chunk, REPLY_MS);
 	}
 
 	function send(payload: { text: string; attachments: AttachmentData[] }) {
@@ -192,8 +202,11 @@
 	}
 
 	function halt() {
-		for (const timer of timers) clearTimeout(timer);
-		timers = [];
+		// Only the reply: an upload or a transcription running alongside it has
+		// nothing to do with the answer being stopped, and cancelling their timers
+		// would leave their chips frozen mid-progress.
+		for (const timer of replyTimers) clearTimeout(timer);
+		replyTimers = [];
 		streaming = false;
 	}
 

--- a/src/lib/components/docs/examples/composer/FullComposer.svelte
+++ b/src/lib/components/docs/examples/composer/FullComposer.svelte
@@ -1,0 +1,335 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import {
+		Composer,
+		ComposerInput,
+		ComposerSubmit,
+		ComposerToolbar,
+		ComposerModelPicker,
+		ComposerAttachments,
+		ComposerCommandMenu,
+	} from "$lib/fancy-ui/composer";
+	import { ContextRing } from "$lib/fancy-ui/context-ring";
+	import { VoiceInput } from "$lib/fancy-ui/voice-input";
+	import type {
+		AttachmentData,
+		CommandItemData,
+		ModelOptionData,
+		TokenUsageData,
+	} from "$lib/fancy-ui/_internals/ai-types.js";
+
+	/** Generic tiers, so the fixture says nothing about anyone's product line-up. */
+	const MODELS: ModelOptionData[] = [
+		{ id: "mini", label: "Mini", badge: "Fast", description: "Short answers, small context." },
+		{ id: "pro", label: "Pro", description: "Deeper reasoning, slower." },
+		{ id: "max", label: "Max", badge: "New", description: "Everything, when it matters." },
+	];
+
+	const COMMANDS: CommandItemData[] = [
+		{ id: "deploy", label: "/deploy", description: "Ship the current branch", hint: "⌘⏎" },
+		{ id: "describe", label: "/describe", description: "Summarise the diff" },
+		{ id: "tests", label: "/tests", description: "Run the affected suites" },
+		{ id: "reset", label: "/reset", description: "Clear the conversation" },
+	];
+
+	const PEOPLE: CommandItemData[] = [
+		{ id: "jordan", label: "@jordan", description: "Reviewer" },
+		{ id: "sam", label: "@sam", description: "On call" },
+		{ id: "robin", label: "@robin", description: "Release manager" },
+	];
+
+	/** What the fake recogniser hears, one word at a time. */
+	const HEARD = "add a retry with backoff to the release job";
+
+	/** Tokens the system prompt is holding before anything is typed. */
+	const SYSTEM_TOKENS = 1_850;
+	/** What one attached file costs, roughly, once it has been read. */
+	const FILE_TOKENS = 1_450;
+	/** Four characters to a token is close enough for a meter on a docs page. */
+	const CHARS_PER_TOKEN = 4;
+
+	const UPLOAD_MS = 240;
+	const REPLY_MS = 420;
+	const WORD_MS = 34;
+	const HEAR_MS = 180;
+
+	interface Turn {
+		id: string;
+		role: "user" | "assistant";
+		text: string;
+	}
+
+	let draft = $state("");
+	let attachments = $state<AttachmentData[]>([]);
+	let model = $state("pro");
+	let streaming = $state(false);
+	let recording = $state(false);
+	let heard = $state("");
+	let turns = $state<Turn[]>([]);
+
+	let serial = 0;
+	let timers: ReturnType<typeof setTimeout>[] = [];
+	let reduced = false;
+
+	/** Every timer in this file goes through here, so unmount can take them all back. */
+	function later(fn: () => void, ms: number) {
+		timers.push(setTimeout(fn, ms));
+	}
+
+	// -------------------------------------------------------------------------
+	// The meter
+	// -------------------------------------------------------------------------
+
+	function tokens(text: string): number {
+		return Math.ceil(text.length / CHARS_PER_TOKEN);
+	}
+
+	const historyTokens = $derived(turns.reduce((total, turn) => total + tokens(turn.text), 0));
+	const draftTokens = $derived(tokens(draft));
+	const fileTokens = $derived(attachments.length * FILE_TOKENS);
+
+	// A small window on purpose: the ring should visibly move when you attach a
+	// file, which it would not on a budget nothing in a demo can dent.
+	const usage: TokenUsageData = $derived({
+		used: SYSTEM_TOKENS + historyTokens + draftTokens + fileTokens,
+		max: 16_000,
+		breakdown: [
+			{ label: "System prompt", tokens: SYSTEM_TOKENS },
+			{ label: "Transcript", tokens: historyTokens },
+			{ label: "Attachments", tokens: fileTokens },
+			{ label: "Draft", tokens: draftTokens },
+		],
+	});
+
+	// -------------------------------------------------------------------------
+	// The fake upload
+	// -------------------------------------------------------------------------
+
+	function patch(id: string, next: Partial<AttachmentData>) {
+		attachments = attachments.map((entry) => (entry.id === id ? { ...entry, ...next } : entry));
+	}
+
+	function march(id: string) {
+		later(() => {
+			const entry = attachments.find((item) => item.id === id);
+			// The chip may have been removed mid-upload, and a fake upload with no
+			// chip left to fill has nothing to do.
+			if (!entry || entry.status !== "uploading") return;
+			const progress = Math.min(1, (entry.progress ?? 0) + 0.2);
+			patch(id, progress >= 1 ? { progress: 1, status: "done" } : { progress });
+			if (progress < 1) march(id);
+		}, UPLOAD_MS);
+	}
+
+	/**
+	 * The composer never uploads anything: it hands the picked files over and the
+	 * consumer pushes onto `attachments` once the upload has an id for them.
+	 */
+	function attach(files: File[]) {
+		for (const file of files) {
+			serial += 1;
+			const id = `${file.name}#${serial}`;
+			const entry: AttachmentData = {
+				id,
+				name: file.name,
+				size: file.size,
+				type: file.type,
+				progress: reduced ? 1 : 0,
+				status: reduced ? "done" : "uploading",
+			};
+			attachments = [...attachments, entry];
+			// A progress bar creeping across a chip is motion; reduced motion gets
+			// the finished upload instead, which is where it was heading anyway.
+			if (!reduced) march(id);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// The fake model
+	// -------------------------------------------------------------------------
+
+	function replyFor(prompt: string): string {
+		return `Nothing is wired up behind this composer — “${prompt.slice(0, 60)}” went nowhere. The reply is on a timer, and the ring above counts this sentence against the window as it arrives.`;
+	}
+
+	function stream(prompt: string) {
+		const words = replyFor(prompt).split(" ");
+		serial += 1;
+		const id = `assistant-${serial}`;
+
+		turns = [...turns, { id, role: "assistant", text: reduced ? words.join(" ") : "" }];
+		if (reduced) return;
+
+		streaming = true;
+		let i = 0;
+
+		function chunk() {
+			if (i >= words.length) {
+				streaming = false;
+				return;
+			}
+			const word = words[i];
+			turns = turns.map((turn) =>
+				turn.id === id ? { ...turn, text: turn.text === "" ? word : `${turn.text} ${word}` } : turn
+			);
+			i += 1;
+			later(chunk, WORD_MS);
+		}
+
+		later(chunk, REPLY_MS);
+	}
+
+	function send(payload: { text: string; attachments: AttachmentData[] }) {
+		const files = payload.attachments;
+		const label =
+			payload.text || `${files.length} file${files.length === 1 ? "" : "s"}, and nothing else`;
+		serial += 1;
+		turns = [...turns, { id: `user-${serial}`, role: "user", text: label }];
+		// The turn has really left, so its files go with it — the composer leaves
+		// that call to us, since only we know whether an upload is still in flight.
+		attachments = [];
+		stream(payload.text || label);
+	}
+
+	function halt() {
+		for (const timer of timers) clearTimeout(timer);
+		timers = [];
+		streaming = false;
+	}
+
+	// -------------------------------------------------------------------------
+	// The fake microphone
+	// -------------------------------------------------------------------------
+
+	function startVoice() {
+		recording = true;
+		heard = reduced ? HEARD : "";
+		if (reduced) return;
+
+		const words = HEARD.split(" ");
+		let i = 0;
+
+		function next() {
+			// A cancelled recording stops being transcribed.
+			if (!recording || i >= words.length) return;
+			heard = i === 0 ? words[0] : `${heard} ${words[i]}`;
+			i += 1;
+			later(next, HEAR_MS);
+		}
+
+		later(next, HEAR_MS);
+	}
+
+	/** Confirmed: what was heard joins the draft, where it can still be edited. */
+	function keepVoice() {
+		draft = draft === "" ? heard : `${draft} ${heard}`;
+		heard = "";
+	}
+
+	function dropVoice() {
+		heard = "";
+	}
+
+	onMount(() => {
+		reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+		// Nothing here autoplays — every timer above is started by something you did
+		// — so reduced motion changes only how the fake work lands: all at once
+		// rather than in steps.
+		return () => {
+			for (const timer of timers) clearTimeout(timer);
+			timers = [];
+		};
+	});
+</script>
+
+<div class="flex w-full max-w-2xl flex-col gap-3 p-6">
+	{#each turns as turn (turn.id)}
+		{#if turn.role === "user"}
+			<div
+				class="bg-primary text-primary-foreground ml-auto max-w-[85%] rounded-2xl rounded-br-sm px-4 py-2.5"
+			>
+				<p class="text-sm leading-relaxed">{turn.text}</p>
+			</div>
+		{:else}
+			<div class="bg-muted text-foreground mr-auto max-w-[85%] rounded-2xl rounded-bl-sm px-4 py-3">
+				<p class="text-sm leading-relaxed">{turn.text}</p>
+			</div>
+		{/if}
+	{/each}
+
+	<Composer
+		bind:value={draft}
+		bind:attachments
+		{streaming}
+		onSubmit={send}
+		onStop={halt}
+		onAttach={attach}
+		accessory={recording ? voicePanel : undefined}
+	>
+		{#snippet children()}
+			<ComposerAttachments accept="image/*,.pdf,.md" />
+
+			<ComposerInput placeholder="Ask anything — / for commands, @ to mention" maxRows={6} />
+
+			<ComposerToolbar class="mt-2">
+				<ComposerModelPicker models={MODELS} bind:value={model} />
+
+				<button
+					type="button"
+					class="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors focus-visible:ring-1 focus-visible:outline-none"
+					aria-label="Start voice input"
+					title="Start voice input"
+					onclick={startVoice}
+				>
+					<svg
+						class="size-4"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.75"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
+						<path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+						<path d="M12 19v3" />
+					</svg>
+				</button>
+
+				<!-- The spacer is the split: everything after it sits on the right. -->
+				<div class="flex-1"></div>
+
+				<ContextRing {usage} size={22} strokeWidth={3} showLabel={false} expandable />
+				<ComposerSubmit />
+			</ComposerToolbar>
+
+			<!-- Two menus, one draft: each answers only to its own trigger character,
+			     so only one of them can ever be on screen. -->
+			<ComposerCommandMenu trigger="/" items={COMMANDS} />
+			<ComposerCommandMenu trigger="@" items={PEOPLE} />
+		{/snippet}
+	</Composer>
+
+	<p class="text-muted-foreground text-xs">
+		Type <code>/</code> for commands or <code>@</code> to mention someone — arrows move, Enter or Tab
+		completes, Escape dismisses that token. The paperclip runs a fake upload, the ring counts the draft
+		against a small window, and the microphone covers the composer with the accessory overlay.
+	</p>
+</div>
+
+{#snippet voicePanel()}
+	<!-- The accessory is a plain layer over the composition, not a focus trap:
+	     what it holds and how it is dismissed are the consumer's to decide. -->
+	<div class="bg-background flex h-full items-center rounded-xl border p-2">
+		<VoiceInput
+			bind:active={recording}
+			transcript={heard}
+			demo
+			height={40}
+			class="w-full"
+			onStop={keepVoice}
+			onCancel={dropVoice}
+		/>
+	</div>
+{/snippet}

--- a/src/lib/components/docs/examples/context-ring/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/context-ring/BasicUsage.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { ContextRing } from "$lib/fancy-ui/context-ring";
+	import type { TokenUsageData } from "$lib/fancy-ui/_internals/ai-types.js";
+
+	// Nothing is on a timer here: every ring is a fixed reading and the popover
+	// only moves when you move it, so there is no rig to hold still for reduced
+	// motion and no effect in this file at all.
+	const comfortable: TokenUsageData = { used: 12_400, max: 200_000 };
+	const warning: TokenUsageData = { used: 164_000, max: 200_000 };
+	const critical: TokenUsageData = { used: 192_500, max: 200_000 };
+
+	const detailed: TokenUsageData = {
+		used: 84_300,
+		max: 200_000,
+		breakdown: [
+			{ label: "System prompt", tokens: 1850 },
+			{ label: "Transcript", tokens: 61_200 },
+			{ label: "Tool results", tokens: 18_400 },
+			{ label: "Attachments", tokens: 2850 },
+		],
+	};
+</script>
+
+<div class="flex w-full max-w-xl flex-col gap-6 p-6">
+	<div class="flex flex-wrap items-center gap-8">
+		<ContextRing usage={comfortable} />
+		<ContextRing usage={warning} />
+		<ContextRing usage={critical} />
+	</div>
+
+	<p class="text-muted-foreground text-xs">
+		The band shifts at 75% and again at 90%, using the same run-status colours as the rest of the AI
+		family. The arc's length says the same thing as its hue, so neither is load-bearing on its own.
+	</p>
+
+	<div class="border-border flex items-center gap-3 border-t pt-6">
+		<ContextRing usage={detailed} size={34} strokeWidth={4} expandable />
+		<span class="text-muted-foreground text-xs">
+			Press the ring for the breakdown. Escape closes it.
+		</span>
+	</div>
+</div>

--- a/src/lib/components/docs/examples/registry.ts
+++ b/src/lib/components/docs/examples/registry.ts
@@ -446,4 +446,10 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 	"recommendation-card": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"artifact-card": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"ai-data-table": [{ name: "BasicUsage", title: "Basic Usage" }],
+	composer: [
+		{ name: "BasicUsage", title: "Basic Usage" },
+		{ name: "FullComposer", title: "Full Composer" },
+	],
+	"voice-input": [{ name: "BasicUsage", title: "Basic Usage" }],
+	"context-ring": [{ name: "BasicUsage", title: "Basic Usage" }],
 };

--- a/src/lib/components/docs/examples/voice-input/BasicUsage.svelte
+++ b/src/lib/components/docs/examples/voice-input/BasicUsage.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { VoiceInput } from "$lib/fancy-ui/voice-input";
+
+	/** How fast the pretend recogniser hands back another word. */
+	const WORD_MS = 400;
+	const WORDS = "show me the retry policy for failed webhook deliveries".split(" ");
+
+	let active = $state(false);
+	let transcript = $state("");
+
+	// Plain, not reactive: it is the rig's cursor into WORDS, not something the
+	// markup reads.
+	let spoken = 0;
+
+	function reset() {
+		spoken = 0;
+		transcript = "";
+	}
+
+	onMount(() => {
+		// A transcript that types itself is exactly the motion this setting asks us
+		// not to run, so it gets the finished state instead: the panel already open,
+		// the sentence already said, and no timer of any kind.
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			active = true;
+			transcript = WORDS.join(" ");
+			return;
+		}
+
+		// One interval for the life of the example rather than one per recording:
+		// it reads `active` each tick and does nothing until the mic is pressed.
+		const timer = setInterval(() => {
+			if (!active || spoken >= WORDS.length) return;
+			transcript = transcript ? `${transcript} ${WORDS[spoken]}` : WORDS[spoken];
+			spoken += 1;
+		}, WORD_MS);
+		return () => clearInterval(timer);
+	});
+</script>
+
+<div class="flex w-full max-w-md flex-col gap-3 p-6">
+	<!--
+		`demo` draws the synthetic waveform, because this page has no microphone
+		behind it. A real integration drops that and passes `samples` from its own
+		audio pipeline instead.
+	-->
+	<VoiceInput bind:active {transcript} demo onStop={reset} onCancel={reset} />
+
+	<p class="text-muted-foreground text-xs">
+		Press the mic and the words arrive as a recogniser would hand them over. The check keeps the
+		transcript and closes the panel; the cross throws it away.
+	</p>
+</div>

--- a/src/lib/fancy-ui/_internals/float.ts
+++ b/src/lib/fancy-ui/_internals/float.ts
@@ -131,13 +131,21 @@ export function float(node: HTMLElement, opts: FloatOptions): ActionReturn<Float
 	let sizes: ResizeObserver | null = null;
 
 	const position = () => {
+		// Out of flow *before* the anchor is measured. A float rendered as a sibling
+		// of its anchor still occupies a slot in the layout until this line runs,
+		// and that slot pushes the anchor somewhere it will not be once the float
+		// is fixed — so a rect read first describes a position that no longer
+		// exists, and the float lands beside it for good.
+		node.style.position = "fixed";
+		node.style.visibility = "";
+
 		const anchor = readAnchor(options.anchor);
 		if (!anchor) {
 			node.style.visibility = "hidden";
 			return;
 		}
-		node.style.position = "fixed";
-		node.style.visibility = "";
+		// Still ahead of the node's own measurement: a forced width changes how the
+		// content wraps, and therefore the height the placement is computed from.
 		node.style.width = options.matchWidth ? `${anchor.width}px` : "";
 
 		const box = node.getBoundingClientRect();

--- a/src/lib/fancy-ui/composer/Composer.svelte
+++ b/src/lib/fancy-ui/composer/Composer.svelte
@@ -1,0 +1,235 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { AttachmentData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for Composer
+	 */
+	export interface ComposerProps {
+		/** The draft text, bindable. Cleared by a successful submit. */
+		value?: string;
+		/** Files riding along with the draft, bindable. The consumer owns uploading them. */
+		attachments?: AttachmentData[];
+		/** Blocks typing, sending, and attaching. */
+		disabled?: boolean;
+		/** A response is arriving: the send button becomes a stop button. */
+		streaming?: boolean;
+		/** Placeholder for the default input. Ignored once `children` replaces the composition. */
+		placeholder?: string;
+		/** Called with the trimmed draft and a snapshot of the attachments. */
+		onSubmit?: (payload: { text: string; attachments: AttachmentData[] }) => void;
+		/** Called when the stop button is pressed while streaming. */
+		onStop?: () => void;
+		/** Called with the files handed to `addFiles`. Upload them, then push onto `attachments`. */
+		onAttach?: (files: File[]) => void;
+		/** Replaces the default input-and-send-row composition entirely. */
+		children?: Snippet;
+		/** An overlay covering the composer — a voice panel, a drop target, a confirmation. */
+		accessory?: Snippet;
+		/** Additional CSS classes */
+		class?: string;
+		/** The form element, bindable. */
+		ref?: HTMLFormElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { setContext, tick } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import { findTokenStart } from "./caret.js";
+	import ComposerInput from "./ComposerInput.svelte";
+	import ComposerSubmit from "./ComposerSubmit.svelte";
+	import { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";
+
+	let {
+		value = $bindable(""),
+		attachments = $bindable([]),
+		disabled = false,
+		streaming = false,
+		placeholder,
+		onSubmit,
+		onStop,
+		onAttach,
+		children,
+		accessory,
+		class: className,
+		ref = $bindable(null),
+	}: ComposerProps = $props();
+
+	// Written by ComposerInput through the context, read by insertText's caret
+	// arithmetic. A composer with no input part keeps it null and falls back to
+	// appending at the end of the draft.
+	let textareaEl = $state<HTMLTextAreaElement | null>(null);
+
+	function submit() {
+		// A composer that is off or already busy sends nothing, whatever the draft
+		// says — the send button is disabled in both states, but Enter and a
+		// programmatic `submit()` reach here too.
+		if (disabled || streaming) return;
+		const text = value.trim();
+		if (text === "" && attachments.length === 0) return;
+		// A copy, so a consumer stashing the payload does not end up holding the
+		// live list it is about to mutate.
+		onSubmit?.({ text, attachments: [...attachments] });
+		// The text is ours to clear; the attachments belong to the consumer, who
+		// alone knows whether an upload is still in flight.
+		value = "";
+	}
+
+	function stop() {
+		if (!streaming) return;
+		onStop?.();
+	}
+
+	function setValue(next: string) {
+		value = next;
+	}
+
+	function insertText(text: string, replaceTriggerToken = false) {
+		// A composer that is off or already busy takes no dictation either — the
+		// textarea is readonly in both states, and a menu writing through the
+		// context would be the one way around that.
+		if (disabled || streaming) return;
+		const current = value;
+		const rawEnd = textareaEl?.selectionEnd;
+		const end = typeof rawEnd === "number" ? rawEnd : current.length;
+		const rawStart = textareaEl?.selectionStart;
+		const selectionStart = typeof rawStart === "number" ? Math.min(rawStart, end) : end;
+
+		// The menus' own definition of a token, not a second one that could drift
+		// from it: what a menu matched is exactly what a completion overwrites.
+		const trigger = replaceTriggerToken ? findTokenStart(current, end) : -1;
+		const start = trigger >= 0 ? trigger : selectionStart;
+		const trailing = current.slice(end);
+
+		// Completing a token leaves the caret ready for the next word; a plain
+		// insert splices exactly what it was handed, and nothing more.
+		const needsSpace = trigger >= 0 && !/\s$/.test(text) && !/^\s/.test(trailing);
+		const insertion = needsSpace ? `${text} ` : text;
+		const caret = start + insertion.length;
+
+		value = `${current.slice(0, start)}${insertion}${trailing}`;
+
+		const el = textareaEl;
+		if (!el) return;
+		// The caret can only be placed once the controlled value has reached the
+		// DOM, so it waits a tick. Focus comes back with it: the insertion was
+		// almost certainly triggered from a menu that stole it.
+		void tick().then(() => {
+			if (!el.isConnected) return;
+			el.focus();
+			el.setSelectionRange(caret, caret);
+		});
+	}
+
+	function addFiles(files: File[]) {
+		if (disabled || files.length === 0) return;
+		onAttach?.(files);
+	}
+
+	function removeAttachment(id: string) {
+		attachments = attachments.filter((attachment) => attachment.id !== id);
+	}
+
+	const context: ComposerContext = {
+		value: {
+			get current() {
+				return value;
+			},
+		},
+		attachments: {
+			get current() {
+				return attachments;
+			},
+		},
+		get disabled() {
+			return disabled;
+		},
+		get streaming() {
+			return streaming;
+		},
+		// Declared read-only on ComposerContext so no other part writes it; the
+		// setter exists for ComposerInput alone, which registers its element here
+		// on mount. See the note at the top of types.ts.
+		textareaRef: {
+			get current() {
+				return textareaEl;
+			},
+			set current(next: HTMLTextAreaElement | null) {
+				textareaEl = next;
+			},
+		},
+		submit,
+		stop,
+		setValue,
+		insertText,
+		addFiles,
+		removeAttachment,
+	};
+
+	setContext(COMPOSER_CONTEXT_KEY, context);
+
+	function handleSubmit(event: SubmitEvent) {
+		// Nothing here navigates: the draft leaves through onSubmit.
+		event.preventDefault();
+		submit();
+	}
+</script>
+
+<form
+	bind:this={ref}
+	class={cn("ft-composer relative flex w-full flex-col border p-2", className)}
+	class:ft-composer-disabled={disabled}
+	data-streaming={streaming ? "" : undefined}
+	onsubmit={handleSubmit}
+>
+	{#if children}
+		{@render children()}
+	{:else}
+		<ComposerInput {placeholder} />
+		<div class="mt-2 flex items-center gap-2">
+			<div class="flex-1"></div>
+			<ComposerSubmit />
+		</div>
+	{/if}
+
+	{#if accessory}
+		<div class="ft-composer-accessory absolute inset-0 z-10">
+			{@render accessory()}
+		</div>
+	{/if}
+</form>
+
+<style>
+	/*
+	 * The surface is a form, not a card: it reads as one input the whole row of
+	 * controls lives inside, which is why the focus ring belongs to the container
+	 * rather than to the textarea buried in it.
+	 */
+	.ft-composer {
+		border-radius: var(--ft-composer-radius, 0.75rem);
+		border-color: var(--ft-composer-border, color-mix(in oklab, currentColor 14%, transparent));
+		background: var(--ft-composer-bg, color-mix(in oklab, currentColor 4%, transparent));
+	}
+
+	.ft-composer:focus-within {
+		border-color: var(
+			--ft-composer-border-focus,
+			color-mix(in oklab, currentColor 32%, transparent)
+		);
+		box-shadow: 0 0 0 1px
+			var(--ft-composer-ring, color-mix(in oklab, currentColor 22%, transparent));
+	}
+
+	.ft-composer-disabled {
+		opacity: var(--ft-composer-disabled-opacity, 0.6);
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-composer {
+			transition:
+				border-color 150ms ease,
+				box-shadow 150ms ease;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/composer/Composer.svelte
+++ b/src/lib/fancy-ui/composer/Composer.svelte
@@ -68,9 +68,12 @@
 		if (disabled || streaming) return;
 		const text = value.trim();
 		if (text === "" && attachments.length === 0) return;
+		// With nobody listening there is nowhere for the draft to go, and clearing
+		// it would throw away text the reader has no way of getting back.
+		if (!onSubmit) return;
 		// A copy, so a consumer stashing the payload does not end up holding the
 		// live list it is about to mutate.
-		onSubmit?.({ text, attachments: [...attachments] });
+		onSubmit({ text, attachments: [...attachments] });
 		// The text is ours to clear; the attachments belong to the consumer, who
 		// alone knows whether an upload is still in flight.
 		value = "";
@@ -147,6 +150,9 @@
 		},
 		get streaming() {
 			return streaming;
+		},
+		get stoppable() {
+			return typeof onStop === "function";
 		},
 		// Declared read-only on ComposerContext so no other part writes it; the
 		// setter exists for ComposerInput alone, which registers its element here

--- a/src/lib/fancy-ui/composer/Composer.test.ts
+++ b/src/lib/fancy-ui/composer/Composer.test.ts
@@ -1,0 +1,495 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet, tick } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import Composer from "./Composer.svelte";
+import ComposerInput from "./ComposerInput.svelte";
+import ComposerSubmit from "./ComposerSubmit.svelte";
+import Harness from "./ComposerHarness.test.svelte";
+import type { ComposerContext } from "./types.js";
+import type { AttachmentData } from "../_internals/ai-types.js";
+
+function snippet(html: string) {
+	return createRawSnippet(() => ({ render: () => html }));
+}
+
+function form(container: HTMLElement): HTMLFormElement {
+	return container.querySelector("form") as HTMLFormElement;
+}
+
+function textarea(container: HTMLElement): HTMLTextAreaElement {
+	return container.querySelector("textarea") as HTMLTextAreaElement;
+}
+
+function sendButton(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector("button.ft-composer-submit") as HTMLButtonElement;
+}
+
+function readout(container: HTMLElement, id: string): string {
+	return (container.querySelector(`[data-testid="${id}"]`) as HTMLElement).textContent ?? "";
+}
+
+/** Two ticks: one for the state to reach the DOM, one for the caret restore that waits on it. */
+async function settle() {
+	await tick();
+	await tick();
+}
+
+/** Type into the composer the way a person would, through the real input handler. */
+async function type(container: HTMLElement, text: string) {
+	const el = textarea(container);
+	await fireEvent.input(el, { target: { value: text } });
+	el.setSelectionRange(text.length, text.length);
+}
+
+interface HarnessOptions {
+	initialValue?: string;
+	initialAttachments?: AttachmentData[];
+	disabled?: boolean;
+	streaming?: boolean;
+	placeholder?: string;
+	maxRows?: number;
+	autoAttach?: boolean;
+	onSubmit?: (payload: { text: string; attachments: AttachmentData[] }) => void;
+	onStop?: () => void;
+	onAttach?: (files: File[]) => void;
+}
+
+/** Mount the rig and hand back its container plus the context its parts see. */
+function mount(props: HarnessOptions = {}) {
+	let context: ComposerContext | undefined;
+	const { container } = render(Harness, {
+		props: { ...props, onContext: (next: ComposerContext | undefined) => (context = next) },
+	});
+	return { container, context: context as ComposerContext };
+}
+
+describe("Composer", () => {
+	afterEach(cleanup);
+
+	it("is a form carrying the composer chrome", () => {
+		const { container } = render(Composer, {});
+		expect(form(container).className).toContain("ft-composer");
+		expect(form(container).className).toContain("border");
+	});
+
+	it("composes an input and a send button by default", () => {
+		const { container } = render(Composer, { props: { placeholder: "Ask anything" } });
+		expect(textarea(container).getAttribute("placeholder")).toBe("Ask anything");
+		expect(sendButton(container).getAttribute("aria-label")).toBe("Send");
+	});
+
+	it("hands the composition over to children, placeholder included", () => {
+		const { container } = render(Composer, {
+			props: { placeholder: "Ignored", children: snippet("<p>Custom</p>") },
+		});
+		expect(container.querySelector("p")?.textContent).toBe("Custom");
+		expect(container.querySelector("textarea")).toBeNull();
+	});
+
+	it("renders the accessory as an overlay on top of the composer", () => {
+		const { container } = render(Composer, { props: { accessory: snippet("<p>Voice</p>") } });
+		const overlay = container.querySelector(".ft-composer-accessory") as HTMLElement;
+		expect(overlay.className).toContain("absolute");
+		expect(overlay.textContent).toBe("Voice");
+	});
+
+	it("keeps the submit event to itself instead of letting the page navigate", () => {
+		const { container } = mount({ initialValue: "hi" });
+		const event = new Event("submit", { bubbles: true, cancelable: true });
+		form(container).dispatchEvent(event);
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it("submits the trimmed draft and then clears it", async () => {
+		const onSubmit = vi.fn();
+		const { container } = mount({ initialValue: "  hello there  ", onSubmit });
+
+		await fireEvent.submit(form(container));
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0]).toEqual({ text: "hello there", attachments: [] });
+		expect(readout(container, "bound-value")).toBe("");
+		expect(textarea(container).value).toBe("");
+	});
+
+	it("refuses an empty and a whitespace-only draft", async () => {
+		const onSubmit = vi.fn();
+		const { container } = mount({ onSubmit });
+
+		await fireEvent.submit(form(container));
+		expect(onSubmit).not.toHaveBeenCalled();
+
+		await type(container, "   \n  ");
+		await fireEvent.submit(form(container));
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("sends an attachment-only draft, and leaves the attachments to the consumer", async () => {
+		const onSubmit = vi.fn();
+		const attachment: AttachmentData = { id: "a1", name: "notes.pdf" };
+		const { container } = mount({ initialAttachments: [attachment], onSubmit });
+
+		await fireEvent.submit(form(container));
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		const payload = onSubmit.mock.calls[0][0] as { text: string; attachments: AttachmentData[] };
+		expect(payload.text).toBe("");
+		expect(payload.attachments.map((entry) => entry.id)).toEqual(["a1"]);
+		// Cleared text, untouched attachments: only the consumer knows whether the
+		// upload it started is still in flight.
+		expect(readout(container, "bound-attachments")).toBe("1");
+	});
+
+	it("hands out a copy of the attachments rather than the live list", async () => {
+		const onSubmit = vi.fn();
+		const { container, context } = mount({
+			initialAttachments: [{ id: "a1", name: "notes.pdf" }],
+			onSubmit,
+		});
+
+		await fireEvent.submit(form(container));
+		const payload = onSubmit.mock.calls[0][0] as { attachments: AttachmentData[] };
+		context.removeAttachment("a1");
+		await tick();
+
+		expect(readout(container, "bound-attachments")).toBe("0");
+		expect(payload.attachments).toHaveLength(1);
+	});
+
+	it("sends nothing while disabled", async () => {
+		const onSubmit = vi.fn();
+		const { container, context } = mount({ initialValue: "hello", disabled: true, onSubmit });
+
+		await fireEvent.submit(form(container));
+		context.submit();
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("sends nothing while streaming — that is what stop is for", async () => {
+		const onSubmit = vi.fn();
+		const { container, context } = mount({ initialValue: "hello", streaming: true, onSubmit });
+
+		await fireEvent.submit(form(container));
+		context.submit();
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("only stops while streaming", () => {
+		const onStop = vi.fn();
+		const idle = mount({ initialValue: "hello", onStop });
+		idle.context.stop();
+		expect(onStop).not.toHaveBeenCalled();
+		cleanup();
+
+		const busy = mount({ initialValue: "hello", streaming: true, onStop });
+		busy.context.stop();
+		expect(onStop).toHaveBeenCalledTimes(1);
+	});
+
+	it("publishes its state and commands through the context", async () => {
+		const { container, context } = mount({ streaming: true, initialValue: "draft" });
+
+		expect(context).toBeDefined();
+		expect(readout(container, "context-value")).toBe("draft");
+		expect(readout(container, "context-streaming")).toBe("yes");
+		expect(readout(container, "context-disabled")).toBe("no");
+		expect(readout(container, "context-attachments")).toBe("0");
+
+		context.setValue("rewritten");
+		await tick();
+		expect(readout(container, "context-value")).toBe("rewritten");
+		expect(readout(container, "bound-value")).toBe("rewritten");
+		expect(textarea(container).value).toBe("rewritten");
+	});
+
+	it("writes the draft back through the bindable prop as it is typed", async () => {
+		const { container } = mount({});
+		await type(container, "bound both ways");
+		expect(readout(container, "bound-value")).toBe("bound both ways");
+	});
+
+	it("forwards attached files to the consumer and drops attachments by id", async () => {
+		const onAttach = vi.fn();
+		const files = [new File(["x"], "one.png"), new File(["y"], "two.png")];
+		const { container, context } = mount({ autoAttach: true, onAttach });
+
+		context.addFiles(files);
+		await tick();
+		expect(onAttach).toHaveBeenCalledTimes(1);
+		expect(onAttach.mock.calls[0][0]).toEqual(files);
+		expect(readout(container, "bound-attachments")).toBe("2");
+
+		context.removeAttachment("one.png#0");
+		await tick();
+		expect(readout(container, "bound-attachments")).toBe("1");
+		expect(readout(container, "context-attachments")).toBe("1");
+	});
+
+	it("attaches nothing while disabled, and ignores an empty file list", () => {
+		const onAttach = vi.fn();
+		const off = mount({ disabled: true, onAttach });
+		off.context.addFiles([new File(["x"], "one.png")]);
+		expect(onAttach).not.toHaveBeenCalled();
+		cleanup();
+
+		const on = mount({ onAttach });
+		on.context.addFiles([]);
+		expect(onAttach).not.toHaveBeenCalled();
+	});
+});
+
+describe("Composer.insertText", () => {
+	afterEach(cleanup);
+
+	it("replaces a trigger token sitting at the start of the draft", async () => {
+		const { container, context } = mount({});
+		await type(container, "/he");
+
+		context.insertText("/help", true);
+		await settle();
+
+		expect(readout(container, "bound-value")).toBe("/help ");
+		expect(textarea(container).selectionStart).toBe(6);
+	});
+
+	it("replaces a trigger token mid-draft, leaving the text around it alone", async () => {
+		const { container, context } = mount({});
+		await type(container, "please run /dep");
+
+		context.insertText("/deploy", true);
+		await settle();
+
+		expect(readout(container, "bound-value")).toBe("please run /deploy ");
+		expect(textarea(container).selectionStart).toBe(19);
+	});
+
+	it("replaces a trigger token before the caret without disturbing what follows", async () => {
+		const { container, context } = mount({});
+		await type(container, "ping @jo tomorrow");
+		textarea(container).setSelectionRange(8, 8);
+
+		context.insertText("@jordan", true);
+		await settle();
+
+		// The trailing space is already there, so the completion does not add one.
+		expect(readout(container, "bound-value")).toBe("ping @jordan tomorrow");
+		expect(textarea(container).selectionStart).toBe(12);
+	});
+
+	it("falls back to a plain insert at the caret when no trigger token is in reach", async () => {
+		const { container, context } = mount({});
+		await type(container, "hello");
+
+		context.insertText("@jordan", true);
+		await settle();
+
+		expect(readout(container, "bound-value")).toBe("hello@jordan");
+		expect(textarea(container).selectionStart).toBe(12);
+	});
+
+	it("treats a word that only contains a trigger character as ordinary text", async () => {
+		const { container, context } = mount({});
+		await type(container, "src/li");
+
+		context.insertText("X", true);
+		await settle();
+
+		// `src/li` is a path fragment, not a command: nothing gets swallowed.
+		expect(readout(container, "bound-value")).toBe("src/liX");
+	});
+
+	it("splices at the caret, with no trailing space, when not completing a token", async () => {
+		const { container, context } = mount({});
+		await type(container, "ab");
+		textarea(container).setSelectionRange(1, 1);
+
+		context.insertText("-X-");
+		await settle();
+
+		expect(readout(container, "bound-value")).toBe("a-X-b");
+		expect(textarea(container).selectionStart).toBe(4);
+	});
+
+	it("replaces the selection when there is one", async () => {
+		const { container, context } = mount({});
+		await type(container, "keep this out");
+		textarea(container).setSelectionRange(5, 9);
+
+		context.insertText("that");
+		await settle();
+
+		expect(readout(container, "bound-value")).toBe("keep that out");
+		expect(textarea(container).selectionStart).toBe(9);
+	});
+
+	it("returns focus to the input with the caret after the insertion", async () => {
+		const { container, context } = mount({});
+		await type(container, "/he");
+		textarea(container).blur();
+
+		context.insertText("/help", true);
+		await settle();
+
+		expect(document.activeElement).toBe(textarea(container));
+		expect(textarea(container).selectionEnd).toBe(6);
+	});
+
+	it("appends at the end of the draft when no input part has registered", async () => {
+		const { container, context } = mount({ initialValue: "draft" });
+		// Unregister the element the way an unmounting input would, then insert.
+		(
+			context as unknown as { textareaRef: { current: HTMLTextAreaElement | null } }
+		).textareaRef.current = null;
+
+		expect(() => context.insertText("!")).not.toThrow();
+		await settle();
+		expect(readout(container, "bound-value")).toBe("draft!");
+	});
+});
+
+describe("ComposerInput", () => {
+	afterEach(cleanup);
+
+	it("carries its rows, placeholder and no-resize chrome", () => {
+		const { container } = render(ComposerInput, {});
+		expect(textarea(container).getAttribute("rows")).toBe("1");
+		expect(textarea(container).getAttribute("placeholder")).toBe("Message…");
+		expect(textarea(container).className).toContain("resize-none");
+	});
+
+	it("submits on Enter and adds a newline on Shift+Enter", async () => {
+		const onSubmit = vi.fn();
+		const { container } = mount({ initialValue: "send me", onSubmit });
+
+		const shifted = await fireEvent.keyDown(textarea(container), { key: "Enter", shiftKey: true });
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(shifted).toBe(true);
+
+		await fireEvent.keyDown(textarea(container), { key: "Enter" });
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].text).toBe("send me");
+	});
+
+	it("leaves Enter to the IME while a composition is open", async () => {
+		const onSubmit = vi.fn();
+		const { container } = mount({ initialValue: "kanji", onSubmit });
+
+		await fireEvent.keyDown(textarea(container), { key: "Enter", isComposing: true });
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("goes read-only rather than disabled while locked, keeping it focusable", async () => {
+		const off = mount({ initialValue: "x", disabled: true });
+		expect(textarea(off.container).readOnly).toBe(true);
+		expect(textarea(off.container).disabled).toBe(false);
+		expect(textarea(off.container).getAttribute("aria-disabled")).toBe("true");
+		cleanup();
+
+		const busy = mount({ initialValue: "x", streaming: true });
+		expect(textarea(busy.container).readOnly).toBe(true);
+		cleanup();
+
+		const idle = mount({ initialValue: "x" });
+		expect(textarea(idle.container).readOnly).toBe(false);
+		expect(idle.container.querySelector("textarea[aria-disabled]")).toBeNull();
+	});
+
+	it("sizes itself to its content, between the declared rows and the ceiling", async () => {
+		const { container } = mount({ maxRows: 3 });
+		const el = textarea(container);
+
+		await type(container, "one\ntwo\nthree\nfour\nfive");
+		expect(el.style.height).toMatch(/^\d+(\.\d+)?px$/);
+		expect(el.style.overflowY).toBeTruthy();
+	});
+
+	it("registers itself into the context so the caret arithmetic can reach it", () => {
+		const { container, context } = mount({});
+		expect(context.textareaRef.current).toBe(textarea(container));
+	});
+
+	it("renders inert, without throwing, outside a composer", async () => {
+		const { container } = render(ComposerInput, { props: { placeholder: "Alone" } });
+		expect(() => fireEvent.keyDown(textarea(container), { key: "Enter" })).not.toThrow();
+		await fireEvent.input(textarea(container), { target: { value: "typed" } });
+		expect(textarea(container).value).toBe("typed");
+	});
+});
+
+describe("ComposerSubmit", () => {
+	afterEach(cleanup);
+
+	it("stays disabled on an empty draft and wakes up once there is text", async () => {
+		const { container } = mount({});
+		expect(sendButton(container).disabled).toBe(true);
+
+		await type(container, "hi");
+		expect(sendButton(container).disabled).toBe(false);
+
+		await type(container, "   ");
+		expect(sendButton(container).disabled).toBe(true);
+	});
+
+	it("wakes up for an attachment-only draft", () => {
+		const { container } = mount({ initialAttachments: [{ id: "a1", name: "notes.pdf" }] });
+		expect(sendButton(container).disabled).toBe(false);
+	});
+
+	it("is disabled while the composer is", () => {
+		const { container } = mount({ initialValue: "hello", disabled: true });
+		expect(sendButton(container).disabled).toBe(true);
+	});
+
+	it("becomes a stop button while streaming", async () => {
+		const onStop = vi.fn();
+		const onSubmit = vi.fn();
+		const { container } = mount({ initialValue: "hello", streaming: true, onStop, onSubmit });
+		const button = sendButton(container);
+
+		expect(button.getAttribute("type")).toBe("button");
+		expect(button.getAttribute("aria-label")).toBe("Stop");
+		expect(button.disabled).toBe(false);
+
+		await fireEvent.click(button);
+		expect(onStop).toHaveBeenCalledTimes(1);
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("submits the form on click while idle", async () => {
+		const onSubmit = vi.fn();
+		const { container } = mount({ initialValue: "hello", onSubmit });
+		const button = sendButton(container);
+
+		expect(button.getAttribute("type")).toBe("submit");
+		await fireEvent.click(button);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+	});
+
+	it("takes custom labels and a custom icon", () => {
+		const { container } = render(ComposerSubmit, {
+			props: { label: "Ask", children: snippet("<span>Go</span>") },
+		});
+		expect(sendButton(container).getAttribute("aria-label")).toBe("Ask");
+		expect(sendButton(container).textContent?.trim()).toBe("Go");
+		expect(container.querySelector("svg")).toBeNull();
+	});
+
+	it("renders as a disabled button, without throwing, outside a composer", () => {
+		const { container } = render(ComposerSubmit, {});
+		expect(sendButton(container).disabled).toBe(true);
+		expect(sendButton(container).getAttribute("aria-label")).toBe("Send");
+	});
+
+	it("composes inside a composer without warnings", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const { container } = mount({ initialValue: "hello" });
+		await fireEvent.submit(form(container));
+
+		expect(warn).not.toHaveBeenCalled();
+		expect(error).not.toHaveBeenCalled();
+		warn.mockRestore();
+		error.mockRestore();
+	});
+});

--- a/src/lib/fancy-ui/composer/Composer.test.ts
+++ b/src/lib/fancy-ui/composer/Composer.test.ts
@@ -112,6 +112,16 @@ describe("Composer", () => {
 		expect(textarea(container).value).toBe("");
 	});
 
+	it("keeps the draft when nothing is listening for a submit", async () => {
+		// Clearing here would throw away text with nowhere for it to have gone.
+		const { container } = mount({ initialValue: "hello there" });
+
+		await fireEvent.submit(form(container));
+
+		expect(readout(container, "bound-value")).toBe("hello there");
+		expect(textarea(container).value).toBe("hello there");
+	});
+
 	it("refuses an empty and a whitespace-only draft", async () => {
 		const onSubmit = vi.fn();
 		const { container } = mount({ onSubmit });
@@ -432,6 +442,21 @@ describe("ComposerSubmit", () => {
 
 	it("wakes up for an attachment-only draft", () => {
 		const { container } = mount({ initialAttachments: [{ id: "a1", name: "notes.pdf" }] });
+		expect(sendButton(container).disabled).toBe(false);
+	});
+
+	it("greys out the stop control when there is no onStop behind it", () => {
+		// The root always publishes a callable `stop`, so the control has to ask
+		// the context whether anything is actually listening.
+		const { container } = mount({ initialValue: "hello", streaming: true });
+		const button = sendButton(container);
+
+		expect(button.getAttribute("aria-label")).toBe("Stop");
+		expect(button.disabled).toBe(true);
+	});
+
+	it("offers the stop control once a handler exists", () => {
+		const { container } = mount({ initialValue: "hello", streaming: true, onStop: () => {} });
 		expect(sendButton(container).disabled).toBe(false);
 	});
 

--- a/src/lib/fancy-ui/composer/ComposerAttachment.svelte
+++ b/src/lib/fancy-ui/composer/ComposerAttachment.svelte
@@ -1,0 +1,220 @@
+<script lang="ts" module>
+	import type { AttachmentData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for ComposerAttachment
+	 */
+	export interface ComposerAttachmentProps {
+		/** The file to show: its name, and whatever the upload knows so far. */
+		attachment: AttachmentData;
+		/** Called with the attachment id instead of the composer's own removal. */
+		onRemove?: (id: string) => void;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";
+
+	let { attachment, onRemove, class: className }: ComposerAttachmentProps = $props();
+
+	/**
+	 * Powers of 1024, stopping at megabytes: a chip is not where gigabytes belong,
+	 * and a four-digit megabyte count still reads faster than a unit nobody
+	 * expects next to a file name.
+	 */
+	const UNITS = ["B", "KB", "MB"] as const;
+
+	// Undefined when the chip is used outside a Composer: it then relies on
+	// `onRemove` alone, and goes inert without one rather than throwing.
+	const composer = getContext<ComposerContext | undefined>(COMPOSER_CONTEXT_KEY);
+
+	const status = $derived(attachment.status);
+	const uploading = $derived(status === "uploading");
+	const failed = $derived(status === "error");
+	// Out-of-range progress is a consumer bug, not a reason to paint a bar past
+	// the end of the chip.
+	const percent = $derived(Math.round(Math.min(1, Math.max(0, attachment.progress ?? 0)) * 100));
+	const size = $derived(formatSize(attachment.size));
+	const removeLabel = $derived(`Remove ${attachment.name}`);
+
+	// A remove button with nothing to call is a lie, and so is a live one inside a
+	// composer that has been switched off.
+	const removable = $derived(onRemove !== undefined || composer !== undefined);
+	const removeDisabled = $derived(!removable || (composer?.disabled ?? false));
+
+	/** Bytes as a chip-sized caption. Anything unmeasurable prints nothing at all. */
+	function formatSize(bytes: number | undefined): string {
+		if (bytes === undefined || !Number.isFinite(bytes) || bytes < 0) return "";
+		let scaled = bytes;
+		let unit = 0;
+		while (scaled >= 1024 && unit < UNITS.length - 1) {
+			scaled /= 1024;
+			unit += 1;
+		}
+		// Bytes are whole things; the scaled units keep one decimal, and a trailing
+		// `.0` is noise at this size.
+		const rounded = unit === 0 ? Math.round(scaled) : Math.round(scaled * 10) / 10;
+		return `${rounded} ${UNITS[unit]}`;
+	}
+
+	function remove() {
+		// The prop wins outright: a consumer that passes one is running its own
+		// upload bookkeeping and will drop the entry itself.
+		if (onRemove) {
+			onRemove(attachment.id);
+			return;
+		}
+		composer?.removeAttachment(attachment.id);
+	}
+</script>
+
+<div
+	class={cn(
+		"ft-composer-attachment relative flex max-w-full min-w-0 items-center gap-1.5 py-1 pr-1 pl-1.5 text-xs",
+		className
+	)}
+	class:ft-failed={failed}
+	data-status={status}
+	aria-busy={uploading ? "true" : undefined}
+>
+	{#if attachment.previewUrl}
+		<!-- Decorative: the file name sits right beside it and says the same thing. -->
+		<img
+			class="ft-composer-attachment-thumb size-5 shrink-0 rounded object-cover"
+			src={attachment.previewUrl}
+			alt=""
+		/>
+	{:else}
+		<svg
+			class="size-3.5 shrink-0"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="1.75"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5z" />
+			<path d="M14 2v6h6" />
+		</svg>
+	{/if}
+
+	<span class="ft-composer-attachment-name max-w-32 truncate" title={attachment.name}
+		>{attachment.name}</span
+	>
+
+	{#if size}
+		<span class="ft-composer-attachment-size text-foreground/70 shrink-0 tabular-nums">{size}</span>
+	{/if}
+
+	{#if failed}
+		<!-- The tint is the only other thing that says so, and it says it to no one. -->
+		<span class="sr-only">Upload failed</span>
+	{/if}
+
+	<button
+		type="button"
+		class="ft-composer-attachment-remove hover:bg-muted focus-visible:ring-ring inline-flex size-4 shrink-0 cursor-pointer items-center justify-center rounded transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-40"
+		disabled={removeDisabled}
+		aria-label={removeLabel}
+		title={removeLabel}
+		onclick={remove}
+	>
+		<svg
+			class="size-3"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2.5"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M18 6 6 18" />
+			<path d="m6 6 12 12" />
+		</svg>
+	</button>
+
+	{#if uploading}
+		<span
+			class="ft-composer-attachment-track"
+			role="progressbar"
+			aria-label="Uploading {attachment.name}"
+			aria-valuemin="0"
+			aria-valuemax="100"
+			aria-valuenow={percent}
+		>
+			<span class="ft-composer-attachment-bar" style="width: {percent}%"></span>
+		</span>
+	{/if}
+</div>
+
+<style>
+	.ft-composer-attachment {
+		border-radius: var(--ft-composer-attachment-radius, 0.5rem);
+		border: 1px solid
+			var(--ft-composer-attachment-border, color-mix(in oklab, currentColor 14%, transparent));
+		background: var(--ft-composer-attachment-bg, color-mix(in oklab, currentColor 5%, transparent));
+	}
+
+	/*
+	 * The failed chip is read at the point of use through two hooks: the
+	 * component's own `--ft-composer-attachment-error`, then the `--ft-status-*`
+	 * vocabulary the whole AI family shares, then the literal. Setting either
+	 * anywhere up the tree retints it without a specificity fight, and the shared
+	 * one recolours every failure in the family at once.
+	 */
+	.ft-composer-attachment.ft-failed {
+		--ft-attachment-failed: var(
+			--ft-composer-attachment-error,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+		border-color: color-mix(in oklab, var(--ft-attachment-failed) 45%, transparent);
+		background: color-mix(in oklab, var(--ft-attachment-failed) 10%, transparent);
+		color: var(--ft-attachment-failed);
+	}
+
+	/* Pinned to the chip's own bottom edge: the upload belongs to this file, and
+	   the row it sits in must not grow a line while the bar is up. */
+	.ft-composer-attachment-track {
+		position: absolute;
+		right: 0.25rem;
+		bottom: 0.1875rem;
+		left: 0.25rem;
+		display: block;
+		height: var(--ft-composer-attachment-track-height, 2px);
+		overflow: hidden;
+		border-radius: 9999px;
+		background: var(
+			--ft-composer-attachment-track,
+			color-mix(in oklab, currentColor 15%, transparent)
+		);
+	}
+
+	.ft-composer-attachment-bar {
+		display: block;
+		height: 100%;
+		border-radius: inherit;
+		background: var(
+			--ft-composer-attachment-progress,
+			var(--ft-status-running, light-dark(oklch(0.5 0.18 265), oklch(0.72 0.15 265)))
+		);
+	}
+
+	/*
+	 * The only thing that moves is the bar catching up to its width. With this
+	 * rule gone it simply lands there, which is the same information without the
+	 * travel — nothing here needs a reduced-motion counterpart.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-composer-attachment-bar {
+			transition: width var(--ft-composer-attachment-fill-duration, 220ms)
+				cubic-bezier(0.4, 0, 0.2, 1);
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/composer/ComposerAttachments.svelte
+++ b/src/lib/fancy-ui/composer/ComposerAttachments.svelte
@@ -1,0 +1,158 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	/**
+	 * Props for ComposerAttachments
+	 */
+	export interface ComposerAttachmentsProps {
+		/** Replaces the default chips. The add button and its file input stay. */
+		children?: Snippet;
+		/** Accessible name and tooltip for the add button. */
+		addLabel?: string;
+		/** `accept` for the file picker, e.g. `"image/*,.pdf"`. Omitted by default. */
+		accept?: string;
+		/** Whether one pick may carry several files. */
+		multiple?: boolean;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import ComposerAttachment from "./ComposerAttachment.svelte";
+	import { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";
+
+	let {
+		children,
+		addLabel = "Attach files",
+		accept,
+		multiple = true,
+		class: className,
+	}: ComposerAttachmentsProps = $props();
+
+	// Undefined when the row is used outside a Composer: there is then nothing to
+	// list and nowhere to send a pick, so it renders nothing rather than throwing.
+	const composer = getContext<ComposerContext | undefined>(COMPOSER_CONTEXT_KEY);
+
+	// Only ever reached imperatively, from the add button's click. `$state` because
+	// `bind:this` writes it after mount, and nothing else may.
+	let inputEl = $state<HTMLInputElement | null>(null);
+
+	const attachments = $derived(composer?.attachments.current ?? []);
+	const disabled = $derived(composer?.disabled ?? false);
+	// An empty row inside a composer still earns its line — that is where the
+	// paperclip lives. An empty row outside one is a button that could not work.
+	const empty = $derived(composer === undefined && attachments.length === 0);
+
+	function pick() {
+		// The real picker is the hidden input; the button exists to be named,
+		// focusable, and styled like the rest of the composer chrome.
+		inputEl?.click();
+	}
+
+	function handleChange(event: Event & { currentTarget: HTMLInputElement }) {
+		const el = event.currentTarget;
+		const files = Array.from(el.files ?? []);
+		// Cleared before anything else: re-picking the same file fires no second
+		// change event while the input still holds the first pick, and a consumer
+		// that rejects an upload would be stuck with it.
+		el.value = "";
+		if (files.length === 0) return;
+		composer?.addFiles(files);
+	}
+</script>
+
+{#if !empty}
+	<div class={cn("ft-composer-attachments flex flex-wrap items-center gap-1.5", className)}>
+		{#if children}
+			{@render children()}
+		{:else}
+			<!-- The index rides along in the key: two uploads of the same file can
+			     arrive carrying the same id, and a duplicate key is a crash. -->
+			{#each attachments as attachment, index (`${attachment.id}#${index}`)}
+				<div class="ft-composer-attachment-slot flex min-w-0">
+					<ComposerAttachment {attachment} />
+				</div>
+			{/each}
+		{/if}
+
+		<button
+			type="button"
+			class="ft-composer-attach text-foreground/70 hover:bg-muted hover:text-foreground focus-visible:ring-ring inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-40"
+			{disabled}
+			aria-label={addLabel}
+			title={addLabel}
+			onclick={pick}
+		>
+			<svg
+				class="size-4"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="1.75"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				aria-hidden="true"
+			>
+				<path
+					d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"
+				/>
+			</svg>
+		</button>
+
+		<!-- Out of the tab order and out of the accessibility tree: the button above
+		     is the control, and two names for one picker is one too many. -->
+		<input
+			bind:this={inputEl}
+			class="ft-composer-file-input"
+			type="file"
+			{accept}
+			{multiple}
+			{disabled}
+			tabindex="-1"
+			aria-hidden="true"
+			onchange={handleChange}
+		/>
+	</div>
+{/if}
+
+<style>
+	/* Visually hidden rather than `display: none`: a clipped input still opens its
+	   picker on every engine, and still belongs to the form it sits in. */
+	.ft-composer-file-input {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip-path: inset(50%);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	/*
+	 * The entrance belongs to the row, not to the chip: a chip appears because
+	 * this list grew one. With the rule gone a new chip is simply there, which is
+	 * the same information without the travel.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-composer-attachment-slot {
+			animation: ft-composer-attachment-enter var(--ft-composer-attachment-enter-duration, 180ms)
+				cubic-bezier(0.16, 1, 0.3, 1) both;
+		}
+
+		@keyframes ft-composer-attachment-enter {
+			from {
+				opacity: 0;
+				transform: translateY(4px) scale(0.96);
+			}
+			to {
+				opacity: 1;
+				transform: none;
+			}
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/composer/ComposerAttachments.test.ts
+++ b/src/lib/fancy-ui/composer/ComposerAttachments.test.ts
@@ -29,6 +29,7 @@ function fakeComposer(options: { attachments?: AttachmentData[]; disabled?: bool
 		attachments: { current: attachments },
 		disabled: options.disabled ?? false,
 		streaming: false,
+		stoppable: false,
 		textareaRef: { current: null },
 		submit: vi.fn(),
 		stop: vi.fn(),

--- a/src/lib/fancy-ui/composer/ComposerAttachments.test.ts
+++ b/src/lib/fancy-ui/composer/ComposerAttachments.test.ts
@@ -1,0 +1,442 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet, tick } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import ComposerAttachment from "./ComposerAttachment.svelte";
+import ComposerAttachments from "./ComposerAttachments.svelte";
+import Harness from "./ComposerHarness.test.svelte";
+import { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";
+import type { AttachmentData } from "../_internals/ai-types.js";
+
+function snippet(html: string) {
+	return createRawSnippet(() => ({ render: () => html }));
+}
+
+/**
+ * A composer standing in for the real root.
+ *
+ * `getContext` only answers during a child's initialisation, so the parts are
+ * mounted with the context handed straight to Svelte's `mount` — the same trick
+ * the card-3d suite uses. It keeps every assertion about the part itself rather
+ * than about a root that has its own tests, and the last case in this file
+ * mounts them against a real `Composer` to prove the two halves meet.
+ */
+function fakeComposer(options: { attachments?: AttachmentData[]; disabled?: boolean } = {}) {
+	const attachments = options.attachments ?? [];
+	const addFiles = vi.fn();
+	const removeAttachment = vi.fn();
+	const context: ComposerContext = {
+		value: { current: "" },
+		attachments: { current: attachments },
+		disabled: options.disabled ?? false,
+		streaming: false,
+		textareaRef: { current: null },
+		submit: vi.fn(),
+		stop: vi.fn(),
+		setValue: vi.fn(),
+		insertText: vi.fn(),
+		addFiles,
+		removeAttachment,
+	};
+	return { context, addFiles, removeAttachment };
+}
+
+function provide(context: ComposerContext) {
+	return new Map<symbol, ComposerContext>([[COMPOSER_CONTEXT_KEY, context]]);
+}
+
+function chips(container: HTMLElement): HTMLElement[] {
+	return Array.from(container.querySelectorAll<HTMLElement>(".ft-composer-attachment"));
+}
+
+function names(container: HTMLElement): string[] {
+	return Array.from(container.querySelectorAll(".ft-composer-attachment-name")).map(
+		(node) => node.textContent ?? ""
+	);
+}
+
+function addButton(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector("button.ft-composer-attach") as HTMLButtonElement;
+}
+
+function fileInput(container: HTMLElement): HTMLInputElement {
+	return container.querySelector('input[type="file"]') as HTMLInputElement;
+}
+
+function removeButton(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector("button.ft-composer-attachment-remove") as HTMLButtonElement;
+}
+
+function bar(container: HTMLElement): HTMLElement | null {
+	return container.querySelector(".ft-composer-attachment-bar");
+}
+
+function sizeText(container: HTMLElement): string {
+	return container.querySelector(".ft-composer-attachment-size")?.textContent ?? "";
+}
+
+/**
+ * Watch what the component writes to `input.value` without letting jsdom's own
+ * file-input semantics answer for it.
+ */
+function watchValue(input: HTMLInputElement): string[] {
+	const written: string[] = [];
+	Object.defineProperty(input, "value", {
+		configurable: true,
+		get: () => "C:\\fakepath\\one.png",
+		set: (next: string) => written.push(next),
+	});
+	return written;
+}
+
+describe("ComposerAttachments", () => {
+	afterEach(cleanup);
+
+	it("renders a chip per attachment the composer is carrying, in order", () => {
+		const { context } = fakeComposer({
+			attachments: [
+				{ id: "a1", name: "notes.pdf", size: 2048 },
+				{ id: "a2", name: "shot.png", size: 1024 },
+			],
+		});
+		const { container } = render(ComposerAttachments, { context: provide(context) });
+
+		expect(chips(container)).toHaveLength(2);
+		expect(names(container)).toEqual(["notes.pdf", "shot.png"]);
+	});
+
+	it("survives two attachments arriving under the same id", () => {
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		const { context } = fakeComposer({
+			attachments: [
+				{ id: "dup", name: "first.png" },
+				{ id: "dup", name: "second.png" },
+			],
+		});
+
+		const { container } = render(ComposerAttachments, { context: provide(context) });
+
+		expect(names(container)).toEqual(["first.png", "second.png"]);
+		expect(error).not.toHaveBeenCalled();
+		error.mockRestore();
+	});
+
+	it("keeps its line inside a composer with nothing attached yet", () => {
+		const { context } = fakeComposer();
+		const { container } = render(ComposerAttachments, { context: provide(context) });
+
+		expect(chips(container)).toHaveLength(0);
+		expect(addButton(container)).not.toBeNull();
+	});
+
+	it("renders nothing at all outside a composer", () => {
+		const { container } = render(ComposerAttachments, {});
+
+		expect(container.querySelector(".ft-composer-attachments")).toBeNull();
+		expect(container.textContent).toBe("");
+	});
+
+	it("names the add button, by default and on request", async () => {
+		const { context } = fakeComposer();
+		const { container, rerender } = render(ComposerAttachments, { context: provide(context) });
+
+		expect(addButton(container).getAttribute("aria-label")).toBe("Attach files");
+		expect(addButton(container).getAttribute("title")).toBe("Attach files");
+		// Inside a form, so it must say it is not the submit button.
+		expect(addButton(container).getAttribute("type")).toBe("button");
+
+		await rerender({ addLabel: "Add a file" });
+		expect(addButton(container).getAttribute("aria-label")).toBe("Add a file");
+	});
+
+	it("carries accept and multiple through to the hidden picker", async () => {
+		const { context } = fakeComposer();
+		const { container, rerender } = render(ComposerAttachments, { context: provide(context) });
+
+		// Out of the tab order and out of the accessibility tree: the button names it.
+		expect(fileInput(container).getAttribute("tabindex")).toBe("-1");
+		expect(fileInput(container).getAttribute("aria-hidden")).toBe("true");
+		expect(fileInput(container).multiple).toBe(true);
+		expect(fileInput(container).hasAttribute("accept")).toBe(false);
+
+		await rerender({ accept: "image/*", multiple: false });
+		expect(fileInput(container).getAttribute("accept")).toBe("image/*");
+		expect(fileInput(container).multiple).toBe(false);
+	});
+
+	it("opens the picker from the add button", async () => {
+		const { context } = fakeComposer();
+		const { container } = render(ComposerAttachments, { context: provide(context) });
+		const opened = vi.spyOn(fileInput(container), "click").mockImplementation(() => {});
+
+		await fireEvent.click(addButton(container));
+
+		expect(opened).toHaveBeenCalledTimes(1);
+	});
+
+	it("hands the picked files to the composer and clears the input", async () => {
+		const { context, addFiles } = fakeComposer();
+		const { container } = render(ComposerAttachments, { context: provide(context) });
+		const input = fileInput(container);
+		const written = watchValue(input);
+		const files = [new File(["a"], "one.png"), new File(["b"], "two.png")];
+
+		await fireEvent.change(input, { target: { files } });
+
+		expect(addFiles).toHaveBeenCalledTimes(1);
+		expect(addFiles.mock.calls[0][0]).toEqual(files);
+		// Cleared, or re-picking the same file would fire no second change event.
+		expect(written).toEqual([""]);
+	});
+
+	it("stays quiet when a pick is cancelled, and still clears the input", async () => {
+		const { context, addFiles } = fakeComposer();
+		const { container } = render(ComposerAttachments, { context: provide(context) });
+		const input = fileInput(container);
+		const written = watchValue(input);
+
+		await fireEvent.change(input, { target: { files: [] } });
+
+		expect(addFiles).not.toHaveBeenCalled();
+		expect(written).toEqual([""]);
+	});
+
+	it("goes flat while the composer is disabled", () => {
+		const { context } = fakeComposer({ disabled: true });
+		const { container } = render(ComposerAttachments, { context: provide(context) });
+
+		expect(addButton(container).disabled).toBe(true);
+		expect(fileInput(container).disabled).toBe(true);
+	});
+
+	it("lets children replace the chips while keeping the picker wiring", () => {
+		const { context } = fakeComposer({ attachments: [{ id: "a1", name: "notes.pdf" }] });
+		const { container } = render(ComposerAttachments, {
+			props: { children: snippet("<span data-testid='own'>own chips</span>") },
+			context: provide(context),
+		});
+
+		expect(chips(container)).toHaveLength(0);
+		expect(container.querySelector("[data-testid='own']")?.textContent).toBe("own chips");
+		expect(addButton(container)).not.toBeNull();
+		expect(fileInput(container)).not.toBeNull();
+	});
+
+	it("merges custom classes onto the row", () => {
+		const { context } = fakeComposer();
+		const { container } = render(ComposerAttachments, {
+			props: { class: "mb-2" },
+			context: provide(context),
+		});
+		const row = container.querySelector(".ft-composer-attachments") as HTMLElement;
+
+		expect(row.className).toContain("mb-2");
+		expect(row.className).toContain("flex-wrap");
+	});
+});
+
+describe("ComposerAttachment", () => {
+	afterEach(cleanup);
+
+	it("names, sizes and file-icons a plain chip", () => {
+		const { container } = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "notes.pdf", size: 1536 } },
+		});
+
+		expect(names(container)).toEqual(["notes.pdf"]);
+		expect(container.querySelector(".ft-composer-attachment-name")?.getAttribute("title")).toBe(
+			"notes.pdf"
+		);
+		expect(sizeText(container)).toBe("1.5 KB");
+		expect(container.querySelector("img")).toBeNull();
+	});
+
+	it("shows the thumbnail instead of the icon once a preview exists", () => {
+		const { container } = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "shot.png", previewUrl: "blob:preview" } },
+		});
+		const thumb = container.querySelector("img") as HTMLImageElement;
+
+		expect(thumb.getAttribute("src")).toBe("blob:preview");
+		// Decorative: the file name beside it already says which file this is.
+		expect(thumb.getAttribute("alt")).toBe("");
+		// Only the remove button's cross is left.
+		expect(container.querySelectorAll("svg")).toHaveLength(1);
+	});
+
+	it("reports an upload in progress, in words and as a bar", () => {
+		const { container } = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "clip.mov", status: "uploading", progress: 0.6 } },
+		});
+		const chip = chips(container)[0];
+		const meter = container.querySelector('[role="progressbar"]') as HTMLElement;
+
+		expect(chip.getAttribute("aria-busy")).toBe("true");
+		expect(chip.getAttribute("data-status")).toBe("uploading");
+		expect(meter.getAttribute("aria-valuenow")).toBe("60");
+		expect(meter.getAttribute("aria-label")).toBe("Uploading clip.mov");
+		expect(bar(container)?.style.width).toBe("60%");
+	});
+
+	it("pins the bar inside its track whatever the progress claims", async () => {
+		const { container, rerender } = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "clip.mov", status: "uploading", progress: 1.8 } },
+		});
+		expect(bar(container)?.style.width).toBe("100%");
+
+		await rerender({
+			attachment: { id: "a1", name: "clip.mov", status: "uploading", progress: -2 },
+		});
+		expect(bar(container)?.style.width).toBe("0%");
+
+		await rerender({ attachment: { id: "a1", name: "clip.mov", status: "uploading" } });
+		expect(bar(container)?.style.width).toBe("0%");
+	});
+
+	it("tints a failed upload and says so out loud", () => {
+		const { container } = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "notes.pdf", status: "error" } },
+		});
+		const chip = chips(container)[0];
+
+		expect(chip.className).toContain("ft-failed");
+		expect(chip.getAttribute("data-status")).toBe("error");
+		expect(container.querySelector(".sr-only")?.textContent).toBe("Upload failed");
+		expect(chip.hasAttribute("aria-busy")).toBe(false);
+		expect(container.querySelector('[role="progressbar"]')).toBeNull();
+	});
+
+	it("drops the bar and the busy flag once the upload is done", () => {
+		const { container } = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "notes.pdf", status: "done", progress: 1 } },
+		});
+		const chip = chips(container)[0];
+
+		expect(chip.hasAttribute("aria-busy")).toBe(false);
+		expect(chip.className).not.toContain("ft-failed");
+		expect(container.querySelector('[role="progressbar"]')).toBeNull();
+	});
+
+	it("removes itself through the composer, by id", async () => {
+		const { context, removeAttachment } = fakeComposer();
+		const { container } = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "notes.pdf" } },
+			context: provide(context),
+		});
+
+		expect(removeButton(container).getAttribute("aria-label")).toBe("Remove notes.pdf");
+		expect(removeButton(container).getAttribute("type")).toBe("button");
+
+		await fireEvent.click(removeButton(container));
+		expect(removeAttachment).toHaveBeenCalledTimes(1);
+		expect(removeAttachment).toHaveBeenCalledWith("a1");
+	});
+
+	it("hands removal to onRemove instead, when there is one", async () => {
+		const onRemove = vi.fn();
+		const { context, removeAttachment } = fakeComposer();
+		const { container } = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "notes.pdf" }, onRemove },
+			context: provide(context),
+		});
+
+		await fireEvent.click(removeButton(container));
+
+		expect(onRemove).toHaveBeenCalledWith("a1");
+		expect(removeAttachment).not.toHaveBeenCalled();
+	});
+
+	it("cannot be removed while the composer is disabled", () => {
+		const { context } = fakeComposer({ disabled: true });
+		const { container } = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "notes.pdf" } },
+			context: provide(context),
+		});
+
+		expect(removeButton(container).disabled).toBe(true);
+	});
+
+	it("renders standalone, with the cross inert until something can answer it", async () => {
+		const alone = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "notes.pdf", size: 10 } },
+		});
+
+		expect(names(alone.container)).toEqual(["notes.pdf"]);
+		expect(sizeText(alone.container)).toBe("10 B");
+		expect(removeButton(alone.container).disabled).toBe(true);
+		await expect(fireEvent.click(removeButton(alone.container))).resolves.not.toThrow();
+		cleanup();
+
+		const onRemove = vi.fn();
+		const handled = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "notes.pdf" }, onRemove },
+		});
+		expect(removeButton(handled.container).disabled).toBe(false);
+		await fireEvent.click(removeButton(handled.container));
+		expect(onRemove).toHaveBeenCalledWith("a1");
+	});
+
+	it("merges custom classes onto the chip", () => {
+		const { container } = render(ComposerAttachment, {
+			props: { attachment: { id: "a1", name: "notes.pdf" }, class: "border-dashed" },
+		});
+
+		expect(chips(container)[0].className).toContain("border-dashed");
+		expect(chips(container)[0].className).toContain("items-center");
+	});
+
+	it("formats sizes down to the byte and up to the megabyte", () => {
+		const table: Array<[number | undefined, string]> = [
+			[undefined, ""],
+			[Number.NaN, ""],
+			[-1, ""],
+			[0, "0 B"],
+			[512, "512 B"],
+			[1023, "1023 B"],
+			[1024, "1 KB"],
+			[1536, "1.5 KB"],
+			[1024 * 1024, "1 MB"],
+			[2.5 * 1024 * 1024, "2.5 MB"],
+			// Past the last unit the number keeps growing rather than inventing one.
+			[1024 * 1024 * 1024, "1024 MB"],
+		];
+
+		for (const [size, expected] of table) {
+			const { container } = render(ComposerAttachment, {
+				props: { attachment: { id: "a1", name: "notes.pdf", size } },
+			});
+			expect(sizeText(container), `${size} bytes`).toBe(expected);
+			cleanup();
+		}
+	});
+});
+
+describe("ComposerAttachments inside a real Composer", () => {
+	afterEach(cleanup);
+
+	it("lists the root's attachments and drops the one it removes", async () => {
+		let context: ComposerContext | undefined;
+		const root = render(Harness, {
+			props: {
+				initialAttachments: [
+					{ id: "a1", name: "notes.pdf", size: 2048 },
+					{ id: "a2", name: "shot.png" },
+				],
+				onContext: (next: ComposerContext | undefined) => (context = next),
+			},
+		});
+		const { container } = render(ComposerAttachments, {
+			context: provide(context as ComposerContext),
+		});
+
+		expect(names(container)).toEqual(["notes.pdf", "shot.png"]);
+
+		await fireEvent.click(removeButton(container));
+		await tick();
+
+		// The root owns the list: the chip goes because the attachment did.
+		expect(names(container)).toEqual(["shot.png"]);
+		expect(root.container.querySelector('[data-testid="bound-attachments"]')?.textContent).toBe(
+			"1"
+		);
+	});
+});

--- a/src/lib/fancy-ui/composer/ComposerCommandMenu.svelte
+++ b/src/lib/fancy-ui/composer/ComposerCommandMenu.svelte
@@ -1,0 +1,393 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { CommandItemData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for ComposerCommandMenu
+	 */
+	export interface ComposerCommandMenuProps {
+		/** The character that opens the menu — `/` for commands, `@` for mentions. */
+		trigger: string;
+		/** Everything the menu can offer, before filtering. */
+		items: CommandItemData[];
+		/**
+		 * Handles a picked item. Defaults to completing the trigger token with the
+		 * item's label. `query` is what had been typed after the trigger.
+		 */
+		onSelect?: (
+			item: CommandItemData,
+			ctx: { insertText: (text: string, replaceTriggerToken?: boolean) => void; query: string }
+		) => void;
+		/** Decides which items survive the query. Defaults to a case-insensitive label/description match. */
+		filter?: (item: CommandItemData, query: string) => boolean;
+		/** Shown in place of the rows when nothing matches. */
+		empty?: Snippet;
+		/** How many matches the menu shows at once. */
+		maxItems?: number;
+		/** What this menu offers: its accessible name, and the noun it is counted in. */
+		label?: string;
+		/** Additional CSS classes */
+		class?: string;
+		/** The menu element, bindable. Null whenever the menu is closed — it is not rendered then. */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { getContext, untrack } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import { float, type FloatRect } from "../_internals/float.js";
+	import { findTriggerToken, measureCaretRect } from "./caret.js";
+	import { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";
+
+	let {
+		trigger,
+		items,
+		onSelect,
+		filter,
+		empty,
+		maxItems = 8,
+		label = "Commands",
+		class: className,
+		ref = $bindable(null),
+	}: ComposerCommandMenuProps = $props();
+
+	// Undefined outside a Composer: the menu then has no textarea to watch and
+	// renders nothing at all, rather than throwing on a missing provider.
+	const composer = getContext<ComposerContext | undefined>(COMPOSER_CONTEXT_KEY);
+
+	const uid = $props.id();
+	const listId = `${uid}-list`;
+
+	/** Anchors the float before the caret has ever been measured. */
+	const ORIGIN: FloatRect = { x: 0, y: 0, width: 0, height: 0 };
+
+	const textarea = $derived(composer?.textareaRef.current ?? null);
+	// A composer that is off or streaming takes no dictation: completing into it
+	// would write through a textarea the reader cannot type in.
+	const inert = $derived((composer?.disabled ?? false) || (composer?.streaming ?? false));
+
+	let open = $state(false);
+	let query = $state("");
+	/** Where the open token starts, or -1. This is what "the same token" means. */
+	let tokenStart = $state(-1);
+	/** The token Escape dismissed, so it does not spring back on the next keystroke. */
+	let dismissedStart = $state(-1);
+	let activeIndex = $state(0);
+	let caret = $state<FloatRect | null>(null);
+
+	const matches = $derived(items.filter((item) => (filter ?? defaultFilter)(item, query)));
+	const visible = $derived(matches.slice(0, Math.max(0, maxItems)));
+	// The stored index is a wish; this is what it can actually be once the query
+	// has shortened the list under it.
+	const active = $derived(visible.length === 0 ? -1 : Math.min(activeIndex, visible.length - 1));
+	const anchor = $derived(caret ?? ORIGIN);
+
+	/**
+	 * The menu never takes focus — the reader is typing, and a completion list that
+	 * steals the caret would break the very sentence it is completing. That rules
+	 * out the usual combobox wiring, which needs `role`, `aria-expanded`,
+	 * `aria-controls` and `aria-activedescendant` on the input itself, and this
+	 * component is in no position to put them there: the textarea belongs to
+	 * `ComposerInput`, and reaching across to rewrite another component's
+	 * attributes from a sibling is exactly the kind of spooky action a compound
+	 * component should not do (it would also fight that component's own renders).
+	 *
+	 * So the announcement is made out loud instead, through a live region that is
+	 * always in the DOM — a region inserted at the same moment as its text usually
+	 * goes unread. The tradeoff is real: a screen-reader user hears how many
+	 * matches there are and that the arrows do something, but cannot hear each row
+	 * as it becomes active. Pointer and sighted-keyboard users lose nothing.
+	 *
+	 * The rows still carry stable ids, so a consumer who owns their own input part
+	 * — and may therefore write to it — can read the menu through `ref`, point
+	 * `aria-activedescendant` at the selected row, and have the full pattern.
+	 */
+	const announcement = $derived.by(() => {
+		if (!open) return "";
+		const noun = label.toLowerCase();
+		const word = visible.length === 1 && noun.endsWith("s") ? noun.slice(0, -1) : noun;
+		return `${visible.length} ${word} available, use the arrow keys`;
+	});
+
+	function defaultFilter(item: CommandItemData, text: string): boolean {
+		if (text === "") return true;
+		const needle = text.toLowerCase();
+		return (
+			item.label.toLowerCase().includes(needle) ||
+			(item.description?.toLowerCase().includes(needle) ?? false)
+		);
+	}
+
+	function close() {
+		open = false;
+		tokenStart = -1;
+	}
+
+	/**
+	 * Re-read the draft and decide whether the menu belongs on screen.
+	 *
+	 * Called from the textarea's own events rather than from an effect: the caret
+	 * is not reactive state, so nothing would wake an effect when it moves.
+	 */
+	function sync() {
+		const el = textarea;
+		if (!el || inert) {
+			close();
+			return;
+		}
+		const end = el.selectionEnd ?? el.value.length;
+		// Mid-selection there is no caret to complete at, only a range.
+		if ((el.selectionStart ?? end) !== end) {
+			close();
+			return;
+		}
+
+		const token = findTriggerToken(el.value, end, trigger);
+		if (!token) {
+			// Outside any token, a dismissal has nothing left to apply to: coming
+			// back to the same spot should open the menu again.
+			dismissedStart = -1;
+			close();
+			return;
+		}
+		if (token.start === dismissedStart) {
+			open = false;
+			return;
+		}
+		// A different token, or a different query within it, starts the list again
+		// from the top — the row that was active may not even be in it any more.
+		if (token.start !== tokenStart || token.query !== query) activeIndex = 0;
+		tokenStart = token.start;
+		query = token.query;
+		// Anchored to the trigger character, not to the caret: the menu then holds
+		// still while the query is typed instead of crawling along with it.
+		caret = measureCaretRect(el, token.start);
+		open = true;
+	}
+
+	/**
+	 * Take the key away from everything else.
+	 *
+	 * `preventDefault` alone is not enough: the input's Enter-to-send handler never
+	 * asks whether the event was already handled, and it is registered further up
+	 * the tree, so the event has to stop travelling.
+	 */
+	function consume(event: KeyboardEvent) {
+		event.preventDefault();
+		event.stopPropagation();
+	}
+
+	function move(delta: number) {
+		const count = visible.length;
+		if (count === 0) return;
+		const from = active < 0 ? 0 : active;
+		activeIndex = (from + delta + count) % count;
+	}
+
+	function select(item: CommandItemData | undefined) {
+		if (!item) return;
+		const insertText = (text: string, replaceTriggerToken?: boolean) =>
+			composer?.insertText(text, replaceTriggerToken);
+		if (onSelect) onSelect(item, { insertText, query });
+		// The trailing space is part of the completion: it closes the token, which
+		// is also what stops the menu from immediately reopening on it.
+		else insertText(`${item.label} `, true);
+		dismissedStart = -1;
+		close();
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (!open) return;
+		// Mid-composition these keys belong to the IME, which is picking a candidate
+		// of its own.
+		if (event.isComposing) return;
+
+		if (event.key === "Escape") {
+			// Dismissed for this token only. Typing on in it keeps the menu away;
+			// starting another one brings it back.
+			dismissedStart = tokenStart;
+			close();
+			consume(event);
+			return;
+		}
+		if (event.key === "ArrowDown") {
+			move(1);
+			consume(event);
+			return;
+		}
+		if (event.key === "ArrowUp") {
+			move(-1);
+			consume(event);
+			return;
+		}
+		if (event.key === "Enter" || event.key === "Tab") {
+			// Nothing to complete: Enter goes back to meaning send.
+			if (active < 0) return;
+			select(visible[active]);
+			consume(event);
+		}
+	}
+
+	function handleBlur() {
+		close();
+	}
+
+	// Wired here rather than with `on*` attributes because the element belongs to
+	// another component: this part only ever gets handed the node through the
+	// context, and it must let go of it just as cleanly.
+	$effect(() => {
+		const el = textarea;
+		if (!el) {
+			open = false;
+			return;
+		}
+		const doc = el.ownerDocument;
+		const handleSelectionChange = () => {
+			// `selectionchange` only fires on the document, for every selection on the
+			// page: the guard is what makes it mean "the caret moved in *our* input",
+			// and it is the only way to notice arrow keys and clicks that move the
+			// caret without changing a character.
+			if (doc.activeElement === el) sync();
+		};
+
+		el.addEventListener("input", sync);
+		el.addEventListener("keydown", handleKeydown);
+		el.addEventListener("blur", handleBlur);
+		doc.addEventListener("selectionchange", handleSelectionChange);
+		return () => {
+			el.removeEventListener("input", sync);
+			el.removeEventListener("keydown", handleKeydown);
+			el.removeEventListener("blur", handleBlur);
+			doc.removeEventListener("selectionchange", handleSelectionChange);
+		};
+	});
+
+	// Reads the switches, writes only the menu: a composer that goes dark or
+	// starts streaming mid-query takes the open menu down with it.
+	$effect(() => {
+		if (inert) close();
+	});
+
+	// The draft can also change under the menu without a keystroke — a submit
+	// clearing it, a consumer restoring one — and neither fires `input`. Reading
+	// the draft here is what wakes the token search on those writes; `open` is
+	// read untracked, so the effect answers to the draft alone and never to the
+	// state `sync` itself sets.
+	$effect(() => {
+		void composer?.value.current;
+		if (untrack(() => open)) sync();
+	});
+</script>
+
+{#if textarea}
+	{#if open}
+		<!--
+			Only in the DOM while it is open: a closed completion list is not a hidden
+			one, it does not exist, and neither its rows nor its live geometry should
+			cost anything while the reader is just typing.
+		-->
+		<div
+			bind:this={ref}
+			id={listId}
+			role="listbox"
+			aria-label={label}
+			class={cn("ft-composer-command-menu flex flex-col text-sm", className)}
+			use:float={{ anchor, placement: "top-start", offset: 6 }}
+		>
+			{#if visible.length > 0}
+				<!-- Suffixed with the index: two items may arrive carrying the same id. -->
+				{#each visible as item, index (`${item.id}#${index}`)}
+					<button
+						type="button"
+						role="option"
+						id={`${listId}-${index}`}
+						tabindex="-1"
+						aria-selected={index === active}
+						class="ft-composer-command flex w-full items-baseline gap-2 rounded-md px-2 py-1.5 text-left"
+						class:ft-active={index === active}
+						onmousedown={(event) => event.preventDefault()}
+						onclick={() => select(item)}
+					>
+						<span class="ft-composer-command-label min-w-0 truncate font-medium">{item.label}</span>
+						{#if item.description}
+							<!--
+								`text-foreground/70` rather than `text-muted-foreground`: this text
+								sits on the menu's own opaque surface, and on the tinted active row
+								above it, where the muted token drops under 4.5:1. See the note on
+								`.ft-active` for the arithmetic.
+							-->
+							<span class="text-foreground/70 min-w-0 flex-1 truncate text-xs">
+								{item.description}
+							</span>
+						{/if}
+						{#if item.hint}
+							<span class="text-foreground/70 ml-auto flex-none font-mono text-xs">
+								{item.hint}
+							</span>
+						{/if}
+					</button>
+				{/each}
+			{:else if empty}
+				{@render empty()}
+			{:else}
+				<p class="text-foreground/70 px-2 py-1.5 text-xs italic">No matches.</p>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- Mounted whether or not the menu is: see the note on `announcement`. -->
+	<div class="sr-only" role="status" aria-live="polite">{announcement}</div>
+{/if}
+
+<style>
+	.ft-composer-command-menu {
+		z-index: var(--ft-composer-menu-z, 50);
+		min-width: var(--ft-composer-menu-min-width, 14rem);
+		max-width: min(var(--ft-composer-menu-max-width, 24rem), calc(100vw - 1rem));
+		max-height: var(--ft-composer-menu-max-height, 15rem);
+		overflow-y: auto;
+		gap: 0.0625rem;
+		border-radius: var(--ft-composer-menu-radius, 0.625rem);
+		border: 1px solid
+			var(--ft-composer-menu-border, color-mix(in oklab, currentColor 14%, transparent));
+		/* Opaque on purpose: the menu covers the draft it is completing, and a
+		   translucent one would leave the reader deciphering two texts at once. */
+		background: var(--ft-composer-menu-bg, light-dark(oklch(1 0 0), oklch(0.21 0.01 264)));
+		box-shadow: var(--ft-composer-menu-shadow, 0 10px 30px -12px rgb(0 0 0 / 0.45));
+		padding: 0.25rem;
+		scrollbar-width: thin;
+	}
+
+	/*
+	 * The active row is the one Enter would take, and it is set by the arrow keys
+	 * rather than by the pointer — so it is painted, not left to `:hover`. Hover
+	 * gets the same tint at half strength so the pointer still has a target.
+	 */
+	.ft-composer-command {
+		color: var(--ft-composer-menu-color, inherit);
+	}
+
+	.ft-composer-command:hover {
+		background: var(--ft-composer-menu-hover, color-mix(in oklab, currentColor 6%, transparent));
+	}
+
+	/*
+	 * Eleven percent of the row's own colour is the strongest tint the secondary
+	 * text can still be read on. The description and the hint are `foreground/70`,
+	 * which lands at #5F5F5F over the tinted row on a light menu (4.5:1 needs
+	 * #767676 or darker there) and at #C2C2C2 on a dark one — 5.2:1 and 5.8:1,
+	 * both clear of the 4.5:1 a 12px caption owes. Pushing the tint further, or
+	 * putting the muted token back on these two spans, drops the description under
+	 * the threshold on exactly the row the reader is about to take.
+	 */
+	.ft-composer-command.ft-active {
+		background: var(--ft-composer-menu-active, color-mix(in oklab, currentColor 11%, transparent));
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-composer-command {
+			transition: background-color 120ms ease;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/composer/ComposerCommandMenu.svelte
+++ b/src/lib/fancy-ui/composer/ComposerCommandMenu.svelte
@@ -74,14 +74,20 @@
 	/** The token Escape dismissed, so it does not spring back on the next keystroke. */
 	let dismissedStart = $state(-1);
 	let activeIndex = $state(0);
-	let caret = $state<FloatRect | null>(null);
 
 	const matches = $derived(items.filter((item) => (filter ?? defaultFilter)(item, query)));
 	const visible = $derived(matches.slice(0, Math.max(0, maxItems)));
 	// The stored index is a wish; this is what it can actually be once the query
 	// has shortened the list under it.
 	const active = $derived(visible.length === 0 ? -1 : Math.min(activeIndex, visible.length - 1));
-	const anchor = $derived(caret ?? ORIGIN);
+	// A getter, not a rect measured once when the token opened: the float action
+	// re-reads its anchor on every scroll and resize, and a frozen rect would send
+	// it repositioning against where the caret used to be.
+	const anchor = $derived.by(() => {
+		const el = textarea;
+		const start = tokenStart;
+		return (): FloatRect => (el && start >= 0 ? measureCaretRect(el, start) : ORIGIN);
+	});
 
 	/**
 	 * The menu never takes focus — the reader is typing, and a completion list that
@@ -158,11 +164,11 @@
 		// A different token, or a different query within it, starts the list again
 		// from the top — the row that was active may not even be in it any more.
 		if (token.start !== tokenStart || token.query !== query) activeIndex = 0;
+		// Anchored to the trigger character, not to the caret: the menu then holds
+		// still while the query is typed instead of crawling along with it. The
+		// anchor getter above reads this position live.
 		tokenStart = token.start;
 		query = token.query;
-		// Anchored to the trigger character, not to the caret: the menu then holds
-		// still while the query is typed instead of crawling along with it.
-		caret = measureCaretRect(el, token.start);
 		open = true;
 	}
 

--- a/src/lib/fancy-ui/composer/ComposerCommandMenu.test.ts
+++ b/src/lib/fancy-ui/composer/ComposerCommandMenu.test.ts
@@ -1,0 +1,406 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet, tick } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import ComposerCommandMenu from "./ComposerCommandMenu.svelte";
+import type { ComposerCommandMenuProps } from "./ComposerCommandMenu.svelte";
+import { findTriggerToken } from "./caret.js";
+import { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";
+import type { AttachmentData, CommandItemData } from "../_internals/ai-types.js";
+
+const ITEMS: CommandItemData[] = [
+	{ id: "deploy", label: "/deploy", description: "Ship the current branch", hint: "⌘⏎" },
+	{ id: "describe", label: "/describe", description: "Summarise the diff" },
+	{ id: "docs", label: "/docs", description: "Open the handbook" },
+	{ id: "reset", label: "/reset", description: "Clear the conversation" },
+];
+
+const PEOPLE: CommandItemData[] = [
+	{ id: "jordan", label: "@jordan", description: "Reviewer" },
+	{ id: "sam", label: "@sam", description: "On call" },
+];
+
+/**
+ * A stand-in for the composer root.
+ *
+ * The parts cannot be composed from a `.ts` file, so the rig publishes the same
+ * contract by hand around a real textarea — including the token arithmetic
+ * `insertText` performs, so the assertions can read the draft a person would
+ * actually end up with.
+ */
+interface Rig {
+	el: HTMLTextAreaElement;
+	context: ComposerContext;
+	inserts: Array<{ text: string; replaceTriggerToken?: boolean }>;
+}
+
+const mounted: HTMLTextAreaElement[] = [];
+
+function rig(trigger = "/", registerTextarea = true): Rig {
+	const el = document.createElement("textarea");
+	document.body.appendChild(el);
+	mounted.push(el);
+
+	const inserts: Rig["inserts"] = [];
+	let value = "";
+
+	const context: ComposerContext = {
+		value: {
+			get current() {
+				return value;
+			},
+		},
+		attachments: {
+			get current() {
+				return [] as AttachmentData[];
+			},
+		},
+		disabled: false,
+		streaming: false,
+		textareaRef: {
+			get current() {
+				return registerTextarea ? el : null;
+			},
+		},
+		submit() {},
+		stop() {},
+		setValue(next: string) {
+			value = next;
+			el.value = next;
+		},
+		insertText(text: string, replaceTriggerToken?: boolean) {
+			inserts.push({ text, replaceTriggerToken });
+			const end = el.selectionEnd ?? el.value.length;
+			const token = replaceTriggerToken ? findTriggerToken(el.value, end, trigger) : null;
+			const start = token ? token.start : end;
+			value = `${el.value.slice(0, start)}${text}${el.value.slice(end)}`;
+			el.value = value;
+			const caret = start + text.length;
+			el.setSelectionRange(caret, caret);
+		},
+		addFiles() {},
+		removeAttachment() {},
+	};
+
+	return { el, context, inserts };
+}
+
+function mountMenu(
+	context: ComposerContext | undefined,
+	props: Partial<ComposerCommandMenuProps> = {}
+) {
+	const componentProps = { trigger: "/", items: ITEMS, ...props };
+	return context
+		? render(ComposerCommandMenu, {
+				props: componentProps,
+				context: new Map<unknown, unknown>([[COMPOSER_CONTEXT_KEY, context]]),
+			})
+		: render(ComposerCommandMenu, { props: componentProps });
+}
+
+/** Type into the rig's textarea and let the menu react to it. */
+async function type({ el, context }: Rig, text: string, caret = text.length) {
+	context.setValue(text);
+	el.setSelectionRange(caret, caret);
+	await fireEvent.input(el);
+	await tick();
+}
+
+function menu(container: HTMLElement): HTMLElement | null {
+	return container.querySelector('[role="listbox"]');
+}
+
+function rows(container: HTMLElement): HTMLElement[] {
+	return Array.from(container.querySelectorAll('[role="option"]'));
+}
+
+function labels(container: HTMLElement): string[] {
+	return rows(container).map(
+		(row) => row.querySelector(".ft-composer-command-label")?.textContent ?? ""
+	);
+}
+
+function activeLabel(container: HTMLElement): string {
+	const row = container.querySelector('[role="option"][aria-selected="true"]');
+	return row?.querySelector(".ft-composer-command-label")?.textContent ?? "";
+}
+
+function live(container: HTMLElement): string {
+	return container.querySelector('[role="status"]')?.textContent ?? "";
+}
+
+function snippet(html: string) {
+	return createRawSnippet(() => ({ render: () => html }));
+}
+
+describe("ComposerCommandMenu", () => {
+	afterEach(() => {
+		cleanup();
+		while (mounted.length > 0) mounted.pop()?.remove();
+	});
+
+	it("renders nothing at all outside a composer", () => {
+		const { container } = mountMenu(undefined);
+		expect(menu(container)).toBeNull();
+		expect(container.textContent).toBe("");
+	});
+
+	it("renders nothing until an input has registered a textarea", () => {
+		const { container } = mountMenu(rig("/", false).context);
+		expect(menu(container)).toBeNull();
+		expect(container.querySelector('[role="status"]')).toBeNull();
+	});
+
+	it("opens on a trigger token and filters as the query grows", async () => {
+		const composer = rig();
+		const { container } = mountMenu(composer.context);
+		expect(menu(container)).toBeNull();
+
+		await type(composer, "/");
+		expect(menu(container)).not.toBeNull();
+		expect(labels(container)).toEqual(["/deploy", "/describe", "/docs", "/reset"]);
+
+		await type(composer, "/de");
+		expect(labels(container)).toEqual(["/deploy", "/describe"]);
+		// The list restarts from the top: the row that was active may be gone.
+		expect(activeLabel(container)).toBe("/deploy");
+	});
+
+	it("stays shut for text that is not a trigger token", async () => {
+		const composer = rig();
+		const { container } = mountMenu(composer.context);
+
+		await type(composer, "hello");
+		expect(menu(container)).toBeNull();
+
+		// A path fragment, not a command: the slash is mid-word.
+		await type(composer, "open src/li");
+		expect(menu(container)).toBeNull();
+
+		// The caret has moved past the token, onto the next word.
+		await type(composer, "/deploy now");
+		expect(menu(container)).toBeNull();
+	});
+
+	it("moves the active row with the arrows, wrapping at both ends", async () => {
+		const composer = rig();
+		const { container } = mountMenu(composer.context);
+		await type(composer, "/de");
+		expect(activeLabel(container)).toBe("/deploy");
+
+		const consumed = await fireEvent.keyDown(composer.el, { key: "ArrowDown" });
+		expect(consumed).toBe(false);
+		await tick();
+		expect(activeLabel(container)).toBe("/describe");
+
+		await fireEvent.keyDown(composer.el, { key: "ArrowDown" });
+		await tick();
+		expect(activeLabel(container)).toBe("/deploy");
+
+		await fireEvent.keyDown(composer.el, { key: "ArrowUp" });
+		await tick();
+		expect(activeLabel(container)).toBe("/describe");
+	});
+
+	it("completes the token on Enter and keeps the key away from the composer", async () => {
+		const composer = rig();
+		const { container } = mountMenu(composer.context);
+		await type(composer, "/de");
+
+		const consumed = await fireEvent.keyDown(composer.el, { key: "Enter" });
+		await tick();
+
+		expect(consumed).toBe(false);
+		expect(composer.inserts).toEqual([{ text: "/deploy ", replaceTriggerToken: true }]);
+		expect(composer.el.value).toBe("/deploy ");
+		expect(composer.context.value.current).toBe("/deploy ");
+		expect(menu(container)).toBeNull();
+	});
+
+	it("completes on Tab as well", async () => {
+		const composer = rig();
+		const { container } = mountMenu(composer.context);
+		await type(composer, "run /desc", 9);
+
+		const consumed = await fireEvent.keyDown(composer.el, { key: "Tab" });
+		await tick();
+
+		expect(consumed).toBe(false);
+		expect(composer.el.value).toBe("run /describe ");
+		expect(menu(container)).toBeNull();
+	});
+
+	it("hands a custom onSelect the item, the query, and an insertText", async () => {
+		const onSelect = vi.fn(
+			(
+				item: CommandItemData,
+				ctx: { insertText: (text: string, replaceTriggerToken?: boolean) => void; query: string }
+			) => ctx.insertText(`::${item.id}:${ctx.query}`, true)
+		);
+		const composer = rig();
+		const { container } = mountMenu(composer.context, { onSelect });
+		await type(composer, "/de");
+		await fireEvent.keyDown(composer.el, { key: "ArrowDown" });
+		await fireEvent.keyDown(composer.el, { key: "Enter" });
+		await tick();
+
+		expect(onSelect).toHaveBeenCalledTimes(1);
+		expect(onSelect.mock.calls[0][0].id).toBe("describe");
+		expect(onSelect.mock.calls[0][1].query).toBe("de");
+		// The default completion is replaced outright, not run alongside.
+		expect(composer.inserts).toEqual([{ text: "::describe:de", replaceTriggerToken: true }]);
+		expect(composer.el.value).toBe("::describe:de");
+		expect(menu(container)).toBeNull();
+	});
+
+	it("selects the row that is clicked, without taking focus off the draft", async () => {
+		const composer = rig();
+		const { container } = mountMenu(composer.context);
+		await type(composer, "/de");
+
+		const row = rows(container)[1];
+		const focusKept = await fireEvent.mouseDown(row);
+		await fireEvent.click(row);
+		await tick();
+
+		// The default mousedown is what would blur the textarea mid-completion.
+		expect(focusKept).toBe(false);
+		expect(composer.el.value).toBe("/describe ");
+		expect(menu(container)).toBeNull();
+	});
+
+	it("closes on Escape, stays closed for that token, and comes back on a new one", async () => {
+		const composer = rig();
+		const { container } = mountMenu(composer.context);
+		await type(composer, "/de");
+
+		const consumed = await fireEvent.keyDown(composer.el, { key: "Escape" });
+		await tick();
+		expect(consumed).toBe(false);
+		expect(menu(container)).toBeNull();
+
+		// Still the same token, however much of it gets typed.
+		await type(composer, "/dep");
+		expect(menu(container)).toBeNull();
+
+		// A token further along the draft is a new question, so it answers again.
+		await type(composer, "/dep and /doc");
+		expect(menu(container)).not.toBeNull();
+		expect(labels(container)).toEqual(["/docs"]);
+	});
+
+	it("takes a filter override in place of the label match", async () => {
+		const composer = rig();
+		const { container } = mountMenu(composer.context, {
+			filter: (item) => item.id === "docs",
+		});
+		await type(composer, "/de");
+		expect(labels(container)).toEqual(["/docs"]);
+	});
+
+	it("shows no more rows than maxItems", async () => {
+		const composer = rig();
+		const { container } = mountMenu(composer.context, { maxItems: 2 });
+		await type(composer, "/");
+		expect(labels(container)).toEqual(["/deploy", "/describe"]);
+		expect(live(container)).toContain("2 commands available");
+	});
+
+	it("renders the empty snippet when nothing matches, and a default line otherwise", async () => {
+		const composer = rig();
+		const custom = mountMenu(composer.context, {
+			empty: snippet('<p data-testid="empty">Nothing like that</p>'),
+		});
+		await type(composer, "/zzz");
+		expect(rows(custom.container)).toHaveLength(0);
+		expect(custom.container.querySelector('[data-testid="empty"]')?.textContent).toBe(
+			"Nothing like that"
+		);
+		cleanup();
+
+		const plain = mountMenu(rig().context);
+		const other = mounted[mounted.length - 1];
+		other.value = "/zzz";
+		other.setSelectionRange(4, 4);
+		await fireEvent.input(other);
+		await tick();
+		expect(plain.container.querySelector('[role="listbox"]')?.textContent?.trim()).toBe(
+			"No matches."
+		);
+	});
+
+	it("leaves Enter to the composer when there is nothing to complete", async () => {
+		const composer = rig();
+		const { container } = mountMenu(composer.context);
+		await type(composer, "/zzz");
+		expect(menu(container)).not.toBeNull();
+
+		const consumed = await fireEvent.keyDown(composer.el, { key: "Enter" });
+		expect(consumed).toBe(true);
+		expect(composer.inserts).toEqual([]);
+	});
+
+	it("announces the match count while it is open, and nothing while it is not", async () => {
+		const composer = rig();
+		const { container } = mountMenu(composer.context);
+		expect(live(container)).toBe("");
+
+		await type(composer, "/de");
+		expect(live(container)).toBe("2 commands available, use the arrow keys");
+
+		await type(composer, "/deplo");
+		expect(live(container)).toBe("1 command available, use the arrow keys");
+
+		await type(composer, "hello");
+		expect(live(container)).toBe("");
+	});
+
+	it("is the same primitive for mentions, on whatever trigger it is given", async () => {
+		const composer = rig("@");
+		const { container } = mountMenu(composer.context, { trigger: "@", items: PEOPLE });
+
+		await type(composer, "ping /jo");
+		expect(menu(container)).toBeNull();
+
+		await type(composer, "ping @jo");
+		expect(labels(container)).toEqual(["@jordan"]);
+
+		await fireEvent.keyDown(composer.el, { key: "Enter" });
+		await tick();
+		expect(composer.el.value).toBe("ping @jordan ");
+	});
+
+	it("lets go of every listener it took when it unmounts", async () => {
+		const composer = rig();
+		const added = vi.spyOn(composer.el, "addEventListener");
+		const removed = vi.spyOn(composer.el, "removeEventListener");
+		const docAdded = vi.spyOn(document, "addEventListener");
+		const docRemoved = vi.spyOn(document, "removeEventListener");
+
+		const { container, unmount } = mountMenu(composer.context);
+		await type(composer, "/de");
+		expect(menu(container)).not.toBeNull();
+
+		const names = (spy: typeof added) => spy.mock.calls.map(([name]) => name).sort();
+		const selectionChanges = (spy: typeof docAdded) =>
+			spy.mock.calls.filter(([name]) => name === "selectionchange").length;
+
+		expect(names(added)).toEqual(["blur", "input", "keydown"]);
+		expect(selectionChanges(docAdded)).toBe(1);
+		expect(names(removed)).toEqual([]);
+
+		unmount();
+		await tick();
+
+		expect(names(removed)).toEqual(["blur", "input", "keydown"]);
+		expect(selectionChanges(docRemoved)).toBe(1);
+
+		// Nothing left listening: typing on cannot resurrect the menu.
+		await fireEvent.input(composer.el);
+		expect(menu(container)).toBeNull();
+
+		added.mockRestore();
+		removed.mockRestore();
+		docAdded.mockRestore();
+		docRemoved.mockRestore();
+	});
+});

--- a/src/lib/fancy-ui/composer/ComposerCommandMenu.test.ts
+++ b/src/lib/fancy-ui/composer/ComposerCommandMenu.test.ts
@@ -56,6 +56,7 @@ function rig(trigger = "/", registerTextarea = true): Rig {
 		},
 		disabled: false,
 		streaming: false,
+		stoppable: false,
 		textareaRef: {
 			get current() {
 				return registerTextarea ? el : null;

--- a/src/lib/fancy-ui/composer/ComposerHarness.test.svelte
+++ b/src/lib/fancy-ui/composer/ComposerHarness.test.svelte
@@ -1,0 +1,99 @@
+<!--
+  Test-only composition rig. Two things cannot be done from a `.ts` test file:
+  mounting the parts inside a real root, and reading the context the root
+  publishes — `getContext` only answers during a child's initialisation. So the
+  rig renders itself a second time, in `probe` mode, as a child of the composer:
+  that instance hands the live context back through `onContext` and mirrors it
+  into the DOM. Not exported from index.ts, and not collected by Vitest (the run
+  includes `*.test.ts` only).
+-->
+<script lang="ts">
+	import { getContext, untrack } from "svelte";
+	import Composer from "./Composer.svelte";
+	import ComposerInput from "./ComposerInput.svelte";
+	import ComposerSubmit from "./ComposerSubmit.svelte";
+	import Self from "./ComposerHarness.test.svelte";
+	import { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";
+	import type { AttachmentData } from "../_internals/ai-types.js";
+
+	interface Props {
+		/** Render as the context probe rather than as the composer. */
+		probe?: boolean;
+		onContext?: (context: ComposerContext | undefined) => void;
+		initialValue?: string;
+		initialAttachments?: AttachmentData[];
+		disabled?: boolean;
+		streaming?: boolean;
+		placeholder?: string;
+		maxRows?: number;
+		/** Stand in for a consumer that uploads and then appends the attachment. */
+		autoAttach?: boolean;
+		onSubmit?: (payload: { text: string; attachments: AttachmentData[] }) => void;
+		onStop?: () => void;
+		onAttach?: (files: File[]) => void;
+	}
+
+	let {
+		probe = false,
+		onContext,
+		initialValue = "",
+		initialAttachments = [],
+		disabled = false,
+		streaming = false,
+		placeholder,
+		maxRows,
+		autoAttach = false,
+		onSubmit,
+		onStop,
+		onAttach,
+	}: Props = $props();
+
+	// Read once, on purpose: the mode and the seeds are fixed for a mounted rig,
+	// and untrack says so rather than leaving a compiler hint behind.
+	const isProbe = untrack(() => probe);
+	const notify = untrack(() => onContext);
+	const context = isProbe
+		? getContext<ComposerContext | undefined>(COMPOSER_CONTEXT_KEY)
+		: undefined;
+	if (isProbe) notify?.(context);
+
+	let value = $state(untrack(() => initialValue));
+	let attachments = $state<AttachmentData[]>(untrack(() => [...initialAttachments]));
+
+	function handleAttach(files: File[]) {
+		onAttach?.(files);
+		if (!autoAttach) return;
+		attachments = [
+			...attachments,
+			...files.map((file, index) => ({ id: `${file.name}#${index}`, name: file.name })),
+		];
+	}
+</script>
+
+{#if isProbe}
+	<output data-testid="context-value">{context?.value.current ?? ""}</output>
+	<output data-testid="context-attachments">{context?.attachments.current.length ?? 0}</output>
+	<output data-testid="context-disabled">{context?.disabled ? "yes" : "no"}</output>
+	<output data-testid="context-streaming">{context?.streaming ? "yes" : "no"}</output>
+{:else}
+	<Composer
+		bind:value
+		bind:attachments
+		{disabled}
+		{streaming}
+		{onSubmit}
+		{onStop}
+		onAttach={handleAttach}
+	>
+		{#snippet children()}
+			<ComposerInput {placeholder} {maxRows} />
+			<div class="flex items-center gap-2">
+				<div class="flex-1"></div>
+				<ComposerSubmit />
+			</div>
+			<Self probe {onContext} />
+		{/snippet}
+	</Composer>
+	<output data-testid="bound-value">{value}</output>
+	<output data-testid="bound-attachments">{attachments.length}</output>
+{/if}

--- a/src/lib/fancy-ui/composer/ComposerInput.svelte
+++ b/src/lib/fancy-ui/composer/ComposerInput.svelte
@@ -1,0 +1,178 @@
+<script lang="ts" module>
+	/**
+	 * Props for ComposerInput
+	 */
+	export interface ComposerInputProps {
+		/** Shown while the draft is empty. */
+		placeholder?: string;
+		/** Height, in lines, before anything has been typed. Also the SSR height. */
+		rows?: number;
+		/** Height ceiling, in lines. Past it the textarea scrolls instead of growing. */
+		maxRows?: number;
+		/** Take focus on mount. */
+		autofocus?: boolean;
+		/** Additional CSS classes */
+		class?: string;
+		/** The textarea element, bindable. */
+		ref?: HTMLTextAreaElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { getContext, onMount } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";
+
+	let {
+		placeholder = "Message…",
+		rows = 1,
+		maxRows = 8,
+		autofocus = false,
+		class: className,
+		ref = $bindable(null),
+	}: ComposerInputProps = $props();
+
+	/** Used when the platform reports no usable line-height, e.g. under jsdom. */
+	const FALLBACK_LINE_HEIGHT = 20;
+	/** Multiplier applied to the font size when only that is measurable. */
+	const NORMAL_LINE_RATIO = 1.5;
+
+	// Undefined when the input is used outside a Composer: it then behaves as a
+	// plain uncontrolled textarea rather than throwing, and Enter does nothing.
+	const composer = getContext<ComposerContext | undefined>(COMPOSER_CONTEXT_KEY);
+
+	const value = $derived(composer?.value.current ?? "");
+
+	/**
+	 * A line count a textarea can actually be built from.
+	 *
+	 * `rows={0}` collapses the box to nothing and `maxRows={NaN}` poisons every
+	 * height derived from it — both arrive from a consumer computing the number
+	 * rather than writing it, so they fall back instead of reaching the geometry.
+	 */
+	function lines(count: number, fallback: number): number {
+		const whole = Math.floor(count);
+		return Number.isFinite(whole) && whole >= 1 ? whole : fallback;
+	}
+
+	const minLines = $derived(lines(rows, 1));
+	// A ceiling below the floor is not a ceiling: the box would be told to grow
+	// and to stop growing at the same height.
+	const maxLines = $derived(Math.max(lines(maxRows, 8), minLines));
+	// Readonly rather than disabled: a disabled textarea drops out of the tab
+	// order and stops announcing its content, and a reader mid-draft should still
+	// be able to select and copy what they wrote while a response streams in.
+	const locked = $derived((composer?.disabled ?? false) || (composer?.streaming ?? false));
+
+	// Measured once from the mounted element — line-height does not change under
+	// this component's feet, and re-reading it on every keystroke would force a
+	// layout for an answer we already have.
+	let metrics: { line: number; extra: number } | null = null;
+
+	function px(input: string): number {
+		const parsed = Number.parseFloat(input);
+		return Number.isFinite(parsed) ? parsed : 0;
+	}
+
+	function measure(el: HTMLTextAreaElement): { line: number; extra: number } {
+		if (metrics) return metrics;
+		const style = getComputedStyle(el);
+		const declared = Number.parseFloat(style.lineHeight);
+		const fontSize = Number.parseFloat(style.fontSize);
+		const line =
+			Number.isFinite(declared) && declared > 0
+				? declared
+				: Number.isFinite(fontSize) && fontSize > 0
+					? fontSize * NORMAL_LINE_RATIO
+					: FALLBACK_LINE_HEIGHT;
+		const padding = px(style.paddingTop) + px(style.paddingBottom);
+		// scrollHeight covers content and padding but never the border, which a
+		// border-box height does include.
+		const border =
+			style.boxSizing === "border-box" ? px(style.borderTopWidth) + px(style.borderBottomWidth) : 0;
+		metrics = { line, extra: padding + border };
+		return metrics;
+	}
+
+	/**
+	 * Fit the box to its content, between the declared rows and the ceiling.
+	 *
+	 * `height: auto` first, otherwise scrollHeight reports the box we last set
+	 * rather than the text inside it, and the textarea can only ever grow.
+	 */
+	function grow() {
+		const el = ref;
+		if (!el) return;
+		const { line, extra } = measure(el);
+		el.style.height = "auto";
+		const content = el.scrollHeight;
+		const min = minLines * line + extra;
+		const max = maxLines * line + extra;
+		const height = Math.min(Math.max(content, min), max);
+		el.style.height = `${height}px`;
+		el.style.overflowY = content > max ? "auto" : "hidden";
+	}
+
+	function handleInput(event: Event & { currentTarget: HTMLTextAreaElement }) {
+		composer?.setValue(event.currentTarget.value);
+		grow();
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key !== "Enter" || event.shiftKey) return;
+		// Mid-composition Enter belongs to the IME, which is picking a candidate,
+		// not to the composer.
+		if (event.isComposing) return;
+		event.preventDefault();
+		composer?.submit();
+	}
+
+	onMount(() => {
+		// Registering here rather than through a prop keeps the wiring inside the
+		// pair that needs it: the root's caret arithmetic reaches the element, and
+		// no consumer has to thread a ref between two components it composed.
+		// The cast is the documented escape hatch from the read-only view every
+		// other part sees — see the note at the top of types.ts.
+		const slot = composer?.textareaRef as { current: HTMLTextAreaElement | null } | undefined;
+		if (slot) slot.current = ref;
+		if (autofocus) ref?.focus();
+		grow();
+		return () => {
+			// Only retract our own registration: a second input may have replaced
+			// us in the slot already.
+			if (slot && slot.current === ref) slot.current = null;
+		};
+	});
+
+	// Growth has to answer to programmatic writes too — an inserted slash command
+	// or a restored draft never passes through the input handler. Reads the draft,
+	// writes only the element's style, so it can never wake itself.
+	$effect(() => {
+		void value;
+		grow();
+	});
+</script>
+
+<textarea
+	bind:this={ref}
+	class={cn(
+		"ft-composer-input placeholder:text-muted-foreground w-full resize-none bg-transparent px-2 py-1.5 text-sm leading-relaxed outline-none",
+		className
+	)}
+	rows={minLines}
+	{placeholder}
+	{value}
+	readonly={locked}
+	aria-disabled={locked ? "true" : undefined}
+	oninput={handleInput}
+	onkeydown={handleKeydown}
+></textarea>
+
+<style>
+	.ft-composer-input {
+		/* Kept out of the auto-grow arithmetic: scrollbar-gutter would change the
+		   content box mid-measurement. */
+		scrollbar-width: thin;
+		color: var(--ft-composer-input-color, inherit);
+	}
+</style>

--- a/src/lib/fancy-ui/composer/ComposerIntegration.test.ts
+++ b/src/lib/fancy-ui/composer/ComposerIntegration.test.ts
@@ -1,0 +1,362 @@
+/**
+ * End-to-end tests for the composer compound.
+ *
+ * Every other suite in this folder tests one part against a hand-written stand-in
+ * for the root's context. This one mocks nothing: `IntegrationHarness` mounts the
+ * real `Composer` around the real parts, so what is under test here is the wiring
+ * between them — the input registering its element, the menus reading it back off
+ * the context, the root's own caret arithmetic completing a token, and the
+ * bindings carrying the result out to the consumer.
+ *
+ * Nothing is reached through an internal: the harness composes the public API,
+ * and the assertions go through the DOM a person actually operates.
+ */
+
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import Harness, { MODELS } from "./IntegrationHarness.test.svelte";
+import type { AttachmentData, CommandItemData } from "../_internals/ai-types.js";
+
+/** A file already riding along with the draft when the rig mounts. */
+const SEED: AttachmentData[] = [{ id: "spec-1", name: "spec.pdf", size: 2048 }];
+
+function form(container: HTMLElement): HTMLFormElement {
+	return container.querySelector("form.ft-composer") as HTMLFormElement;
+}
+
+function textarea(container: HTMLElement): HTMLTextAreaElement {
+	return container.querySelector("textarea") as HTMLTextAreaElement;
+}
+
+function sendButton(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector("button.ft-composer-submit") as HTMLButtonElement;
+}
+
+function attachButton(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector("button.ft-composer-attach") as HTMLButtonElement;
+}
+
+function fileInput(container: HTMLElement): HTMLInputElement {
+	return container.querySelector("input.ft-composer-file-input") as HTMLInputElement;
+}
+
+function modelTrigger(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector("button.ft-composer-model") as HTMLButtonElement;
+}
+
+function modelMenu(container: HTMLElement): HTMLElement | null {
+	return container.querySelector(".ft-composer-model-menu");
+}
+
+/** The two trigger menus are told apart by the classes the rig gives them. */
+function commandMenu(container: HTMLElement): HTMLElement | null {
+	return container.querySelector(".ft-menu-commands");
+}
+
+function mentionMenu(container: HTMLElement): HTMLElement | null {
+	return container.querySelector(".ft-menu-mentions");
+}
+
+function chips(container: HTMLElement): HTMLElement[] {
+	return Array.from(container.querySelectorAll(".ft-composer-attachment"));
+}
+
+function chipNames(container: HTMLElement): string[] {
+	return chips(container).map(
+		(chip) => chip.querySelector(".ft-composer-attachment-name")?.textContent ?? ""
+	);
+}
+
+function removeButton(container: HTMLElement, name: string): HTMLButtonElement {
+	return container.querySelector(`button[aria-label="Remove ${name}"]`) as HTMLButtonElement;
+}
+
+function options(root: HTMLElement): HTMLElement[] {
+	return Array.from(root.querySelectorAll('[role="option"]'));
+}
+
+function labels(menu: HTMLElement): string[] {
+	return options(menu).map(
+		(row) => row.querySelector(".ft-composer-command-label")?.textContent ?? ""
+	);
+}
+
+function readout(container: HTMLElement, id: string): string {
+	return (container.querySelector(`[data-testid="${id}"]`) as HTMLElement).textContent ?? "";
+}
+
+/** Two ticks: one for the state to reach the DOM, one for the caret restore that waits on it. */
+async function settle() {
+	await tick();
+	await tick();
+}
+
+/**
+ * Type into the composer the way a person would.
+ *
+ * The caret is placed before the event rather than after it, because everything
+ * downstream — the token search, the menu's anchor — reads `selectionEnd` while
+ * the input event is being handled.
+ */
+async function type(container: HTMLElement, text: string, caret = text.length) {
+	const el = textarea(container);
+	el.value = text;
+	el.setSelectionRange(caret, caret);
+	await fireEvent.input(el);
+	await settle();
+	return el;
+}
+
+describe("Composer integration", () => {
+	afterEach(cleanup);
+
+	it("mounts every part of the flagship composition inside one form", () => {
+		const { container } = render(Harness, {});
+
+		expect(form(container)).not.toBeNull();
+		expect(textarea(container).getAttribute("placeholder")).toBe("Ask anything");
+		expect(sendButton(container).getAttribute("aria-label")).toBe("Send");
+		expect(attachButton(container).getAttribute("aria-label")).toBe("Attach files");
+		expect(modelTrigger(container).textContent).toContain(MODELS[0].label);
+
+		// Nothing floats until something asks it to: no menu, no chips, no overlay.
+		expect(container.querySelector('[role="listbox"]')).toBeNull();
+		expect(chips(container)).toHaveLength(0);
+		expect(container.querySelector(".ft-composer-accessory")).toBeNull();
+	});
+
+	it("sends the trimmed draft and a snapshot of the attachments on Enter", async () => {
+		const onSubmit = vi.fn();
+		const { container } = render(Harness, { props: { initialAttachments: SEED, onSubmit } });
+
+		await type(container, "  Ship it  ");
+		await fireEvent.keyDown(textarea(container), { key: "Enter" });
+		await settle();
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0]).toEqual({ text: "Ship it", attachments: SEED });
+		// The text is the composer's to clear; the files belong to the consumer,
+		// who alone knows whether an upload is still in flight.
+		expect(readout(container, "draft")).toBe("");
+		expect(readout(container, "attachment-count")).toBe("1");
+	});
+
+	it("leaves Shift+Enter to the textarea", async () => {
+		const onSubmit = vi.fn();
+		const { container } = render(Harness, { props: { onSubmit } });
+
+		await type(container, "line one");
+		await fireEvent.keyDown(textarea(container), { key: "Enter", shiftKey: true });
+		await settle();
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(readout(container, "draft")).toBe("line one");
+	});
+
+	it("sends on a form submit, and refuses an empty draft", async () => {
+		const onSubmit = vi.fn();
+		const { container } = render(Harness, { props: { onSubmit } });
+
+		await fireEvent.submit(form(container));
+		await settle();
+		expect(onSubmit).not.toHaveBeenCalled();
+
+		await type(container, "hello");
+		await fireEvent.submit(form(container));
+		await settle();
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].text).toBe("hello");
+	});
+
+	it("opens the command menu on a slash token and completes it through the core", async () => {
+		const onSubmit = vi.fn();
+		const { container } = render(Harness, { props: { onSubmit } });
+
+		const el = await type(container, "/de");
+		const menu = commandMenu(container);
+		expect(menu).not.toBeNull();
+		expect(labels(menu as HTMLElement)).toEqual(["/deploy", "/describe"]);
+		// One trigger, one menu: the mention list has no business in a slash token.
+		expect(mentionMenu(container)).toBeNull();
+
+		await fireEvent.keyDown(el, { key: "Enter" });
+		await settle();
+
+		// The completion ran through the root's own caret arithmetic, so the draft
+		// the consumer is bound to and the element agree on the result.
+		expect(readout(container, "draft")).toBe("/deploy ");
+		expect(el.value).toBe("/deploy ");
+		// And the key never reached the input's Enter-to-send.
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(commandMenu(container)).toBeNull();
+	});
+
+	it("answers the second trigger with the mention menu alone", async () => {
+		const { container } = render(Harness, {});
+
+		const el = await type(container, "ping @jo");
+		expect(commandMenu(container)).toBeNull();
+		expect(labels(mentionMenu(container) as HTMLElement)).toEqual(["@jordan"]);
+
+		await fireEvent.keyDown(el, { key: "Enter" });
+		await settle();
+
+		// Spliced mid-draft, with the words either side left alone.
+		expect(readout(container, "draft")).toBe("ping @jordan ");
+	});
+
+	it("routes a custom onSelect through the same insertText", async () => {
+		const mentionSelect = vi.fn(
+			(
+				item: CommandItemData,
+				ctx: { insertText: (text: string, replaceTriggerToken?: boolean) => void; query: string }
+			) => ctx.insertText(`<@${item.id}>`, true)
+		);
+		const { container } = render(Harness, { props: { mentionSelect } });
+
+		const el = await type(container, "cc @sa");
+		await fireEvent.keyDown(el, { key: "Enter" });
+		await settle();
+
+		expect(mentionSelect).toHaveBeenCalledTimes(1);
+		expect(mentionSelect.mock.calls[0][0].id).toBe("sam");
+		expect(mentionSelect.mock.calls[0][1].query).toBe("sa");
+		// The core closes the completed token with the space the handler omitted.
+		expect(readout(container, "draft")).toBe("cc <@sam> ");
+	});
+
+	it("keeps a mid-word slash out of the menu, so Enter still sends", async () => {
+		const onSubmit = vi.fn();
+		const { container } = render(Harness, { props: { onSubmit } });
+
+		const el = await type(container, "open src/li");
+		expect(commandMenu(container)).toBeNull();
+
+		await fireEvent.keyDown(el, { key: "Enter" });
+		await settle();
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].text).toBe("open src/li");
+	});
+
+	it("switches model through the picker and writes the choice out", async () => {
+		const onModelChange = vi.fn();
+		const { container } = render(Harness, { props: { onModelChange } });
+		// Unset means "whichever model comes first": the binding is still empty.
+		expect(readout(container, "model")).toBe("");
+
+		await fireEvent.click(modelTrigger(container));
+		await settle();
+		const menu = modelMenu(container);
+		expect(menu).not.toBeNull();
+		expect(options(menu as HTMLElement)).toHaveLength(MODELS.length);
+
+		await fireEvent.click(options(menu as HTMLElement)[1]);
+		await settle();
+
+		expect(readout(container, "model")).toBe(MODELS[1].id);
+		expect(onModelChange).toHaveBeenCalledExactlyOnceWith(MODELS[1].id);
+		expect(modelMenu(container)).toBeNull();
+		expect(modelTrigger(container).textContent).toContain(MODELS[1].label);
+	});
+
+	it("adds files through the chip row's picker and lists them", async () => {
+		const onAttach = vi.fn();
+		const { container } = render(Harness, { props: { onAttach } });
+
+		const files = [new File(["a"], "diagram.png"), new File(["b"], "notes.md")];
+		await fireEvent.change(fileInput(container), { target: { files } });
+		await settle();
+
+		expect(onAttach).toHaveBeenCalledTimes(1);
+		expect(onAttach.mock.calls[0][0]).toEqual(files);
+		expect(readout(container, "attachment-count")).toBe("2");
+		expect(chipNames(container)).toEqual(["diagram.png", "notes.md"]);
+		// Files alone are a sendable draft, with no text at all.
+		expect(sendButton(container).disabled).toBe(false);
+	});
+
+	it("drops an attachment from its own chip", async () => {
+		const { container } = render(Harness, {
+			props: {
+				initialAttachments: [
+					{ id: "a", name: "one.png" },
+					{ id: "b", name: "two.png" },
+				],
+			},
+		});
+		expect(chips(container)).toHaveLength(2);
+
+		await fireEvent.click(removeButton(container, "one.png"));
+		await settle();
+
+		// The removal reached the consumer's own list, not just the row.
+		expect(readout(container, "attachment-ids")).toBe("b");
+		expect(chipNames(container)).toEqual(["two.png"]);
+	});
+
+	it("turns the send button into a stop button while streaming", async () => {
+		const onStop = vi.fn();
+		const onSubmit = vi.fn();
+		const { container } = render(Harness, {
+			props: { initialValue: "half an answer", streaming: true, onStop, onSubmit },
+		});
+
+		const button = sendButton(container);
+		expect(button.getAttribute("aria-label")).toBe("Stop");
+		// A submit button inside a form would send the draft it is meant to halt.
+		expect(button.getAttribute("type")).toBe("button");
+		expect(button.disabled).toBe(false);
+
+		await fireEvent.click(button);
+		await settle();
+
+		expect(onStop).toHaveBeenCalledTimes(1);
+		expect(onSubmit).not.toHaveBeenCalled();
+		// The draft survives the interruption.
+		expect(readout(container, "draft")).toBe("half an answer");
+	});
+
+	it("refuses to send while a response is still arriving", async () => {
+		const onSubmit = vi.fn();
+		const { container } = render(Harness, {
+			props: { initialValue: "queued", streaming: true, onSubmit },
+		});
+
+		await fireEvent.keyDown(textarea(container), { key: "Enter" });
+		await fireEvent.submit(form(container));
+		await settle();
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		// Readonly rather than disabled: the draft stays selectable and copyable.
+		expect(textarea(container).readOnly).toBe(true);
+		expect(form(container).getAttribute("data-streaming")).toBe("");
+	});
+
+	it("goes inert everywhere from the root's single disabled flag", () => {
+		const { container } = render(Harness, {
+			props: { initialValue: "hold on", initialAttachments: SEED, disabled: true },
+		});
+
+		expect(textarea(container).readOnly).toBe(true);
+		expect(sendButton(container).disabled).toBe(true);
+		expect(attachButton(container).disabled).toBe(true);
+		expect(fileInput(container).disabled).toBe(true);
+		expect(modelTrigger(container).disabled).toBe(true);
+		expect(removeButton(container, "spec.pdf").disabled).toBe(true);
+		expect(form(container).className).toContain("ft-composer-disabled");
+	});
+
+	it("lays the accessory over the composition without replacing it", () => {
+		const { container } = render(Harness, { props: { accessory: true } });
+
+		const overlay = container.querySelector(".ft-composer-accessory");
+		expect(overlay).not.toBeNull();
+		expect(overlay?.querySelector('[data-testid="accessory"]')).not.toBeNull();
+		// The composition is still underneath, waiting for the overlay to lift.
+		expect(textarea(container)).not.toBeNull();
+		expect(sendButton(container)).not.toBeNull();
+	});
+});

--- a/src/lib/fancy-ui/composer/ComposerModelPicker.svelte
+++ b/src/lib/fancy-ui/composer/ComposerModelPicker.svelte
@@ -1,0 +1,375 @@
+<!--
+	The model switcher that lives on the composer's bottom rail.
+
+	Props
+	-----
+	- `models: ModelOptionData[]` — required; an empty list leaves the control inert.
+	- `value?: string`            — bindable id of the selected model; defaults to the first one.
+	- `onChange?: (id: string) => void` — a *change* of model, so re-picking the current one is silent.
+	- `label?: string`            — accessible name for the control and its menu. Defaults to `Model`.
+	- `class?: string`            — merged onto the trigger button.
+
+	Focus lives on the listbox while the menu is open — the element carrying
+	`aria-activedescendant` has to be the one holding focus — and returns to the
+	trigger when the menu closes on Escape or on a pick. The menu is only in the
+	DOM while it is open, and the one document listener it needs is added on open
+	and taken back on close.
+-->
+<script lang="ts" module>
+	import type { ModelOptionData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for ComposerModelPicker
+	 */
+	export interface ComposerModelPickerProps {
+		/** The models on offer. An empty list leaves the picker inert. */
+		models: ModelOptionData[];
+		/** The selected model's id, bindable. Falls back to the first model. */
+		value?: string;
+		/** Called with the id of a newly picked model. Silent when the pick changes nothing. */
+		onChange?: (id: string) => void;
+		/** Accessible name for the control and its menu. */
+		label?: string;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import { float } from "../_internals/float.js";
+	import { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";
+
+	let {
+		models,
+		value = $bindable(),
+		onChange,
+		label = "Model",
+		class: className,
+	}: ComposerModelPickerProps = $props();
+
+	// Undefined when the picker is used outside a Composer: it then behaves as a
+	// standalone select rather than throwing, and nothing switches it off.
+	const composer = getContext<ComposerContext | undefined>(COMPOSER_CONTEXT_KEY);
+
+	const uid = $props.id();
+	const menuId = `${uid}-menu`;
+	// Ids are built from the position, not from the model's own id: two entries
+	// arriving with the same id — a duplicated tier, a badly deduplicated list —
+	// would otherwise both answer to the same `aria-activedescendant`.
+	const optionId = (index: number) => `${uid}-option-${index}`;
+
+	let open = $state(false);
+	let activeIndex = $state(0);
+	let triggerEl = $state<HTMLButtonElement | null>(null);
+	let menuEl = $state<HTMLDivElement | null>(null);
+
+	// An unset `value` means "whichever model comes first", so the picker can be
+	// dropped in without the consumer having to seed the binding.
+	const selectedId = $derived(value ?? models[0]?.id);
+	// Deliberately not falling back to the first model: a `value` naming something
+	// that is not on offer shows the bare label instead of quietly claiming a
+	// model the consumer never selected.
+	const selected = $derived(models.find((model) => model.id === selectedId));
+	const activeId = $derived(models[activeIndex] ? optionId(activeIndex) : undefined);
+	// Nothing to choose from is as inert as a composer that is switched off.
+	const isDisabled = $derived((composer?.disabled ?? false) || models.length === 0);
+
+	function openMenu() {
+		if (isDisabled || open) return;
+		// The menu opens on the model in force, so Enter without touching an arrow
+		// is a no-op rather than a silent switch to whatever sits at the top.
+		const current = models.findIndex((model) => model.id === selectedId);
+		activeIndex = current >= 0 ? current : 0;
+		open = true;
+	}
+
+	function closeMenu(returnFocus: boolean) {
+		if (!open) return;
+		open = false;
+		// Focus was moved into the listbox on open; leaving it there would drop the
+		// keyboard user at the top of the document when the listbox disappears.
+		if (returnFocus) triggerEl?.focus();
+	}
+
+	function move(delta: number) {
+		if (models.length === 0) return;
+		// Wraps: the list is short, and a menu that dead-ends at its last entry
+		// makes the reader reverse direction to reach the option one step past it.
+		activeIndex = (activeIndex + delta + models.length) % models.length;
+	}
+
+	function select(index: number) {
+		const model = models[index];
+		if (!model || isDisabled) return;
+		const changed = model.id !== selectedId;
+		value = model.id;
+		closeMenu(true);
+		// `onChange` reports a change, not an interaction: re-picking the model
+		// already in force has nothing to announce.
+		if (changed) onChange?.(model.id);
+	}
+
+	function handleTriggerKeydown(event: KeyboardEvent) {
+		if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+		// Both arrows open. The menu sits above the composer, which is where "up"
+		// expects to find it, and "down" is the habit every native select taught.
+		event.preventDefault();
+		openMenu();
+	}
+
+	function handleMenuKeydown(event: KeyboardEvent) {
+		switch (event.key) {
+			case "ArrowDown":
+				event.preventDefault();
+				move(1);
+				break;
+			case "ArrowUp":
+				event.preventDefault();
+				move(-1);
+				break;
+			case "Enter":
+			case " ":
+				// preventDefault also stops the browser turning the key into a click on
+				// the option button that is about to be removed.
+				event.preventDefault();
+				select(activeIndex);
+				break;
+			case "Escape":
+				event.preventDefault();
+				closeMenu(true);
+				break;
+			case "Tab":
+				// Focus is leaving of its own accord: the menu steps aside and puts
+				// focus back on the trigger, so the browser's own Tab — left to run —
+				// continues from the picker rather than from the top of the document.
+				closeMenu(true);
+				break;
+		}
+	}
+
+	$effect(() => {
+		if (!open) return;
+		// mousedown rather than click: the menu has to be gone before the press
+		// lands, or a press that starts outside and finishes on the trigger closes
+		// and reopens in one gesture.
+		const onPointerDown = (event: MouseEvent) => {
+			const target = event.target as Node | null;
+			if (target && (menuEl?.contains(target) || triggerEl?.contains(target))) return;
+			// No focus return: the press is already moving focus somewhere else.
+			closeMenu(false);
+		};
+		// Capture, so a surface that swallows mousedown on the way up cannot pin the
+		// menu open. Registered only while open, and retracted the moment it closes.
+		document.addEventListener("mousedown", onPointerDown, true);
+		return () => document.removeEventListener("mousedown", onPointerDown, true);
+	});
+
+	$effect(() => {
+		if (!open) return;
+		// Focus moves into the listbox instead of staying on the trigger: the
+		// element pointing at the active option with `aria-activedescendant` must be
+		// the element that actually holds focus.
+		menuEl?.focus();
+	});
+
+	// Reads the switch, writes only the menu: a composer that goes dark mid-pick
+	// takes its menu down with it.
+	$effect(() => {
+		if (isDisabled) open = false;
+	});
+</script>
+
+<button
+	bind:this={triggerEl}
+	type="button"
+	class={cn(
+		"ft-composer-model text-foreground/70 hover:bg-muted hover:text-foreground inline-flex max-w-full cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 font-mono text-xs transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-40",
+		className
+	)}
+	disabled={isDisabled}
+	data-open={open ? "" : undefined}
+	aria-haspopup="listbox"
+	aria-expanded={open}
+	aria-controls={open ? menuId : undefined}
+	aria-label={selected ? `${label}: ${selected.label}` : label}
+	onclick={() => (open ? closeMenu(true) : openMenu())}
+	onkeydown={handleTriggerKeydown}
+>
+	<span class="truncate">{selected?.label ?? label}</span>
+	{#if selected?.badge}
+		<span class="ft-composer-model-badge shrink-0 rounded px-1 py-px text-[0.625rem] tracking-wide">
+			{selected.badge}
+		</span>
+	{/if}
+	<svg
+		class="ft-composer-model-chevron size-3 shrink-0"
+		viewBox="0 0 16 16"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="1.5"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		aria-hidden="true"
+	>
+		<path d="m4 6 4 4 4-4" />
+	</svg>
+</button>
+
+{#if open}
+	<!--
+		In the DOM only while it is on screen. A permanently mounted menu is a list
+		of every model on offer that every reader of the page has to step past to
+		reach the composer, once per composer.
+
+		The anchor is read through a getter so the action re-measures the trigger on
+		each scroll and resize tick instead of holding a rect that went stale the
+		moment the page moved.
+	-->
+	<div
+		bind:this={menuEl}
+		id={menuId}
+		role="listbox"
+		tabindex="-1"
+		aria-label={label}
+		aria-activedescendant={activeId}
+		class="ft-composer-model-menu z-50 max-h-64 min-w-52 overflow-y-auto rounded-lg border p-1 shadow-lg outline-none"
+		use:float={{
+			anchor: () => triggerEl?.getBoundingClientRect() ?? null,
+			placement: "top-start",
+			offset: 6,
+		}}
+		onkeydown={handleMenuKeydown}
+	>
+		{#each models as model, index (`${model.id}#${index}`)}
+			<!--
+				A button carrying `role="option"`: the row has to be clickable and it has
+				to be an option, and starting from a button is what keeps the press,
+				the pointer cursor and the disabled semantics native. `tabindex="-1"`
+				keeps it out of the tab order, where the listbox does the walking.
+			-->
+			<button
+				type="button"
+				role="option"
+				tabindex="-1"
+				id={optionId(index)}
+				aria-selected={model.id === selectedId}
+				data-active={index === activeIndex ? "" : undefined}
+				class="ft-composer-model-option flex w-full cursor-pointer flex-col items-start gap-0.5 rounded-md px-2 py-1.5 text-left"
+				onclick={() => select(index)}
+				onmouseenter={() => (activeIndex = index)}
+			>
+				<span class="flex w-full items-center gap-1.5">
+					<span class="truncate text-xs font-medium">{model.label}</span>
+					{#if model.badge}
+						<span
+							class="ft-composer-model-badge shrink-0 rounded px-1 py-px text-[0.625rem] tracking-wide"
+						>
+							{model.badge}
+						</span>
+					{/if}
+					{#if model.id === selectedId}
+						<svg
+							class="ml-auto size-3 shrink-0"
+							viewBox="0 0 16 16"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<path d="m3 8.5 3.5 3.5L13 5" />
+						</svg>
+					{/if}
+				</span>
+				{#if model.description}
+					<span class="ft-composer-model-description text-[0.6875rem] leading-snug">
+						{model.description}
+					</span>
+				{/if}
+			</button>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	/*
+	 * The floating surface reads its colours at the point of use with a fallback
+	 * rather than declaring them on a root, so a value set anywhere up the tree —
+	 * a wrapper's `style`, a theme class, `:root` — wins without having to
+	 * out-specify these scoped rules.
+	 */
+	/*
+	 * The rail's controls sit on the composer's own tinted surface, not on the
+	 * page, so the ring has to be read against that surface rather than against
+	 * white. Fifty-five percent of the row's colour lands at #828282 on the light
+	 * composer (3.5:1) and #9E9E9E on the dark one (5.1:1); a 1px ring in the
+	 * theme's `--ring` token measured 2.4:1 there, under the 3:1 a control's focus
+	 * indicator owes. Two pixels rather than one for the same reason a thin ring
+	 * disappears against a tint: the ring is the only thing saying where focus is.
+	 */
+	.ft-composer-model:focus-visible {
+		box-shadow: 0 0 0 2px
+			var(--ft-composer-control-ring, color-mix(in oklab, currentColor 55%, transparent));
+	}
+
+	.ft-composer-model-menu {
+		max-width: min(20rem, calc(100vw - 1rem));
+		background: var(--ft-composer-menu-bg, var(--color-popover, canvas));
+		border-color: var(--ft-composer-menu-border, var(--color-border, currentColor));
+		color: var(--ft-composer-menu-fg, var(--color-popover-foreground, inherit));
+	}
+
+	/*
+	 * One highlight for both roads into a row — the arrow keys and the pointer —
+	 * so the option Enter is about to take is the option under the cursor.
+	 */
+	.ft-composer-model-option[data-active] {
+		background: var(
+			--ft-composer-option-active-bg,
+			color-mix(in oklab, currentColor 10%, transparent)
+		);
+	}
+
+	.ft-composer-model-description {
+		color: var(--ft-composer-menu-muted, color-mix(in oklab, currentColor 60%, transparent));
+	}
+
+	/* Mixed from currentColor, so retinting the picker retints its pills with it. */
+	.ft-composer-model-badge {
+		background: var(--ft-composer-badge-bg, color-mix(in oklab, currentColor 14%, transparent));
+		text-transform: uppercase;
+	}
+
+	.ft-composer-model[data-open] .ft-composer-model-chevron {
+		transform: rotate(180deg);
+	}
+
+	/*
+	 * Both movements live entirely inside `no-preference`, so reduced motion is
+	 * not a second variant to keep in sync: the chevron flips and the menu appears,
+	 * already placed.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-composer-model-chevron {
+			transition: transform 150ms ease;
+		}
+
+		.ft-composer-model-menu {
+			animation: ft-composer-menu-in 120ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+	}
+
+	@keyframes ft-composer-menu-in {
+		from {
+			opacity: 0;
+			transform: translateY(4px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/composer/ComposerSubmit.svelte
+++ b/src/lib/fancy-ui/composer/ComposerSubmit.svelte
@@ -39,7 +39,10 @@
 	);
 	// A stop button with nothing to call is a lie, so it goes grey — which is also
 	// what happens with no context at all.
-	const stoppable = $derived(typeof composer?.stop === "function");
+	// `composer.stop` is always a function — the root publishes one whether or not
+	// a consumer passed `onStop` — so the context reports separately whether there
+	// is anything behind it.
+	const stoppable = $derived(composer?.stoppable ?? false);
 	// Outside a composer both branches land on disabled: there is nothing to stop,
 	// and an absent draft is an empty one.
 	const isDisabled = $derived((composer?.disabled ?? false) || (streaming ? !stoppable : empty));

--- a/src/lib/fancy-ui/composer/ComposerSubmit.svelte
+++ b/src/lib/fancy-ui/composer/ComposerSubmit.svelte
@@ -1,0 +1,82 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	/**
+	 * Props for ComposerSubmit
+	 */
+	export interface ComposerSubmitProps {
+		/** Accessible name while the composer is idle. */
+		label?: string;
+		/** Accessible name while a response is streaming. */
+		stopLabel?: string;
+		/** Replaces the built-in icon. Rendered in both the send and the stop state. */
+		children?: Snippet;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";
+
+	let {
+		label = "Send",
+		stopLabel = "Stop",
+		children,
+		class: className,
+	}: ComposerSubmitProps = $props();
+
+	// Undefined when the button is used outside a Composer: it then renders as a
+	// permanently disabled button rather than throwing.
+	const composer = getContext<ComposerContext | undefined>(COMPOSER_CONTEXT_KEY);
+
+	const streaming = $derived(composer?.streaming ?? false);
+	const empty = $derived(
+		(composer?.value.current ?? "").trim() === "" &&
+			(composer?.attachments.current.length ?? 0) === 0
+	);
+	// A stop button with nothing to call is a lie, so it goes grey — which is also
+	// what happens with no context at all.
+	const stoppable = $derived(typeof composer?.stop === "function");
+	// Outside a composer both branches land on disabled: there is nothing to stop,
+	// and an absent draft is an empty one.
+	const isDisabled = $derived((composer?.disabled ?? false) || (streaming ? !stoppable : empty));
+
+	const name = $derived(streaming ? stopLabel : label);
+</script>
+
+<button
+	type={streaming ? "button" : "submit"}
+	class={cn(
+		"ft-composer-submit bg-foreground text-background hover:bg-foreground/90 focus-visible:ring-ring inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-40",
+		className
+	)}
+	disabled={isDisabled}
+	aria-label={name}
+	title={name}
+	onclick={streaming ? () => composer?.stop() : undefined}
+>
+	{#if children}
+		{@render children()}
+	{:else if streaming}
+		<svg viewBox="0 0 16 16" class="size-3.5" aria-hidden="true">
+			<rect x="3" y="3" width="10" height="10" rx="2" fill="currentColor" />
+		</svg>
+	{:else}
+		<svg
+			viewBox="0 0 16 16"
+			class="size-4"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="1.5"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M14 2 2 6.8l4.6 2.6L9.2 14z" />
+			<path d="M14 2 6.6 9.4" />
+		</svg>
+	{/if}
+</button>

--- a/src/lib/fancy-ui/composer/ComposerToolbar.svelte
+++ b/src/lib/fancy-ui/composer/ComposerToolbar.svelte
@@ -1,0 +1,55 @@
+<!--
+	The bottom rail of a composer: one row, one gap, no opinions about what sits
+	on it. A model picker, an attach button and a send button are all just
+	children here, laid out left to right in source order.
+
+	Props
+	-----
+	- `children?: Snippet` — the controls on the rail, in the order they appear.
+	- `class?: string`     — merged over the row's own layout classes.
+
+	The trailing spacer convention
+	------------------------------
+	The rail lays everything out from the left. Anything that belongs on the
+	right — the send button, a token meter — is pushed there by a spacer the
+	integrator writes into `children`, rather than by a second slot this
+	component would have to invent:
+
+	```svelte
+	<ComposerToolbar>
+		<ComposerModelPicker {models} />
+		<div class="flex-1"></div>
+		<ComposerSubmit />
+	</ComposerToolbar>
+	```
+
+	One flexible box, any number of groups, and the split stays visible in the
+	consumer's markup instead of being buried in ours.
+
+	Deliberately not `role="toolbar"`: that role promises arrow-key roving focus
+	between its controls, and a row that announces itself as a toolbar without
+	implementing that is worse for a keyboard user than a plain row of tab stops.
+-->
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	/**
+	 * Props for ComposerToolbar
+	 */
+	export interface ComposerToolbarProps {
+		/** The controls on the rail, laid out left to right in source order. */
+		children?: Snippet;
+		/** Additional CSS classes */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { children, class: className }: ComposerToolbarProps = $props();
+</script>
+
+<div class={cn("ft-composer-toolbar flex items-center gap-1", className)}>
+	{@render children?.()}
+</div>

--- a/src/lib/fancy-ui/composer/ComposerToolbar.test.ts
+++ b/src/lib/fancy-ui/composer/ComposerToolbar.test.ts
@@ -1,0 +1,370 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { createRawSnippet, tick } from "svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import ComposerToolbar from "./ComposerToolbar.svelte";
+import ComposerModelPicker from "./ComposerModelPicker.svelte";
+import { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";
+import type { ModelOptionData } from "../_internals/ai-types.js";
+
+/** Generic tiers, so the fixture says nothing about anyone's product line-up. */
+const MODELS: ModelOptionData[] = [
+	{ id: "mini", label: "Mini", badge: "Fast", description: "Short answers, small context." },
+	{ id: "pro", label: "Pro", description: "Deeper reasoning, slower." },
+	{ id: "max", label: "Max", badge: "New" },
+];
+
+function snippet(html: string) {
+	return createRawSnippet(() => ({ render: () => html }));
+}
+
+/**
+ * A composer root standing in for the real one.
+ *
+ * The picker only reads `disabled` off the context, but the object has to be a
+ * whole `ComposerContext` — that is the contract a part is written against, and
+ * a partial stand-in would let a part start reading something this rig does not
+ * provide without the test noticing. `disabled` arrives as a getter so a test
+ * can flip it mid-life, the way a real root's own state does.
+ */
+function composerContext(disabled: () => boolean = () => false): Map<symbol, ComposerContext> {
+	const context: ComposerContext = {
+		value: { current: "" },
+		attachments: { current: [] },
+		get disabled() {
+			return disabled();
+		},
+		streaming: false,
+		textareaRef: { current: null },
+		submit: () => {},
+		stop: () => {},
+		setValue: () => {},
+		insertText: () => {},
+		addFiles: () => {},
+		removeAttachment: () => {},
+	};
+	return new Map<symbol, ComposerContext>([[COMPOSER_CONTEXT_KEY, context]]);
+}
+
+interface PickerProps {
+	models?: ModelOptionData[];
+	value?: string;
+	onChange?: (id: string) => void;
+	label?: string;
+	class?: string;
+}
+
+function renderPicker(props: PickerProps = {}, context?: Map<symbol, ComposerContext>) {
+	const { models = MODELS, ...rest } = props;
+	return render(ComposerModelPicker, { props: { models, ...rest }, context });
+}
+
+function trigger(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector("button.ft-composer-model") as HTMLButtonElement;
+}
+
+function menu(container: HTMLElement): HTMLElement | null {
+	return container.querySelector('[role="listbox"]');
+}
+
+function options(container: HTMLElement): HTMLElement[] {
+	return Array.from(container.querySelectorAll('[role="option"]'));
+}
+
+async function openMenu(container: HTMLElement) {
+	await fireEvent.click(trigger(container));
+	return menu(container) as HTMLElement;
+}
+
+describe("ComposerToolbar", () => {
+	afterEach(cleanup);
+
+	it("lays its children out on a single row", () => {
+		const { container } = render(ComposerToolbar, {
+			props: { children: snippet("<span><button>Attach</button><button>Send</button></span>") },
+		});
+		const row = container.querySelector("div") as HTMLElement;
+
+		expect(row.className).toContain("ft-composer-toolbar");
+		expect(row.className).toContain("flex");
+		expect(row.className).toContain("items-center");
+		expect(row.className).toContain("gap-1");
+		expect(row.querySelectorAll("button")).toHaveLength(2);
+	});
+
+	it("takes extra classes without dropping its own layout", () => {
+		const { container } = render(ComposerToolbar, { props: { class: "mt-2" } });
+		const row = container.querySelector("div") as HTMLElement;
+
+		expect(row.className).toContain("mt-2");
+		expect(row.className).toContain("items-center");
+	});
+
+	it("renders an empty rail rather than throwing when it has nothing on it", () => {
+		const { container } = render(ComposerToolbar, {});
+		const row = container.querySelector("div") as HTMLElement;
+
+		expect(row).not.toBeNull();
+		expect(row.textContent?.trim()).toBe("");
+	});
+});
+
+describe("ComposerModelPicker", () => {
+	afterEach(cleanup);
+
+	it("falls back to the first model, badge included", () => {
+		const { container } = renderPicker();
+
+		expect(trigger(container).textContent).toContain("Mini");
+		expect(trigger(container).textContent).toContain("Fast");
+		expect(trigger(container).getAttribute("aria-label")).toBe("Model: Mini");
+	});
+
+	it("shows the model named by `value`, and follows it when it changes", async () => {
+		const { container, rerender } = renderPicker({ value: "pro" });
+		expect(trigger(container).textContent).toContain("Pro");
+
+		await rerender({ value: "max" });
+		expect(trigger(container).textContent).toContain("Max");
+	});
+
+	it("keeps the menu out of the DOM until it is opened, and takes it back out", async () => {
+		const { container } = renderPicker();
+		expect(menu(container)).toBeNull();
+		expect(trigger(container).getAttribute("aria-expanded")).toBe("false");
+
+		const list = await openMenu(container);
+		expect(list).not.toBeNull();
+		expect(trigger(container).getAttribute("aria-expanded")).toBe("true");
+		expect(trigger(container).getAttribute("aria-controls")).toBe(list.id);
+
+		await fireEvent.click(trigger(container));
+		expect(menu(container)).toBeNull();
+		expect(trigger(container).getAttribute("aria-controls")).toBeNull();
+	});
+
+	it("lists every model with its badge and its description", async () => {
+		const { container } = renderPicker();
+		await openMenu(container);
+		const rows = options(container);
+
+		expect(rows).toHaveLength(3);
+		expect(rows[0].textContent).toContain("Mini");
+		expect(rows[0].textContent).toContain("Fast");
+		expect(rows[0].textContent).toContain("Short answers, small context.");
+		expect(rows[2].textContent).toContain("New");
+	});
+
+	it("opens on the selected model, and points activedescendant at it", async () => {
+		const { container } = renderPicker({ value: "pro" });
+		const list = await openMenu(container);
+		const rows = options(container);
+
+		expect(list.getAttribute("role")).toBe("listbox");
+		expect(list.getAttribute("aria-activedescendant")).toBe(rows[1].id);
+		expect(rows[1].getAttribute("aria-selected")).toBe("true");
+		expect(rows[0].getAttribute("aria-selected")).toBe("false");
+		expect(document.activeElement).toBe(list);
+	});
+
+	it("moves the active option with the arrows, wrapping at both ends", async () => {
+		const { container } = renderPicker();
+		const list = await openMenu(container);
+		const rows = options(container);
+
+		await fireEvent.keyDown(list, { key: "ArrowDown" });
+		expect(list.getAttribute("aria-activedescendant")).toBe(rows[1].id);
+
+		await fireEvent.keyDown(list, { key: "ArrowUp" });
+		await fireEvent.keyDown(list, { key: "ArrowUp" });
+		expect(list.getAttribute("aria-activedescendant")).toBe(rows[2].id);
+
+		await fireEvent.keyDown(list, { key: "ArrowDown" });
+		expect(list.getAttribute("aria-activedescendant")).toBe(rows[0].id);
+	});
+
+	it("opens from the trigger's own arrow keys", async () => {
+		const { container } = renderPicker();
+
+		await fireEvent.keyDown(trigger(container), { key: "ArrowUp" });
+		expect(menu(container)).not.toBeNull();
+	});
+
+	it("selects the active option on Enter, reporting the change and closing", async () => {
+		const onChange = vi.fn();
+		const { container } = renderPicker({ onChange });
+		const list = await openMenu(container);
+
+		await fireEvent.keyDown(list, { key: "ArrowDown" });
+		await fireEvent.keyDown(list, { key: "Enter" });
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange).toHaveBeenCalledWith("pro");
+		expect(menu(container)).toBeNull();
+		expect(trigger(container).textContent).toContain("Pro");
+		expect(document.activeElement).toBe(trigger(container));
+	});
+
+	it("writes the pick back through the bindable value", async () => {
+		// An accessor pair is what `bind:value` compiles down to, and the closest a
+		// `.ts` test can get to one without a rune-carrying rig: the component sees a
+		// settable prop and pushes the pick through it. Only the write-back is
+		// asserted here — a plain closure is not reactive, so the trigger's own
+		// re-render is left to the tests that let the picker hold its own value.
+		let bound = "mini";
+		const { container } = render(ComposerModelPicker, {
+			props: {
+				models: MODELS,
+				get value() {
+					return bound;
+				},
+				set value(next: string) {
+					bound = next;
+				},
+			},
+		});
+
+		await openMenu(container);
+		await fireEvent.click(options(container)[2]);
+
+		expect(bound).toBe("max");
+	});
+
+	it("selects on click, and stays silent when the pick changes nothing", async () => {
+		const onChange = vi.fn();
+		const { container } = renderPicker({ value: "pro", onChange });
+
+		await openMenu(container);
+		await fireEvent.click(options(container)[1]);
+
+		expect(menu(container)).toBeNull();
+		expect(onChange).not.toHaveBeenCalled();
+		expect(trigger(container).textContent).toContain("Pro");
+	});
+
+	it("closes on Escape and hands focus back to the trigger", async () => {
+		const { container } = renderPicker();
+		const list = await openMenu(container);
+
+		await fireEvent.keyDown(list, { key: "Escape" });
+
+		expect(menu(container)).toBeNull();
+		expect(document.activeElement).toBe(trigger(container));
+	});
+
+	it("steps aside on Tab, leaving focus where the browser can carry it on", async () => {
+		const { container } = renderPicker();
+		const list = await openMenu(container);
+
+		await fireEvent.keyDown(list, { key: "Tab" });
+
+		expect(menu(container)).toBeNull();
+		expect(document.activeElement).toBe(trigger(container));
+	});
+
+	it("closes on a press outside, and survives a press inside the menu", async () => {
+		const { container } = renderPicker();
+		const list = await openMenu(container);
+
+		await fireEvent.mouseDown(options(container)[1]);
+		expect(menu(container)).not.toBeNull();
+
+		await fireEvent.mouseDown(document.body);
+		expect(menu(container)).toBeNull();
+		// The press is already moving focus elsewhere; the picker does not fight it.
+		expect(document.activeElement).not.toBe(trigger(container));
+		expect(list.isConnected).toBe(false);
+	});
+
+	it("goes inert while the composer is disabled", async () => {
+		const { container } = renderPicker(
+			{},
+			composerContext(() => true)
+		);
+
+		expect(trigger(container).disabled).toBe(true);
+		await fireEvent.keyDown(trigger(container), { key: "ArrowDown" });
+		expect(menu(container)).toBeNull();
+	});
+
+	it("closes itself when the composer switches off mid-menu", async () => {
+		let off = false;
+		const { container, rerender } = renderPicker(
+			{},
+			composerContext(() => off)
+		);
+		await openMenu(container);
+
+		off = true;
+		// The stand-in is a plain object, so nothing re-reads its getter on its own:
+		// the prop update is the nudge a real root's state change would deliver.
+		await rerender({ models: [...MODELS] });
+
+		expect(trigger(container).disabled).toBe(true);
+		expect(menu(container)).toBeNull();
+	});
+
+	it("has nothing to offer, and says so, on an empty model list", () => {
+		const { container } = renderPicker({ models: [], label: "Engine" });
+
+		expect(trigger(container).disabled).toBe(true);
+		expect(trigger(container).textContent).toContain("Engine");
+		expect(trigger(container).getAttribute("aria-label")).toBe("Engine");
+	});
+
+	it("works on its own, outside a composer", async () => {
+		const { container } = renderPicker();
+
+		expect(trigger(container).disabled).toBe(false);
+		await openMenu(container);
+		expect(options(container)).toHaveLength(3);
+	});
+
+	it("adds one document listener while open and takes it back on close", async () => {
+		const add = vi.spyOn(document, "addEventListener");
+		const remove = vi.spyOn(document, "removeEventListener");
+		const { container } = renderPicker();
+
+		const list = await openMenu(container);
+		const added = add.mock.calls.filter(([type]) => type === "mousedown");
+		expect(added).toHaveLength(1);
+		expect(remove.mock.calls.filter(([type]) => type === "mousedown")).toHaveLength(0);
+
+		await fireEvent.keyDown(list, { key: "Escape" });
+		expect(remove.mock.calls.filter(([type]) => type === "mousedown")).toHaveLength(1);
+
+		add.mockRestore();
+		remove.mockRestore();
+	});
+
+	it("leaves no document listener behind when it is destroyed while open", async () => {
+		const add = vi.spyOn(document, "addEventListener");
+		const remove = vi.spyOn(document, "removeEventListener");
+		const { container, unmount } = renderPicker();
+
+		await openMenu(container);
+		expect(add.mock.calls.filter(([type]) => type === "mousedown")).toHaveLength(1);
+
+		unmount();
+		await tick();
+
+		expect(remove.mock.calls.filter(([type]) => type === "mousedown")).toHaveLength(1);
+		add.mockRestore();
+		remove.mockRestore();
+	});
+
+	it("mounts and opens without warnings", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const { container } = renderPicker({ class: "self-center" });
+		const list = await openMenu(container);
+		await fireEvent.keyDown(list, { key: "ArrowDown" });
+		await fireEvent.keyDown(list, { key: "Enter" });
+
+		expect(trigger(container).className).toContain("self-center");
+		expect(warn).not.toHaveBeenCalled();
+		expect(error).not.toHaveBeenCalled();
+		warn.mockRestore();
+		error.mockRestore();
+	});
+});

--- a/src/lib/fancy-ui/composer/ComposerToolbar.test.ts
+++ b/src/lib/fancy-ui/composer/ComposerToolbar.test.ts
@@ -34,6 +34,7 @@ function composerContext(disabled: () => boolean = () => false): Map<symbol, Com
 			return disabled();
 		},
 		streaming: false,
+		stoppable: false,
 		textareaRef: { current: null },
 		submit: () => {},
 		stop: () => {},

--- a/src/lib/fancy-ui/composer/IntegrationHarness.test.svelte
+++ b/src/lib/fancy-ui/composer/IntegrationHarness.test.svelte
@@ -1,0 +1,142 @@
+<!--
+  Test-only integration rig: the flagship composition, assembled the way the
+  README tells a consumer to assemble it.
+
+  The part suites each mock the root's context so they can test one component in
+  isolation. This rig mocks nothing — it mounts the real `Composer` around the
+  real parts, so the wiring between them (the input registering its element, the
+  menus reading it back, the core's token arithmetic, the bindings writing out)
+  is what the assertions actually exercise.
+
+  Fixtures are exported from the module block so the test file and the rig agree
+  on one set of items instead of two copies that can drift. Not exported from
+  index.ts, and not collected by Vitest (the run includes `*.test.ts` only).
+-->
+<script lang="ts" module>
+	import type { CommandItemData, ModelOptionData } from "../_internals/ai-types.js";
+
+	/** Generic tiers, so the fixture says nothing about anyone's product line-up. */
+	export const MODELS: ModelOptionData[] = [
+		{ id: "mini", label: "Mini", badge: "Fast", description: "Short answers, small context." },
+		{ id: "pro", label: "Pro", description: "Deeper reasoning, slower." },
+		{ id: "max", label: "Max", badge: "New" },
+	];
+
+	export const COMMANDS: CommandItemData[] = [
+		{ id: "deploy", label: "/deploy", description: "Ship the current branch" },
+		{ id: "describe", label: "/describe", description: "Summarise the diff" },
+		{ id: "reset", label: "/reset", description: "Clear the conversation" },
+	];
+
+	export const PEOPLE: CommandItemData[] = [
+		{ id: "jordan", label: "@jordan", description: "Reviewer" },
+		{ id: "sam", label: "@sam", description: "On call" },
+	];
+</script>
+
+<script lang="ts">
+	import { untrack } from "svelte";
+	import Composer from "./Composer.svelte";
+	import ComposerInput from "./ComposerInput.svelte";
+	import ComposerSubmit from "./ComposerSubmit.svelte";
+	import ComposerToolbar from "./ComposerToolbar.svelte";
+	import ComposerModelPicker from "./ComposerModelPicker.svelte";
+	import ComposerAttachments from "./ComposerAttachments.svelte";
+	import ComposerCommandMenu from "./ComposerCommandMenu.svelte";
+	import type { ComposerCommandMenuProps } from "./ComposerCommandMenu.svelte";
+	import type { AttachmentData } from "../_internals/ai-types.js";
+
+	interface Props {
+		initialValue?: string;
+		initialAttachments?: AttachmentData[];
+		initialModel?: string;
+		disabled?: boolean;
+		streaming?: boolean;
+		/** Cover the composition with an overlay, the way a voice panel does. */
+		accessory?: boolean;
+		/** Replaces the mention menu's default completion. */
+		mentionSelect?: ComposerCommandMenuProps["onSelect"];
+		onSubmit?: (payload: { text: string; attachments: AttachmentData[] }) => void;
+		onStop?: () => void;
+		onAttach?: (files: File[]) => void;
+		onModelChange?: (id: string) => void;
+	}
+
+	let {
+		initialValue = "",
+		initialAttachments = [],
+		initialModel,
+		disabled = false,
+		streaming = false,
+		accessory = false,
+		mentionSelect,
+		onSubmit,
+		onStop,
+		onAttach,
+		onModelChange,
+	}: Props = $props();
+
+	// Read once, on purpose: the seeds are fixed for a mounted rig, and untrack
+	// says so rather than leaving a compiler hint behind.
+	let draft = $state(untrack(() => initialValue));
+	let attachments = $state<AttachmentData[]>(untrack(() => [...initialAttachments]));
+	let model = $state(untrack(() => initialModel));
+
+	/**
+	 * Stand in for a consumer that uploads and then appends the result.
+	 *
+	 * The id counts from the list length rather than from the file name, so two
+	 * picks of the same file still get two ids — which is what a real upload
+	 * queue produces, and what the chip row has to survive.
+	 */
+	function handleAttach(files: File[]) {
+		onAttach?.(files);
+		attachments = [
+			...attachments,
+			...files.map((file, index) => ({
+				id: `${file.name}#${attachments.length + index}`,
+				name: file.name,
+				size: file.size,
+			})),
+		];
+	}
+</script>
+
+{#snippet overlay()}
+	<div data-testid="accessory">Recording…</div>
+{/snippet}
+
+<Composer
+	bind:value={draft}
+	bind:attachments
+	{disabled}
+	{streaming}
+	{onSubmit}
+	{onStop}
+	onAttach={handleAttach}
+	accessory={accessory ? overlay : undefined}
+>
+	{#snippet children()}
+		<ComposerAttachments />
+		<ComposerInput placeholder="Ask anything" />
+		<ComposerToolbar>
+			<ComposerModelPicker models={MODELS} bind:value={model} onChange={onModelChange} />
+			<div class="flex-1"></div>
+			<ComposerSubmit />
+		</ComposerToolbar>
+
+		<!-- Two menus on one textarea: each answers to its own trigger character. -->
+		<ComposerCommandMenu trigger="/" items={COMMANDS} class="ft-menu-commands" />
+		<ComposerCommandMenu
+			trigger="@"
+			items={PEOPLE}
+			onSelect={mentionSelect}
+			class="ft-menu-mentions"
+		/>
+	{/snippet}
+</Composer>
+
+<output data-testid="draft">{draft}</output>
+<output data-testid="attachment-count">{attachments.length}</output>
+<output data-testid="attachment-ids">{attachments.map((entry) => entry.id).join(",")}</output>
+<output data-testid="model">{model ?? ""}</output>

--- a/src/lib/fancy-ui/composer/README.md
+++ b/src/lib/fancy-ui/composer/README.md
@@ -1,0 +1,415 @@
+# Composer
+
+The input at the bottom of a chat, taken apart. A root that owns the draft and eight parts that read it: a growing textarea, a send button that becomes a stop button, a rail for controls, a model switcher, an attachment row with its chips, and a completion menu you can mount twice on the same draft — once for `/` commands, once for `@` mentions.
+
+Nothing here uploads a file, opens a microphone, or talks to a model. The composer holds a draft and tells you when it leaves.
+
+## Components
+
+- `Composer` — the form, the draft, and the context every part reads
+- `ComposerInput` — the auto-growing textarea, Enter to send
+- `ComposerSubmit` — send, or stop while a response is arriving
+- `ComposerToolbar` — the bottom rail the controls sit on
+- `ComposerModelPicker` — the model switcher, with a keyboard-driven listbox
+- `ComposerAttachments` — the chip row and the paperclip that fills it
+- `ComposerAttachment` — one file chip: name, size, upload progress, remove
+- `ComposerCommandMenu` — a completion menu bound to one trigger character
+
+## Usage
+
+```svelte
+<script>
+	import { Composer } from "fancy-ui-svelte";
+
+	let draft = $state("");
+
+	function send({ text, attachments }) {
+		console.log(text, attachments);
+	}
+</script>
+
+<Composer bind:value={draft} placeholder="Ask anything" onSubmit={send} />
+```
+
+With no `children`, the root composes a `ComposerInput` and a right-aligned `ComposerSubmit` for you. That default exists so a composer can be dropped into a page in one line; everything below is what you write once you outgrow it.
+
+## The context contract
+
+The root publishes one object under a module-private key and every part reads it with `getContext`. That is why the parts take almost no props: the draft, the attachments, the two switches and the six commands are already in scope, wherever in the subtree a part is mounted.
+
+```ts
+interface ComposerContext {
+	readonly value: { readonly current: string };
+	readonly attachments: { readonly current: AttachmentData[] };
+	readonly disabled: boolean;
+	readonly streaming: boolean;
+	readonly textareaRef: { readonly current: HTMLTextAreaElement | null };
+	submit(): void;
+	stop(): void;
+	setValue(next: string): void;
+	insertText(text: string, replaceTriggerToken?: boolean): void;
+	addFiles(files: File[]): void;
+	removeAttachment(id: string): void;
+}
+```
+
+Three properties are worth reading twice:
+
+- **The getters are what make it reactive.** `value.current` read inside a part's own reactive scope re-runs that scope when the root's draft changes. A part that destructures `const { current } = ctx.value` gets a dead string.
+- **`textareaRef` is typed read-only** because exactly one part writes it. `ComposerInput` registers its own element on mount through a documented cast, and retracts it on unmount. Everyone else reads — that is how `ComposerCommandMenu` finds a textarea it never rendered.
+- **Every part must survive without it.** Mounted outside a `Composer`, each one degrades instead of throwing: the input becomes a plain uncontrolled textarea, the submit button goes permanently disabled, the picker behaves as a standalone select, the chip row and the command menu render nothing at all.
+
+`getContext` only answers during a child's initialisation, so a consumer reaching for the context has to do it from a component mounted inside the composer — not from the same component that renders `<Composer>`.
+
+## Recipes
+
+### Minimal
+
+The default composition, written out. This is exactly what the root renders when you pass no `children`:
+
+```svelte
+<Composer bind:value={draft} onSubmit={send}>
+	{#snippet children()}
+		<ComposerInput placeholder="Ask anything" />
+		<div class="mt-2 flex items-center gap-2">
+			<div class="flex-1"></div>
+			<ComposerSubmit />
+		</div>
+	{/snippet}
+</Composer>
+```
+
+### Toolbar and model picker
+
+`ComposerToolbar` is one flexible row with no opinions about what sits on it. Anything belonging on the right is pushed there by a spacer you write, rather than by a second slot the component would have to invent:
+
+```svelte
+<Composer bind:value={draft} onSubmit={send}>
+	{#snippet children()}
+		<ComposerInput />
+		<ComposerToolbar class="mt-2">
+			<ComposerModelPicker models={MODELS} bind:value={model} />
+			<div class="flex-1"></div>
+			<ComposerSubmit />
+		</ComposerToolbar>
+	{/snippet}
+</Composer>
+```
+
+`MODELS` is a `ModelOptionData[]` — `{ id, label, badge?, description? }`. Leave `value` unbound and the picker reports the first model in the list; pass a `value` naming something absent from `models` and the trigger shows its bare label rather than quietly claiming a model nobody selected.
+
+### Attachments
+
+The composer never uploads anything. `addFiles` hands the picked files straight to `onAttach`, and you push onto `attachments` when your upload has an id for them:
+
+```svelte
+<script>
+	let attachments = $state([]);
+
+	async function attach(files) {
+		for (const file of files) {
+			const id = crypto.randomUUID();
+			attachments = [...attachments, { id, name: file.name, size: file.size, status: "uploading" }];
+			const url = await upload(file, (progress) => patch(id, { progress }));
+			patch(id, { status: "done", previewUrl: url });
+		}
+	}
+</script>
+
+<Composer bind:value={draft} bind:attachments onAttach={attach} onSubmit={send}>
+	{#snippet children()}
+		<ComposerAttachments accept="image/*,.pdf" />
+		<ComposerInput />
+		<ComposerToolbar class="mt-2">
+			<div class="flex-1"></div>
+			<ComposerSubmit />
+		</ComposerToolbar>
+	{/snippet}
+</Composer>
+```
+
+A successful submit clears the text and leaves the attachments alone — only you know whether an upload is still in flight. Drop them yourself in `onSubmit` when the turn is really gone.
+
+`ComposerAttachments` renders a `ComposerAttachment` per entry by default. Pass `children` to render your own chips and the paperclip stays; render `ComposerAttachment` directly and it removes through the context, unless you hand it an `onRemove`, which wins outright.
+
+### Two menus on one draft
+
+`ComposerCommandMenu` is one primitive bound to one trigger character. Mount it twice and each answers only to its own:
+
+```svelte
+<Composer bind:value={draft} onSubmit={send}>
+	{#snippet children()}
+		<ComposerInput />
+		<ComposerToolbar class="mt-2">
+			<div class="flex-1"></div>
+			<ComposerSubmit />
+		</ComposerToolbar>
+
+		<ComposerCommandMenu trigger="/" items={COMMANDS} />
+		<ComposerCommandMenu
+			trigger="@"
+			items={PEOPLE}
+			onSelect={(item, { insertText }) => insertText(`<@${item.id}>`, true)}
+		/>
+	{/snippet}
+</Composer>
+```
+
+Both menus listen to the same textarea and both stay shut unless the token under the caret opens with their character, so only one can ever be up. `onSelect` replaces the default completion outright rather than running alongside it — the snippet above inserts a mention id where the default would have inserted the label.
+
+The menus never take focus: the reader is mid-sentence, and a completion list that steals the caret breaks the sentence it is completing. See [Accessibility](#accessibility) for what that costs and how to get the full combobox pattern back.
+
+### A voice accessory
+
+`accessory` is an overlay covering the whole composer — a voice panel, a drop target, a confirmation. It sits above the composition rather than replacing it, so the draft is still there when the overlay lifts:
+
+```svelte
+<script>
+	import {
+		Composer,
+		ComposerInput,
+		ComposerSubmit,
+		ComposerToolbar,
+		VoiceInput,
+	} from "fancy-ui-svelte";
+
+	let recording = $state(false);
+</script>
+
+<Composer bind:value={draft} onSubmit={send} accessory={recording ? voicePanel : undefined}>
+	{#snippet children()}
+		<ComposerInput />
+		<ComposerToolbar class="mt-2">
+			<button type="button" onclick={() => (recording = true)}>Speak</button>
+			<div class="flex-1"></div>
+			<ComposerSubmit />
+		</ComposerToolbar>
+	{/snippet}
+</Composer>
+
+{#snippet voicePanel()}
+	<VoiceInput
+		bind:active={recording}
+		{transcript}
+		onStop={() => {
+			draft = `${draft}${transcript}`;
+			recording = false;
+		}}
+		onCancel={() => (recording = false)}
+	/>
+{/snippet}
+```
+
+The overlay is a plain absolutely-positioned layer, not a focus trap: what it contains and how it is dismissed are yours to decide.
+
+## Enter and Shift+Enter
+
+| Key                 | While idle                          | While `streaming` or `disabled`    |
+| ------------------- | ----------------------------------- | ---------------------------------- |
+| `Enter`             | Sends, then clears the text         | Nothing                            |
+| `Shift+Enter`       | A newline, as in any textarea       | Nothing — the textarea is readonly |
+| `Enter`, menu open  | Completes the token, key never sent | Nothing                            |
+| `Tab`, menu open    | Completes the token                 | Nothing                            |
+| `Escape`, menu open | Dismisses for that token only       | —                                  |
+
+Two details this table flattens:
+
+**Mid-composition Enter belongs to the IME.** `event.isComposing` short-circuits both the input's send and the menu's completion, so picking a candidate never sends the sentence being composed.
+
+**The menu takes the key away rather than just claiming it.** It calls `stopPropagation` as well as `preventDefault`, because the input's Enter-to-send handler is registered further up the tree and never asks whether the event was already handled. When there is nothing to complete — an open menu with no matches — Enter is left alone and goes back to meaning send.
+
+A submit is refused, whatever triggered it, when the composer is `disabled`, when it is `streaming`, or when the draft is empty _and_ carries no attachments. Files alone are a sendable draft.
+
+## Trigger tokens and `insertText`
+
+`insertText(text, replaceTriggerToken)` splices at the caret. With the second argument it replaces the trigger token the caret sits in, and closes the completion with a trailing space unless one is already there.
+
+**A trigger token is the whitespace-delimited run ending at the caret whose first character is not a letter or a digit.** That is the whole rule, and it is deliberately vocabulary-free: the root never holds a list of trigger characters, so `/`, `@`, `#`, `:` and whatever a menu invents all behave identically, and adding a menu on a new character requires no change to the core.
+
+| Draft (`        | ` is the caret) | Token found                                    | Why |
+| --------------- | --------------- | ---------------------------------------------- | --- |
+| `/de\|`         | `/de`           | Runs to the caret, opens on a non-alphanumeric |
+| `ping @jo\|`    | `@jo`           | Whitespace ends the previous run               |
+| `open src/li\|` | none            | The run opens with `o` — a path, not a command |
+| `hello\|`       | none            | Opens with a letter                            |
+| `/deploy \|`    | none            | The caret sits at a word boundary              |
+| `@jo\|rdan`     | `@jo`           | The token ends at the caret, not at the word   |
+
+That last row is why completing `@jo|rdan` searches for `jo`: the query is what the reader has actually committed to.
+
+Without `replaceTriggerToken`, `insertText` splices exactly what it was handed at the caret and adds nothing — no space, no token search. Either way the caret lands after the insertion and focus returns to the textarea on the next tick, since the call almost certainly came from a menu that had taken it.
+
+## Props
+
+### Composer
+
+| Prop          | Type                                                                 | Default     | Description                                                  |
+| ------------- | -------------------------------------------------------------------- | ----------- | ------------------------------------------------------------ |
+| `value`       | `string`                                                             | `""`        | The draft text, bindable. Cleared by a successful submit     |
+| `attachments` | `AttachmentData[]`                                                   | `[]`        | Files riding along with the draft, bindable                  |
+| `disabled`    | `boolean`                                                            | `false`     | Blocks typing, sending, and attaching                        |
+| `streaming`   | `boolean`                                                            | `false`     | A response is arriving: send becomes stop                    |
+| `placeholder` | `string`                                                             | `undefined` | For the default input. Ignored once `children` is passed     |
+| `onSubmit`    | `(payload: { text: string; attachments: AttachmentData[] }) => void` | `undefined` | The trimmed draft and a snapshot of the attachments          |
+| `onStop`      | `() => void`                                                         | `undefined` | The stop button was pressed while streaming                  |
+| `onAttach`    | `(files: File[]) => void`                                            | `undefined` | Files were picked. Upload them, then push onto `attachments` |
+| `children`    | `Snippet`                                                            | `undefined` | Replaces the default input-and-send-row composition          |
+| `accessory`   | `Snippet`                                                            | `undefined` | An overlay covering the composer                             |
+| `class`       | `string`                                                             | `undefined` | Additional CSS classes                                       |
+| `ref`         | `HTMLFormElement \| null`                                            | `null`      | Bindable reference to the form                               |
+
+### ComposerInput
+
+| Prop          | Type                          | Default      | Description                                                   |
+| ------------- | ----------------------------- | ------------ | ------------------------------------------------------------- |
+| `placeholder` | `string`                      | `"Message…"` | Shown while the draft is empty                                |
+| `rows`        | `number`                      | `1`          | Height in lines before anything is typed. Also the SSR height |
+| `maxRows`     | `number`                      | `8`          | Height ceiling in lines. Past it the textarea scrolls         |
+| `autofocus`   | `boolean`                     | `false`      | Take focus on mount                                           |
+| `class`       | `string`                      | `undefined`  | Additional CSS classes                                        |
+| `ref`         | `HTMLTextAreaElement \| null` | `null`       | Bindable reference to the textarea                            |
+
+### ComposerSubmit
+
+| Prop        | Type      | Default     | Description                                   |
+| ----------- | --------- | ----------- | --------------------------------------------- |
+| `label`     | `string`  | `"Send"`    | Accessible name while the composer is idle    |
+| `stopLabel` | `string`  | `"Stop"`    | Accessible name while a response is streaming |
+| `children`  | `Snippet` | `undefined` | Replaces the built-in icon, in both states    |
+| `class`     | `string`  | `undefined` | Additional CSS classes                        |
+
+### ComposerToolbar
+
+| Prop       | Type      | Default     | Description                                             |
+| ---------- | --------- | ----------- | ------------------------------------------------------- |
+| `children` | `Snippet` | `undefined` | The controls on the rail, left to right in source order |
+| `class`    | `string`  | `undefined` | Additional CSS classes                                  |
+
+### ComposerModelPicker
+
+| Prop       | Type                   | Default     | Description                                                |
+| ---------- | ---------------------- | ----------- | ---------------------------------------------------------- |
+| `models`   | `ModelOptionData[]`    | —           | The models on offer. Required; an empty list is inert      |
+| `value`    | `string`               | `undefined` | The selected model's id, bindable. Falls back to the first |
+| `onChange` | `(id: string) => void` | `undefined` | A _change_ of model — re-picking the current one is silent |
+| `label`    | `string`               | `"Model"`   | Accessible name for the control and its menu               |
+| `class`    | `string`               | `undefined` | Additional CSS classes                                     |
+
+### ComposerAttachments
+
+| Prop       | Type      | Default          | Description                                         |
+| ---------- | --------- | ---------------- | --------------------------------------------------- |
+| `children` | `Snippet` | `undefined`      | Replaces the default chips. The add button stays    |
+| `addLabel` | `string`  | `"Attach files"` | Accessible name and tooltip for the add button      |
+| `accept`   | `string`  | `undefined`      | `accept` for the file picker, e.g. `"image/*,.pdf"` |
+| `multiple` | `boolean` | `true`           | Whether one pick may carry several files            |
+| `class`    | `string`  | `undefined`      | Additional CSS classes                              |
+
+### ComposerAttachment
+
+| Prop         | Type                   | Default     | Description                                                      |
+| ------------ | ---------------------- | ----------- | ---------------------------------------------------------------- |
+| `attachment` | `AttachmentData`       | —           | The file to show, and whatever the upload knows so far. Required |
+| `onRemove`   | `(id: string) => void` | `undefined` | Called instead of the composer's own removal                     |
+| `class`      | `string`               | `undefined` | Additional CSS classes                                           |
+
+### ComposerCommandMenu
+
+| Prop       | Type                                                | Default     | Description                                                 |
+| ---------- | --------------------------------------------------- | ----------- | ----------------------------------------------------------- |
+| `trigger`  | `string`                                            | —           | The character that opens the menu. Required                 |
+| `items`    | `CommandItemData[]`                                 | —           | Everything the menu can offer, before filtering. Required   |
+| `onSelect` | `(item, ctx: { insertText, query }) => void`        | `undefined` | Handles a pick. Defaults to completing with the label       |
+| `filter`   | `(item: CommandItemData, query: string) => boolean` | `undefined` | Defaults to a case-insensitive label/description match      |
+| `empty`    | `Snippet`                                           | `undefined` | Shown in place of the rows when nothing matches             |
+| `maxItems` | `number`                                            | `8`         | How many matches the menu shows at once                     |
+| `class`    | `string`                                            | `undefined` | Additional CSS classes                                      |
+| `ref`      | `HTMLDivElement \| null`                            | `null`      | Bindable. Null while closed — the menu is not rendered then |
+
+## Data shapes
+
+All three come from the family's shared vocabulary, so an object can arrive from a token counter, an upload queue or a command registry and land here without translation:
+
+```ts
+interface AttachmentData {
+	id: string;
+	name: string;
+	size?: number;
+	type?: string;
+	previewUrl?: string;
+	progress?: number; // 0–1, drawn as a bar along the chip's bottom edge
+	status?: "uploading" | "done" | "error";
+}
+
+interface ModelOptionData {
+	id: string;
+	label: string;
+	badge?: string;
+	description?: string;
+}
+
+interface CommandItemData {
+	id: string;
+	label: string;
+	description?: string;
+	hint?: string;
+}
+```
+
+## Accessibility
+
+The textarea stays **readonly, never disabled**, while a response streams: a disabled textarea drops out of the tab order and stops announcing its content, and a reader mid-draft should still be able to select and copy what they wrote.
+
+The model picker is a full listbox. Focus moves into it on open — the element carrying `aria-activedescendant` has to be the one holding focus — and returns to the trigger on Escape, on a pick, and on Tab. The menu is in the DOM only while it is open.
+
+The command menu is the deliberate exception, and the tradeoff is worth stating plainly. It never takes focus, which rules out the combobox wiring: that needs `role`, `aria-expanded`, `aria-controls` and `aria-activedescendant` on the input itself, and the menu is in no position to put them there — the textarea belongs to `ComposerInput`, and reaching across to rewrite a sibling's attributes is exactly the spooky action a compound component should not do. So it announces through a live region instead: a screen-reader user hears how many matches there are and that the arrows do something, but not each row as it becomes active.
+
+If you need the full pattern, own the input part yourself: the rows carry stable ids, and `ComposerCommandMenu` exposes its element through `ref`, so you can point your own `aria-activedescendant` at the selected row.
+
+`ComposerToolbar` is deliberately not `role="toolbar"` — that role promises arrow-key roving focus between its controls, and a row announcing itself as a toolbar without implementing that is worse for a keyboard user than a plain row of tab stops.
+
+## Styling
+
+Every colour is read at the point of use with a fallback rather than declared on a root, so a value set anywhere up the tree wins without having to out-specify the components' own scoped rules.
+
+| Variable                            | Applies to                                      |
+| ----------------------------------- | ----------------------------------------------- |
+| `--ft-composer-radius`              | The composer's corner radius                    |
+| `--ft-composer-bg`                  | The composer surface                            |
+| `--ft-composer-border`              | The composer border, at rest                    |
+| `--ft-composer-border-focus`        | The composer border, with focus inside          |
+| `--ft-composer-ring`                | The focus ring around the whole surface         |
+| `--ft-composer-disabled-opacity`    | The whole composer while disabled               |
+| `--ft-composer-input-color`         | The textarea's own text colour                  |
+| `--ft-composer-menu-bg`             | Both menus' surface                             |
+| `--ft-composer-menu-border`         | Both menus' border                              |
+| `--ft-composer-menu-shadow`         | The command menu's shadow                       |
+| `--ft-composer-menu-radius`         | The command menu's corner radius                |
+| `--ft-composer-menu-active`         | The command row Enter would take                |
+| `--ft-composer-menu-hover`          | The command row under the pointer               |
+| `--ft-composer-menu-min-width`      | The command menu's floor width                  |
+| `--ft-composer-menu-max-width`      | The command menu's ceiling width                |
+| `--ft-composer-menu-max-height`     | Where the command menu starts scrolling         |
+| `--ft-composer-menu-z`              | The command menu's stacking order               |
+| `--ft-composer-option-active-bg`    | The model row under the cursor or the arrows    |
+| `--ft-composer-menu-muted`          | Model descriptions                              |
+| `--ft-composer-badge-bg`            | Model badge pills                               |
+| `--ft-composer-attachment-radius`   | Chip corner radius                              |
+| `--ft-composer-attachment-bg`       | Chip surface                                    |
+| `--ft-composer-attachment-border`   | Chip border                                     |
+| `--ft-composer-attachment-error`    | A failed chip, ahead of the shared status token |
+| `--ft-composer-attachment-track`    | The progress track along a chip                 |
+| `--ft-composer-attachment-progress` | The progress bar itself                         |
+
+Failed and uploading chips fall through to `--ft-status-error` and `--ft-status-running`, the run-status vocabulary shared with the rest of the AI family, so retinting one recolours every failure and every progress bar at once. Their defaults are `light-dark()` pairs, which means **your theme must declare `color-scheme`**:
+
+```css
+:root {
+	color-scheme: light;
+}
+.dark {
+	color-scheme: dark;
+}
+```
+
+Every animation in the compound — the chip's entrance, the progress fill, the chevron flip, the model menu's appearance, the command row's tint — lives entirely inside `@media (prefers-reduced-motion: no-preference)`. Reduced motion is not a second variant kept in sync: the rules simply do not exist, and everything is already where it was going.

--- a/src/lib/fancy-ui/composer/README.md
+++ b/src/lib/fancy-ui/composer/README.md
@@ -43,6 +43,7 @@ interface ComposerContext {
 	readonly attachments: { readonly current: AttachmentData[] };
 	readonly disabled: boolean;
 	readonly streaming: boolean;
+	readonly stoppable: boolean;
 	readonly textareaRef: { readonly current: HTMLTextAreaElement | null };
 	submit(): void;
 	stop(): void;

--- a/src/lib/fancy-ui/composer/caret.test.ts
+++ b/src/lib/fancy-ui/composer/caret.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, it, expect } from "vitest";
+import { findTriggerToken, measureCaretRect, type TriggerToken } from "./caret.js";
+
+/** `|` marks the caret in the case names — it is not part of the value. */
+const CASES: Array<[name: string, value: string, caret: number, expected: TriggerToken | null]> = [
+	["opens the draft: /de|", "/de", 3, { start: 0, query: "de" }],
+	["follows a space: run /de|", "run /de", 7, { start: 4, query: "de" }],
+	["follows a newline: one\\n/de|", "one\n/de", 7, { start: 4, query: "de" }],
+	["is still empty: /|", "/", 1, { start: 0, query: "" }],
+	["stops at the caret, not at the word end: /de|ploy", "/deploy", 3, { start: 0, query: "de" }],
+	["sits mid-word: src/li|", "src/li", 6, null],
+	["sits inside a word: a/b|", "a/b", 3, null],
+	["has the caret before it: |/de", "/de", 0, null],
+	["has the caret on its trigger: run |/de", "run /de", 4, null],
+	["is a plain word: hello|", "hello", 5, null],
+	["is closed by a space: /de |", "/de ", 4, null],
+	["is another trigger's: /help @jo|", "/help @jo", 9, null],
+	["is empty: |", "", 0, null],
+	["is whitespace: ␣␣|", "  ", 2, null],
+];
+
+describe("findTriggerToken", () => {
+	it.each(CASES)("returns %s", (_name, value, caret, expected) => {
+		expect(findTriggerToken(value, caret, "/")).toEqual(expected);
+	});
+
+	it("reads a mention trigger by the same rules", () => {
+		expect(findTriggerToken("ping @jo", 8, "@")).toEqual({ start: 5, query: "jo" });
+		expect(findTriggerToken("ping @jo", 8, "/")).toBeNull();
+		expect(findTriggerToken("mail@example", 12, "@")).toBeNull();
+	});
+
+	it("takes a multi-character trigger whole", () => {
+		expect(findTriggerToken("::sm", 4, "::")).toEqual({ start: 0, query: "sm" });
+		// Only half of it typed so far: not a token yet.
+		expect(findTriggerToken(":", 1, "::")).toBeNull();
+	});
+
+	it("refuses an empty trigger, which every position would match", () => {
+		expect(findTriggerToken("/de", 3, "")).toBeNull();
+		expect(findTriggerToken("", 0, "")).toBeNull();
+	});
+
+	it("clamps a caret that falls outside the value", () => {
+		expect(findTriggerToken("/de", 99, "/")).toEqual({ start: 0, query: "de" });
+		expect(findTriggerToken("/de", -5, "/")).toBeNull();
+	});
+
+	it("ignores everything after the caret, token or not", () => {
+		expect(findTriggerToken("/de rest of the sentence", 3, "/")).toEqual({ start: 0, query: "de" });
+	});
+});
+
+describe("measureCaretRect", () => {
+	const mounted: HTMLTextAreaElement[] = [];
+
+	afterEach(() => {
+		while (mounted.length > 0) mounted.pop()?.remove();
+	});
+
+	function textarea(value: string): HTMLTextAreaElement {
+		const el = document.createElement("textarea");
+		el.value = value;
+		document.body.appendChild(el);
+		mounted.push(el);
+		return el;
+	}
+
+	// jsdom lays nothing out, so the offsets are zero; what is worth pinning down
+	// is the shape, the line height fallback, and the fact that nothing throws.
+	it("returns a zero-width rect one line tall", () => {
+		const rect = measureCaretRect(textarea("hello world"), 6);
+		expect(Object.keys(rect).sort()).toEqual(["height", "width", "x", "y"]);
+		expect(Number.isFinite(rect.x)).toBe(true);
+		expect(Number.isFinite(rect.y)).toBe(true);
+		expect(rect.width).toBe(0);
+		expect(rect.height).toBeGreaterThan(0);
+	});
+
+	it("leaves no mirror behind in the document", () => {
+		const el = textarea("hello");
+		const before = document.body.childElementCount;
+		measureCaretRect(el, 3);
+		measureCaretRect(el, 0);
+		expect(document.body.childElementCount).toBe(before);
+	});
+
+	it("clamps an index outside the value instead of throwing", () => {
+		const el = textarea("hi");
+		expect(() => measureCaretRect(el, 999)).not.toThrow();
+		expect(() => measureCaretRect(el, -20)).not.toThrow();
+		expect(Number.isFinite(measureCaretRect(el, 999).y)).toBe(true);
+	});
+
+	it("measures an empty textarea, where the caret has no text to sit after", () => {
+		const rect = measureCaretRect(textarea(""), 0);
+		expect(Number.isFinite(rect.x)).toBe(true);
+		expect(rect.height).toBeGreaterThan(0);
+	});
+});

--- a/src/lib/fancy-ui/composer/caret.ts
+++ b/src/lib/fancy-ui/composer/caret.ts
@@ -1,0 +1,223 @@
+/**
+ * Caret arithmetic and caret geometry for the composer's trigger menus.
+ *
+ * Two jobs, one file, because a completion menu needs both at the same moment:
+ * *what* the reader is typing after a trigger character, and *where* on screen
+ * that trigger sits so the menu can be pinned to it.
+ *
+ * `findTokenStart` and `findTriggerToken` are pure — no DOM, no globals,
+ * exhaustively testable. `measureCaretRect` has to touch the DOM, since a
+ * textarea exposes no caret geometry of its own: the only way to find out where
+ * character *n* landed is to lay the same text out again in an element that can
+ * be measured.
+ */
+
+import type { FloatRect } from "../_internals/float.js";
+
+/** The trigger token the caret currently sits in. */
+export interface TriggerToken {
+	/** Index of the trigger character itself, within the value. */
+	start: number;
+	/** Everything typed between the trigger and the caret. Empty right after the trigger. */
+	query: string;
+}
+
+/** True when `index` falls between the two halves of a surrogate pair. */
+function splitsPair(value: string, index: number): boolean {
+	const high = value.charCodeAt(index - 1);
+	const low = value.charCodeAt(index);
+	return high >= 0xd800 && high <= 0xdbff && low >= 0xdc00 && low <= 0xdfff;
+}
+
+/**
+ * The caret, brought inside the value and onto a code point boundary.
+ *
+ * Rounding a mid-pair caret down is what keeps every index the token search
+ * hands back — and therefore every slice taken from it — from cutting a
+ * character in half.
+ */
+function tokenEnd(value: string, caret: number): number {
+	const end = Math.max(0, Math.min(caret, value.length));
+	return end > 0 && end < value.length && splitsPair(value, end) ? end - 1 : end;
+}
+
+/**
+ * Where the trigger token under `caret` starts, or -1 when there is none.
+ *
+ * This is *the* definition of a trigger token, and the only one: both the menus
+ * that open on a token and the `insertText` that replaces one measure it here,
+ * so the span a menu matched and the span a completion overwrites can never
+ * drift apart.
+ *
+ * The token is the whitespace-delimited run ending at the caret, and it counts
+ * as a trigger only when it opens with something other than a letter or a digit.
+ * That deliberately avoids a hardcoded trigger vocabulary: `/`, `@`, `#`, `:`
+ * and whatever a menu invents all behave the same, while an ordinary word — or a
+ * `/` sitting mid-word, as in a path fragment — does not.
+ *
+ * The walk counts code points rather than code units. Reading one unit would
+ * mistake the leading half of an astral character for a non-alphanumeric and
+ * swallow the whole word: `𝐀𝐁` is two letters, not a trigger token, and a caret
+ * the platform dropped between two halves belongs to the character as a whole.
+ */
+export function findTokenStart(value: string, caret: number): number {
+	const end = tokenEnd(value, caret);
+
+	let start = end;
+	while (start > 0) {
+		const step = splitsPair(value, start - 1) ? 2 : 1;
+		if (/\s/u.test(value.slice(start - step, start))) break;
+		start -= step;
+	}
+
+	// The caret sits at the very start of a word boundary: there is no token.
+	if (start === end) return -1;
+	const first = String.fromCodePoint(value.codePointAt(start) as number);
+	return /[\p{L}\p{N}]/u.test(first) ? -1 : start;
+}
+
+/**
+ * The trigger token under `caret`, or `null` when there is none.
+ *
+ * The same run `findTokenStart` reports, narrowed to the menus that own it: the
+ * run has to open with the exact `trigger` string. So `/de` and `@jo` open their
+ * own menu and nobody else's; `src/lib` opens neither, because its slash is
+ * mid-word, and neither does a caret sitting before the trigger it would
+ * otherwise match.
+ *
+ * The token deliberately ends *at the caret* rather than at the end of the word:
+ * completing `@jo|rdan` should search for `jo`, which is what the reader has
+ * actually committed to.
+ */
+export function findTriggerToken(
+	value: string,
+	caret: number,
+	trigger: string
+): TriggerToken | null {
+	if (trigger === "") return null;
+
+	const end = tokenEnd(value, caret);
+	const start = findTokenStart(value, end);
+	if (start < 0) return null;
+
+	const token = value.slice(start, end);
+	// Also covers a trigger only half typed: `:` is not yet `::`.
+	if (!token.startsWith(trigger)) return null;
+	return { start, query: token.slice(trigger.length) };
+}
+
+/** Copied onto the mirror so it wraps text exactly the way the textarea does. */
+const MIRRORED_STYLES = [
+	"border-bottom-width",
+	"border-left-width",
+	"border-right-width",
+	"border-top-width",
+	"direction",
+	"font-family",
+	"font-size",
+	"font-stretch",
+	"font-style",
+	"font-variant",
+	"font-weight",
+	"letter-spacing",
+	"line-height",
+	"padding-bottom",
+	"padding-left",
+	"padding-right",
+	"padding-top",
+	"tab-size",
+	"text-align",
+	"text-indent",
+	"text-transform",
+	"word-spacing",
+] as const;
+
+/** Used when the platform reports no usable line-height, e.g. under jsdom. */
+const FALLBACK_LINE_HEIGHT = 20;
+/** Multiplier applied to the font size when only that is measurable. */
+const NORMAL_LINE_RATIO = 1.5;
+
+function px(input: string): number {
+	const parsed = Number.parseFloat(input);
+	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * Where character `index` of a textarea sits, in viewport coordinates.
+ *
+ * The mirror-div technique: a hidden div inherits the textarea's font, padding,
+ * borders and content width, receives the text up to `index`, and then a marker
+ * span holding the rest. The span's offset is the caret's offset, because the
+ * two layouts are the same layout. The rest is bookkeeping — the textarea's own
+ * position, its border, and how far it has been scrolled.
+ *
+ * Returns a zero-width rect one line tall, which is exactly what a float wants
+ * as a virtual anchor. Under jsdom nothing has a layout, so everything measures
+ * zero; the shape still holds and nothing throws.
+ */
+export function measureCaretRect(textarea: HTMLTextAreaElement, index: number): FloatRect {
+	const box = textarea.getBoundingClientRect();
+	const doc = textarea.ownerDocument;
+	const win = doc.defaultView;
+	if (!win) return { x: box.left, y: box.top, width: 0, height: box.height };
+
+	const style = win.getComputedStyle(textarea);
+	const declaredLine = Number.parseFloat(style.lineHeight);
+	const fontSize = Number.parseFloat(style.fontSize);
+	const line =
+		Number.isFinite(declaredLine) && declaredLine > 0
+			? declaredLine
+			: Number.isFinite(fontSize) && fontSize > 0
+				? fontSize * NORMAL_LINE_RATIO
+				: FALLBACK_LINE_HEIGHT;
+
+	const mirror = doc.createElement("div");
+	for (const property of MIRRORED_STYLES) {
+		mirror.style.setProperty(property, style.getPropertyValue(property));
+	}
+	// Content-box on purpose: `clientWidth` already excludes the borders and the
+	// scrollbar, so subtracting the padding leaves the exact width the text wraps
+	// inside — no double counting whichever box model the textarea itself uses.
+	const inner = textarea.clientWidth || box.width;
+	mirror.style.boxSizing = "content-box";
+	mirror.style.width = `${Math.max(0, inner - px(style.paddingLeft) - px(style.paddingRight))}px`;
+	mirror.style.height = "auto";
+	mirror.style.position = "absolute";
+	mirror.style.top = "0";
+	mirror.style.left = "-9999px";
+	mirror.style.visibility = "hidden";
+	mirror.style.overflow = "hidden";
+	// A textarea wraps on soft breaks and breaks long words rather than scrolling
+	// sideways; the mirror has to agree or the two layouts drift apart.
+	mirror.style.whiteSpace = "pre-wrap";
+	mirror.style.overflowWrap = "break-word";
+
+	const value = textarea.value;
+	const clamped = Math.max(0, Math.min(index, value.length));
+	mirror.textContent = value.slice(0, clamped);
+
+	const marker = doc.createElement("span");
+	// The remainder, so the span occupies a real line box; a trailing caret has
+	// nothing left to hold it open, hence the dot.
+	marker.textContent = value.slice(clamped) || ".";
+	mirror.appendChild(marker);
+
+	doc.body.appendChild(mirror);
+	let top = 0;
+	let left = 0;
+	try {
+		top = marker.offsetTop;
+		left = marker.offsetLeft;
+	} finally {
+		mirror.remove();
+	}
+
+	// `offsetTop` is measured from the mirror's padding edge, so it already carries
+	// the padding; only the border is left to add back.
+	return {
+		x: box.left + px(style.borderLeftWidth) + left - textarea.scrollLeft,
+		y: box.top + px(style.borderTopWidth) + top - textarea.scrollTop,
+		width: 0,
+		height: line,
+	};
+}

--- a/src/lib/fancy-ui/composer/index.ts
+++ b/src/lib/fancy-ui/composer/index.ts
@@ -1,0 +1,36 @@
+import Composer from "./Composer.svelte";
+import ComposerInput from "./ComposerInput.svelte";
+import ComposerSubmit from "./ComposerSubmit.svelte";
+import ComposerToolbar from "./ComposerToolbar.svelte";
+import ComposerModelPicker from "./ComposerModelPicker.svelte";
+import ComposerAttachments from "./ComposerAttachments.svelte";
+import ComposerAttachment from "./ComposerAttachment.svelte";
+import ComposerCommandMenu from "./ComposerCommandMenu.svelte";
+import type { ComposerProps } from "./Composer.svelte";
+import type { ComposerInputProps } from "./ComposerInput.svelte";
+import type { ComposerSubmitProps } from "./ComposerSubmit.svelte";
+import type { ComposerToolbarProps } from "./ComposerToolbar.svelte";
+import type { ComposerModelPickerProps } from "./ComposerModelPicker.svelte";
+import type { ComposerAttachmentsProps } from "./ComposerAttachments.svelte";
+import type { ComposerAttachmentProps } from "./ComposerAttachment.svelte";
+import type { ComposerCommandMenuProps } from "./ComposerCommandMenu.svelte";
+
+export {
+	Composer,
+	ComposerInput,
+	ComposerSubmit,
+	ComposerToolbar,
+	ComposerModelPicker,
+	ComposerAttachments,
+	ComposerAttachment,
+	ComposerCommandMenu,
+	type ComposerProps,
+	type ComposerInputProps,
+	type ComposerSubmitProps,
+	type ComposerToolbarProps,
+	type ComposerModelPickerProps,
+	type ComposerAttachmentsProps,
+	type ComposerAttachmentProps,
+	type ComposerCommandMenuProps,
+};
+export { COMPOSER_CONTEXT_KEY, type ComposerContext } from "./types.js";

--- a/src/lib/fancy-ui/composer/types.ts
+++ b/src/lib/fancy-ui/composer/types.ts
@@ -28,6 +28,12 @@ export interface ComposerContext {
 	readonly disabled: boolean;
 	/** A response is arriving: send becomes stop. */
 	readonly streaming: boolean;
+	/**
+	 * Whether `stop()` reaches anyone. The root always publishes a callable
+	 * `stop`, so a control asking "is there a handler behind it" has to ask this
+	 * instead — otherwise a stop button offers itself with nothing to stop.
+	 */
+	readonly stoppable: boolean;
 	/** The live textarea, once `ComposerInput` has mounted one. */
 	readonly textareaRef: { readonly current: HTMLTextAreaElement | null };
 	/** Send the draft. No-ops while disabled, while streaming, and on an empty draft. */

--- a/src/lib/fancy-ui/composer/types.ts
+++ b/src/lib/fancy-ui/composer/types.ts
@@ -1,0 +1,52 @@
+/**
+ * The contract between the composer root and its parts.
+ *
+ * `Composer` owns the draft — the text, the attachments, the textarea element —
+ * and publishes a live, read-only view of it plus the handful of commands a part
+ * may issue. Every part reads it through `getContext` instead of having six
+ * values and four callbacks threaded back down as props, and every part must
+ * render harmlessly (inert, no-op) when the context is absent, so a part dropped
+ * outside a composer degrades instead of throwing.
+ *
+ * The getters keep it reactive: a part that reads `value.current` inside its own
+ * reactive scope re-runs when the root's draft changes.
+ *
+ * `textareaRef` is typed read-only because exactly one part writes it —
+ * `ComposerInput`, which registers its own element through a documented cast to
+ * the writable shape the root actually publishes. Everyone else reads.
+ */
+
+import type { AttachmentData } from "../_internals/ai-types.js";
+
+/** What the root publishes. Parts read it; only the root writes it. */
+export interface ComposerContext {
+	/** The current draft text, exactly as typed — untrimmed. */
+	readonly value: { readonly current: string };
+	/** The attachments riding along with the draft. The consumer owns this list. */
+	readonly attachments: { readonly current: AttachmentData[] };
+	/** Nothing may be typed, sent, or attached. */
+	readonly disabled: boolean;
+	/** A response is arriving: send becomes stop. */
+	readonly streaming: boolean;
+	/** The live textarea, once `ComposerInput` has mounted one. */
+	readonly textareaRef: { readonly current: HTMLTextAreaElement | null };
+	/** Send the draft. No-ops while disabled, while streaming, and on an empty draft. */
+	submit(): void;
+	/** Interrupt the stream. No-ops unless the composer is streaming. */
+	stop(): void;
+	/** Replace the draft outright. */
+	setValue(next: string): void;
+	/**
+	 * Splice `text` in at the caret. With `replaceTriggerToken`, the trigger token
+	 * the caret sits in — the whitespace-delimited run before it, when that run
+	 * opens with a non-alphanumeric character — is replaced instead, and the
+	 * completion closes with a trailing space.
+	 */
+	insertText(text: string, replaceTriggerToken?: boolean): void;
+	/** Hand files to the consumer. It uploads them and pushes onto `attachments`. */
+	addFiles(files: File[]): void;
+	/** Drop one attachment from the draft by id. */
+	removeAttachment(id: string): void;
+}
+
+export const COMPOSER_CONTEXT_KEY = Symbol("composer-context");

--- a/src/lib/fancy-ui/context-ring/ContextRing.svelte
+++ b/src/lib/fancy-ui/context-ring/ContextRing.svelte
@@ -1,0 +1,398 @@
+<script lang="ts" module>
+	import type { TokenUsageData } from "../_internals/ai-types.js";
+
+	/**
+	 * Props for ContextRing
+	 */
+	export interface ContextRingProps {
+		/** Context-window consumption: how many tokens are used, out of how many, and of what. */
+		usage: TokenUsageData;
+		/** Outer diameter of the ring, in pixels. */
+		size?: number;
+		/** Thickness of both the track and the arc, in pixels. */
+		strokeWidth?: number;
+		/** Whether the compact "12.4k / 200k" figure is shown beside the ring. */
+		showLabel?: boolean;
+		/** Fraction at which the ring leaves the quiet band, 0–1. */
+		warnAt?: number;
+		/** Fraction at which the ring turns to the error colour, 0–1. */
+		criticalAt?: number;
+		/** Accessible name for the meter — what this ring is measuring. */
+		label?: string;
+		/** Whether clicking the ring opens a popover listing `usage.breakdown`. */
+		expandable?: boolean;
+		/** Additional CSS classes */
+		class?: string;
+		/** The root element */
+		ref?: HTMLElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import { float } from "../_internals/float.js";
+
+	let {
+		usage,
+		size = 28,
+		strokeWidth = 3,
+		showLabel = true,
+		warnAt = 0.75,
+		criticalAt = 0.9,
+		label = "Context usage",
+		expandable = false,
+		class: className,
+		ref = $bindable(null),
+	}: ContextRingProps = $props();
+
+	/** Shown in the popover when a caller asked for one but sent no rows. */
+	const NO_BREAKDOWN = "No breakdown reported.";
+
+	const uid = $props.id();
+	const panelId = `${uid}-breakdown`;
+
+	// -------------------------------------------------------------------------
+	// Numbers
+	// -------------------------------------------------------------------------
+
+	function clamp(value: number, min: number, max: number): number {
+		return Math.max(min, Math.min(value, max));
+	}
+
+	/** A fraction prop that arrived as nonsense falls back rather than poisoning the bands. */
+	function fractionProp(value: number, fallback: number): number {
+		return Number.isFinite(value) ? clamp(value, 0, 1) : fallback;
+	}
+
+	/**
+	 * The ring's own tiny formatter, deliberately not `Intl.NumberFormat`'s compact
+	 * notation: that rounds 12,400 to "12K" and drops the digit the reader is
+	 * actually watching. Below a thousand the count is exact, below a hundred
+	 * thousand it keeps one decimal, and above that the decimal is noise on a
+	 * figure nobody reads that precisely. A whole number never carries a hanging
+	 * ".0" — "1k", not "1.0k".
+	 */
+	function compact(value: number): string {
+		if (!Number.isFinite(value)) return "0";
+		const n = Math.max(0, Math.round(value));
+		if (n < 1000) return String(n);
+		if (n < 100_000) {
+			const fixed = (n / 1000).toFixed(1);
+			return `${fixed.endsWith(".0") ? fixed.slice(0, -2) : fixed}k`;
+		}
+		return `${Math.round(n / 1000)}k`;
+	}
+
+	/** The spoken figure is grouped in full, because "12.4k" is a glance, not a reading. */
+	function grouped(value: number): string {
+		return Math.max(0, Math.round(Number.isFinite(value) ? value : 0)).toLocaleString("en-US");
+	}
+
+	const used = $derived(Number.isFinite(usage.used) ? Math.max(0, usage.used) : 0);
+	// A budget of zero — or of nothing at all — is an empty ring, not a division.
+	const max = $derived(Number.isFinite(usage.max) && usage.max > 0 ? usage.max : 0);
+	const fraction = $derived(max > 0 ? Math.min(1, used / max) : 0);
+
+	// `criticalAt` is floored at `warnAt` so a caller who swaps the two gets a ring
+	// that still escalates in one direction instead of one band that can never win.
+	const warn = $derived(fractionProp(warnAt, 0.75));
+	const critical = $derived(Math.max(warn, fractionProp(criticalAt, 0.9)));
+	const band = $derived(fraction >= critical ? "critical" : fraction >= warn ? "warn" : "ok");
+
+	const labelText = $derived(`${compact(used)} / ${compact(max)}`);
+	// Over budget pins the meter at its maximum, which is what `aria-valuenow` is
+	// allowed to say; the text beside it still reports the real figure.
+	const valueNow = $derived(Math.round(Math.min(used, max)));
+	const valueMax = $derived(Math.round(max));
+	const valueText = $derived(`${grouped(used)} of ${grouped(max)} tokens`);
+
+	const rows = $derived(usage.breakdown ?? []);
+
+	// -------------------------------------------------------------------------
+	// Geometry
+	// -------------------------------------------------------------------------
+
+	const px = $derived(Number.isFinite(size) ? Math.max(8, size) : 28);
+	// The stroke is centred on the radius, so it cannot be wider than the ring has
+	// room for — past that the arc eats its own centre and the shape stops reading.
+	const stroke = $derived(
+		clamp(Number.isFinite(strokeWidth) ? strokeWidth : 3, 0.5, Math.max(0.5, px / 2 - 0.5))
+	);
+	const centre = $derived(px / 2);
+	const radius = $derived(Math.max(0.5, (px - stroke) / 2));
+	const circumference = $derived(2 * Math.PI * radius);
+
+	// The ring is painted empty and its target written a frame later, so the sweep
+	// runs from a value the browser has already put on screen. Everything the meter
+	// *means* — its value, its text, its band — is derived above and needs no mount,
+	// so a server render is exact and only the entrance waits for the client.
+	let filled = $state(false);
+	const sweep = $derived(filled ? fraction : 0);
+	const dashOffset = $derived(circumference * (1 - sweep));
+
+	onMount(() => {
+		// Reduced motion wants the settled arc, not a fast one: write it in the same
+		// breath so there is never a frame of empty ring to notice.
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			filled = true;
+			return;
+		}
+
+		// `onMount` still runs inside the frame that mounted the ring, so setting the
+		// target here would land in the same paint as the empty arc and the browser
+		// would have nothing to transition between. Two frames out is the guarantee:
+		// the first callback can still belong to the mounting frame, the second
+		// cannot, so the empty ring is on screen before the target is written.
+		let second = 0;
+		const first = requestAnimationFrame(() => {
+			second = requestAnimationFrame(() => {
+				filled = true;
+			});
+		});
+
+		return () => {
+			cancelAnimationFrame(first);
+			cancelAnimationFrame(second);
+		};
+	});
+
+	// -------------------------------------------------------------------------
+	// Breakdown popover
+	// -------------------------------------------------------------------------
+
+	let open = $state(false);
+	let trigger = $state<HTMLButtonElement | null>(null);
+
+	function toggle() {
+		open = !open;
+	}
+
+	// Escape and a click elsewhere both dismiss. Bound to the window rather than to
+	// the panel so they work whether or not anything inside it holds focus; the
+	// listeners exist only while the panel does.
+	$effect(() => {
+		if (!open) return;
+
+		const onKeydown = (event: KeyboardEvent) => {
+			if (event.key !== "Escape") return;
+			open = false;
+			// Focus goes back to what opened the panel, not to the top of the page.
+			trigger?.focus();
+		};
+		const onPointerDown = (event: Event) => {
+			const target = event.target as Node | null;
+			if (target && ref?.contains(target)) return;
+			open = false;
+		};
+
+		window.addEventListener("keydown", onKeydown);
+		window.addEventListener("pointerdown", onPointerDown, true);
+		return () => {
+			window.removeEventListener("keydown", onKeydown);
+			window.removeEventListener("pointerdown", onPointerDown, true);
+		};
+	});
+</script>
+
+{#snippet face()}
+	<!--
+		One `meter` for the pair: the arc says nothing out loud and the compact figure
+		is a glance rather than a reading, so assistive tech is given the full count
+		once through `aria-valuetext` and both halves are hidden behind it.
+	-->
+	<span
+		class="ft-ctxring-meter inline-flex flex-none"
+		role="meter"
+		aria-label={label}
+		aria-valuenow={valueNow}
+		aria-valuemin={0}
+		aria-valuemax={valueMax}
+		aria-valuetext={valueText}
+	>
+		<svg
+			class="ft-ctxring-ring"
+			viewBox="0 0 {px} {px}"
+			style:width="{px}px"
+			style:height="{px}px"
+			aria-hidden="true"
+		>
+			<circle
+				class="ft-ctxring-track"
+				cx={centre}
+				cy={centre}
+				r={radius}
+				fill="none"
+				stroke-width={stroke}
+			/>
+			<circle
+				class="ft-ctxring-value"
+				class:ft-status-pending={band === "ok"}
+				class:ft-status-running={band === "warn"}
+				class:ft-status-error={band === "critical"}
+				cx={centre}
+				cy={centre}
+				r={radius}
+				fill="none"
+				stroke-width={stroke}
+				stroke-linecap="round"
+				stroke-dasharray={circumference}
+				stroke-dashoffset={dashOffset}
+				transform="rotate(-90 {centre} {centre})"
+			/>
+		</svg>
+	</span>
+
+	{#if showLabel}
+		<span class="ft-ctxring-label text-foreground/70 text-xs tabular-nums" aria-hidden="true">
+			{labelText}
+		</span>
+	{/if}
+{/snippet}
+
+<div
+	bind:this={ref}
+	class={cn("ft-ctxring inline-flex items-center gap-2", className)}
+	data-band={band}
+>
+	{#if expandable}
+		<!--
+			No `aria-label` here on purpose: the button takes its name from the meter
+			it contains, so the one string a consumer sets through `label` names both
+			and the two can never drift apart.
+		-->
+		<button
+			bind:this={trigger}
+			type="button"
+			class="ft-ctxring-trigger hover:bg-foreground/5 focus-visible:ring-ring -mx-1 -my-0.5 inline-flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+			aria-expanded={open}
+			aria-controls={panelId}
+			onclick={toggle}
+		>
+			{@render face()}
+		</button>
+	{:else}
+		{@render face()}
+	{/if}
+
+	{#if expandable && open}
+		<!--
+			Rendered only while it is on screen: a breakdown that lives in the DOM
+			permanently is a hidden list every screen-reader element list has to step
+			over. The anchor is read through a getter so the action re-measures the
+			trigger on every scroll and resize tick rather than holding a stale rect.
+		-->
+		<div
+			id={panelId}
+			role="group"
+			aria-label="{label} breakdown"
+			class="ft-ctxring-panel z-50 rounded-lg border p-2 text-left text-xs shadow-lg"
+			use:float={{
+				anchor: () => trigger?.getBoundingClientRect() ?? null,
+				placement: "bottom-end",
+				offset: 8,
+			}}
+		>
+			{#if rows.length > 0}
+				<ul class="flex flex-col gap-1">
+					<!--
+						Keyed on the label *and* the index: a model happily reports two rows
+						called "System prompt", and a key that is only the label would make
+						the second one replace the first.
+					-->
+					{#each rows as row, i (`${row.label}#${i}`)}
+						<li class="ft-ctxring-row flex items-baseline justify-between gap-4">
+							<span class="min-w-0 truncate">{row.label}</span>
+							<span class="ft-ctxring-row-value flex-none tabular-nums">{compact(row.tokens)}</span>
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p class="ft-ctxring-empty italic">{NO_BREAKDOWN}</p>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style>
+	/*
+	 * Every colour is read at the point of use through two hooks: this ring's own
+	 * `--ft-ctxring-*`, then the `--ft-status-*` vocabulary the whole AI family
+	 * shares, then the literal. Setting either anywhere up the tree retints the
+	 * ring without having to win a specificity fight against these scoped rules,
+	 * and the shared one recolours every sibling component at once.
+	 */
+	.ft-ctxring-track {
+		stroke: var(--ft-ctxring-track, color-mix(in oklab, currentColor 15%, transparent));
+	}
+
+	/*
+	 * The band is carried by the arc's length as much as by its hue — a quarter
+	 * ring and a nearly closed one are told apart without seeing colour at all,
+	 * and the figure beside it says the count in words either way.
+	 */
+	.ft-ctxring-value.ft-status-pending {
+		stroke: var(
+			--ft-ctxring-ok,
+			var(--ft-status-pending, light-dark(oklch(0.5 0.02 260), oklch(0.72 0.02 260)))
+		);
+	}
+
+	.ft-ctxring-value.ft-status-running {
+		stroke: var(
+			--ft-ctxring-warn,
+			var(--ft-status-running, light-dark(oklch(0.5 0.18 265), oklch(0.72 0.15 265)))
+		);
+	}
+
+	.ft-ctxring-value.ft-status-error {
+		stroke: var(
+			--ft-ctxring-critical,
+			var(--ft-status-error, light-dark(oklch(0.5 0.19 25), oklch(0.7 0.18 25)))
+		);
+	}
+
+	.ft-ctxring-panel {
+		width: var(--ft-ctxring-panel-width, 14rem);
+		max-width: calc(100vw - 1rem);
+		background: var(--ft-ctxring-panel-bg, var(--color-popover, canvas));
+		border-color: var(--ft-ctxring-panel-border, var(--color-border, currentColor));
+		color: var(--ft-ctxring-panel-fg, var(--color-popover-foreground, canvastext));
+	}
+
+	.ft-ctxring-row-value {
+		color: var(--ft-ctxring-row-value, color-mix(in oklab, currentColor 70%, transparent));
+	}
+
+	.ft-ctxring-empty {
+		color: var(--ft-ctxring-row-value, color-mix(in oklab, currentColor 70%, transparent));
+	}
+
+	/*
+	 * Everything that moves lives behind the query, so reduced motion is not a
+	 * degraded variant to keep in sync: the arc is drawn at its final length, the
+	 * band change is instant, and the panel simply appears, already placed.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-ctxring-value {
+			transition:
+				stroke-dashoffset 600ms cubic-bezier(0.4, 0, 0.2, 1),
+				stroke 300ms linear;
+		}
+
+		.ft-ctxring-panel {
+			animation: ft-ctxring-in 140ms cubic-bezier(0.4, 0, 0.2, 1);
+		}
+	}
+
+	@keyframes ft-ctxring-in {
+		from {
+			opacity: 0;
+			transform: translateY(-3px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/context-ring/ContextRing.svelte
+++ b/src/lib/fancy-ui/context-ring/ContextRing.svelte
@@ -168,6 +168,13 @@
 		open = !open;
 	}
 
+	// Taking expandability away takes the panel with it. Left open, it would keep
+	// its window listeners with no trigger on screen, and turning expandability
+	// back on would reopen a panel nobody asked to see again.
+	$effect(() => {
+		if (!expandable) open = false;
+	});
+
 	// Escape and a click elsewhere both dismiss. Bound to the window rather than to
 	// the panel so they work whether or not anything inside it holds focus; the
 	// listeners exist only while the panel does.
@@ -257,9 +264,10 @@
 >
 	{#if expandable}
 		<!--
-			No `aria-label` here on purpose: the button takes its name from the meter
-			it contains, so the one string a consumer sets through `label` names both
-			and the two can never drift apart.
+			An explicit `aria-label`, because a button flattens everything inside it to
+			presentational: the `role="meter"` and its value below never reach
+			assistive tech once they are nested here. The button's own name carries
+			both the meter's name and its current reading instead.
 		-->
 		<button
 			bind:this={trigger}
@@ -267,6 +275,7 @@
 			class="ft-ctxring-trigger hover:bg-foreground/5 focus-visible:ring-ring -mx-1 -my-0.5 inline-flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors focus-visible:ring-2 focus-visible:outline-none"
 			aria-expanded={open}
 			aria-controls={panelId}
+			aria-label="{label}, {valueText}"
 			onclick={toggle}
 		>
 			{@render face()}

--- a/src/lib/fancy-ui/context-ring/ContextRing.test.ts
+++ b/src/lib/fancy-ui/context-ring/ContextRing.test.ts
@@ -285,4 +285,37 @@ describe("ContextRing", () => {
 		expect(root(container).className).toContain("my-ring");
 		expect(root(container).className).toContain("ft-ctxring");
 	});
+
+	it("names the trigger with the reading, since the meter inside it is not exposed", () => {
+		// A button flattens its descendants to presentational, so the nested meter
+		// and its value never reach assistive tech.
+		const { container } = render(ContextRing, {
+			props: { usage: usage({ used: 12_400, max: 200_000 }), expandable: true },
+		});
+
+		expect(trigger(container)?.getAttribute("aria-label")).toBe(
+			"Context usage, 12,400 of 200,000 tokens"
+		);
+	});
+
+	it("closes the popover when expandability is taken away, and leaves it closed", async () => {
+		const initial = {
+			usage: usage({ breakdown: [{ label: "System prompt", tokens: 1200 }] }),
+			expandable: true,
+		};
+		const { container, rerender } = render(ContextRing, { props: initial });
+
+		await fireEvent.click(trigger(container) as HTMLButtonElement);
+		expect(panel(container)).not.toBeNull();
+
+		await rerender({ ...initial, expandable: false });
+		await tick();
+		expect(panel(container)).toBeNull();
+
+		// Turning it back on must not reopen a panel nobody asked for again.
+		await rerender({ ...initial, expandable: true });
+		await tick();
+		expect(panel(container)).toBeNull();
+		expect(trigger(container)?.getAttribute("aria-expanded")).toBe("false");
+	});
 });

--- a/src/lib/fancy-ui/context-ring/ContextRing.test.ts
+++ b/src/lib/fancy-ui/context-ring/ContextRing.test.ts
@@ -1,0 +1,288 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, describe, it, expect } from "vitest";
+import ContextRing from "./ContextRing.svelte";
+import type { TokenUsageData } from "../_internals/ai-types.js";
+
+function usage(overrides: Partial<TokenUsageData> = {}): TokenUsageData {
+	return { used: 12_400, max: 200_000, ...overrides };
+}
+
+function root(container: HTMLElement): HTMLElement {
+	return container.querySelector(".ft-ctxring") as HTMLElement;
+}
+
+function meter(container: HTMLElement): HTMLElement {
+	return container.querySelector('[role="meter"]') as HTMLElement;
+}
+
+function arc(container: HTMLElement): SVGCircleElement {
+	return container.querySelector(".ft-ctxring-value") as SVGCircleElement;
+}
+
+function trigger(container: HTMLElement): HTMLButtonElement | null {
+	return container.querySelector(".ft-ctxring-trigger");
+}
+
+function panel(container: HTMLElement): HTMLElement | null {
+	return container.querySelector(".ft-ctxring-panel");
+}
+
+function labelText(container: HTMLElement): string {
+	return container.querySelector(".ft-ctxring-label")?.textContent?.trim() ?? "";
+}
+
+function rows(container: HTMLElement): string[] {
+	return [...container.querySelectorAll(".ft-ctxring-row")].map((el) =>
+		(el.textContent ?? "").replace(/\s+/g, " ").trim()
+	);
+}
+
+/** The fraction the arc is currently drawn at, read back off its dash attributes. */
+function drawn(container: HTMLElement): number {
+	const circle = arc(container);
+	const circumference = Number(circle.getAttribute("stroke-dasharray"));
+	const offset = Number(circle.getAttribute("stroke-dashoffset"));
+	return 1 - offset / circumference;
+}
+
+/**
+ * Two real frames, then a Svelte flush: what the ring waits for before it writes
+ * its target, so the empty state reaches the screen first.
+ */
+async function settle(): Promise<void> {
+	await new Promise<void>((resolve) =>
+		requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+	);
+	await tick();
+}
+
+describe("ContextRing", () => {
+	afterEach(cleanup);
+
+	it("exposes the usage as a meter, without waiting for a frame to be correct", () => {
+		const { container } = render(ContextRing, { props: { usage: usage() } });
+		const el = meter(container);
+
+		expect(el.getAttribute("aria-label")).toBe("Context usage");
+		expect(el.getAttribute("aria-valuenow")).toBe("12400");
+		expect(el.getAttribute("aria-valuemin")).toBe("0");
+		expect(el.getAttribute("aria-valuemax")).toBe("200000");
+	});
+
+	it("spells the counts out in full for assistive tech", () => {
+		const { container } = render(ContextRing, { props: { usage: usage() } });
+
+		expect(meter(container).getAttribute("aria-valuetext")).toBe("12,400 of 200,000 tokens");
+	});
+
+	it("takes a custom name for what is being measured", () => {
+		const { container } = render(ContextRing, {
+			props: { usage: usage(), label: "Thread budget" },
+		});
+
+		expect(meter(container).getAttribute("aria-label")).toBe("Thread budget");
+	});
+
+	it("draws the arc at the exact fraction once the entrance has run", async () => {
+		const { container } = render(ContextRing, { props: { usage: usage({ used: 50, max: 200 }) } });
+		await settle();
+
+		expect(drawn(container)).toBeCloseTo(0.25, 5);
+	});
+
+	it("starts empty so the fill has somewhere to animate from", async () => {
+		const { container } = render(ContextRing, { props: { usage: usage({ used: 50, max: 200 }) } });
+
+		expect(drawn(container)).toBeCloseTo(0, 5);
+		await settle();
+		expect(drawn(container)).toBeCloseTo(0.25, 5);
+	});
+
+	it("clamps an over-budget count to a closed ring and pins the meter at its max", async () => {
+		const { container } = render(ContextRing, {
+			props: { usage: usage({ used: 260_000, max: 200_000 }) },
+		});
+		await settle();
+
+		expect(drawn(container)).toBeCloseTo(1, 5);
+		expect(meter(container).getAttribute("aria-valuenow")).toBe("200000");
+		// The spoken figure stays honest about the overrun.
+		expect(meter(container).getAttribute("aria-valuetext")).toBe("260,000 of 200,000 tokens");
+	});
+
+	it("renders an empty ring rather than dividing by a budget of zero", async () => {
+		const { container } = render(ContextRing, { props: { usage: usage({ used: 900, max: 0 }) } });
+		await settle();
+
+		expect(drawn(container)).toBeCloseTo(0, 5);
+		expect(root(container).dataset.band).toBe("ok");
+	});
+
+	it.each([
+		[0.5, "ok", "ft-status-pending"],
+		[0.8, "warn", "ft-status-running"],
+		[0.95, "critical", "ft-status-error"],
+	])("puts %f in the %s band", (fraction, expectedBand, expectedClass) => {
+		const { container } = render(ContextRing, {
+			props: { usage: usage({ used: fraction * 200_000, max: 200_000 }) },
+		});
+
+		expect(root(container).dataset.band).toBe(expectedBand);
+		expect(arc(container).classList.contains(expectedClass)).toBe(true);
+	});
+
+	it("moves the bands where the thresholds are set", () => {
+		const { container } = render(ContextRing, {
+			props: { usage: usage({ used: 60, max: 100 }), warnAt: 0.5, criticalAt: 0.55 },
+		});
+
+		expect(root(container).dataset.band).toBe("critical");
+	});
+
+	it("keeps criticalAt from sinking below warnAt when the two arrive swapped", () => {
+		const { container } = render(ContextRing, {
+			props: { usage: usage({ used: 80, max: 100 }), warnAt: 0.9, criticalAt: 0.5 },
+		});
+
+		// 0.8 is under the 0.9 warn line, so it stays quiet rather than being read as
+		// critical by a threshold that was accidentally set lower than the warning.
+		expect(root(container).dataset.band).toBe("ok");
+	});
+
+	it.each([
+		[850, 200_000, "850 / 200k"],
+		[12_400, 200_000, "12.4k / 200k"],
+		[154_000, 200_000, "154k / 200k"],
+		[1000, 8000, "1k / 8k"],
+	])("formats %i of %i compactly", (used, max, expected) => {
+		const { container } = render(ContextRing, { props: { usage: usage({ used, max }) } });
+
+		expect(labelText(container)).toBe(expected);
+	});
+
+	it("drops the figure when the ring should stand alone", () => {
+		const { container } = render(ContextRing, {
+			props: { usage: usage(), showLabel: false },
+		});
+
+		expect(container.querySelector(".ft-ctxring-label")).toBeNull();
+		expect(meter(container)).not.toBeNull();
+	});
+
+	it("sizes the ring and its stroke from the props", () => {
+		const { container } = render(ContextRing, {
+			props: { usage: usage(), size: 40, strokeWidth: 5 },
+		});
+		const svg = container.querySelector(".ft-ctxring-ring") as SVGSVGElement;
+
+		expect(svg.getAttribute("viewBox")).toBe("0 0 40 40");
+		expect(arc(container).getAttribute("stroke-width")).toBe("5");
+		// Radius is inset by half the stroke so the arc stays inside the box.
+		expect(Number(arc(container).getAttribute("r"))).toBeCloseTo(17.5, 5);
+		expect(arc(container).getAttribute("transform")).toBe("rotate(-90 20 20)");
+	});
+
+	it("stays a plain readout with nothing to press when it is not expandable", () => {
+		const { container } = render(ContextRing, {
+			props: { usage: usage({ breakdown: [{ label: "System prompt", tokens: 1200 }] }) },
+		});
+
+		expect(trigger(container)).toBeNull();
+		expect(panel(container)).toBeNull();
+	});
+
+	it("opens a breakdown popover on click and lists every row", async () => {
+		const { container } = render(ContextRing, {
+			props: {
+				usage: usage({
+					breakdown: [
+						{ label: "System prompt", tokens: 1200 },
+						{ label: "Transcript", tokens: 9800 },
+						{ label: "Tool results", tokens: 1400 },
+					],
+				}),
+				expandable: true,
+			},
+		});
+
+		const button = trigger(container) as HTMLButtonElement;
+		expect(button.getAttribute("aria-expanded")).toBe("false");
+		expect(panel(container)).toBeNull();
+
+		await fireEvent.click(button);
+
+		expect(button.getAttribute("aria-expanded")).toBe("true");
+		expect(panel(container)?.id).toBe(button.getAttribute("aria-controls"));
+		expect(rows(container)).toEqual(["System prompt 1.2k", "Transcript 9.8k", "Tool results 1.4k"]);
+	});
+
+	it("closes the popover on Escape", async () => {
+		const { container } = render(ContextRing, {
+			props: {
+				usage: usage({ breakdown: [{ label: "System prompt", tokens: 1200 }] }),
+				expandable: true,
+			},
+		});
+
+		await fireEvent.click(trigger(container) as HTMLButtonElement);
+		expect(panel(container)).not.toBeNull();
+
+		await fireEvent.keyDown(window, { key: "Escape" });
+
+		expect(panel(container)).toBeNull();
+		expect(trigger(container)?.getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("closes the popover when the ring is pressed again", async () => {
+		const { container } = render(ContextRing, {
+			props: {
+				usage: usage({ breakdown: [{ label: "System prompt", tokens: 1200 }] }),
+				expandable: true,
+			},
+		});
+		const button = trigger(container) as HTMLButtonElement;
+
+		await fireEvent.click(button);
+		await fireEvent.click(button);
+
+		expect(panel(container)).toBeNull();
+	});
+
+	it("keeps both rows when a model reports the same label twice", async () => {
+		const { container } = render(ContextRing, {
+			props: {
+				usage: usage({
+					breakdown: [
+						{ label: "Tool results", tokens: 1400 },
+						{ label: "Tool results", tokens: 2600 },
+					],
+				}),
+				expandable: true,
+			},
+		});
+
+		await fireEvent.click(trigger(container) as HTMLButtonElement);
+
+		expect(rows(container)).toEqual(["Tool results 1.4k", "Tool results 2.6k"]);
+	});
+
+	it("says so when a breakdown was asked for but never reported", async () => {
+		const { container } = render(ContextRing, {
+			props: { usage: usage(), expandable: true },
+		});
+
+		await fireEvent.click(trigger(container) as HTMLButtonElement);
+
+		expect(panel(container)?.textContent?.trim()).toBe("No breakdown reported.");
+	});
+
+	it("merges custom classes onto the root", () => {
+		const { container } = render(ContextRing, {
+			props: { usage: usage(), class: "my-ring" },
+		});
+
+		expect(root(container).className).toContain("my-ring");
+		expect(root(container).className).toContain("ft-ctxring");
+	});
+});

--- a/src/lib/fancy-ui/context-ring/README.md
+++ b/src/lib/fancy-ui/context-ring/README.md
@@ -1,0 +1,138 @@
+# Context Ring
+
+How much of the context window is gone, in the space of a favicon: a small donut that fills as the conversation grows, the count beside it in compact form, and — if you ask — a popover breaking the total down by what is holding it.
+
+## Components
+
+- `ContextRing` — the ring, its figure, and the optional breakdown popover
+
+## Usage
+
+```svelte
+<script>
+	import { ContextRing } from "fancy-ui-svelte";
+
+	const usage = {
+		used: 12_400,
+		max: 200_000,
+		breakdown: [
+			{ label: "System prompt", tokens: 1200 },
+			{ label: "Transcript", tokens: 9800 },
+			{ label: "Tool results", tokens: 1400 },
+		],
+	};
+</script>
+
+<ContextRing {usage} expandable />
+```
+
+## The data contract
+
+`usage` is a `TokenUsageData`, the shape shared by every component in this family — the same object can come straight off a token counter and land here without translation:
+
+```ts
+interface TokenUsageData {
+	used: number;
+	max: number;
+	breakdown?: Array<{ label: string; tokens: number }>;
+}
+```
+
+Only `used` and `max` are required. `breakdown` is what the popover lists; without it an expandable ring still opens, and says there is nothing to show.
+
+## Props
+
+| Prop          | Type                  | Default           | Description                                         |
+| ------------- | --------------------- | ----------------- | --------------------------------------------------- |
+| `usage`       | `TokenUsageData`      | —                 | Tokens used, out of how many, and of what. Required |
+| `size`        | `number`              | `28`              | Outer diameter of the ring, in pixels               |
+| `strokeWidth` | `number`              | `3`               | Thickness of the track and the arc, in pixels       |
+| `showLabel`   | `boolean`             | `true`            | Whether the compact figure is shown beside the ring |
+| `warnAt`      | `number`              | `0.75`            | Fraction at which the ring leaves the quiet band    |
+| `criticalAt`  | `number`              | `0.9`             | Fraction at which the ring turns to the error hue   |
+| `label`       | `string`              | `"Context usage"` | Accessible name for the meter                       |
+| `expandable`  | `boolean`             | `false`           | Whether clicking opens the breakdown popover        |
+| `class`       | `string`              | `undefined`       | Additional CSS classes                              |
+| `ref`         | `HTMLElement \| null` | `null`            | Bindable reference to the root element              |
+
+## Reading the ring
+
+The arc carries `used / max`, clamped to 0–1: a conversation that has run past its budget shows a closed ring rather than a second lap. A `max` of zero — or of nothing sensible at all — draws an empty ring instead of dividing by it.
+
+Colour comes from three bands, borrowed from the run-status vocabulary the rest of the AI family speaks, so the ring introduces no palette of its own:
+
+| Fraction                | Band       | Token                 | Reads as                |
+| ----------------------- | ---------- | --------------------- | ----------------------- |
+| `< warnAt`              | `ok`       | `--ft-status-pending` | Plenty of room          |
+| `warnAt` … `criticalAt` | `warn`     | `--ft-status-running` | Worth keeping an eye on |
+| `>= criticalAt`         | `critical` | `--ft-status-error`   | About to run out        |
+
+The band is on the root as `data-band`, so a consumer can key their own chrome off the same three words. Colour is never the only signal: the arc's length carries the fraction, and the figure beside it says the count.
+
+Set `criticalAt` below `warnAt` and it is floored at `warnAt` rather than obeyed — a critical threshold under the warning is a band that can never win, and a ring that escalates in one direction is more useful than one that escalates in none.
+
+## The figure
+
+`showLabel` renders a compact reading beside the ring — `12.4k / 200k`. The formatter is deliberately not `Intl.NumberFormat`'s compact notation, which rounds `12,400` to `12K` and drops exactly the digit a reader watches:
+
+| Tokens    | Renders as | Rule                              |
+| --------- | ---------- | --------------------------------- |
+| `850`     | `850`      | Under a thousand, counted exactly |
+| `1000`    | `1k`       | No hanging `.0`                   |
+| `12,400`  | `12.4k`    | One decimal under 100k            |
+| `154,000` | `154k`     | Rounded above 100k                |
+
+The figure is `aria-hidden`. The whole readout is one `role="meter"` whose `aria-valuetext` spells the counts out in full — `"12,400 of 200,000 tokens"` — because a compact figure is a glance, not a reading. `aria-valuenow` is pinned at `aria-valuemax` when the conversation is over budget, since a meter's value may not exceed its maximum; the `aria-valuetext` still reports the real number.
+
+## The breakdown
+
+`expandable` turns the ring into a button that toggles a popover listing each `breakdown` row with its own compact count. It closes on Escape — returning focus to the ring — on a click outside, and on a second press of the ring itself.
+
+The button takes its accessible name from the meter it contains, so the single string passed as `label` names both and the two cannot drift apart. Rows are keyed on their label _and_ their index, because a model will happily report two rows called "Tool results" and a key that is only the label would make the second replace the first.
+
+The popover is positioned with the shared float helper (`bottom-end`, re-measured on scroll and resize) and is only in the DOM while it is open, so an idle ring adds nothing for a screen reader to step over.
+
+## Styling
+
+Colour comes from `--ft-status-*`, the run-status vocabulary shared with `ToolCall`, `ToolTimeline`, `RecommendationCard`, `TerminalBlock` and `ChatError`. Set one anywhere up the tree and every component in the family follows:
+
+| Variable              | Default (light / dark)                         | Used here for   |
+| --------------------- | ---------------------------------------------- | --------------- |
+| `--ft-status-pending` | `oklch(0.5 0.02 260)` / `oklch(0.72 0.02 260)` | `ok` band       |
+| `--ft-status-running` | `oklch(0.5 0.18 265)` / `oklch(0.72 0.15 265)` | `warn` band     |
+| `--ft-status-error`   | `oklch(0.5 0.19 25)` / `oklch(0.7 0.18 25)`    | `critical` band |
+
+Each default is a `light-dark()` pair, because no single token clears the contrast it owes against both white and near-black. Which half applies is decided by `color-scheme`, so **your theme must declare it**:
+
+```css
+:root {
+	color-scheme: light;
+}
+.dark {
+	color-scheme: dark;
+}
+```
+
+Every colour is read at the point of use, so a value set by a consumer wins without having to out-specify the component's own scoped rules. The `--ft-ctxring-*` names sit in front of the shared ones for the case where this ring alone should differ:
+
+| Variable                    | Default                      | Applies to                        |
+| --------------------------- | ---------------------------- | --------------------------------- |
+| `--ft-ctxring-ok`           | `--ft-status-pending`        | Arc below `warnAt`                |
+| `--ft-ctxring-warn`         | `--ft-status-running`        | Arc between the thresholds        |
+| `--ft-ctxring-critical`     | `--ft-status-error`          | Arc at `criticalAt` and above     |
+| `--ft-ctxring-track`        | `currentColor` at 15%        | The unfilled part of the ring     |
+| `--ft-ctxring-panel-bg`     | `--color-popover`            | Breakdown popover surface         |
+| `--ft-ctxring-panel-fg`     | `--color-popover-foreground` | Breakdown popover text            |
+| `--ft-ctxring-panel-border` | `--color-border`             | Breakdown popover border          |
+| `--ft-ctxring-panel-width`  | `14rem`                      | Breakdown popover width           |
+| `--ft-ctxring-row-value`    | `currentColor` at 70%        | Per-row counts and the empty line |
+
+Geometry is props rather than variables: `size` and `strokeWidth` feed the `viewBox`, the radius and the dash array together, so they cannot be set half-way from CSS.
+
+## Implementation Notes
+
+- The arc is one SVG circle with a `stroke-dasharray` of its own circumference and a `stroke-dashoffset` carrying the fraction — no arc maths, no measuring. The stroke is inset by half its own width so a thick ring stays inside its box, and is clamped to the radius so it can never eat its own centre.
+- It starts empty and its target is written two animation frames later, because a transition never runs from a value the browser has not painted yet: `onMount` alone still lands inside the mounting frame, so the fill would be the first thing drawn and there would be nothing to animate between. Under reduced motion the target is written immediately instead, so there is no empty frame to notice.
+- Everything the meter _means_ — its value, its text, its band, the compact figure — is derived from the props alone, so a server render is exact and mount-independent. Only the entrance sweep waits for the client.
+- Both moving parts live behind `prefers-reduced-motion: no-preference`: the arc's `stroke-dashoffset` and colour transition, and the popover's entrance. Reduced motion gets the same states, instantly.
+- Nothing is scheduled and no DOM is touched at construction time, so the ring renders under SSR unchanged.

--- a/src/lib/fancy-ui/context-ring/index.ts
+++ b/src/lib/fancy-ui/context-ring/index.ts
@@ -1,0 +1,4 @@
+import ContextRing from "./ContextRing.svelte";
+import type { ContextRingProps } from "./ContextRing.svelte";
+
+export { ContextRing, type ContextRingProps };

--- a/src/lib/fancy-ui/index.ts
+++ b/src/lib/fancy-ui/index.ts
@@ -89,6 +89,9 @@ export * from "./approval-card/index.js";
 export * from "./recommendation-card/index.js";
 export * from "./artifact-card/index.js";
 export * from "./ai-data-table/index.js";
+export * from "./composer/index.js";
+export * from "./voice-input/index.js";
+export * from "./context-ring/index.js";
 
 // =============================================================================
 // Registry

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -3693,6 +3693,215 @@ export const registry: Record<string, ComponentMeta> = {
 			},
 		],
 	},
+	composer: {
+		name: "Composer",
+		slug: "composer",
+		description:
+			"The input at the bottom of a chat, taken apart: a root that owns the draft and eight parts that read it — a growing textarea, a send button that becomes a stop button, a toolbar, a model picker, an attachment row with its chips, and a completion menu you can mount twice on the same draft for / commands and @ mentions",
+		category: "ai-chat",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "chat", "composer", "input", "compound"],
+		props: [
+			{
+				name: "value",
+				type: "string",
+				default: '""',
+				description:
+					"The draft text, bindable. Cleared by a successful submit; the attachments are not, since only the consumer knows whether an upload is still in flight",
+			},
+			{
+				name: "attachments",
+				type: "AttachmentData[]",
+				default: "[]",
+				description:
+					"Files riding along with the draft, bindable. The consumer owns uploading them and pushing the results here",
+			},
+			{
+				name: "disabled",
+				type: "boolean",
+				default: "false",
+				description:
+					"Blocks typing, sending, and attaching. Every part reads it off the context, so one flag takes the whole composition inert",
+			},
+			{
+				name: "streaming",
+				type: "boolean",
+				default: "false",
+				description:
+					"A response is arriving: the send button becomes a stop button, the textarea goes readonly rather than disabled, and a submit is refused whatever triggered it",
+			},
+			{
+				name: "placeholder",
+				type: "string",
+				description:
+					"Placeholder for the default input. Ignored once children replaces the composition — the ComposerInput inside it carries its own",
+			},
+			{
+				name: "onSubmit",
+				type: "(payload: { text: string; attachments: AttachmentData[] }) => void",
+				description:
+					"Called with the trimmed draft and a snapshot of the attachments. Never fires on an empty draft that carries no files",
+			},
+			{
+				name: "onStop",
+				type: "() => void",
+				description: "Called when the stop button is pressed while streaming",
+			},
+			{
+				name: "onAttach",
+				type: "(files: File[]) => void",
+				description:
+					"Called with the files handed to the picker. Upload them, then push the results onto attachments — the composer never uploads anything itself",
+			},
+		],
+		slots: [
+			{
+				name: "children",
+				description:
+					"Replaces the default input-and-send-row composition entirely: mount the parts in whatever order the layout needs",
+			},
+			{
+				name: "accessory",
+				description:
+					"An overlay covering the composer — a voice panel, a drop target, a confirmation. It sits above the composition rather than replacing it, so the draft is still there when it lifts",
+			},
+		],
+	},
+	"voice-input": {
+		name: "VoiceInput",
+		slug: "voice-input",
+		description:
+			"A mic button that opens into a recording panel: a live waveform painted from amplitude levels you supply, a stopwatch, the transcript as it arrives, and a cross and a check to throw it away or keep it",
+		category: "ai-chat",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "chat", "voice", "waveform", "input"],
+		props: [
+			{
+				name: "active",
+				type: "boolean",
+				default: "false",
+				description:
+					"Whether a recording is in progress (bindable). Every button writes through it; setting it from outside opens or closes the panel without firing a callback",
+			},
+			{
+				name: "transcript",
+				type: "string",
+				default: '""',
+				description:
+					"Live text pushed by the consumer as their recogniser produces it, rendered muted under the waveform; a growing string grows in place",
+			},
+			{
+				name: "samples",
+				type: "ArrayLike<number>",
+				description:
+					"Amplitude levels in 0..1 bridged from your own audio pipeline, one entry per bar. The component never opens a microphone itself",
+			},
+			{
+				name: "demo",
+				type: "boolean",
+				default: "false",
+				description:
+					"Draw a deterministic synthetic wave when no samples arrive, so the panel is legible on a page with no audio behind it. Real samples always win",
+			},
+			{
+				name: "onStart",
+				type: "() => void",
+				description: "Called when the mic button starts a recording",
+			},
+			{
+				name: "onStop",
+				type: "() => void",
+				description: "Called when the check ends the recording and keeps the transcript",
+			},
+			{
+				name: "onCancel",
+				type: "() => void",
+				description: "Called when the cross abandons the recording",
+			},
+			{
+				name: "height",
+				type: "number",
+				default: "48",
+				description: "Waveform height in CSS pixels, clamped to 16..240",
+			},
+			{
+				name: "color",
+				type: "string",
+				default: "var(--ft-voice-color, currentColor)",
+				description:
+					"Any CSS colour for the bars, including a var() or currentColor — written onto the canvas as its CSS color and read back resolved, because a 2D context understands neither",
+			},
+		],
+	},
+	"context-ring": {
+		name: "ContextRing",
+		slug: "context-ring",
+		description:
+			"How much of the context window is gone, in the space of a favicon: a donut that fills as the conversation grows, the compact count beside it, and an optional popover breaking the total down by what is holding it",
+		category: "ai-chat",
+		status: "done",
+		credits: [{ source: "assistant-ui", url: "https://www.assistant-ui.com/elements" }],
+		tags: ["ai", "chat", "tokens", "context", "indicator"],
+		props: [
+			{
+				name: "usage",
+				type: "TokenUsageData",
+				description:
+					"Context-window consumption: tokens used, out of how many, and optionally the breakdown rows the popover lists",
+				required: true,
+			},
+			{
+				name: "size",
+				type: "number",
+				default: "28",
+				description: "Outer diameter of the ring, in pixels; drives the viewBox and the radius",
+			},
+			{
+				name: "strokeWidth",
+				type: "number",
+				default: "3",
+				description:
+					"Thickness of the track and the arc, in pixels; clamped to the radius so a thick ring cannot eat its own centre",
+			},
+			{
+				name: "showLabel",
+				type: "boolean",
+				default: "true",
+				description:
+					'Whether the compact "12.4k / 200k" figure is shown beside the ring — exact under a thousand, one decimal under 100k, rounded above',
+			},
+			{
+				name: "warnAt",
+				type: "number",
+				default: "0.75",
+				description:
+					"Fraction at which the ring leaves the quiet band and takes the running colour",
+			},
+			{
+				name: "criticalAt",
+				type: "number",
+				default: "0.9",
+				description:
+					"Fraction at which the ring takes the error colour. Floored at warnAt, so a threshold set below the warning cannot create a band that never wins",
+			},
+			{
+				name: "label",
+				type: "string",
+				default: '"Context usage"',
+				description:
+					"Accessible name for the meter, and — when expandable — for the button that contains it",
+			},
+			{
+				name: "expandable",
+				type: "boolean",
+				default: "false",
+				description:
+					"Turns the ring into a button that toggles a popover listing usage.breakdown; closes on Escape, on a click outside, or on a second press",
+			},
+		],
+	},
 };
 
 // =============================================================================

--- a/src/lib/fancy-ui/voice-input/README.md
+++ b/src/lib/fancy-ui/voice-input/README.md
@@ -1,0 +1,149 @@
+# Voice Input
+
+A mic button that opens into a recording panel: a live waveform, a stopwatch, the transcript as it arrives, and a cross and a check to throw it away or keep it.
+
+## Components
+
+- `VoiceInput` — the mic button and the panel it becomes
+
+## Usage
+
+```svelte
+<script>
+	import { VoiceInput } from "fancy-ui-svelte";
+
+	let active = $state(false);
+	let transcript = $state("");
+</script>
+
+<VoiceInput bind:active {transcript} onStart={startRecogniser} onStop={submit} onCancel={discard} />
+```
+
+## This component never opens a microphone
+
+It draws a recording; it does not make one. There is no `getUserMedia` call, no `AudioContext`, no `MediaRecorder`, and no speech-recognition API anywhere in it — so it adds no permission prompt, no autoplay-policy surprise, and nothing that has to be torn down on a route change.
+
+That leaves you owning the pipeline, which is the only way this works across the many that exist. You feed it two things:
+
+- **`samples`** — amplitude levels in `0..1`, one entry per bar you want drawn, refreshed as often as you like. From a Web Audio `AnalyserNode` that is `getByteFrequencyData` into a `Uint8Array`, divided by 255.
+- **`transcript`** — whatever text your recogniser has produced so far.
+
+Neither has to arrive on any particular schedule. The waveform redraws every frame from whatever `samples` currently holds, and the transcript is plain reactive text.
+
+```svelte
+<script>
+	let active = $state(false);
+	let samples = $state(new Float32Array(0));
+	let transcript = $state("");
+
+	async function startRecogniser() {
+		const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+		const ctx = new AudioContext();
+		const analyser = ctx.createAnalyser();
+		analyser.fftSize = 128;
+		ctx.createMediaStreamSource(stream).connect(analyser);
+
+		const bytes = new Uint8Array(analyser.frequencyBinCount);
+		const next = new Float32Array(analyser.frequencyBinCount);
+		(function poll() {
+			if (!active) return;
+			analyser.getByteFrequencyData(bytes);
+			for (let i = 0; i < bytes.length; i++) next[i] = bytes[i] / 255;
+			samples = next.slice();
+			requestAnimationFrame(poll);
+		})();
+	}
+</script>
+
+<VoiceInput bind:active {samples} {transcript} onStart={startRecogniser} />
+```
+
+With no `samples` and no `demo`, the waveform draws a flat floor: a live signal with nothing in it, rather than an empty box.
+
+## Demo mode
+
+`demo` swaps in a deterministic synthetic wave so the component is legible on a docs page, in a story, or in a design review with no audio behind it. It is a stand-in and nothing more: **the moment real `samples` arrive they win**, so leaving `demo` on in production degrades to a plausible waveform instead of a dead one, and never overwrites a real signal.
+
+## Props
+
+| Prop         | Type                     | Default                               | Description                                         |
+| ------------ | ------------------------ | ------------------------------------- | --------------------------------------------------- |
+| `active`     | `boolean`                | `false`                               | Whether a recording is in progress. Bindable        |
+| `transcript` | `string`                 | `""`                                  | Live text; rendered muted under the waveform        |
+| `samples`    | `ArrayLike<number>`      | `undefined`                           | Amplitude levels in `0..1`, from your own pipeline  |
+| `demo`       | `boolean`                | `false`                               | Draw a synthetic wave when no samples arrive        |
+| `onStart`    | `() => void`             | `undefined`                           | The mic button started a recording                  |
+| `onStop`     | `() => void`             | `undefined`                           | The check ended it and kept the transcript          |
+| `onCancel`   | `() => void`             | `undefined`                           | The cross abandoned it                              |
+| `height`     | `number`                 | `48`                                  | Waveform height in CSS pixels, clamped to `16..240` |
+| `color`      | `string`                 | `var(--ft-voice-color, currentColor)` | Any CSS colour for the bars                         |
+| `class`      | `string`                 | `undefined`                           | Additional CSS classes                              |
+| `ref`        | `HTMLDivElement \| null` | `null`                                | Bindable reference to the root element              |
+
+## The active contract
+
+`active` is the whole state machine. It starts `false` — the mic button alone — and each button writes through it:
+
+| Button | Writes           | Calls      |
+| ------ | ---------------- | ---------- |
+| mic    | `active = true`  | `onStart`  |
+| cross  | `active = false` | `onCancel` |
+| check  | `active = false` | `onStop`   |
+
+Set it from outside and the panel opens or closes to match, **without** firing any callback — the callbacks report what the user did, not what the state is. So a consumer that starts a recording from a keyboard shortcut sets `active = true` and calls their own recogniser directly; they will not get an `onStart` for it.
+
+Neither the transcript nor the samples are cleared on cancel. The component does not own that text — you pushed it in, and you decide whether the next recording starts from empty. `onCancel` is where you do it.
+
+## Accessibility
+
+- The root is a `role="group"` named _"Voice input"_, so the mic and the panel it becomes read as one control rather than as unrelated buttons appearing and disappearing.
+- The three buttons carry the labels _"Start voice input"_, _"Cancel voice input"_ and _"Stop voice input"_ — the icons say nothing out loud.
+- Recording is announced through an `sr-only` `role="status"` line that is **always in the document** and changes its text between `""` and `"Recording"`. A live region inserted along with its own content is announced unreliably; one that outlives the change is not.
+- The canvas is `aria-hidden`. It is a picture of an amplitude the stopwatch and the transcript already state in words.
+- The transcript is deliberately **not** a live region. Partial recogniser output announced word by word is unusable; wrap the component and mirror the text into your own region if your application wants it announced.
+
+## Styling
+
+| Variable                           | Default               | Applies to                      |
+| ---------------------------------- | --------------------- | ------------------------------- |
+| `--ft-voice-color`                 | `currentColor`        | Waveform bars                   |
+| `--ft-voice-dot`                   | `--ft-status-running` | The recording dot and its pulse |
+| `--ft-voice-pulse-duration`        | `1.6s`                | Speed of the dot's pulse        |
+| `--ft-voice-transcript-max-height` | `4.5rem`              | Scroll cap on a long transcript |
+
+The dot takes `--ft-status-running`, the run-in-flight colour shared with `ToolCall`, `ToolTimeline` and the rest of the family, because a recording _is_ a run in flight — retinting the family's error colour should not turn the record light red. Its default is the same `light-dark()` pair those components use:
+
+```css
+light-dark(oklch(0.5 0.18 265), oklch(0.72 0.15 265));
+```
+
+Which half applies is decided by `color-scheme`, so your theme must declare it:
+
+```css
+:root {
+	color-scheme: light;
+}
+.dark {
+	color-scheme: dark;
+}
+```
+
+If you want the classic red record dot, that is one line and it does not disturb anything else:
+
+```css
+.my-composer {
+	--ft-voice-dot: oklch(0.6 0.2 25);
+}
+```
+
+`color` is a prop rather than only a variable because it reaches the canvas, which is not styled by CSS. Whatever you pass — a hex, an `oklch()`, a `var()` — is written onto the canvas element as its CSS `color` and read back resolved before painting, so `var()` and `currentColor` work there exactly as they do everywhere else.
+
+## Implementation Notes
+
+- One `$effect` owns the entire canvas lifetime. It re-runs when the panel opens or closes and when `height` or `color` changes — all rare. Everything that changes per frame, `samples` and `demo` included, is read from inside the `requestAnimationFrame` callback, which is outside any tracking context: a consumer pushing sixty buffers a second does not tear the loop down and rebuild it sixty times a second.
+- The drawing itself is `drawWaveformFrame` from the shared waveform core, which is pure and unit-tested against a stub context. The component contributes the canvas, the DPR transform, and the loop.
+- Backing-store size is `devicePixelRatio`-scaled and a `setTransform` is re-applied after every resize — assigning `width` or `height` resets the context — so all the geometry above stays in CSS pixels.
+- A `getContext("2d")` that returns `null` (jsdom, a surface the browser refuses to back) is a return, not a throw. The panel keeps its dot, timer, transcript and buttons; only the bars are missing.
+- **Reduced motion paints one still frame and starts no loop at all.** A sixty-per-second amplitude meter is exactly the motion the setting asks us not to run, and the recording is still announced, still timed and still transcribed without it. The frame is painted inside `untrack`, so incoming samples cannot restart the effect and turn the still back into an animation. The dot's pulse is the only other animation and it lives behind `prefers-reduced-motion: no-preference`.
+- The stopwatch is `createElapsed` from the shared elapsed module. `start()` hands back its own stop function, which doubles as the effect cleanup, so the timer exists only while `active` is true and each recording is timed from its own zero.
+- Nothing is scheduled and no DOM is touched at construction time, so the mic button renders under SSR unchanged.

--- a/src/lib/fancy-ui/voice-input/VoiceInput.svelte
+++ b/src/lib/fancy-ui/voice-input/VoiceInput.svelte
@@ -1,0 +1,407 @@
+<script lang="ts" module>
+	/**
+	 * Props for VoiceInput
+	 */
+	export interface VoiceInputProps {
+		/**
+		 * Whether a recording is in progress. Bindable — the mic, cancel and confirm
+		 * buttons all write through it, and setting it from outside opens or closes
+		 * the panel without firing any callback.
+		 */
+		active?: boolean;
+		/**
+		 * Live text pushed by the consumer as their recogniser produces it. Rendered
+		 * muted under the waveform; a growing string simply grows in place.
+		 */
+		transcript?: string;
+		/**
+		 * Amplitude levels in 0..1, bridged from whatever audio pipeline the
+		 * consumer already owns. This component never opens a microphone itself.
+		 */
+		samples?: ArrayLike<number>;
+		/**
+		 * Draw a synthetic waveform when no `samples` arrive, so the component is
+		 * legible on a docs page or in a story with no audio behind it.
+		 */
+		demo?: boolean;
+		/** Called when the mic button starts a recording. */
+		onStart?: () => void;
+		/** Called when the confirm button ends a recording and keeps the transcript. */
+		onStop?: () => void;
+		/** Called when the cancel button abandons a recording. */
+		onCancel?: () => void;
+		/** Waveform height in CSS pixels. Clamped to 16..240. */
+		height?: number;
+		/** Any CSS colour for the bars, including a `var()` — resolved before painting. */
+		color?: string;
+		/** Additional CSS classes */
+		class?: string;
+		/** Element reference */
+		ref?: HTMLDivElement | null;
+	}
+</script>
+
+<script lang="ts">
+	import { onMount, untrack } from "svelte";
+	import { cn } from "$lib/utils.js";
+	import { createElapsed } from "../_internals/elapsed.svelte.js";
+	import { drawWaveformFrame, fakeWaveSample } from "../_internals/waveform-core.js";
+
+	let {
+		active = $bindable(false),
+		transcript = "",
+		samples,
+		demo = false,
+		onStart,
+		onStop,
+		onCancel,
+		height = 48,
+		color = "var(--ft-voice-color, currentColor)",
+		class: className,
+		ref = $bindable(null),
+	}: VoiceInputProps = $props();
+
+	/** Bar geometry, in CSS pixels. Fixed: the waveform is a meter, not a chart. */
+	const BAR_WIDTH = 3;
+	const BAR_GAP = 2;
+	/** Amplitude floor, so silence still reads as a live signal rather than a gap. */
+	const MIN_AMP = 0.06;
+	/** Below the floor the bars stop resolving; above the ceiling this is a chart. */
+	const MIN_HEIGHT = 16;
+	const MAX_HEIGHT = 240;
+	/** Handed to the renderer when there is no signal and no stand-in for one. */
+	const NO_SIGNAL: number[] = [];
+
+	let mounted = $state(false);
+	let canvasEl = $state<HTMLCanvasElement | null>(null);
+
+	const barHeight = $derived(
+		Number.isFinite(height) ? Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, height)) : 48
+	);
+
+	const elapsed = createElapsed();
+	// ISO 8601 duration, so the reading is machine-readable and not just decorative.
+	const elapsedDateTime = $derived(`PT${Math.max(0, Math.floor(elapsed.ms / 1000))}S`);
+
+	onMount(() => {
+		mounted = true;
+	});
+
+	// `start` hands back its own stop function, which doubles as the cleanup: the
+	// stopwatch exists only between the two, and each recording is timed from its
+	// own zero rather than continuing the last one.
+	$effect(() => {
+		if (active) return elapsed.start(Date.now());
+	});
+
+	function prefersReducedMotion(): boolean {
+		return (
+			typeof window.matchMedia === "function" &&
+			window.matchMedia("(prefers-reduced-motion: reduce)").matches
+		);
+	}
+
+	function start() {
+		if (active) return;
+		active = true;
+		onStart?.();
+	}
+
+	function cancel() {
+		active = false;
+		onCancel?.();
+	}
+
+	function finish() {
+		active = false;
+		onStop?.();
+	}
+
+	/*
+	 * The whole canvas lifetime is one effect. It re-runs when the panel appears
+	 * or disappears, when the canvas is (re)attached, and when the geometry or the
+	 * colour changes — all rare. Everything that changes per frame is read from
+	 * inside the rAF callback, which runs outside any tracking context, so a
+	 * consumer pushing sixty sample buffers a second does not tear the loop down
+	 * and rebuild it sixty times a second.
+	 */
+	$effect(() => {
+		// `$effect` never runs on the server; `mounted` additionally keeps the loop
+		// from starting before the panel's canvas is in the document.
+		if (!mounted || !active) return;
+
+		const el = canvasEl;
+		if (!el) return;
+
+		// jsdom and a browser that refuses to back the surface both hand back null.
+		// The panel is still legible without bars — a timer, a transcript and two
+		// buttons — so this is a return, not a throw.
+		const context = el.getContext("2d");
+		if (!context) return;
+
+		// Re-declared with non-null types: the helpers below capture both, and a
+		// narrowing does not survive the closure boundary.
+		const canvas: HTMLCanvasElement = el;
+		const ctx: CanvasRenderingContext2D = context;
+
+		// Tracked on purpose: a new height or colour restarts the loop with it.
+		const h = barHeight;
+		const requested = color;
+
+		// `fillStyle` understands neither `var()` nor `currentColor`, so the prop is
+		// written onto the element as its CSS `color` (see the `style:color` below)
+		// and read back resolved. One style recalculation per effect run, never one
+		// per frame.
+		const fill = getComputedStyle(canvas).color || requested;
+
+		const style = {
+			color: fill,
+			barWidth: BAR_WIDTH,
+			gap: BAR_GAP,
+			minAmp: MIN_AMP,
+			mirror: true,
+		};
+
+		const reduced = prefersReducedMotion();
+
+		let cssWidth = 0;
+		let synthetic = new Float32Array(0);
+		let frame: number | undefined;
+
+		function resize() {
+			const dpr = window.devicePixelRatio || 1;
+			cssWidth = canvas.clientWidth;
+			canvas.width = Math.max(1, Math.round(cssWidth * dpr));
+			canvas.height = Math.max(1, Math.round(h * dpr));
+			// Assigning width or height resets the context, so the device-pixel
+			// transform is re-applied here and every measurement below stays in CSS
+			// pixels.
+			ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+			// One synthetic sample per bar, so `demo` never has to be resampled.
+			const bars = Math.max(0, Math.floor(cssWidth / (BAR_WIDTH + BAR_GAP)));
+			if (synthetic.length !== bars) synthetic = new Float32Array(bars);
+		}
+
+		function levels(tMs: number): ArrayLike<number> {
+			// A real pipeline always wins. `demo` is the stand-in for a page with no
+			// microphone behind it, and neither one means an honest flat floor.
+			if (samples && samples.length > 0) return samples;
+			if (!demo) return NO_SIGNAL;
+			for (let i = 0; i < synthetic.length; i++) synthetic[i] = fakeWaveSample(i, tMs);
+			return synthetic;
+		}
+
+		function paint(tMs: number) {
+			drawWaveformFrame(ctx, levels(tMs), cssWidth, h, style);
+		}
+
+		resize();
+
+		const observer = new ResizeObserver(() => {
+			resize();
+			// The animated path repaints on its own a frame later; the still one has
+			// to be told, or a resized panel keeps a stale drawing.
+			if (reduced) untrack(() => paint(0));
+		});
+		observer.observe(canvas);
+
+		if (reduced) {
+			// One frame and then nothing. A sixty-per-second amplitude meter is
+			// precisely the motion this setting asks us not to run, and the recording
+			// is still announced, still timed, and still transcribed without it.
+			// Untracked so that a consumer pushing samples cannot restart the effect
+			// and turn the still frame back into an animation.
+			untrack(() => paint(0));
+		} else {
+			const started = performance.now();
+			const loop = (now: number) => {
+				paint(now - started);
+				frame = requestAnimationFrame(loop);
+			};
+			frame = requestAnimationFrame(loop);
+		}
+
+		return () => {
+			if (frame !== undefined) cancelAnimationFrame(frame);
+			observer.disconnect();
+		};
+	});
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("ft-voice", className)}
+	role="group"
+	aria-label="Voice input"
+	data-active={active ? "true" : "false"}
+>
+	<!--
+		A live region that outlives the state change it reports: swapping the text
+		inside a region already in the document is announced reliably, where a
+		region inserted along with its own text is not.
+	-->
+	<span class="ft-voice-status sr-only" role="status">{active ? "Recording" : ""}</span>
+
+	{#if !active}
+		<button
+			type="button"
+			class="ft-voice-mic text-muted-foreground hover:text-foreground hover:bg-foreground/5 inline-flex size-9 flex-none items-center justify-center rounded-full border transition-colors"
+			aria-label="Start voice input"
+			onclick={start}
+		>
+			<svg
+				class="size-4"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				aria-hidden="true"
+			>
+				<path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
+				<path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+				<path d="M12 19v3" />
+			</svg>
+		</button>
+	{:else}
+		<div
+			class="ft-voice-panel bg-card/50 flex w-full items-center gap-3 rounded-lg border px-3 py-2"
+		>
+			<span class="ft-voice-dot flex-none" aria-hidden="true"></span>
+
+			<div class="ft-voice-signal min-w-0 flex-1">
+				<!--
+					Purely a picture of the amplitude that the timer and the transcript
+					already state in words, so it is hidden rather than described.
+				-->
+				<canvas
+					bind:this={canvasEl}
+					class="ft-voice-canvas block w-full"
+					style:height="{barHeight}px"
+					style:color
+					aria-hidden="true"
+				></canvas>
+
+				{#if transcript}
+					<p class="ft-voice-transcript text-muted-foreground mt-1 text-xs leading-relaxed">
+						{transcript}
+					</p>
+				{/if}
+			</div>
+
+			<time
+				class="ft-voice-elapsed text-muted-foreground flex-none text-xs tabular-nums"
+				datetime={elapsedDateTime}>{elapsed.text}</time
+			>
+
+			<button
+				type="button"
+				class="ft-voice-btn text-muted-foreground hover:text-foreground hover:bg-foreground/5 inline-flex size-7 flex-none items-center justify-center rounded-full transition-colors"
+				aria-label="Cancel voice input"
+				onclick={cancel}
+			>
+				<svg
+					class="size-3.5"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true"
+				>
+					<path d="M18 6 6 18" />
+					<path d="m6 6 12 12" />
+				</svg>
+			</button>
+
+			<button
+				type="button"
+				class="ft-voice-btn ft-voice-confirm text-foreground hover:bg-foreground/10 bg-foreground/5 inline-flex size-7 flex-none items-center justify-center rounded-full transition-colors"
+				aria-label="Stop voice input"
+				onclick={finish}
+			>
+				<svg
+					class="size-3.5"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2.5"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true"
+				>
+					<path d="M20 6 9 17l-5-5" />
+				</svg>
+			</button>
+		</div>
+	{/if}
+</div>
+
+<style>
+	/*
+	 * The dot is read at the point of use through two hooks: this component's own
+	 * `--ft-voice-dot`, then the `--ft-status-*` vocabulary the whole AI family
+	 * shares. Setting either anywhere up the tree retints it without having to win
+	 * a specificity fight against these scoped rules.
+	 *
+	 * It takes `running` rather than `error` because a recording in progress is a
+	 * run in flight, not a failure — retinting the family's error colour should
+	 * not turn the record light red. Consumers who want the classic red record dot
+	 * say so in one line: `--ft-voice-dot: oklch(0.6 0.2 25)`.
+	 */
+	.ft-voice-dot {
+		position: relative;
+		display: inline-block;
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 9999px;
+		background: var(
+			--ft-voice-dot,
+			var(--ft-status-running, light-dark(oklch(0.5 0.18 265), oklch(0.72 0.15 265)))
+		);
+	}
+
+	.ft-voice-dot::after {
+		content: "";
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		background: inherit;
+		opacity: 0;
+	}
+
+	.ft-voice-transcript {
+		/* Wrapping rather than scrolling sideways, and capped rather than unbounded:
+		   a two-minute dictation should not push the controls off the panel. */
+		max-height: var(--ft-voice-transcript-max-height, 4.5rem);
+		overflow-y: auto;
+		overflow-wrap: anywhere;
+	}
+
+	/*
+	 * The only animation in the component lives behind the query, so reduced
+	 * motion is not a second variant to keep in sync: the dot is simply a static
+	 * dot, still the same colour, still saying the same thing.
+	 */
+	@media (prefers-reduced-motion: no-preference) {
+		.ft-voice-dot::after {
+			animation: ft-voice-pulse var(--ft-voice-pulse-duration, 1.6s) cubic-bezier(0, 0, 0.2, 1)
+				infinite;
+		}
+	}
+
+	@keyframes ft-voice-pulse {
+		0% {
+			transform: scale(1);
+			opacity: 0.55;
+		}
+		75%,
+		100% {
+			transform: scale(2.6);
+			opacity: 0;
+		}
+	}
+</style>

--- a/src/lib/fancy-ui/voice-input/VoiceInput.test.ts
+++ b/src/lib/fancy-ui/voice-input/VoiceInput.test.ts
@@ -1,0 +1,327 @@
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import VoiceInput from "./VoiceInput.svelte";
+import Harness from "./VoiceInputHarness.test.svelte";
+
+function root(container: HTMLElement): HTMLElement {
+	return container.firstElementChild as HTMLElement;
+}
+
+function mic(container: HTMLElement): HTMLButtonElement | null {
+	return container.querySelector('button[aria-label="Start voice input"]');
+}
+
+function cancelButton(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector('button[aria-label="Cancel voice input"]') as HTMLButtonElement;
+}
+
+function confirmButton(container: HTMLElement): HTMLButtonElement {
+	return container.querySelector('button[aria-label="Stop voice input"]') as HTMLButtonElement;
+}
+
+function canvas(container: HTMLElement): HTMLCanvasElement | null {
+	return container.querySelector("canvas");
+}
+
+function statusLine(container: HTMLElement): HTMLElement {
+	return container.querySelector(".ft-voice-status") as HTMLElement;
+}
+
+function transcriptLine(container: HTMLElement): HTMLElement | null {
+	return container.querySelector(".ft-voice-transcript");
+}
+
+/**
+ * Minimal recording stand-in for a 2D context. The global test setup makes
+ * `getContext` return null, which is the null-ctx case one test below asserts —
+ * every test that needs the loop to actually start installs this instead.
+ */
+function stubContext() {
+	const ctx = {
+		clearRect: vi.fn(),
+		fillRect: vi.fn(),
+		setTransform: vi.fn(),
+		fillStyle: "",
+	};
+	const spy = vi
+		.spyOn(HTMLCanvasElement.prototype, "getContext")
+		// `getContext` is overloaded; the spy resolves against the last signature,
+		// and `never` sidesteps naming a context type just to hand back a 2D stub.
+		.mockReturnValue(ctx as never);
+	return { ctx, spy };
+}
+
+/**
+ * jsdom lays nothing out, so every element measures zero and the renderer draws
+ * no bars. Give the canvas a width for the tests that care what was painted.
+ */
+function withCanvasWidth(width: number): () => void {
+	Object.defineProperty(HTMLCanvasElement.prototype, "clientWidth", {
+		configurable: true,
+		get: () => width,
+	});
+	return () => {
+		// Deleting the own property hands `clientWidth` back to Element.prototype.
+		Reflect.deleteProperty(HTMLCanvasElement.prototype, "clientWidth");
+	};
+}
+
+/** Swap `prefers-reduced-motion: reduce` on for one test, then hand back the undo. */
+function withReducedMotion(): () => void {
+	const real = window.matchMedia;
+	window.matchMedia = ((query: string) => ({
+		matches: query.includes("prefers-reduced-motion"),
+		media: query,
+		onchange: null,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		dispatchEvent: () => false,
+		addListener: () => {},
+		removeListener: () => {},
+	})) as unknown as typeof window.matchMedia;
+	return () => {
+		window.matchMedia = real;
+	};
+}
+
+describe("VoiceInput", () => {
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it("names itself as a group so the mic and the panel read as one control", () => {
+		const { container } = render(VoiceInput);
+
+		expect(root(container).getAttribute("role")).toBe("group");
+		expect(root(container).getAttribute("aria-label")).toBe("Voice input");
+	});
+
+	it("shows nothing but the mic button while idle", () => {
+		const { container } = render(VoiceInput);
+
+		expect(mic(container)).not.toBeNull();
+		expect(canvas(container)).toBeNull();
+		expect(container.querySelector(".ft-voice-panel")).toBeNull();
+		expect(root(container).dataset.active).toBe("false");
+	});
+
+	it("opens the panel and reports the start when the mic is pressed", async () => {
+		const onStart = vi.fn();
+		const { container } = render(VoiceInput, { props: { onStart } });
+
+		await fireEvent.click(mic(container) as HTMLButtonElement);
+
+		expect(onStart).toHaveBeenCalledTimes(1);
+		expect(mic(container)).toBeNull();
+		expect(container.querySelector(".ft-voice-panel")).not.toBeNull();
+		expect(canvas(container)).not.toBeNull();
+		expect(root(container).dataset.active).toBe("true");
+	});
+
+	it("writes the recording state back out through the bindable prop", async () => {
+		const { container, getByTestId } = render(Harness);
+		expect(getByTestId("bound-active").textContent).toBe("idle");
+
+		await fireEvent.click(mic(container) as HTMLButtonElement);
+		expect(getByTestId("bound-active").textContent).toBe("recording");
+
+		await fireEvent.click(cancelButton(container));
+		expect(getByTestId("bound-active").textContent).toBe("idle");
+	});
+
+	it("writes the confirm back out through the binding too", async () => {
+		const { container, getByTestId } = render(Harness, { props: { active: true } });
+
+		await fireEvent.click(confirmButton(container));
+
+		expect(getByTestId("bound-active").textContent).toBe("idle");
+	});
+
+	it("follows an active prop driven from outside", async () => {
+		const { container, rerender } = render(VoiceInput, { props: { active: false } });
+		expect(mic(container)).not.toBeNull();
+
+		await rerender({ active: true });
+		expect(mic(container)).toBeNull();
+		expect(container.querySelector(".ft-voice-panel")).not.toBeNull();
+	});
+
+	it("closes the panel and reports the cancel", async () => {
+		const onCancel = vi.fn();
+		const onStop = vi.fn();
+		const { container } = render(VoiceInput, { props: { active: true, onCancel, onStop } });
+
+		await fireEvent.click(cancelButton(container));
+
+		expect(onCancel).toHaveBeenCalledTimes(1);
+		expect(onStop).not.toHaveBeenCalled();
+		expect(mic(container)).not.toBeNull();
+	});
+
+	it("closes the panel and reports the confirm", async () => {
+		const onCancel = vi.fn();
+		const onStop = vi.fn();
+		const { container } = render(VoiceInput, { props: { active: true, onCancel, onStop } });
+
+		await fireEvent.click(confirmButton(container));
+
+		expect(onStop).toHaveBeenCalledTimes(1);
+		expect(onCancel).not.toHaveBeenCalled();
+		expect(mic(container)).not.toBeNull();
+	});
+
+	it("opens on an externally driven active without claiming the user started it", () => {
+		const onStart = vi.fn();
+		const { container } = render(VoiceInput, { props: { active: true, onStart } });
+
+		expect(container.querySelector(".ft-voice-panel")).not.toBeNull();
+		expect(onStart).not.toHaveBeenCalled();
+	});
+
+	it("announces the recording through a live region that survives the state change", async () => {
+		const { container } = render(VoiceInput);
+
+		expect(statusLine(container).getAttribute("role")).toBe("status");
+		expect(statusLine(container).textContent).toBe("");
+
+		await fireEvent.click(mic(container) as HTMLButtonElement);
+		expect(statusLine(container).textContent).toBe("Recording");
+
+		await fireEvent.click(confirmButton(container));
+		expect(statusLine(container).textContent).toBe("");
+	});
+
+	it("renders the transcript under the waveform and lets it grow in place", async () => {
+		const { container, rerender } = render(VoiceInput, {
+			props: { active: true, transcript: "show me" },
+		});
+
+		expect(transcriptLine(container)?.textContent?.trim()).toBe("show me");
+
+		await rerender({ active: true, transcript: "show me the retry policy" });
+		expect(transcriptLine(container)?.textContent?.trim()).toBe("show me the retry policy");
+	});
+
+	it("leaves the transcript line out entirely until there is something to say", () => {
+		const { container } = render(VoiceInput, { props: { active: true } });
+
+		expect(transcriptLine(container)).toBeNull();
+	});
+
+	it("hides the waveform from assistive tech and times the recording out loud", () => {
+		const { container } = render(VoiceInput, { props: { active: true } });
+
+		expect(canvas(container)?.getAttribute("aria-hidden")).toBe("true");
+		const time = container.querySelector("time") as HTMLTimeElement;
+		expect(time.textContent).toBe("0s");
+		expect(time.getAttribute("datetime")).toBe("PT0S");
+	});
+
+	it("renders the panel unharmed when the canvas hands back no context", () => {
+		// The global setup already makes `getContext` return null.
+		expect(canvas(document.body)).toBeNull();
+		const { container } = render(VoiceInput, { props: { active: true, demo: true } });
+
+		expect(container.querySelector(".ft-voice-panel")).not.toBeNull();
+		expect(canvas(container)).not.toBeNull();
+	});
+
+	it("runs the loop from demo samples when no pipeline is feeding it", async () => {
+		const { ctx } = stubContext();
+		const raf = vi.spyOn(globalThis, "requestAnimationFrame").mockReturnValue(1);
+
+		const { container } = render(VoiceInput, { props: { active: true, demo: true } });
+		await Promise.resolve();
+
+		expect(canvas(container)).not.toBeNull();
+		expect(raf).toHaveBeenCalled();
+		expect(ctx.setTransform).toHaveBeenCalled();
+	});
+
+	it("paints one still frame and starts no loop under reduced motion", async () => {
+		const restore = withReducedMotion();
+		try {
+			const { ctx } = stubContext();
+			const raf = vi.spyOn(globalThis, "requestAnimationFrame").mockReturnValue(1);
+
+			render(VoiceInput, { props: { active: true, demo: true } });
+			await Promise.resolve();
+
+			expect(raf).not.toHaveBeenCalled();
+			expect(ctx.clearRect).toHaveBeenCalledTimes(1);
+		} finally {
+			restore();
+		}
+	});
+
+	it("draws the consumer's own samples in preference to the demo wave", async () => {
+		const restore = withReducedMotion();
+		const restoreWidth = withCanvasWidth(25);
+		try {
+			const { ctx } = stubContext();
+
+			// Every level at full scale, which the synthetic wave never reaches — so
+			// a full-height bar can only have come from the pipeline.
+			render(VoiceInput, {
+				props: { active: true, demo: true, samples: [1, 1, 1, 1, 1], height: 48 },
+			});
+			await Promise.resolve();
+
+			// 25px of surface at 3px bars and 2px gaps is five bars, each centred.
+			expect(ctx.fillRect.mock.calls).toEqual([
+				[0, 0, 3, 48],
+				[5, 0, 3, 48],
+				[10, 0, 3, 48],
+				[15, 0, 3, 48],
+				[20, 0, 3, 48],
+			]);
+		} finally {
+			restoreWidth();
+			restore();
+		}
+	});
+
+	it("falls back to a flat floor when there is neither a pipeline nor a demo", async () => {
+		const restore = withReducedMotion();
+		const restoreWidth = withCanvasWidth(25);
+		try {
+			const { ctx } = stubContext();
+
+			render(VoiceInput, { props: { active: true, height: 50 } });
+			await Promise.resolve();
+
+			// 6% of 50px: a live-but-silent signal, not an empty box.
+			expect(ctx.fillRect).toHaveBeenCalledTimes(5);
+			for (const [, , , barHeight] of ctx.fillRect.mock.calls) {
+				expect(barHeight).toBeCloseTo(3, 5);
+			}
+		} finally {
+			restoreWidth();
+			restore();
+		}
+	});
+
+	it("starts no canvas work at all while idle", async () => {
+		stubContext();
+		const raf = vi.spyOn(globalThis, "requestAnimationFrame").mockReturnValue(1);
+
+		render(VoiceInput);
+		await Promise.resolve();
+
+		expect(raf).not.toHaveBeenCalled();
+	});
+
+	it("clamps an absurd height rather than drawing it", () => {
+		const { container } = render(VoiceInput, { props: { active: true, height: 5000 } });
+
+		expect((canvas(container) as HTMLCanvasElement).style.height).toBe("240px");
+	});
+
+	it("merges custom classes onto the root", () => {
+		const { container } = render(VoiceInput, { props: { class: "my-voice" } });
+
+		expect(root(container).className).toContain("my-voice");
+		expect(root(container).className).toContain("ft-voice");
+	});
+});

--- a/src/lib/fancy-ui/voice-input/VoiceInputHarness.test.svelte
+++ b/src/lib/fancy-ui/voice-input/VoiceInputHarness.test.svelte
@@ -1,0 +1,34 @@
+<!--
+  Test-only rig. `bind:` cannot be expressed from a `.ts` test file — the props
+  object a test hands to `render` is copied into the component's own reactive
+  state, so a write inside the component never lands back on it — and binding
+  here and echoing the value into the DOM is the only way to prove the recording
+  state travels back out to the consumer rather than merely changing what the
+  component draws. Not exported from index.ts, and not collected by Vitest (the
+  run includes `*.test.ts` only).
+-->
+<script lang="ts">
+	import VoiceInput from "./VoiceInput.svelte";
+
+	interface Props {
+		active?: boolean;
+		transcript?: string;
+		demo?: boolean;
+		onStart?: () => void;
+		onStop?: () => void;
+		onCancel?: () => void;
+	}
+
+	let {
+		active = $bindable(false),
+		transcript = "",
+		demo = false,
+		onStart,
+		onStop,
+		onCancel,
+	}: Props = $props();
+</script>
+
+<VoiceInput bind:active {transcript} {demo} {onStart} {onStop} {onCancel} />
+
+<span data-testid="bound-active">{active ? "recording" : "idle"}</span>

--- a/src/lib/fancy-ui/voice-input/index.ts
+++ b/src/lib/fancy-ui/voice-input/index.ts
@@ -1,0 +1,4 @@
+import VoiceInput from "./VoiceInput.svelte";
+import type { VoiceInputProps } from "./VoiceInput.svelte";
+
+export { VoiceInput, type VoiceInputProps };

--- a/src/stories/composer.stories.svelte
+++ b/src/stories/composer.stories.svelte
@@ -1,0 +1,108 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import {
+		Composer,
+		ComposerInput,
+		ComposerSubmit,
+		ComposerToolbar,
+		ComposerModelPicker,
+		ComposerAttachments,
+		ComposerCommandMenu,
+	} from "$lib/fancy-ui/composer";
+	import type { AttachmentData, CommandItemData, ModelOptionData } from "$lib/fancy-ui";
+
+	/** Generic tiers, so the fixture says nothing about anyone's product line-up. */
+	const MODELS: ModelOptionData[] = [
+		{ id: "mini", label: "Mini", badge: "Fast", description: "Short answers, small context." },
+		{ id: "pro", label: "Pro", description: "Deeper reasoning, slower." },
+		{ id: "max", label: "Max", badge: "New", description: "Everything, when it matters." },
+	];
+
+	const COMMANDS: CommandItemData[] = [
+		{ id: "deploy", label: "/deploy", description: "Ship the current branch", hint: "⌘⏎" },
+		{ id: "describe", label: "/describe", description: "Summarise the diff" },
+		{ id: "tests", label: "/tests", description: "Run the affected suites" },
+		{ id: "reset", label: "/reset", description: "Clear the conversation" },
+	];
+
+	const PEOPLE: CommandItemData[] = [
+		{ id: "jordan", label: "@jordan", description: "Reviewer" },
+		{ id: "sam", label: "@sam", description: "On call" },
+		{ id: "robin", label: "@robin", description: "Release manager" },
+	];
+
+	const FILES: AttachmentData[] = [
+		{ id: "a1", name: "architecture.png", size: 184_320, status: "done" },
+		{ id: "a2", name: "release-notes.md", size: 4_096, progress: 0.62, status: "uploading" },
+		{ id: "a3", name: "trace.json", size: 1_048_576, status: "error" },
+	];
+
+	const { Story } = defineMeta({
+		title: "AI Chat/Composer",
+		component: Composer,
+		tags: ["autodocs"],
+		args: {
+			placeholder: "Ask anything",
+		},
+		argTypes: {
+			value: { control: "text", description: "The draft text, bindable. Cleared by a submit" },
+			placeholder: {
+				control: "text",
+				description: "Placeholder for the default input; ignored once children replace it",
+			},
+			disabled: {
+				control: "boolean",
+				description: "Blocks typing, sending, and attaching",
+			},
+			streaming: {
+				control: "boolean",
+				description: "A response is arriving: the send button becomes a stop button",
+			},
+		},
+	});
+</script>
+
+<script lang="ts">
+	// Bindings the composed stories need. The root owns the draft on its own, so
+	// the minimal stories bind nothing at all.
+	let model = $state("pro");
+	let attachments = $state<AttachmentData[]>(FILES);
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-xl p-6">
+		<Composer {...args} />
+	</div>
+{/snippet}
+
+{#snippet composed(args: any)}
+	<div class="w-full max-w-xl p-6">
+		<Composer {...args} bind:attachments>
+			{#snippet children()}
+				<ComposerAttachments accept="image/*,.pdf,.md" />
+				<ComposerInput placeholder="Ask anything — / for commands, @ to mention" maxRows={6} />
+				<ComposerToolbar class="mt-2">
+					<ComposerModelPicker models={MODELS} bind:value={model} />
+					<div class="flex-1"></div>
+					<ComposerSubmit />
+				</ComposerToolbar>
+
+				<!-- One primitive, two triggers: only one menu can ever be up. -->
+				<ComposerCommandMenu trigger="/" items={COMMANDS} />
+				<ComposerCommandMenu trigger="@" items={PEOPLE} />
+			{/snippet}
+		</Composer>
+	</div>
+{/snippet}
+
+<Story name="Minimal" {template} />
+
+<Story name="Full" template={composed} />
+
+<Story
+	name="Streaming"
+	{template}
+	args={{ value: "Summarise what changed in the release job", streaming: true }}
+/>
+
+<Story name="Disabled" {template} args={{ value: "Waiting on the session", disabled: true }} />

--- a/src/stories/context-ring.stories.svelte
+++ b/src/stories/context-ring.stories.svelte
@@ -1,0 +1,74 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { ContextRing } from "$lib/fancy-ui/context-ring";
+
+	const { Story } = defineMeta({
+		title: "AI Chat/ContextRing",
+		component: ContextRing,
+		tags: ["autodocs"],
+		args: {
+			usage: { used: 12_400, max: 200_000 },
+		},
+		argTypes: {
+			usage: { description: "Tokens used, out of how many, and optionally of what" },
+			size: {
+				control: { type: "range", min: 12, max: 72, step: 2 },
+				description: "Outer diameter of the ring, in pixels",
+			},
+			strokeWidth: {
+				control: { type: "range", min: 1, max: 10, step: 0.5 },
+				description: "Thickness of the track and the arc, in pixels",
+			},
+			showLabel: { control: "boolean", description: "Show the compact figure beside the ring" },
+			warnAt: {
+				control: { type: "range", min: 0, max: 1, step: 0.05 },
+				description: "Fraction at which the ring leaves the quiet band",
+			},
+			criticalAt: {
+				control: { type: "range", min: 0, max: 1, step: 0.05 },
+				description: "Fraction at which the ring turns to the error colour",
+			},
+			label: { control: "text", description: "Accessible name for the meter" },
+			expandable: {
+				control: "boolean",
+				description: "Clicking the ring opens a popover listing usage.breakdown",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="p-8">
+		<ContextRing {...args} />
+	</div>
+{/snippet}
+
+<Story name="Comfortable" {template} />
+
+<Story name="Warning" {template} args={{ usage: { used: 164_000, max: 200_000 } }} />
+
+<Story name="Critical" {template} args={{ usage: { used: 192_500, max: 200_000 } }} />
+
+<Story name="Over Budget" {template} args={{ usage: { used: 260_000, max: 200_000 } }} />
+
+<Story name="Ring Only" {template} args={{ showLabel: false, size: 40, strokeWidth: 5 }} />
+
+<Story
+	name="Expandable"
+	{template}
+	args={{
+		size: 34,
+		strokeWidth: 4,
+		expandable: true,
+		usage: {
+			used: 84_300,
+			max: 200_000,
+			breakdown: [
+				{ label: "System prompt", tokens: 1850 },
+				{ label: "Transcript", tokens: 61_200 },
+				{ label: "Tool results", tokens: 18_400 },
+				{ label: "Attachments", tokens: 2850 },
+			],
+		},
+	}}
+/>

--- a/src/stories/voice-input.stories.svelte
+++ b/src/stories/voice-input.stories.svelte
@@ -1,0 +1,54 @@
+<script module lang="ts">
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { VoiceInput } from "$lib/fancy-ui/voice-input";
+
+	const { Story } = defineMeta({
+		title: "AI Chat/VoiceInput",
+		component: VoiceInput,
+		tags: ["autodocs"],
+		args: {
+			active: false,
+			transcript: "",
+			demo: true,
+			height: 48,
+		},
+		argTypes: {
+			active: {
+				control: "boolean",
+				description: "Whether a recording is in progress — bindable, and written by every button",
+			},
+			transcript: {
+				control: "text",
+				description: "Live text pushed by the consumer; a growing string grows in place",
+			},
+			demo: {
+				control: "boolean",
+				description: "Draw a synthetic waveform when no samples arrive",
+			},
+			height: {
+				control: { type: "range", min: 16, max: 240, step: 4 },
+				description: "Waveform height in CSS pixels, clamped to 16..240",
+			},
+			color: {
+				control: "color",
+				description: "Any CSS colour for the bars, resolved before painting",
+			},
+		},
+	});
+</script>
+
+{#snippet template(args: any)}
+	<div class="w-full max-w-md p-6">
+		<VoiceInput {...args} />
+	</div>
+{/snippet}
+
+<Story name="Idle" {template} />
+
+<Story name="Active" {template} args={{ active: true }} />
+
+<Story
+	name="With Transcript"
+	{template}
+	args={{ active: true, transcript: "show me the retry policy for failed webhook deliveries" }}
+/>


### PR DESCRIPTION
## Summary

Part 7/8 of the AI/chat family (stacks on #187). Built by a 7-agent pipelined Workflow (core ∥ voice ∥ ring → parts → integrator), reviewed by a 2-agent adversarial Workflow.

| Component | What it does |
|---|---|
| `Composer` (compound, 8 exports) | Root owns the draft (`value`/`attachments` bindable, `onSubmit`/`onStop`/`onAttach`); parts read a Symbol-keyed context |
| `ComposerInput` | Auto-growing textarea (clamped rows), Enter submits / Shift+Enter newline; readonly-not-disabled while streaming so drafts stay announced |
| `ComposerSubmit` | Send ↔ stop per streaming state, disabled-truth-table tested |
| `ComposerToolbar` / `ComposerModelPicker` | Bottom rail + float-positioned listbox picker (keyboard nav, no listener leaks) |
| `ComposerAttachments` / `ComposerAttachment` | File picker + chips with size, upload progress, error tint, remove |
| `ComposerCommandMenu` | ONE caret-anchored completion primitive — mount twice for `/` commands and `@` mentions; virtual-rect float anchoring, vocabulary-free trigger detection |
| `VoiceInput` | Mic button → waveform panel (internals draw core; consumer bridges audio levels — the library never touches getUserMedia) |
| `ContextRing` | Context usage donut with warn/critical bands (canonical status tokens) + breakdown popover |

## Review rounds (all findings fixed)
- **Contracts**: completion menu ignored `disabled`/`streaming` (could rewrite an inert composer's draft) — insertText guarded + menu self-closes; TWO divergent trigger-token definitions unified into `caret.ts findTokenStart` (code-point aware — no more eaten emoji/quotes); menu now re-syncs when the draft changes under it; a11y label prop for mention menus; bogus registry dependency removed.
- **Visual (interaction-driven)**: real bug in the shared `float` action — anchor measured before the node left the flow, permanently misplacing sibling-anchored popovers (ContextRing) — fixed and re-verified across all float consumers; active-row description, three muted-on-tinted texts, and 1px focus rings lifted to AA/3:1.
- One build agent and one fixer died mid-flight on API errors; both were resumed/completed without loss (deliverables verified file-by-file).

## Gates
`check:registry` ✅ (87) · `check:i18n` ✅ · `svelte-check` ✅ 0 errors · `vitest` ✅ 1595/1595 (343 in wave incl. integration suite) · `build` ✅ · `package` + publint ✅

Next (final): thread — scroll-anchor, thread-list, chat-panel + the full-family capstone demo + og/stories/counters sweep.