### PR TITLE
feat(exports): expose the cameleon engine to link: consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
 			"svelte": "./dist/fancy-ui/index.js",
 			"default": "./dist/fancy-ui/index.js"
 		},
-		"./tailwind.css": "./dist/fancy-ui/tailwind.css"
+		"./tailwind.css": "./dist/fancy-ui/tailwind.css",
+		"./cameleon/*": "./dist/cameleon/*"
 	},
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
One line in `exports`. Needed so `apps/main` (rama.app) can consume the Retro OS and Brutal skins for a runtime skin switch.

## Why it is needed at all

The engine is built to `dist/cameleon` by `svelte-package`, and `link:` symlinks the whole checkout — so the files are physically right there. But **`exports` is an allowlist, and Node and Vite enforce it for symlinked packages too**. Every specifier failed:

```
FAIL fancy-ui-svelte/cameleon                     -> ERR_PACKAGE_PATH_NOT_EXPORTED
FAIL fancy-ui-svelte/cameleon/skins/brutal/tokens.js
FAIL fancy-ui-svelte/dist/cameleon/…
```

`link:` alone buys nothing here — that was the surprise.

## What this does and does not do

```diff
   "./tailwind.css": "./dist/fancy-ui/tailwind.css",
+  "./cameleon/*": "./dist/cameleon/*"
```

**`files` is deliberately untouched.** The engine stays out of every published tarball, so this entry is reachable *only* by `link:` consumers. Verified: `npm pack --dry-run` still lists **519 files, 0 cameleon**.

A single `*` matches across `/` separators (substring substitution, not glob), so one entry covers arbitrary depth — no extra patterns needed. Confirmed with a real `await import()` three levels deep:

```
fancy-ui-svelte/cameleon/skins/brutal/tokens.js  -> exports ['brutalTokens'], --skin-page-bg #F4EEE0
fancy-ui-svelte/cameleon/skins/retro-os/…        -> exports ['retroOsTokens'],                #F1E9D4
```

Also verified the baseline entries still resolve (`.`, `./tailwind.css`).

## One accepted tradeoff

`publint --strict` now reports `pkg.exports["./cameleon/*"] is ./dist/cameleon/* but does not match any files.` That is **accurate and intended** — it is the direct consequence of leaving `files` alone. Bare `publint` (what `pnpm package` and both `ci.yml` / `release.yml` run) still exits 0, so nothing breaks today. Flagging it so that if anyone later adds `--strict`, this is a known line rather than a mystery.

## Caveat for consumers

`fancy-ui-svelte/cameleon` (bare, no subpath) does **not** resolve — a `./cameleon/*` pattern cannot match an empty remainder. Use `fancy-ui-svelte/cameleon/index.js` explicitly.

Also note the mapping carries no conditions object, so there is no `"svelte"` condition under `cameleon`: a `.svelte` specifier would resolve to raw source needing the consumer's `vite-plugin-svelte`. Not an issue for the current consumer, which imports only concrete `.js` and `.css`.

## Follow-up

Promoting `dist/cameleon` into `files` (plus a changeset and a minor release) is what would let consumers drop `link:` and depend on a published version. Deliberately not done here — that is a decision about publishing the engine's API surface, not a resolution fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)