### PR TITLE
feat(react): fancy-ui-react — standalone React package, first batch

### DIFF
--- a/.changeset/react-package-intro.md
+++ b/.changeset/react-package-intro.md
@@ -1,0 +1,6 @@
+---
+---
+
+Repo-level: introduces the standalone `react/` package (`fancy-ui-react`) —
+first slice of the dual-framework effort. No change to `fancy-ui-svelte`
+itself, hence the empty bump.

--- a/.changeset/react-package-intro.md
+++ b/.changeset/react-package-intro.md
@@ -4,3 +4,11 @@
 Repo-level: introduces the standalone `react/` package (`fancy-ui-react`) —
 first slice of the dual-framework effort. No change to `fancy-ui-svelte`
 itself, hence the empty bump.
+
+The empty frontmatter is also the honest state of the release path: `react/`
+is a separate install root, so `changeset publish` at the repo root never
+discovers it and this package does not reach npm through the existing
+pipeline. Nothing here is publishable yet by design — the README says so, and
+building that path (a dedicated publish job, a react-local Changesets setup,
+or folding `react/` into a root workspace) is tracked as its own piece of
+work.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,40 @@ jobs:
       - run: pnpm build
       - run: pnpm package
 
+  react:
+    name: React package
+    # Same duplicate-run guard as `check` — see the comment there.
+    if: |
+      (github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.head_ref == 'changeset-release/main') ||
+      (github.event_name == 'pull_request')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: react
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: react/pnpm-lock.yaml
+
+      # react/ is a standalone package with its own lockfile and its own
+      # pnpm-workspace.yaml boundary marker — installs never touch the app.
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm test
+      - run: pnpm build
+
   changeset:
     name: Changeset present
     if: |

--- a/react/.gitignore
+++ b/react/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/react/.npmrc
+++ b/react/.npmrc
@@ -1,0 +1,4 @@
+# react/ is a standalone package living inside the fancy-ui repo. The local
+# pnpm-workspace.yaml (no `packages:` key) marks this dir as its own install
+# root, so pnpm never walks up into the repo-root file of the same name.
+engine-strict=true

--- a/react/PORTING.md
+++ b/react/PORTING.md
@@ -1,0 +1,93 @@
+# Porting conventions — Svelte → React
+
+Law for every component ported into `fancy-ui-react`. The Svelte source under
+`src/lib/fancy-ui/<slug>/` (and `src/lib/cameleon/`) is the reference
+implementation; the port's job is pixel-for-pixel fidelity, not improvement.
+When the Svelte side has a bug, port the bug and note it — divergence is a
+maintenance tax paid on every future change.
+
+## Folder shape
+
+```
+react/src/components/<slug>/
+├── <Name>.tsx          # the component
+├── <name>.css          # ONLY if the Svelte source has a <style> block
+├── <Name>.test.tsx     # transposed from the Svelte <Name>.test.ts
+└── index.ts            # export { <Name> } ...; export type { <Name>Props }
+```
+
+The cameleon engine lives at `react/src/cameleon/` mirroring the Svelte tree
+(`types.ts`, `context.ts`, `FancyProvider.tsx`, `skins/`, `primitives/`).
+
+Every component folder gets a matching export block in `react/src/index.ts`.
+
+## API contract
+
+- Props type is `export interface <Name>Props` — this exact name is a tooling
+  contract (docs generation and design-tool sync key on `<Name>Props`).
+- `class` becomes `className`. Merge with `cn()` from `../utils.js` exactly
+  where the Svelte source uses it — same argument order, same literals.
+- `forwardRef` exactly where the Svelte source declares `ref = $bindable`
+  (use `forwardRef`, not React-19-only ref-as-prop — the package supports 18).
+  A component whose Svelte side exposes no ref gets none here either: the
+  Svelte API surface is the contract, per-component.
+- Rest props spread onto the root element. Polymorphic components (RainbowButton
+  renders `<a>` when `href` is set) keep the same branch logic.
+- `Snippet` props become `ReactNode` props; the default `children` snippet is
+  React `children`.
+
+## Rune → hook mapping
+
+| Svelte | React |
+|---|---|
+| `$props()` | props destructure with defaults |
+| `$state(x)` | `useState(x)` |
+| `$derived(expr)` | plain const per render, or `useMemo` only when measurably expensive |
+| `$effect(...)` | `useEffect` with an honest dependency array |
+| `$bindable(null)` ref | `forwardRef` |
+| `onMount` | `useEffect(..., [])` |
+| `onDestroy` | the effect's cleanup return |
+
+## Styling — the part that breaks silently
+
+1. **Tailwind class strings are copied VERBATIM.** They ship as static literals
+   and the consumer's Tailwind scans `dist/` for them (`tailwind.css` →
+   `@source "./dist"`). Never compute a class name from a variable — the
+   scanner cannot see interpolations.
+2. **Svelte `<style>` blocks become a colocated `.css` file** imported by the
+   component (`import "./<name>.css";`). Vite extracts all of them into one
+   `dist/styles.css`. Keep keyframe names and class names IDENTICAL to the
+   Svelte source (they are part of the visual contract; some are referenced by
+   inline `style` attributes). Svelte's compiler scoped those rules; plain CSS
+   is global, so every rule must be anchored on the component's root class
+   (e.g. `.rainbow-button`, `.fancy-marquee`) exactly as the source names it.
+   `-global-` keyframe name prefixes in Svelte sources drop the prefix — that
+   prefix is Svelte-compiler syntax, the emitted name is what you keep.
+3. **CSS custom properties keep their local fallbacks.** Components must not
+   depend on an app-level token existing (the Svelte contract; e.g.
+   rainbow-button re-declares its `--rainbow-*` locally). Copy those blocks.
+4. **Custom utilities are traps.** A class like `animate-rainbow` is not a
+   stock Tailwind utility. Trace it (`grep -rn` in `src/` at repo root) to its
+   `@theme`/keyframes definition and re-declare the equivalent in the
+   component's own `.css` so consumers need zero app-side theme setup.
+5. **`prefers-reduced-motion` blocks are ported as-is.** Never drop one.
+
+## Tests
+
+Vitest + `@testing-library/react`, jsdom, globals on. Transpose the Svelte
+test file assertion-for-assertion; drop only what is Svelte-specific
+(e.g. rune re-render mechanics), add nothing speculative. Run with
+`npx vitest run src/components/<slug>` from `react/`.
+
+## Hard rules for porting agents
+
+- Work ONLY inside your assigned directories under `react/src/`.
+- NO installs, no `package.json`/config edits, no new dependencies. The only
+  allowed imports are react, the component's own files, `../utils.js` (or the
+  cameleon-internal modules for engine work), clsx/tailwind-merge indirectly
+  via `cn`.
+- Do not spawn sub-agents.
+- No third-party product or library brand names in comments or docs — house
+  rule; write what the code does, not where an idea came from.
+- Every component you port must appear in `react/src/index.ts` and pass
+  `npx tsc --noEmit` + its own vitest file before you report done.

--- a/react/PORTING.md
+++ b/react/PORTING.md
@@ -63,6 +63,13 @@ Every component folder gets a matching export block in `react/src/index.ts`.
    (e.g. `.rainbow-button`, `.fancy-marquee`) exactly as the source names it.
    `-global-` keyframe name prefixes in Svelte sources drop the prefix — that
    prefix is Svelte-compiler syntax, the emitted name is what you keep.
+   When the Svelte source has NO root class to anchor on, ADD one (the
+   component's slug, e.g. `fancy-marquee`) as the first token of the root
+   `cn()` call and anchor the rules under it. This is the one sanctioned
+   class-string addition: a compiler-scoped selector has no public identity in
+   the Svelte package, so anchoring costs nothing — leaking a generic name
+   like `.ripple-animation` into every consumer's page costs plenty. Leave a
+   comment in the `.css` marking the anchor as port-added.
 3. **CSS custom properties keep their local fallbacks.** Components must not
    depend on an app-level token existing (the Svelte contract; e.g.
    rainbow-button re-declares its `--rainbow-*` locally). Copy those blocks.

--- a/react/PORTING.md
+++ b/react/PORTING.md
@@ -35,6 +35,15 @@ Every component folder gets a matching export block in `react/src/index.ts`.
   renders `<a>` when `href` is set) keep the same branch logic.
 - `Snippet` props become `ReactNode` props; the default `children` snippet is
   React `children`.
+- Prop contracts are `interface`, never a `type` alias — including when the
+  props are an intersection of DOM attributes. Intersect the attribute sets
+  FIRST and extend the result (see `RainbowButton`): an interface may not
+  extend two types that declare the same property differently.
+- **Nothing may differ between a server render and its hydration.** No
+  `Math.random()`, `Date.now()` or `window` read in a render path or a lazy
+  `useState` initializer. Where the Svelte source randomises, take a seed
+  prop and use a deterministic PRNG, and record it as a divergence in the
+  README.
 
 ## Rune → hook mapping
 
@@ -78,6 +87,15 @@ Every component folder gets a matching export block in `react/src/index.ts`.
    `@theme`/keyframes definition and re-declare the equivalent in the
    component's own `.css` so consumers need zero app-side theme setup.
 5. **`prefers-reduced-motion` blocks are ported as-is.** Never drop one.
+6. **Semantic colour names are declared once, in `react/tailwind.css`.**
+   `bg-background`, `bg-primary`, `text-primary-foreground` and `ring-ring`
+   are not stock Tailwind either, but unlike rule 4's per-component
+   utilities they are a shared vocabulary — redeclaring them in every
+   component's `.css` would fight itself. The package stylesheet maps them
+   with `@theme inline` and ships defaults in `@layer base`, which serves the
+   same goal rule 4 exists for (zero app-side setup) while still letting an
+   app with its own shadcn tokens win. Adding a new semantic name to a ported
+   component means adding it there too.
 
 ## Tests
 

--- a/react/README.md
+++ b/react/README.md
@@ -1,0 +1,50 @@
+# fancy-ui-react
+
+React counterpart of [`fancy-ui-svelte`](https://www.npmjs.com/package/fancy-ui-svelte) —
+same components, same visual contract, ported from the Svelte 5 reference
+implementation that lives at the root of this repo.
+
+Status: early. This package currently ships the cameleon skin engine
+(FancyProvider + 10 primitives + skins) and a first batch of flagship
+components. The Svelte package remains the reference; each React component is
+a faithful transpose (see `PORTING.md` for the law that governs ports).
+
+## Install
+
+```bash
+npm install fancy-ui-react
+```
+
+Peer dependencies: `react` / `react-dom` 18 or 19, `tailwindcss` 4.
+
+## Setup
+
+```css
+/* app.css */
+@import "tailwindcss";
+@import "fancy-ui-react/tailwind.css"; /* lets Tailwind scan the shipped sources */
+```
+
+```tsx
+import "fancy-ui-react/styles.css"; // keyframes + component-scoped CSS
+import { RainbowButton, Marquee } from "fancy-ui-react";
+```
+
+## Development
+
+Standalone package: its own lockfile, its own install, zero coupling to the
+SvelteKit app at the repo root.
+
+```bash
+cd react
+pnpm install
+pnpm test     # vitest + testing-library
+pnpm check    # tsc --noEmit
+pnpm build    # vite lib build + d.ts via tsc
+```
+
+## Porting a component
+
+Read `PORTING.md` first — folder shape, rune→hook mapping, the styling rules
+that break silently, and the hard rules. The Svelte source under
+`src/lib/fancy-ui/<slug>/` is always the reference.

--- a/react/README.md
+++ b/react/README.md
@@ -43,6 +43,27 @@ pnpm check    # tsc --noEmit
 pnpm build    # vite lib build + d.ts via tsc
 ```
 
+## Divergences from the Svelte API
+
+Deliberate, small, and documented — everything else is a faithful transpose:
+
+- **Two-way binding.** Svelte's `bind:value` / `bind:checked` become the
+  standard React split: uncontrolled by default (a bare `<Switch />` flips on
+  click), controlled once you pass `value`/`checked` — at which point you must
+  also handle the change (`onChange`, or `onClick` for `Switch`). Passing a
+  value with no handler is idiomatic-React frozen input, and React warns
+  loudly; the Svelte side stays typable in that situation.
+- **Bare `<Select>` shows the first option** (native uncontrolled behavior).
+  The Svelte one renders blank, because `$bindable("")` matches no option —
+  that quirk was not imported.
+- **`RainbowButton` accepts no extra DOM props** (`onClick` included) — the
+  Svelte source reads only its declared props and spreads nothing, and its own
+  README example inherits that bug. Ported as-is per the fidelity law; fix it
+  upstream first if it bothers you.
+- Compiler-scoped selectors with no root anchor in the source gained one
+  (`fancy-marquee`, `ripple-button`) so their CSS does not leak into consumer
+  pages — see PORTING.md, styling rule 2.
+
 ## Porting a component
 
 Read `PORTING.md` first — folder shape, rune→hook mapping, the styling rules

--- a/react/README.md
+++ b/react/README.md
@@ -11,8 +11,17 @@ a faithful transpose (see `PORTING.md` for the law that governs ports).
 
 ## Install
 
+> **Not published yet.** `fancy-ui-react` has no npm release: the repo's
+> release pipeline runs `changeset publish` from the root, which only ever
+> sees `fancy-ui-svelte` — `react/` is a separate install root with its own
+> lockfile, so Changesets never discovers it. Building the release path for
+> this package is tracked separately; until it lands, use the package from a
+> checkout (`cd react && pnpm install && pnpm build`) and consume `dist/`
+> directly. The instructions below describe the intended install so the
+> setup they document stays reviewable, not a command that works today.
+
 ```bash
-npm install fancy-ui-react
+npm install fancy-ui-react # once the package is published
 ```
 
 Peer dependencies: `react` / `react-dom` 18 or 19, `tailwindcss` 4.
@@ -29,6 +38,19 @@ Peer dependencies: `react` / `react-dom` 18 or 19, `tailwindcss` 4.
 import "fancy-ui-react/styles.css"; // keyframes + component-scoped CSS
 import { RainbowButton, Marquee } from "fancy-ui-react";
 ```
+
+Those two imports are the whole setup. `tailwind.css` also declares the
+semantic colours the components spend — `--background`, `--primary`,
+`--primary-foreground`, `--ring` — because none of them exist in Tailwind's
+default palette, and without them `bg-primary` and friends compile to nothing.
+They are wired with `@theme inline`, so the utilities resolve the variables at
+use time: an app that already defines the shadcn token set keeps its own
+colours automatically. The defaults ship in `@layer base`, which an unlayered
+`:root` in your app overrides whatever the import order.
+
+Every export is a client module — the built entries carry `"use client"`, so
+`fancy-ui-react` can be imported directly from a React Server Component file
+without a wrapper of your own.
 
 ## Development
 
@@ -63,6 +85,13 @@ Deliberate, small, and documented — everything else is a faithful transpose:
 - Compiler-scoped selectors with no root anchor in the source gained one
   (`fancy-marquee`, `ripple-button`) so their CSS does not leak into consumer
   pages — see PORTING.md, styling rule 2.
+- **`Meteors` takes a `seed`** the Svelte side has no equivalent for. Svelte
+  runs its randomiser once, in the browser; React runs the same initializer on
+  the server AND again during hydration, and `Math.random()` disagrees with
+  itself across the two — a hydration mismatch React may settle by keeping the
+  server values. A seeded PRNG makes both renders agree while leaving the
+  shower in the server HTML. The default seed is shared, so two unseeded
+  showers fall the same way; pass different seeds to separate them.
 
 ## Porting a component
 

--- a/react/package.json
+++ b/react/package.json
@@ -1,0 +1,63 @@
+{
+	"name": "fancy-ui-react",
+	"version": "0.1.0",
+	"description": "Animated UI components for React — the React counterpart of fancy-ui-svelte. WebGL, GSAP and CSS motion, styled with Tailwind CSS v4.",
+	"license": "MIT",
+	"type": "module",
+	"homepage": "https://fancy-ui.rama.app",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/RamaHerbin/fancy-ui.git",
+		"directory": "react"
+	},
+	"scripts": {
+		"build": "vite build && tsc -p tsconfig.build.json",
+		"check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"files": [
+		"dist",
+		"tailwind.css"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./cameleon": {
+			"types": "./dist/cameleon/index.d.ts",
+			"import": "./dist/cameleon.js"
+		},
+		"./styles.css": "./dist/styles.css",
+		"./tailwind.css": "./tailwind.css"
+	},
+	"sideEffects": [
+		"*.css"
+	],
+	"peerDependencies": {
+		"react": "^18.0.0 || ^19.0.0",
+		"react-dom": "^18.0.0 || ^19.0.0",
+		"tailwindcss": "^4.0.0"
+	},
+	"dependencies": {
+		"clsx": "^2.1.1",
+		"tailwind-merge": "^3.4.0"
+	},
+	"devDependencies": {
+		"@testing-library/jest-dom": "^6.6.3",
+		"@testing-library/react": "^16.3.0",
+		"@types/react": "^19.1.0",
+		"@types/react-dom": "^19.1.0",
+		"@vitejs/plugin-react": "^4.6.0",
+		"jsdom": "^26.1.0",
+		"react": "^19.1.0",
+		"react-dom": "^19.1.0",
+		"typescript": "^5.8.0",
+		"vite": "^7.0.0",
+		"vitest": "^4.0.0"
+	},
+	"engines": {
+		"node": ">=20.19.0"
+	}
+}

--- a/react/pnpm-lock.yaml
+++ b/react/pnpm-lock.yaml
@@ -1,0 +1,1908 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      tailwind-merge:
+        specifier: ^3.4.0
+        version: 3.6.0
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.3.3
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.10.0(@testing-library/dom@10.4.1)
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.1.0
+        version: 19.2.4(@types/react@19.2.18)
+      '@vitejs/plugin-react':
+        specifier: ^4.6.0
+        version: 4.7.0(vite@7.3.6)
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
+      react:
+        specifier: ^19.1.0
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.8(react@19.2.8)
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vite:
+        specifier: ^7.0.0
+        version: 7.3.6
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.10(jsdom@26.1.0)(vite@7.3.6)
+
+packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.10.0':
+    resolution: {integrity: sha512-HQwu0KaB2zyT0iLzBL+8CLyZDL3KlZlZJ+2iyc9uCUnlJVskJU/UlPuVCyIPhtukjPQdT2QNoR5nCP5FqTmmDQ==}
+    engines: {node: '>=22', npm: '>=6', yarn: '>=1'}
+    deprecated: Incorrect minor release with breaking changes (Node >=22 and required @testing-library/dom peer). Use 6.9.1 for the 6.x line, or upgrade to 7.0.0.
+    peerDependencies:
+      '@testing-library/dom': '>=10 <11'
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  baseline-browser-mapping@2.11.14:
+    resolution: {integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  electron-to-chromium@1.5.407:
+    resolution: {integrity: sha512-4R8XgQOdfxexCd/u63lRm6wCHjECwI45MV9wxAs2ggtfWe2hwlo1ql97jKsju2IcJ+jFSTwBssyYoiWhh7mauQ==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
+    engines: {node: '>=18'}
+
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  update-browserslist-db@1.3.1:
+    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@adobe/css-tools@4.5.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.8
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      '@testing-library/dom': 10.4.1
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/react-dom@19.2.4(@types/react@19.2.18)':
+    dependencies:
+      '@types/react': 19.2.18
+
+  '@types/react@19.2.18':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@7.3.6)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 7.3.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@7.3.6)':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
+  baseline-browser-mapping@2.11.14: {}
+
+  browserslist@4.28.8:
+    dependencies:
+      baseline-browser-mapping: 2.11.14
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.407
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
+  caniuse-lite@1.0.30001809: {}
+
+  chai@6.2.2: {}
+
+  clsx@2.1.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  dequal@2.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  electron-to-chromium@1.5.407: {}
+
+  entities@6.0.1: {}
+
+  es-module-lexer@2.3.1: {}
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  indent-string@4.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  js-tokens@4.0.0: {}
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  min-indent@1.0.1: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.18: {}
+
+  node-releases@2.0.53: {}
+
+  nwsapi@2.2.24: {}
+
+  obug@2.1.4: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.8: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  symbol-tree@3.2.4: {}
+
+  tailwind-merge@3.6.0: {}
+
+  tailwindcss@4.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  typescript@5.9.3: {}
+
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
+    dependencies:
+      browserslist: 4.28.8
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@7.3.6:
+    dependencies:
+      esbuild: 0.28.2
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.1.10(jsdom@26.1.0)(vite@7.3.6):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6)
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 7.3.6
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.21.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}

--- a/react/pnpm-workspace.yaml
+++ b/react/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+# Two jobs, mirroring the repo-root file's role:
+# 1. Marks react/ as its own install root, so pnpm stops walking up and never
+#    tries to join the (non-)workspace at the repo root.
+# 2. Allows esbuild's postinstall build script (pnpm v10+ blocks it otherwise
+#    and vite ships a broken esbuild without it).
+# No `packages:` key — this is a standalone package, not a workspace.
+# If pnpm ever rewrites the allowBuilds line into a "set this to true or false"
+# placeholder (it has done so repeatedly on the root file), restore `true`.
+allowBuilds:
+  esbuild: true
+onlyBuiltDependencies:
+  - esbuild

--- a/react/src/cameleon/FancyProvider.test.tsx
+++ b/react/src/cameleon/FancyProvider.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { FancyProvider } from "./FancyProvider.js";
+import { defaultSkin } from "./skins/default.js";
+import { glassSkin } from "./skins/glass/index.js";
+
+describe("FancyProvider", () => {
+	it("renders the data-skin attribute", () => {
+		render(
+			<FancyProvider skin={defaultSkin}>
+				<span>content</span>
+			</FancyProvider>
+		);
+		const root = screen.getByText("content").closest("[data-skin]");
+		expect(root).toHaveAttribute("data-skin", "default");
+	});
+
+	it("applies the skin's tokens as inline CSS custom properties", () => {
+		render(
+			<FancyProvider skin={defaultSkin}>
+				<span>content</span>
+			</FancyProvider>
+		);
+		const root = screen.getByText("content").closest("[data-skin]") as HTMLElement;
+		expect(root.style.getPropertyValue("--skin-page-bg")).toBe("#ffffff");
+		expect(root.style.getPropertyValue("--skin-page-fg")).toBe("#0a0a0a");
+	});
+
+	it("adds the dark class only when manageColorScheme is set on a dark-scheme skin", () => {
+		const { rerender } = render(
+			<FancyProvider skin={glassSkin}>
+				<span>content</span>
+			</FancyProvider>
+		);
+		let root = screen.getByText("content").closest("[data-skin]") as HTMLElement;
+		expect(root.className).not.toContain("dark");
+
+		rerender(
+			<FancyProvider skin={glassSkin} manageColorScheme>
+				<span>content</span>
+			</FancyProvider>
+		);
+		root = screen.getByText("content").closest("[data-skin]") as HTMLElement;
+		expect(root.className).toContain("dark");
+	});
+
+	it("never adds the dark class for a light-scheme skin, even with manageColorScheme", () => {
+		render(
+			<FancyProvider skin={defaultSkin} manageColorScheme>
+				<span>content</span>
+			</FancyProvider>
+		);
+		const root = screen.getByText("content").closest("[data-skin]") as HTMLElement;
+		expect(root.className).not.toContain("dark");
+	});
+
+	it("renders children", () => {
+		render(
+			<FancyProvider skin={defaultSkin}>
+				<button>click me</button>
+			</FancyProvider>
+		);
+		expect(screen.getByRole("button", { name: "click me" })).toBeInTheDocument();
+	});
+});

--- a/react/src/cameleon/FancyProvider.tsx
+++ b/react/src/cameleon/FancyProvider.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useMemo, type CSSProperties, type ReactNode } from "react";
+import { cn } from "../utils.js";
+import type { Skin } from "./types.js";
+import { SkinReactContext, type SkinContext } from "./context.js";
+import "./cameleon.css";
+
+export interface FancyProviderProps {
+	/** The active skin. Changing it re-flows the whole subtree live. */
+	skin: Skin;
+	/** Scope `.dark` to this subtree for skins whose colorScheme is "dark". */
+	manageColorScheme?: boolean;
+	className?: string;
+	children?: ReactNode;
+}
+
+export function FancyProvider({
+	skin,
+	manageColorScheme = false,
+	className = "",
+	children,
+}: FancyProviderProps) {
+	// Fresh context value whenever `skin` changes — this is what makes a live
+	// skin switch reactive; consumers re-render because the value identity changes.
+	const ctx = useMemo<SkinContext>(() => ({ skin }), [skin]);
+
+	// Skin tokens as scoped inline CSS variables. Overriding these var names on
+	// this element re-flows every utility that reads them, for THIS subtree only.
+	// The provider never touches <html>, so it can't fight the global theme store.
+	const styleVars = useMemo(() => ({ ...skin.tokens }) as CSSProperties, [skin.tokens]);
+
+	// Inject skin webfonts once (deduped by id). useEffect only ever runs
+	// client-side, so this is SSR-safe with no extra guard.
+	useEffect(() => {
+		if (!skin.fonts) return;
+		for (const font of skin.fonts) {
+			if (document.getElementById(font.id)) continue;
+			const link = document.createElement("link");
+			link.id = font.id;
+			link.rel = "stylesheet";
+			link.href = font.href;
+			document.head.appendChild(link);
+		}
+	}, [skin.fonts]);
+
+	return (
+		<SkinReactContext.Provider value={ctx}>
+			<div
+				data-skin={skin.name}
+				className={cn(
+					"cameleon-root",
+					manageColorScheme && skin.colorScheme === "dark" && "dark",
+					className
+				)}
+				style={styleVars}
+			>
+				{children}
+			</div>
+		</SkinReactContext.Provider>
+	);
+}

--- a/react/src/cameleon/cameleon.css
+++ b/react/src/cameleon/cameleon.css
@@ -1,0 +1,27 @@
+/**
+ * Base styles for the Cameleon provider root. The skin's tokens are set as
+ * inline CSS variables on the same element; these rules consume them so the
+ * whole "world" (page background, text color, base font) changes per skin.
+ */
+.cameleon-root {
+	background: var(--skin-page-bg, transparent);
+	color: var(--skin-page-fg, inherit);
+	font-family: var(--skin-font-sans, inherit);
+	-webkit-font-smoothing: antialiased;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cameleon-root * {
+		transition-duration: 0.01ms !important;
+		animation-duration: 0.01ms !important;
+	}
+}
+
+/* Skin-agnostic error affordance for the native range slider: the per-skin
+   .cam-range CSS styles the track/thumb but not the invalid state, so give
+   <Slider error> a consistent red outline driven by the skin's red token. */
+.cam-range[aria-invalid="true"] {
+	outline: 2px solid var(--skin-red, #e5372b);
+	outline-offset: 3px;
+	border-radius: 2px;
+}

--- a/react/src/cameleon/context.test.tsx
+++ b/react/src/cameleon/context.test.tsx
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+import { useSkin } from "./context.js";
+import { FancyProvider } from "./FancyProvider.js";
+import { defaultSkin } from "./skins/default.js";
+import { brutalSkin } from "./skins/brutal/index.js";
+
+function SkinNameProbe({ onName }: { onName: (name: string) => void }) {
+	const ctx = useSkin();
+	onName(ctx.skin.name);
+	return null;
+}
+
+describe("useSkin", () => {
+	it("falls back to the default skin without a provider", () => {
+		let seen = "";
+		render(<SkinNameProbe onName={(name) => (seen = name)} />);
+		expect(seen).toBe(defaultSkin.name);
+	});
+
+	it("returns the provided skin inside a FancyProvider", () => {
+		let seen = "";
+		render(
+			<FancyProvider skin={brutalSkin}>
+				<SkinNameProbe onName={(name) => (seen = name)} />
+			</FancyProvider>
+		);
+		expect(seen).toBe("brutal");
+	});
+});

--- a/react/src/cameleon/context.ts
+++ b/react/src/cameleon/context.ts
@@ -1,0 +1,28 @@
+import { createContext, useContext } from "react";
+import type { Skin } from "./types.js";
+import { defaultSkin } from "./skins/default.js";
+
+/**
+ * The context value is a plain object holding the active skin, not the skin
+ * itself. <FancyProvider> builds a fresh `{ skin }` object whenever its `skin`
+ * prop changes, so its identity changes and every consumer re-renders — this
+ * is what makes a live skin switch reactive. (Mirrors the getter-object shape
+ * of the Svelte context, which relies on Svelte's own reactivity instead.)
+ */
+export interface SkinContext {
+	readonly skin: Skin;
+}
+
+/** Internal — <FancyProvider> is the only place that should reach for this directly. */
+export const SkinReactContext = createContext<SkinContext | null>(null);
+
+const FALLBACK: SkinContext = {
+	get skin() {
+		return defaultSkin;
+	},
+};
+
+/** Read the active skin. Falls back to the default skin with no provider. */
+export function useSkin(): SkinContext {
+	return useContext(SkinReactContext) ?? FALLBACK;
+}

--- a/react/src/cameleon/index.ts
+++ b/react/src/cameleon/index.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * Cameleon Engine — multi-skin UI primitives for fancy-ui.
  *

--- a/react/src/cameleon/index.ts
+++ b/react/src/cameleon/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Cameleon Engine — multi-skin UI primitives for fancy-ui.
+ *
+ * Same component API, radically different art directions ("skins"). Internal /
+ * not published yet: this compiles into dist but is not surfaced from the
+ * package root, so it stays a docs-site subsystem until deliberately promoted.
+ *
+ *   import { FancyProvider, Button, brutalSkin } from "./cameleon/index.js";
+ *   <FancyProvider skin={brutalSkin}> ... </FancyProvider>
+ */
+export { FancyProvider, type FancyProviderProps } from "./FancyProvider.js";
+export { useSkin, type SkinContext } from "./context.js";
+export type {
+	Skin,
+	SkinRecipes,
+	SkinOrnaments,
+	SkinFont,
+	SkinMeta,
+	RecipeFn,
+	RecipeArgs,
+	RecipeResult,
+	PartState,
+} from "./types.js";
+export * from "./primitives/index.js";
+
+export { defaultSkin } from "./skins/default.js";
+export { brutalSkin } from "./skins/brutal/index.js";
+export { glassSkin } from "./skins/glass/index.js";
+export { terminalSkin } from "./skins/terminal/index.js";
+export { retroOsSkin } from "./skins/retro-os/index.js";

--- a/react/src/cameleon/ornaments.test.tsx
+++ b/react/src/cameleon/ornaments.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { FancyProvider } from "./FancyProvider.js";
+import { Button } from "./primitives/index.js";
+import { brutalSkin } from "./skins/brutal/index.js";
+import { terminalSkin } from "./skins/terminal/index.js";
+import { retroOsSkin } from "./skins/retro-os/index.js";
+import { glassSkin } from "./skins/glass/index.js";
+
+describe("skin ornaments (createRawSnippet → JSX)", () => {
+	it("brutal Button renders the trailing arrow svg", () => {
+		render(
+			<FancyProvider skin={brutalSkin}>
+				<Button>Go</Button>
+			</FancyProvider>
+		);
+		const button = screen.getByRole("button", { name: "Go" });
+		const path = button.querySelector("svg path");
+		expect(path).toHaveAttribute("d", "M3 11 L11 3 M4.5 3 L11 3 L11 9.5");
+	});
+
+	it("terminal Button renders the blinking caret span", () => {
+		render(
+			<FancyProvider skin={terminalSkin}>
+				<Button>Run</Button>
+			</FancyProvider>
+		);
+		const button = screen.getByRole("button", { name: "Run" });
+		const caret = button.querySelector(".cam-caret");
+		expect(caret).toBeInTheDocument();
+		expect(caret?.textContent).toBe("▊");
+	});
+
+	it("retro-os Button renders the 2x2 pixel grid glyph", () => {
+		render(
+			<FancyProvider skin={retroOsSkin}>
+				<Button>Start</Button>
+			</FancyProvider>
+		);
+		const button = screen.getByRole("button", { name: "Start" });
+		const glyph = button.querySelector('span[aria-hidden="true"]');
+		expect(glyph).toBeInTheDocument();
+		expect(glyph?.querySelectorAll("span")).toHaveLength(4);
+	});
+
+	it("glass Button has no ornament (glass defines no buttonTrailing)", () => {
+		render(
+			<FancyProvider skin={glassSkin}>
+				<Button>Send</Button>
+			</FancyProvider>
+		);
+		const button = screen.getByRole("button", { name: "Send" });
+		expect(button.querySelector("svg")).not.toBeInTheDocument();
+	});
+});

--- a/react/src/cameleon/primitives.test.tsx
+++ b/react/src/cameleon/primitives.test.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { FancyProvider } from "./FancyProvider.js";
+import { defaultSkin } from "./skins/default.js";
+import {
+	Badge,
+	Button,
+	Checkbox,
+	Input,
+	Radio,
+	Select,
+	Slider,
+	Switch,
+	Textarea,
+	Tooltip,
+} from "./primitives/index.js";
+
+function withSkin(children: ReactNode) {
+	return render(<FancyProvider skin={defaultSkin}>{children}</FancyProvider>);
+}
+
+describe("cameleon primitives", () => {
+	it("Button renders with a recipe-derived class and honors disabled", () => {
+		withSkin(<Button disabled>Go</Button>);
+		const button = screen.getByRole("button", { name: "Go" });
+		expect(button.className).toContain("cam-btn");
+		expect(button).toBeDisabled();
+	});
+
+	it("Input renders with a recipe-derived class", () => {
+		withSkin(<Input placeholder="name" />);
+		expect(screen.getByPlaceholderText("name").className.length).toBeGreaterThan(0);
+	});
+
+	it("Textarea renders with a recipe-derived class", () => {
+		withSkin(<Textarea placeholder="bio" />);
+		expect(screen.getByPlaceholderText("bio").className.length).toBeGreaterThan(0);
+	});
+
+	it("Select renders with a recipe-derived class", () => {
+		withSkin(
+			<Select data-testid="select">
+				<option value="a">A</option>
+			</Select>
+		);
+		expect(screen.getByTestId("select").className.length).toBeGreaterThan(0);
+	});
+
+	it("Checkbox renders with a recipe-derived class and toggles", () => {
+		withSkin(<Checkbox aria-label="agree" />);
+		const checkbox = screen.getByRole("checkbox", { name: "agree" }) as HTMLInputElement;
+		expect(checkbox.closest("label")?.className.length).toBeGreaterThan(0);
+		expect(checkbox.checked).toBe(false);
+		fireEvent.click(checkbox);
+		expect(checkbox.checked).toBe(true);
+	});
+
+	it("Radio renders with a recipe-derived class", () => {
+		withSkin(<Radio aria-label="fruit" value="apple" />);
+		const radio = screen.getByRole("radio", { name: "fruit" });
+		expect(radio.closest("label")?.className.length).toBeGreaterThan(0);
+	});
+
+	it("Switch renders with a recipe-derived class and flips aria-checked on click", () => {
+		withSkin(<Switch aria-label="notifications" />);
+		const toggle = screen.getByRole("switch", { name: "notifications" });
+		expect(toggle.className.length).toBeGreaterThan(0);
+		expect(toggle).toHaveAttribute("aria-checked", "false");
+		fireEvent.click(toggle);
+		expect(toggle).toHaveAttribute("aria-checked", "true");
+	});
+
+	it("Slider renders with the cam-range hook class", () => {
+		withSkin(<Slider aria-label="volume" />);
+		expect(screen.getByRole("slider", { name: "volume" }).className).toContain("cam-range");
+	});
+
+	it("Badge renders with a recipe-derived class", () => {
+		withSkin(<Badge>New</Badge>);
+		expect(screen.getByText("New").className.length).toBeGreaterThan(0);
+	});
+
+	it("Tooltip renders with a recipe-derived class", () => {
+		withSkin(<Tooltip content="Helpful hint" />);
+		expect(screen.getByRole("tooltip").textContent).toBe("Helpful hint");
+		expect(
+			screen.getByRole("button", { name: "Helpful hint" }).className.length
+		).toBeGreaterThan(0);
+	});
+});

--- a/react/src/cameleon/primitives/Badge.tsx
+++ b/react/src/cameleon/primitives/Badge.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+import { cn } from "../../utils.js";
+import { useSkin } from "../context.js";
+import type { PartState } from "../types.js";
+
+export interface BadgeProps {
+	variant?: "default" | "solid" | "blue" | "red" | "yellow" | "green" | "purple";
+	/** Force a visual state for the /skins state matrix. */
+	demoState?: PartState;
+	className?: string;
+	children?: ReactNode;
+}
+
+export function Badge({ variant = "default", demoState, className, children }: BadgeProps) {
+	const ctx = useSkin();
+	const parts = ctx.skin.recipes.badge({ variant, state: demoState });
+
+	return <span className={cn(parts.root, className)}>{children}</span>;
+}

--- a/react/src/cameleon/primitives/Button.tsx
+++ b/react/src/cameleon/primitives/Button.tsx
@@ -1,0 +1,53 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
+import { cn } from "../../utils.js";
+import { useSkin } from "../context.js";
+import type { RecipeArgs } from "../types.js";
+
+export interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className"> {
+	variant?: "primary" | "secondary" | "destructive";
+	size?: "sm" | "md" | "lg";
+	loading?: boolean;
+	/** Force a visual state for the /skins state matrix (non-interactive). */
+	demoState?: "hover" | "active" | "focus";
+	className?: string;
+	children?: ReactNode;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+	{
+		variant = "primary",
+		size = "md",
+		loading = false,
+		disabled = false,
+		type = "button",
+		demoState,
+		className,
+		children,
+		...rest
+	},
+	ref
+) {
+	const ctx = useSkin();
+	const args: RecipeArgs = {
+		variant,
+		size,
+		state: demoState ?? (loading ? "loading" : disabled ? "disabled" : "default"),
+	};
+	// Re-derived on every render — this is what makes a live skin switch work.
+	const parts = ctx.skin.recipes.button(args);
+	const trailing = ctx.skin.ornaments?.buttonTrailing;
+
+	return (
+		<button
+			ref={ref}
+			type={type}
+			className={cn("cam-btn", parts.root, className)}
+			disabled={disabled || loading}
+			data-variant={variant}
+			{...rest}
+		>
+			{parts.label !== undefined ? <span className={parts.label}>{children}</span> : children}
+			{trailing ? trailing(args) : null}
+		</button>
+	);
+});

--- a/react/src/cameleon/primitives/Checkbox.tsx
+++ b/react/src/cameleon/primitives/Checkbox.tsx
@@ -1,0 +1,48 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
+import { cn } from "../../utils.js";
+import { useSkin } from "../context.js";
+import type { PartState } from "../types.js";
+
+export interface CheckboxProps
+	extends Omit<InputHTMLAttributes<HTMLInputElement>, "className" | "type"> {
+	checked?: boolean;
+	error?: boolean;
+	demoState?: PartState;
+	className?: string;
+	children?: ReactNode;
+}
+
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+	{ checked, error = false, demoState, className, children, ...rest },
+	ref
+) {
+	const ctx = useSkin();
+	const parts = ctx.skin.recipes.checkbox({ state: demoState });
+
+	return (
+		<label className={cn(parts.root, className)}>
+			<input
+				type="checkbox"
+				className="peer sr-only"
+				ref={ref}
+				checked={checked}
+				aria-invalid={error}
+				{...rest}
+			/>
+			<span className={parts.box}>
+				<svg
+					width="12"
+					height="12"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="3.5"
+					aria-hidden="true"
+				>
+					<path d="M5 13l4 4L19 7" strokeLinecap="round" strokeLinejoin="round" />
+				</svg>
+			</span>
+			{children}
+		</label>
+	);
+});

--- a/react/src/cameleon/primitives/Input.tsx
+++ b/react/src/cameleon/primitives/Input.tsx
@@ -1,0 +1,22 @@
+import { forwardRef, type InputHTMLAttributes } from "react";
+import { cn } from "../../utils.js";
+import { useSkin } from "../context.js";
+import type { PartState } from "../types.js";
+
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "className"> {
+	error?: boolean;
+	/** Force a visual state for the /skins state matrix. */
+	demoState?: PartState;
+	className?: string;
+	value?: string;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+	{ error = false, demoState, className, ...rest },
+	ref
+) {
+	const ctx = useSkin();
+	const parts = ctx.skin.recipes.input({ state: demoState });
+
+	return <input ref={ref} className={cn(parts.root, className)} aria-invalid={error} {...rest} />;
+});

--- a/react/src/cameleon/primitives/Radio.tsx
+++ b/react/src/cameleon/primitives/Radio.tsx
@@ -1,0 +1,43 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
+import { cn } from "../../utils.js";
+import { useSkin } from "../context.js";
+import type { PartState } from "../types.js";
+
+export interface RadioProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "className" | "type"> {
+	/** The currently selected value across this radio's group, if controlled. */
+	group?: string;
+	value?: string;
+	error?: boolean;
+	demoState?: PartState;
+	className?: string;
+	children?: ReactNode;
+}
+
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
+	{ group, value, name, error = false, demoState, className, children, ...rest },
+	ref
+) {
+	const ctx = useSkin();
+	const parts = ctx.skin.recipes.radio({ state: demoState });
+
+	return (
+		<label className={cn(parts.root, className)}>
+			{/* radio invalidity belongs on the group, not the input; drive the demo
+			    error visual off a data-attribute so we don't misuse aria-invalid.
+			    name defaults to the group so same-group radios stay mutually exclusive
+			    natively even when the parent doesn't pass a shared `group` value. */}
+			<input
+				type="radio"
+				className="peer sr-only"
+				ref={ref}
+				name={name ?? group}
+				value={value}
+				checked={group !== undefined ? group === value : undefined}
+				data-invalid={error ? "true" : undefined}
+				{...rest}
+			/>
+			<span className={parts.box} />
+			{children}
+		</label>
+	);
+});

--- a/react/src/cameleon/primitives/Select.tsx
+++ b/react/src/cameleon/primitives/Select.tsx
@@ -1,0 +1,40 @@
+import { forwardRef, type ReactNode, type SelectHTMLAttributes } from "react";
+import { cn } from "../../utils.js";
+import { useSkin } from "../context.js";
+import type { PartState } from "../types.js";
+
+export interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, "className"> {
+	error?: boolean;
+	demoState?: PartState;
+	className?: string;
+	value?: string;
+	children?: ReactNode;
+}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+	{ error = false, demoState, className, children, ...rest },
+	ref
+) {
+	const ctx = useSkin();
+	const parts = ctx.skin.recipes.select({ state: demoState });
+
+	return (
+		<div className={cn(parts.root, className)}>
+			<select ref={ref} className={parts.field} aria-invalid={error} {...rest}>
+				{children}
+			</select>
+			<span className={parts.chevron} aria-hidden="true">
+				<svg
+					width="14"
+					height="14"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2.5"
+				>
+					<path d="M6 9l6 6 6-6" strokeLinecap="round" strokeLinejoin="round" />
+				</svg>
+			</span>
+		</div>
+	);
+});

--- a/react/src/cameleon/primitives/Slider.tsx
+++ b/react/src/cameleon/primitives/Slider.tsx
@@ -1,0 +1,27 @@
+import { forwardRef, type InputHTMLAttributes } from "react";
+import { cn } from "../../utils.js";
+import { useSkin } from "../context.js";
+
+export interface SliderProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "className" | "type"> {
+	error?: boolean;
+	className?: string;
+	value?: number;
+}
+
+export const Slider = forwardRef<HTMLInputElement, SliderProps>(function Slider(
+	{ error = false, className, ...rest },
+	ref
+) {
+	const ctx = useSkin();
+	const parts = ctx.skin.recipes.slider({ state: error ? "error" : undefined });
+
+	return (
+		<input
+			type="range"
+			ref={ref}
+			className={cn(parts.root, className)}
+			aria-invalid={error || undefined}
+			{...rest}
+		/>
+	);
+});

--- a/react/src/cameleon/primitives/Switch.tsx
+++ b/react/src/cameleon/primitives/Switch.tsx
@@ -1,0 +1,47 @@
+import { forwardRef, useState, type ButtonHTMLAttributes, type MouseEvent } from "react";
+import { cn } from "../../utils.js";
+import { useSkin } from "../context.js";
+import type { PartState } from "../types.js";
+
+export interface SwitchProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className"> {
+	checked?: boolean;
+	error?: boolean;
+	demoState?: PartState;
+	className?: string;
+}
+
+export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch(
+	{ checked, error = false, disabled = false, demoState, className, onClick, ...rest },
+	ref
+) {
+	const ctx = useSkin();
+	const parts = ctx.skin.recipes.switch({ state: demoState });
+
+	// Uncontrolled by default (mirrors the Svelte $bindable(false) local-state
+	// behavior): clicking flips it even with no parent wired up. Passing
+	// `checked` switches it to a standard React controlled component, where the
+	// parent owns the value and `onClick` is how it learns about a flip — the
+	// role Svelte's two-way `bind:checked` plays on the source side.
+	const [uncontrolledChecked, setUncontrolledChecked] = useState(false);
+	const isControlled = checked !== undefined;
+	const isChecked = isControlled ? checked : uncontrolledChecked;
+
+	return (
+		<button
+			ref={ref}
+			type="button"
+			role="switch"
+			aria-checked={isChecked}
+			aria-invalid={error}
+			disabled={disabled}
+			onClick={(event: MouseEvent<HTMLButtonElement>) => {
+				if (!isControlled) setUncontrolledChecked((c) => !c);
+				onClick?.(event);
+			}}
+			className={cn(parts.root, className)}
+			{...rest}
+		>
+			<span className={parts.thumb} />
+		</button>
+	);
+});

--- a/react/src/cameleon/primitives/Textarea.tsx
+++ b/react/src/cameleon/primitives/Textarea.tsx
@@ -1,0 +1,23 @@
+import { forwardRef, type TextareaHTMLAttributes } from "react";
+import { cn } from "../../utils.js";
+import { useSkin } from "../context.js";
+import type { PartState } from "../types.js";
+
+export interface TextareaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "className"> {
+	error?: boolean;
+	demoState?: PartState;
+	className?: string;
+	value?: string;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+	{ error = false, demoState, className, ...rest },
+	ref
+) {
+	const ctx = useSkin();
+	const parts = ctx.skin.recipes.textarea({ state: demoState });
+
+	return (
+		<textarea ref={ref} className={cn(parts.root, className)} aria-invalid={error} {...rest} />
+	);
+});

--- a/react/src/cameleon/primitives/Tooltip.tsx
+++ b/react/src/cameleon/primitives/Tooltip.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+import { cn } from "../../utils.js";
+import { useSkin } from "../context.js";
+import type { PartState } from "../types.js";
+
+export interface TooltipProps {
+	/** Text shown in the bubble on hover / keyboard focus. */
+	content: string;
+	/** Force a visual state (focus / error) for the /skins state matrix. */
+	demoState?: PartState;
+	/** Force the bubble visible (state matrix). */
+	demoOpen?: boolean;
+	className?: string;
+	/** Trigger contents; defaults to a "?" glyph. */
+	children?: ReactNode;
+}
+
+export function Tooltip({ content, demoState, demoOpen = false, className, children }: TooltipProps) {
+	const ctx = useSkin();
+	const parts = ctx.skin.recipes.tooltip({ state: demoState });
+
+	return (
+		<span className={cn(parts.root, className)}>
+			<button type="button" className={parts.trigger} aria-label={content}>
+				{children ?? "?"}
+			</button>
+			<span role="tooltip" className={cn(parts.bubble, demoOpen && "opacity-100")}>
+				{content}
+			</span>
+		</span>
+	);
+}

--- a/react/src/cameleon/primitives/index.ts
+++ b/react/src/cameleon/primitives/index.ts
@@ -1,0 +1,10 @@
+export { Button, type ButtonProps } from "./Button.js";
+export { Input, type InputProps } from "./Input.js";
+export { Textarea, type TextareaProps } from "./Textarea.js";
+export { Select, type SelectProps } from "./Select.js";
+export { Checkbox, type CheckboxProps } from "./Checkbox.js";
+export { Radio, type RadioProps } from "./Radio.js";
+export { Switch, type SwitchProps } from "./Switch.js";
+export { Slider, type SliderProps } from "./Slider.js";
+export { Badge, type BadgeProps } from "./Badge.js";
+export { Tooltip, type TooltipProps } from "./Tooltip.js";

--- a/react/src/cameleon/skins.test.ts
+++ b/react/src/cameleon/skins.test.ts
@@ -1,0 +1,42 @@
+import { defaultSkin } from "./skins/default.js";
+import { brutalSkin } from "./skins/brutal/index.js";
+import { glassSkin } from "./skins/glass/index.js";
+import { terminalSkin } from "./skins/terminal/index.js";
+import { retroOsSkin } from "./skins/retro-os/index.js";
+import type { Skin } from "./types.js";
+
+const skins: Skin[] = [defaultSkin, brutalSkin, glassSkin, terminalSkin, retroOsSkin];
+
+const RECIPE_NAMES = [
+	"button",
+	"badge",
+	"input",
+	"textarea",
+	"select",
+	"checkbox",
+	"radio",
+	"switch",
+	"slider",
+	"tooltip",
+] as const;
+
+describe("cameleon skins", () => {
+	for (const skin of skins) {
+		describe(skin.name, () => {
+			it("implements all 10 recipes, each returning a non-empty root class for default args", () => {
+				for (const name of RECIPE_NAMES) {
+					const fn = skin.recipes[name];
+					expect(typeof fn).toBe("function");
+					const { root } = fn({});
+					expect(typeof root).toBe("string");
+					expect(root).toBeTruthy();
+				}
+			});
+
+			it("declares --skin-page-bg and --skin-page-fg tokens", () => {
+				expect(skin.tokens["--skin-page-bg"]).toBeTruthy();
+				expect(skin.tokens["--skin-page-fg"]).toBeTruthy();
+			});
+		});
+	}
+});

--- a/react/src/cameleon/skins/brutal/brutal.css
+++ b/react/src/cameleon/skins/brutal/brutal.css
@@ -1,0 +1,35 @@
+/* Brutal skin — native range slider: ink track + ink thumb, blue focus ring. */
+[data-skin="brutal"] .cam-range {
+	height: 20px;
+}
+[data-skin="brutal"] .cam-range::-webkit-slider-runnable-track {
+	height: 4px;
+	background: #141414;
+	border-radius: 999px;
+}
+[data-skin="brutal"] .cam-range::-webkit-slider-thumb {
+	-webkit-appearance: none;
+	appearance: none;
+	height: 16px;
+	width: 16px;
+	margin-top: -6px;
+	background: #141414;
+	border: 1.5px solid #141414;
+	border-radius: 50%;
+}
+[data-skin="brutal"] .cam-range:focus-visible::-webkit-slider-thumb {
+	border-color: #1b6ef3;
+	box-shadow: 0 0 0 3px rgba(27, 110, 243, 0.35);
+}
+[data-skin="brutal"] .cam-range::-moz-range-track {
+	height: 4px;
+	background: #141414;
+	border-radius: 999px;
+}
+[data-skin="brutal"] .cam-range::-moz-range-thumb {
+	height: 16px;
+	width: 16px;
+	background: #141414;
+	border: 1.5px solid #141414;
+	border-radius: 50%;
+}

--- a/react/src/cameleon/skins/brutal/index.ts
+++ b/react/src/cameleon/skins/brutal/index.ts
@@ -1,0 +1,44 @@
+import type { Skin } from "../../types.js";
+import { brutalTokens } from "./tokens.js";
+import { brutalMeta } from "./meta.js";
+import {
+	brutalButton,
+	brutalInput,
+	brutalTextarea,
+	brutalSelect,
+	brutalCheckbox,
+	brutalRadio,
+	brutalSwitch,
+	brutalSlider,
+	brutalBadge,
+	brutalTooltip,
+} from "./recipes.js";
+import { buttonTrailing } from "./ornaments.js";
+import "./brutal.css";
+
+export const brutalSkin: Skin = {
+	name: "brutal",
+	label: "Brutal",
+	colorScheme: "light",
+	tokens: brutalTokens,
+	meta: brutalMeta,
+	fonts: [
+		{
+			id: "cam-font-brutal",
+			href: "https://fonts.googleapis.com/css2?family=Archivo:wght@400..900&family=Space+Mono:wght@400;700&display=swap",
+		},
+	],
+	recipes: {
+		button: brutalButton,
+		input: brutalInput,
+		textarea: brutalTextarea,
+		select: brutalSelect,
+		checkbox: brutalCheckbox,
+		radio: brutalRadio,
+		switch: brutalSwitch,
+		slider: brutalSlider,
+		badge: brutalBadge,
+		tooltip: brutalTooltip,
+	},
+	ornaments: { buttonTrailing },
+};

--- a/react/src/cameleon/skins/brutal/meta.ts
+++ b/react/src/cameleon/skins/brutal/meta.ts
@@ -1,0 +1,73 @@
+import type { SkinMeta } from "../../types.js";
+
+/** Brutal design metadata — the exact values from the design reference. */
+export const brutalMeta: SkinMeta = {
+	palette: [
+		{ name: "Paper", value: "#F4EEE0", note: "page · sidebar · header" },
+		{ name: "Card", value: "#FBF7EB", note: "cards · pills · search" },
+		{ name: "Surface", value: "#FFFCF2", note: "inline code chip" },
+		{ name: "Ink", value: "#141414", note: "text · borders · code bg" },
+		{ name: "Blue", value: "#1B6EF3", note: "active nav · link · focus" },
+		{ name: "Blue 700", value: "#144FB0", note: "link hover" },
+		{ name: "Red", value: "#E5372B", note: "category dot · step 02" },
+		{ name: "Yellow", value: "#F5B40C", note: "CTA strip · press flash" },
+		{ name: "Green", value: "#12A147", note: "category dot · tile" },
+		{ name: "Purple", value: "#8E55E9", note: "category dot · lede" },
+	],
+	type: [
+		{
+			sample: "Display",
+			spec: "ARCHIVO 900 · -0.035EM · CLAMP(38, 5VW, 56)",
+			style: "font-size:56px;font-weight:900;letter-spacing:-0.035em;line-height:0.98;",
+		},
+		{
+			sample: "Heading — section title",
+			spec: "ARCHIVO 850 · -0.015EM · CLAMP(19, 2VW, 23)",
+			style: "font-size:23px;font-weight:850;letter-spacing:-0.015em;",
+		},
+		{
+			sample: "Card head — Svelte 5 native",
+			spec: "ARCHIVO 800 · 14.5",
+			style: "font-size:14.5px;font-weight:800;",
+		},
+		{
+			sample: "Nav item — Introduction",
+			spec: "ARCHIVO 600 · 13.5 · ACTIVE 750",
+			style: "font-size:13.5px;font-weight:600;",
+		},
+		{
+			sample: "Lede — 50+ animated, interactive components you can drop into any page.",
+			spec: "ARCHIVO 500 · CLAMP(15, 1.4VW, 18) · LH 1.55",
+			style: "font-size:18px;font-weight:500;line-height:1.55;max-width:56ch;",
+		},
+		{
+			sample: "MONO LABEL — GETTING STARTED",
+			spec: "SPACE MONO 700 CAPS · 7.5–12 + 0.1EM",
+			style:
+				"font-family:var(--skin-font-mono);font-size:10px;font-weight:700;letter-spacing:0.1em;",
+		},
+	],
+	specs: {
+		radius: [
+			{ size: "3px", label: "marker" },
+			{ size: "5px", label: "chip" },
+			{ size: "7px", label: "tile" },
+			{ size: "9px", label: "nav" },
+			{ size: "10px", label: "code" },
+			{ size: "12px", label: "card" },
+			{ size: "999px", label: "pill" },
+		],
+		border: "1.5px solid ink everywhere · 1.3px inline chips · 1px 8px markers.",
+		shadowRest: "0 8px 16px rgba(60,50,20,.07) soft ambient — never a hard offset at rest",
+		shadowHover: "3–4px hard offset 0 ink + translate(-1,-1) / (-2,-2), hover only",
+		spacing: "3 / 4 / 6 / 8 / 10 / 12 / 14 / 18 / 20 / 32 / 38 / 40",
+	},
+	responsive: [
+		{
+			label: "Desktop ≥1180",
+			note: "sidebar 264px + rail 200px · full breadcrumb · hover lifts on",
+		},
+		{ label: "Tablet 768–1179", note: "sidebar + rail hidden · compact header · 28px FU tile" },
+		{ label: "Mobile <768", note: "search pill + language button hidden · 44px+ tap targets" },
+	],
+};

--- a/react/src/cameleon/skins/brutal/ornaments.tsx
+++ b/react/src/cameleon/skins/brutal/ornaments.tsx
@@ -1,0 +1,21 @@
+/**
+ * Brutal ornaments as plain functions returning JSX. currentColor makes the
+ * arrow track the button's per-variant text color.
+ */
+import type { ReactNode } from "react";
+import type { RecipeArgs } from "../../types.js";
+
+export function buttonTrailing(_args: RecipeArgs): ReactNode {
+	return (
+		<svg width="12" height="12" viewBox="0 0 14 14" aria-hidden="true" style={{ display: "block", flex: "none" }}>
+			<path
+				d="M3 11 L11 3 M4.5 3 L11 3 L11 9.5"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.9"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+}

--- a/react/src/cameleon/skins/brutal/recipes.ts
+++ b/react/src/cameleon/skins/brutal/recipes.ts
@@ -1,0 +1,193 @@
+/**
+ * Brutal recipes — the full "Core components" set from the design system.
+ * Static class literals only (Tailwind JIT-safe). States are attribute-driven
+ * for real interaction (disabled/aria-invalid/aria-checked + hover/focus/peer/
+ * group variants); the /skins state-matrix additionally FORCES hover/active/focus
+ * statically via `args.state` (see the FORCE maps below + `demoState` on the
+ * primitives). Real interaction still works; forced classes are additive.
+ *
+ * Design tokens: paper #F4EEE0, card #FBF7EB, surface #FFFCF2, ink #141414,
+ * accents blue #1B6EF3 / red #E5372B / yellow #F5B40C / green #12A147 / purple
+ * #8E55E9. Focus ring 0 0 0 3px rgba(27,110,243,.35). Error ring rgba(229,55,43,.28).
+ */
+import type { PartState, RecipeArgs, RecipeResult } from "../../types.js";
+
+const forced = (map: Partial<Record<PartState, string>>, state?: PartState): string =>
+	(state && map[state]) || "";
+
+/* ---- Button ------------------------------------------------------------- */
+const BTN_BASE =
+	"inline-flex items-center justify-center gap-[7px] rounded-full border-[1.5px] " +
+	"font-extrabold tracking-[-0.01em] whitespace-nowrap cursor-pointer select-none " +
+	"transition-[transform,box-shadow] duration-150 ease-out " +
+	"hover:-translate-x-0.5 hover:-translate-y-0.5 active:translate-x-0 active:translate-y-0 " +
+	"focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[rgba(27,110,243,0.45)] " +
+	"disabled:pointer-events-none disabled:cursor-not-allowed";
+const BTN_SIZE = {
+	sm: "px-[13px] py-[6px] text-[11px]",
+	md: "px-[18px] py-[9px] text-[12.5px]",
+	lg: "px-[22px] py-[11px] text-[14px]",
+} as const;
+const BTN_VARIANT = {
+	primary:
+		"border-[#141414] bg-[#141414] text-[#F4EEE0] shadow-[0_4px_10px_rgba(60,50,20,0.1)] " +
+		"hover:shadow-[4px_4px_0_#141414] active:bg-black active:shadow-[0_1px_0_#141414] " +
+		"disabled:border-[rgba(20,20,20,0.25)] disabled:bg-[rgba(20,20,20,0.22)] disabled:text-[rgba(20,20,20,0.4)] disabled:shadow-none",
+	secondary:
+		"border-[#141414] bg-[#FFFCF2] text-[#141414] shadow-[0_4px_10px_rgba(60,50,20,0.1)] " +
+		"hover:shadow-[4px_4px_0_#141414] active:shadow-[0_1px_0_#141414] disabled:opacity-50 disabled:shadow-none",
+	destructive:
+		"border-[#141414] bg-[#E5372B] text-white shadow-[0_4px_10px_rgba(60,50,20,0.1)] " +
+		"hover:shadow-[4px_4px_0_#141414] active:shadow-[0_1px_0_#141414] disabled:opacity-50 disabled:shadow-none",
+} as const;
+const BTN_FORCE: Partial<Record<PartState, string>> = {
+	hover: "-translate-x-0.5 -translate-y-0.5 shadow-[4px_4px_0_#141414]",
+	active: "bg-black shadow-[0_1px_0_#141414]",
+	focus: "border-[#1B6EF3] ring-[3px] ring-[rgba(27,110,243,0.45)]",
+};
+
+export function brutalButton(args: RecipeArgs): RecipeResult {
+	const size = BTN_SIZE[(args.size as keyof typeof BTN_SIZE) ?? "md"] ?? BTN_SIZE.md;
+	const variant =
+		BTN_VARIANT[(args.variant as keyof typeof BTN_VARIANT) ?? "primary"] ?? BTN_VARIANT.primary;
+	return { root: `${BTN_BASE} ${size} ${variant} ${forced(BTN_FORCE, args.state)}`, label: "" };
+}
+
+/* ---- Text fields (input / textarea / select) ---------------------------- */
+const FIELD_BASE =
+	"w-full rounded-lg border-[1.5px] border-[#141414] bg-[#FFFCF2] px-[11px] py-2 " +
+	"text-[12px] font-semibold text-[#141414] outline-none " +
+	"transition-[box-shadow,border-color,background] duration-150 " +
+	"placeholder:text-[#141414]/40 " +
+	"hover:bg-white hover:shadow-[0_3px_8px_rgba(60,50,20,0.12)] " +
+	"focus:border-[#1B6EF3] focus:shadow-[0_0_0_3px_rgba(27,110,243,0.35)] " +
+	"disabled:bg-[#EAE3D2] disabled:text-[#141414]/40 disabled:border-[#141414]/30 disabled:shadow-none disabled:cursor-not-allowed " +
+	"aria-[invalid=true]:border-[#E5372B] aria-[invalid=true]:shadow-[0_0_0_3px_rgba(229,55,43,0.28)]";
+const FIELD_FORCE: Partial<Record<PartState, string>> = {
+	hover: "bg-white shadow-[0_3px_8px_rgba(60,50,20,0.12)]",
+	active: "bg-white",
+	focus: "border-[#1B6EF3] shadow-[0_0_0_3px_rgba(27,110,243,0.35)]",
+};
+
+export const brutalInput = (args: RecipeArgs): RecipeResult => ({
+	root: `${FIELD_BASE} ${forced(FIELD_FORCE, args.state)}`,
+});
+
+export const brutalTextarea = (args: RecipeArgs): RecipeResult => ({
+	root: `${FIELD_BASE} min-h-[80px] leading-relaxed resize-y ${forced(FIELD_FORCE, args.state)}`,
+});
+
+export const brutalSelect = (args: RecipeArgs): RecipeResult => ({
+	root: "relative inline-block w-full",
+	field: `${FIELD_BASE} appearance-none pr-9 cursor-pointer ${forced(FIELD_FORCE, args.state)}`,
+	chevron: "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#141414]",
+});
+
+/* ---- Checkbox / Radio (native input + custom box) ----------------------- */
+const CHOICE_ROOT =
+	"inline-flex items-center gap-2 cursor-pointer select-none text-[12px] font-semibold text-[#141414] " +
+	"has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-60";
+const CHOICE_BOX_BASE =
+	"grid place-items-center h-[18px] w-[18px] shrink-0 border-[1.5px] border-[#141414] bg-[#FFFCF2] " +
+	"transition-colors text-transparent " +
+	"peer-focus-visible:shadow-[0_0_0_3px_rgba(27,110,243,0.35)] " +
+	"peer-disabled:bg-[#EAE3D2] peer-disabled:border-[#141414]/30 " +
+	"peer-aria-[invalid=true]:border-[#E5372B] peer-aria-[invalid=true]:shadow-[0_0_0_3px_rgba(229,55,43,0.28)] " +
+	"peer-data-[invalid=true]:border-[#E5372B] peer-data-[invalid=true]:shadow-[0_0_0_3px_rgba(229,55,43,0.28)]";
+const CHOICE_FORCE: Partial<Record<PartState, string>> = {
+	hover: "shadow-[2px_2px_0_rgba(20,20,20,0.3)]",
+	focus: "border-[#1B6EF3] shadow-[0_0_0_3px_rgba(27,110,243,0.35)]",
+};
+
+export const brutalCheckbox = (args: RecipeArgs): RecipeResult => ({
+	root: CHOICE_ROOT,
+	box: `${CHOICE_BOX_BASE} rounded-[4px] peer-checked:bg-[#141414] peer-checked:text-[#FFFCF2] ${forced(CHOICE_FORCE, args.state)}`,
+});
+
+export const brutalRadio = (args: RecipeArgs): RecipeResult => ({
+	root: CHOICE_ROOT,
+	box: `${CHOICE_BOX_BASE} rounded-full peer-checked:bg-[#141414] ${forced(CHOICE_FORCE, args.state)}`,
+});
+
+/* ---- Switch (button role=switch) ---------------------------------------- */
+const SWITCH_FORCE: Partial<Record<PartState, string>> = {
+	hover: "shadow-[2px_2px_0_rgba(20,20,20,0.3)]",
+	focus: "border-[#1B6EF3] shadow-[0_0_0_3px_rgba(27,110,243,0.35)]",
+};
+
+export const brutalSwitch = (args: RecipeArgs): RecipeResult => ({
+	root:
+		"group inline-flex h-[22px] w-[40px] shrink-0 items-center rounded-full border-[1.5px] border-[#141414] " +
+		"bg-[#FFFCF2] p-[2px] cursor-pointer transition-colors " +
+		"aria-[checked=true]:bg-[#1B6EF3] " +
+		"focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_rgba(27,110,243,0.35)] " +
+		"disabled:bg-[#EAE3D2] disabled:cursor-not-allowed " +
+		"aria-[invalid=true]:border-[#E5372B] aria-[invalid=true]:shadow-[0_0_0_3px_rgba(229,55,43,0.28)] " +
+		forced(SWITCH_FORCE, args.state),
+	thumb:
+		"h-[14px] w-[14px] rounded-full border-[1.5px] border-[#141414] bg-white " +
+		"transition-transform group-aria-[checked=true]:translate-x-[18px]",
+});
+
+/* ---- Slider (native range; thumb/track in brutal.css via .cam-range) ----- */
+export const brutalSlider = (): RecipeResult => ({
+	root: "cam-range w-[160px] cursor-pointer appearance-none bg-transparent disabled:cursor-not-allowed disabled:opacity-50",
+});
+
+/* ---- Badge -------------------------------------------------------------- */
+const BADGE_BASE =
+	"inline-flex items-center rounded-full border-[1.5px] px-[10px] py-[3px] text-[11px] font-bold " +
+	"before:content-[''] before:mr-[6px] before:h-[7px] before:w-[7px] before:rounded-full before:shrink-0";
+const BADGE_VARIANT = {
+	default: "border-[#141414] bg-[#FFFCF2] text-[#141414] before:bg-[#141414]",
+	solid: "border-[#141414] bg-[#141414] text-[#F4EEE0] before:bg-[#F4EEE0]",
+	blue: "border-[#1B6EF3] bg-[#FFFCF2] text-[#1B6EF3] before:bg-[#1B6EF3]",
+	red: "border-[#E5372B] bg-[#FFFCF2] text-[#E5372B] before:bg-[#E5372B]",
+	yellow: "border-[#F5B40C] bg-[#FFFCF2] text-[#9A7100] before:bg-[#F5B40C]",
+	green: "border-[#12A147] bg-[#FFFCF2] text-[#12A147] before:bg-[#12A147]",
+	purple: "border-[#8E55E9] bg-[#FFFCF2] text-[#6E35C8] before:bg-[#8E55E9]",
+} as const;
+// The badge state row (default variant, 6 states). Forced overrides the resting look.
+const BADGE_FORCE: Partial<Record<PartState, string>> = {
+	hover: "shadow-[2px_2px_0_rgba(20,20,20,0.3)]",
+	active: "bg-[#141414] text-[#F4EEE0] before:bg-[#F4EEE0]",
+	focus: "border-[#1B6EF3] shadow-[0_0_0_3px_rgba(27,110,243,0.35)]",
+	disabled:
+		"border-[rgba(20,20,20,0.3)] bg-[#EAE3D2] text-[rgba(20,20,20,0.4)] before:bg-[rgba(20,20,20,0.3)]",
+	error: "border-[#E5372B] bg-[#FDECEA] text-[#C42B20] before:bg-[#E5372B]",
+};
+
+export function brutalBadge(args: RecipeArgs): RecipeResult {
+	const variant =
+		BADGE_VARIANT[(args.variant as keyof typeof BADGE_VARIANT) ?? "default"] ??
+		BADGE_VARIANT.default;
+	return { root: `${BADGE_BASE} ${variant} ${forced(BADGE_FORCE, args.state)}` };
+}
+
+/* ---- Tooltip ------------------------------------------------------------ */
+// Tooltip has default / focus / error variants (via args.state); no active/disabled.
+const TT_TRIGGER: Partial<Record<PartState, string>> = {
+	focus: "border-[#1B6EF3] bg-[#FFFCF2] text-[#1B6EF3] shadow-[0_0_0_3px_rgba(27,110,243,0.3)]",
+	error: "border-[#E5372B] bg-[#FFFCF2] text-[#E5372B]",
+};
+const TT_BUBBLE: Partial<Record<PartState, string>> = {
+	focus: "border-[#1B6EF3] shadow-[0_0_0_3px_rgba(27,110,243,0.35)]",
+	error: "bg-[#E5372B] border-[#E5372B]",
+};
+
+export function brutalTooltip(args: RecipeArgs): RecipeResult {
+	return {
+		root: "relative inline-flex group",
+		trigger:
+			"grid place-items-center h-[26px] w-[26px] rounded-full border-[1.5px] border-[#141414] " +
+			"bg-[#1B6EF3] text-white text-[12px] font-bold cursor-help " +
+			"focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_rgba(27,110,243,0.35)] " +
+			forced(TT_TRIGGER, args.state),
+		bubble:
+			"pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 whitespace-nowrap " +
+			"rounded-lg border-[1.5px] border-[#141414] bg-[#141414] px-3 py-1.5 text-[12px] font-semibold text-[#F4EEE0] " +
+			"opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 " +
+			"shadow-[0_10px_18px_rgba(60,50,20,0.15)] " +
+			forced(TT_BUBBLE, args.state),
+	};
+}

--- a/react/src/cameleon/skins/brutal/tokens.ts
+++ b/react/src/cameleon/skins/brutal/tokens.ts
@@ -1,0 +1,26 @@
+/**
+ * Brutal skin tokens — "Swiss Grid × Playful Brutalism × Editorial".
+ * Every value is transcribed from the in-repo design reference
+ * (vendor/design-refs/brutal/FancyUI-Intro-CV-Style.dc.html) — do not eyeball
+ * or round these; the docs skin is calibrated against that file pixel for pixel.
+ * Paper palette, ink borders, five flat accents, Archivo + Space Mono.
+ */
+export const brutalTokens: Record<string, string> = {
+	"--skin-page-bg": "#F4EEE0",
+	"--skin-page-fg": "#141414",
+	"--skin-paper": "#F4EEE0",
+	"--skin-card": "#FBF7EB",
+	"--skin-surface": "#FFFCF2",
+	"--skin-ink": "#141414",
+	"--skin-line": "#141414",
+	"--skin-blue": "#1B6EF3",
+	// Darker blue, used by the reference for `a:hover` only — the single shade
+	// of an accent in the whole system, hence the numeric suffix.
+	"--skin-blue-700": "#144FB0",
+	"--skin-red": "#E5372B",
+	"--skin-yellow": "#F5B40C",
+	"--skin-green": "#12A147",
+	"--skin-purple": "#8E55E9",
+	"--skin-font-sans": "'Archivo', Helvetica, Arial, sans-serif",
+	"--skin-font-mono": "'Space Mono', monospace",
+};

--- a/react/src/cameleon/skins/default.ts
+++ b/react/src/cameleon/skins/default.ts
@@ -1,0 +1,110 @@
+import type { RecipeArgs, RecipeResult, Skin, SkinMeta } from "../types.js";
+
+const meta: SkinMeta = {
+	palette: [
+		{ name: "Background", value: "#ffffff", note: "page" },
+		{ name: "Foreground", value: "#0a0a0a", note: "text" },
+		{ name: "Border", value: "#d4d4d4", note: "lines" },
+		{ name: "Accent", value: "#171717", note: "primary" },
+	],
+	type: [
+		{ sample: "Heading", spec: "SYSTEM SANS · 600", style: "font-size:28px;font-weight:600;" },
+		{ sample: "Body text", spec: "SYSTEM SANS · 400", style: "font-size:14px;font-weight:400;" },
+	],
+	specs: {
+		radius: [
+			{ size: "6px", label: "md" },
+			{ size: "9999px", label: "pill" },
+		],
+		border: "1px solid neutral-300",
+		shadowRest: "none",
+		shadowHover: "none",
+		spacing: "4 / 8 / 12 / 16 / 24",
+	},
+	responsive: [{ label: "All", note: "fluid single column" }],
+};
+
+/**
+ * Neutral fallback skin. Used by `useSkin()` when no <FancyProvider> is present,
+ * so primitives always render something sane. Deliberately plain — implements
+ * the full recipe contract with unstyled-ish neutral defaults.
+ */
+const FIELD =
+	"w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 outline-none " +
+	"transition focus:border-neutral-500 focus:ring-2 focus:ring-neutral-300 " +
+	"disabled:opacity-50 disabled:cursor-not-allowed aria-[invalid=true]:border-red-500 aria-[invalid=true]:ring-red-200";
+const CHOICE_ROOT =
+	"inline-flex items-center gap-2 cursor-pointer select-none text-sm text-neutral-900";
+const CHOICE_BOX =
+	"grid place-items-center h-[18px] w-[18px] shrink-0 border border-neutral-400 bg-white transition text-transparent " +
+	"peer-focus-visible:ring-2 peer-focus-visible:ring-neutral-300 peer-disabled:opacity-40 " +
+	"peer-aria-[invalid=true]:border-red-500 peer-data-[invalid=true]:border-red-500";
+
+const button = (args: RecipeArgs): RecipeResult => ({
+	root:
+		"cam-btn inline-flex items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm font-medium " +
+		"cursor-pointer transition-colors border-neutral-300 focus-visible:outline-none focus-visible:ring-2 " +
+		"focus-visible:ring-neutral-400 disabled:pointer-events-none disabled:opacity-50 " +
+		(args.variant === "destructive"
+			? "bg-red-600 text-white hover:bg-red-500"
+			: args.variant === "secondary"
+				? "bg-white text-neutral-900 hover:bg-neutral-100"
+				: "bg-neutral-900 text-white hover:bg-neutral-700"),
+	label: "",
+});
+
+const badge = (args: RecipeArgs): RecipeResult => ({
+	root:
+		"inline-flex items-center rounded-full border border-neutral-300 bg-white px-2.5 py-0.5 text-xs font-medium text-neutral-700 " +
+		"before:content-[''] before:mr-1.5 before:h-[7px] before:w-[7px] before:rounded-full before:bg-neutral-400",
+});
+
+export const defaultSkin: Skin = {
+	name: "default",
+	label: "Default",
+	colorScheme: "light",
+	meta,
+	tokens: {
+		"--skin-page-bg": "#ffffff",
+		"--skin-page-fg": "#0a0a0a",
+		"--skin-font-sans": "ui-sans-serif, system-ui, -apple-system, sans-serif",
+	},
+	recipes: {
+		button,
+		badge,
+		input: () => ({ root: FIELD }),
+		textarea: () => ({ root: `${FIELD} min-h-[80px] resize-y` }),
+		select: () => ({
+			root: "relative inline-block w-full",
+			field: `${FIELD} appearance-none pr-9 cursor-pointer`,
+			chevron: "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-neutral-500",
+		}),
+		checkbox: () => ({
+			root: CHOICE_ROOT,
+			box: `${CHOICE_BOX} rounded peer-checked:bg-neutral-900 peer-checked:text-white`,
+		}),
+		radio: () => ({
+			root: CHOICE_ROOT,
+			box: `${CHOICE_BOX} rounded-full peer-checked:bg-neutral-900`,
+		}),
+		switch: () => ({
+			root:
+				"group inline-flex h-[22px] w-[40px] shrink-0 items-center rounded-full border border-neutral-300 bg-neutral-200 p-[2px] " +
+				"cursor-pointer transition-colors aria-[checked=true]:bg-neutral-900 focus-visible:outline-none focus-visible:ring-2 " +
+				"focus-visible:ring-neutral-400 disabled:opacity-50",
+			thumb:
+				"h-[14px] w-[14px] rounded-full bg-white shadow transition-transform group-aria-[checked=true]:translate-x-[18px]",
+		}),
+		slider: () => ({
+			root: "cam-range w-[160px] cursor-pointer appearance-none bg-transparent disabled:opacity-50",
+		}),
+		tooltip: () => ({
+			root: "relative inline-flex group",
+			trigger:
+				"grid place-items-center h-[26px] w-[26px] rounded-full border border-neutral-300 bg-neutral-900 text-white text-xs font-bold cursor-help",
+			bubble:
+				"pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-neutral-900 px-3 py-1.5 text-xs text-white " +
+				"opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100",
+		}),
+	},
+};

--- a/react/src/cameleon/skins/glass/glass.css
+++ b/react/src/cameleon/skins/glass/glass.css
@@ -1,0 +1,55 @@
+/* Glass skin — specular top sheen on interactive surfaces. Scoped by data-skin. */
+[data-skin="glass"] .cam-btn {
+	overflow: hidden;
+}
+[data-skin="glass"] .cam-btn::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	border-radius: inherit;
+	pointer-events: none;
+	background: linear-gradient(180deg, rgba(255, 255, 255, 0.4) 0%, rgba(255, 255, 255, 0) 48%);
+	opacity: 0.65;
+}
+
+/* Glass skin — native range slider: frosted white track + white thumb, glow ring on focus. */
+[data-skin="glass"] .cam-range {
+	height: 20px;
+}
+[data-skin="glass"] .cam-range::-webkit-slider-runnable-track {
+	height: 6px;
+	background: rgba(255, 255, 255, 0.2);
+	border: 1px solid rgba(255, 255, 255, 0.25);
+	border-radius: 999px;
+}
+[data-skin="glass"] .cam-range::-webkit-slider-thumb {
+	-webkit-appearance: none;
+	appearance: none;
+	height: 16px;
+	width: 16px;
+	margin-top: -6px;
+	background: #ffffff;
+	border: 1px solid rgba(255, 255, 255, 0.6);
+	border-radius: 50%;
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+}
+[data-skin="glass"] .cam-range:focus-visible::-webkit-slider-thumb {
+	box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.5);
+}
+[data-skin="glass"] .cam-range::-moz-range-track {
+	height: 6px;
+	background: rgba(255, 255, 255, 0.2);
+	border: 1px solid rgba(255, 255, 255, 0.25);
+	border-radius: 999px;
+}
+[data-skin="glass"] .cam-range::-moz-range-thumb {
+	height: 16px;
+	width: 16px;
+	background: #ffffff;
+	border: 1px solid rgba(255, 255, 255, 0.6);
+	border-radius: 50%;
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+}
+[data-skin="glass"] .cam-range:focus-visible::-moz-range-thumb {
+	box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.5);
+}

--- a/react/src/cameleon/skins/glass/index.ts
+++ b/react/src/cameleon/skins/glass/index.ts
@@ -1,0 +1,14 @@
+import type { Skin } from "../../types.js";
+import { glassTokens } from "./tokens.js";
+import { glassMeta } from "./meta.js";
+import { glassRecipes } from "./recipes.js";
+import "./glass.css";
+
+export const glassSkin: Skin = {
+	name: "glass",
+	label: "Glass",
+	colorScheme: "dark",
+	tokens: glassTokens,
+	meta: glassMeta,
+	recipes: glassRecipes,
+};

--- a/react/src/cameleon/skins/glass/meta.ts
+++ b/react/src/cameleon/skins/glass/meta.ts
@@ -1,0 +1,64 @@
+import type { SkinMeta } from "../../types.js";
+
+/** Glass design metadata — frosted translucent surfaces on a purple gradient world. */
+export const glassMeta: SkinMeta = {
+	palette: [
+		{ name: "Glass 8%", value: "rgba(255,255,255,0.08)", note: "section card" },
+		{ name: "Glass 12%", value: "rgba(255,255,255,0.12)", note: "inner surface" },
+		{ name: "Border 25%", value: "rgba(255,255,255,0.25)", note: "hairline edge" },
+		{ name: "Blue", value: "#7dd3fc", note: "accent · info" },
+		{ name: "Red", value: "#fca5a5", note: "accent · error" },
+		{ name: "Yellow", value: "#fde68a", note: "accent · warn" },
+		{ name: "Green", value: "#86efac", note: "accent · ok" },
+		{ name: "Purple", value: "#c4b5fd", note: "accent · brand" },
+	],
+	type: [
+		{
+			sample: "Display",
+			spec: "SYSTEM SANS 600 · -0.03EM · CLAMP(48, 8VW, 112)",
+			style: "font-size:60px;font-weight:600;letter-spacing:-0.03em;line-height:1;",
+		},
+		{
+			sample: "Heading — section title",
+			spec: "SYSTEM SANS 600 · 22–30",
+			style: "font-size:28px;font-weight:600;letter-spacing:-0.02em;",
+		},
+		{
+			sample: "Subheading — frosted panel",
+			spec: "SYSTEM SANS 500 · 16–19",
+			style: "font-size:18px;font-weight:500;letter-spacing:-0.01em;",
+		},
+		{
+			sample:
+				"Body — Translucent surfaces float above a deep gradient, softened by blur and bloom.",
+			spec: "SYSTEM SANS 400 · 14–16 · 1.6 LINE",
+			style: "font-size:15px;font-weight:400;line-height:1.6;max-width:52ch;",
+		},
+		{
+			sample: "mono-label — rgba(255,255,255,0.12)",
+			spec: "SF MONO 500 · 10–12 + 0.02EM",
+			style:
+				"font-family:var(--skin-font-mono);font-size:11px;font-weight:500;letter-spacing:0.02em;",
+		},
+	],
+	specs: {
+		radius: [
+			{ size: "12px", label: "tile · input" },
+			{ size: "16px", label: "card" },
+			{ size: "24px", label: "button · panel" },
+			{ size: "999px", label: "pill · badge" },
+		],
+		border: "1px translucent white (rgba(255,255,255,.25)), hairline on every surface.",
+		shadowRest: "0 2px 12px rgba(0,0,0,.18)",
+		shadowHover: "0 12px 34px rgba(0,0,0,.30) soft bloom",
+		spacing: "4 / 8 / 12 / 16 / 24",
+	},
+	responsive: [
+		{ label: "Desktop ≥1024", note: "wide frosted panels · blur + bloom on hover · 2–3 col grids" },
+		{ label: "Tablet 720–1023", note: "stacked glass cards · reduced blur radius · 2-col grids" },
+		{
+			label: "Mobile <720",
+			note: "single column · solid-leaning surfaces for legibility · 44px targets",
+		},
+	],
+};

--- a/react/src/cameleon/skins/glass/recipes.ts
+++ b/react/src/cameleon/skins/glass/recipes.ts
@@ -1,0 +1,202 @@
+/**
+ * Glass recipes — the full "Core components" set, frosted-glass art direction.
+ * Translucent surfaces on a dark/gradient world: light text, `bg-white/10..15`,
+ * `border-white/20..25`, `backdrop-blur-md`, soft shadows and gentle transitions.
+ * Static class literals only (Tailwind JIT-safe). States are attribute-driven:
+ * primitives set `disabled`, `aria-invalid`, `aria-checked` and Tailwind's
+ * state variants (hover, focus, peer-, group-, disabled, aria) do the rest.
+ *
+ * Focus = `ring-2 ring-white/50` (no hard offset). Error = red-tinted glass
+ * (`border-red-300/50`, `ring-red-400/40`) with text kept readable/white.
+ * A specular top-sheen is added by glass.css via `[data-skin="glass"] .cam-btn`.
+ */
+import type { PartState, RecipeArgs, RecipeResult, SkinRecipes } from "../../types.js";
+
+const forced = (map: Partial<Record<PartState, string>>, state?: PartState): string =>
+	(state && map[state]) || "";
+
+/* ---- Button ------------------------------------------------------------- */
+const BTN_BASE =
+	"relative inline-flex items-center justify-center gap-2 rounded-2xl border font-medium " +
+	"whitespace-nowrap cursor-pointer select-none backdrop-blur-md " +
+	"transition duration-200 ease-out " +
+	"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 " +
+	"disabled:pointer-events-none disabled:opacity-40";
+
+const BTN_SIZE = {
+	sm: "px-4 py-1.5 text-xs",
+	md: "px-5 py-2.5 text-sm",
+	lg: "px-6 py-3 text-base",
+} as const;
+
+const BTN_VARIANT = {
+	primary:
+		"border-white/25 bg-white/15 text-white shadow-[0_2px_12px_rgba(0,0,0,0.18)] " +
+		"hover:bg-white/25 hover:shadow-[0_12px_34px_rgba(0,0,0,0.30)]",
+	secondary: "border-white/15 bg-white/[0.06] text-white/90 hover:bg-white/15",
+	destructive:
+		"border-red-300/40 bg-red-500/25 text-white hover:bg-red-500/40 " +
+		"focus-visible:ring-red-300/60",
+} as const;
+const BTN_FORCE: Partial<Record<PartState, string>> = {
+	hover: "bg-white/25 shadow-[0_12px_34px_rgba(0,0,0,0.30)]",
+	active: "bg-white/30 shadow-[0_2px_12px_rgba(0,0,0,0.18)]",
+	focus: "ring-2 ring-white/50",
+};
+
+export function glassButton(args: RecipeArgs): RecipeResult {
+	const size = BTN_SIZE[(args.size as keyof typeof BTN_SIZE) ?? "md"] ?? BTN_SIZE.md;
+	const variant =
+		BTN_VARIANT[(args.variant as keyof typeof BTN_VARIANT) ?? "primary"] ?? BTN_VARIANT.primary;
+	return { root: `${BTN_BASE} ${size} ${variant} ${forced(BTN_FORCE, args.state)}`, label: "" };
+}
+
+/* ---- Text fields (input / textarea / select) ---------------------------- */
+const FIELD_BASE =
+	"w-full rounded-xl border border-white/20 bg-white/10 px-3.5 py-2 " +
+	"text-sm text-white outline-none backdrop-blur-md " +
+	"transition duration-200 ease-out " +
+	"placeholder:text-white/40 " +
+	"hover:bg-white/15 hover:border-white/25 " +
+	"focus:border-white/40 focus:ring-2 focus:ring-white/50 " +
+	"disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-white/10 " +
+	"aria-[invalid=true]:border-red-300/50 aria-[invalid=true]:ring-2 aria-[invalid=true]:ring-red-400/40";
+const FIELD_FORCE: Partial<Record<PartState, string>> = {
+	hover: "bg-white/15 border-white/25",
+	active: "bg-white/15",
+	focus: "border-white/40 ring-2 ring-white/50",
+};
+
+export const glassInput = (args: RecipeArgs): RecipeResult => ({
+	root: `${FIELD_BASE} ${forced(FIELD_FORCE, args.state)}`,
+});
+
+export const glassTextarea = (args: RecipeArgs): RecipeResult => ({
+	root: `${FIELD_BASE} min-h-[80px] leading-relaxed resize-y ${forced(FIELD_FORCE, args.state)}`,
+});
+
+export const glassSelect = (args: RecipeArgs): RecipeResult => ({
+	root: "relative inline-block w-full",
+	field: `${FIELD_BASE} appearance-none pr-9 cursor-pointer ${forced(FIELD_FORCE, args.state)}`,
+	chevron: "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-white/70",
+});
+
+/* ---- Checkbox / Radio (native input + custom box) ----------------------- */
+const CHOICE_ROOT =
+	"inline-flex items-center gap-2 cursor-pointer select-none text-sm text-white " +
+	"has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50";
+const CHOICE_BOX_BASE =
+	"grid place-items-center h-[18px] w-[18px] shrink-0 border border-white/25 bg-white/10 " +
+	"backdrop-blur-md transition text-transparent " +
+	"peer-focus-visible:ring-2 peer-focus-visible:ring-white/50 " +
+	"peer-disabled:opacity-40 " +
+	"peer-aria-[invalid=true]:border-red-300/50 peer-aria-[invalid=true]:ring-2 peer-aria-[invalid=true]:ring-red-400/40 " +
+	"peer-data-[invalid=true]:border-red-300/50 peer-data-[invalid=true]:ring-2 peer-data-[invalid=true]:ring-red-400/40";
+const CHOICE_FORCE: Partial<Record<PartState, string>> = {
+	hover: "bg-white/20 border-white/40",
+	focus: "border-white/40 ring-2 ring-white/50",
+};
+
+export const glassCheckbox = (args: RecipeArgs): RecipeResult => ({
+	root: CHOICE_ROOT,
+	box: `${CHOICE_BOX_BASE} rounded-md peer-checked:bg-white/80 peer-checked:border-white/60 peer-checked:text-black ${forced(CHOICE_FORCE, args.state)}`,
+});
+
+export const glassRadio = (args: RecipeArgs): RecipeResult => ({
+	root: CHOICE_ROOT,
+	box: `${CHOICE_BOX_BASE} rounded-full peer-checked:bg-white/80 peer-checked:border-white/60 ${forced(CHOICE_FORCE, args.state)}`,
+});
+
+/* ---- Switch (button role=switch) ---------------------------------------- */
+const SWITCH_FORCE: Partial<Record<PartState, string>> = {
+	hover: "bg-white/20 border-white/40",
+	focus: "border-white/40 ring-2 ring-white/50",
+};
+
+export const glassSwitch = (args: RecipeArgs): RecipeResult => ({
+	root:
+		"group inline-flex h-[22px] w-[40px] shrink-0 items-center rounded-full border border-white/25 " +
+		"bg-white/10 p-[2px] cursor-pointer backdrop-blur-md transition-colors " +
+		"aria-[checked=true]:bg-white/40 aria-[checked=true]:border-white/40 " +
+		"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 " +
+		"disabled:opacity-40 disabled:cursor-not-allowed " +
+		"aria-[invalid=true]:border-red-300/50 aria-[invalid=true]:ring-2 aria-[invalid=true]:ring-red-400/40 " +
+		forced(SWITCH_FORCE, args.state),
+	thumb:
+		"h-[14px] w-[14px] rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.35)] " +
+		"transition-transform group-aria-[checked=true]:translate-x-[18px]",
+});
+
+/* ---- Slider (native range; thumb/track in glass.css via .cam-range) ------ */
+export const glassSlider = (): RecipeResult => ({
+	root: "cam-range w-[160px] cursor-pointer appearance-none bg-transparent disabled:cursor-not-allowed disabled:opacity-50",
+});
+
+/* ---- Badge -------------------------------------------------------------- */
+const BADGE_BASE =
+	"inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium backdrop-blur-md " +
+	"before:content-[''] before:mr-1.5 before:h-[7px] before:w-[7px] before:rounded-full before:shrink-0";
+const BADGE_VARIANT = {
+	default: "border-white/25 bg-white/10 text-white before:bg-white",
+	solid: "border-white/60 bg-white/90 text-black before:bg-black",
+	blue: "border-blue-300/40 bg-blue-400/20 text-blue-100 before:bg-blue-300",
+	red: "border-red-300/40 bg-red-400/20 text-red-100 before:bg-red-300",
+	yellow: "border-yellow-300/40 bg-yellow-400/20 text-yellow-100 before:bg-yellow-300",
+	green: "border-green-300/40 bg-green-400/20 text-green-100 before:bg-green-300",
+	purple: "border-purple-300/40 bg-purple-400/20 text-purple-100 before:bg-purple-300",
+} as const;
+// The badge state row (default variant, 6 states). Forced overrides the resting look.
+const BADGE_FORCE: Partial<Record<PartState, string>> = {
+	hover: "bg-white/20 shadow-[0_2px_12px_rgba(0,0,0,0.18)]",
+	active: "bg-white/90 text-black before:bg-black",
+	focus: "border-white/40 ring-2 ring-white/50",
+	disabled: "border-white/15 bg-white/[0.04] text-white/40 before:bg-white/40",
+	error: "border-red-300/50 bg-red-400/20 text-red-100 before:bg-red-300",
+};
+
+export function glassBadge(args: RecipeArgs): RecipeResult {
+	const variant =
+		BADGE_VARIANT[(args.variant as keyof typeof BADGE_VARIANT) ?? "default"] ??
+		BADGE_VARIANT.default;
+	return { root: `${BADGE_BASE} ${variant} ${forced(BADGE_FORCE, args.state)}` };
+}
+
+/* ---- Tooltip ------------------------------------------------------------ */
+// Tooltip has default / focus / error variants (via args.state); no active/disabled.
+const TT_TRIGGER: Partial<Record<PartState, string>> = {
+	focus: "border-white/40 ring-2 ring-white/50",
+	error: "border-red-300/50 bg-red-400/20 text-red-100",
+};
+const TT_BUBBLE: Partial<Record<PartState, string>> = {
+	focus: "border-white/40 ring-2 ring-white/50 opacity-100",
+	error: "border-red-300/50 bg-red-500/70 opacity-100",
+};
+
+export const glassTooltip = (args: RecipeArgs): RecipeResult => ({
+	root: "relative inline-flex group",
+	trigger:
+		"grid place-items-center h-[26px] w-[26px] rounded-full border border-white/25 " +
+		"bg-white/10 backdrop-blur-md text-white text-[12px] font-semibold cursor-help " +
+		"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 " +
+		forced(TT_TRIGGER, args.state),
+	bubble:
+		"pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 whitespace-nowrap " +
+		"rounded-xl border border-white/15 bg-black/70 backdrop-blur-md px-3 py-1.5 text-[12px] font-medium text-white " +
+		"opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100 " +
+		"shadow-[0_10px_30px_rgba(0,0,0,0.4)] " +
+		forced(TT_BUBBLE, args.state),
+});
+
+/* ---- Skin registry ------------------------------------------------------ */
+export const glassRecipes: SkinRecipes = {
+	button: glassButton,
+	input: glassInput,
+	textarea: glassTextarea,
+	select: glassSelect,
+	checkbox: glassCheckbox,
+	radio: glassRadio,
+	switch: glassSwitch,
+	slider: glassSlider,
+	badge: glassBadge,
+	tooltip: glassTooltip,
+};

--- a/react/src/cameleon/skins/glass/tokens.ts
+++ b/react/src/cameleon/skins/glass/tokens.ts
@@ -1,0 +1,18 @@
+/**
+ * Glass skin tokens — the library's existing premium / frosted direction.
+ * Translucent surfaces over a rich gradient backdrop; light type; soft blooms.
+ */
+export const glassTokens: Record<string, string> = {
+	"--skin-page-bg": "radial-gradient(120% 120% at 15% 0%, #312e81 0%, #4c1d95 42%, #831843 100%)",
+	"--skin-page-fg": "#ffffff",
+	"--skin-font-sans": "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif",
+	"--skin-card": "rgba(255,255,255,0.08)",
+	"--skin-surface": "rgba(255,255,255,0.12)",
+	"--skin-line": "rgba(255,255,255,0.25)",
+	"--skin-font-mono": "ui-monospace, SFMono-Regular, 'SF Mono', monospace",
+	"--skin-blue": "#7dd3fc",
+	"--skin-red": "#fca5a5",
+	"--skin-yellow": "#fde68a",
+	"--skin-green": "#86efac",
+	"--skin-purple": "#c4b5fd",
+};

--- a/react/src/cameleon/skins/retro-os/index.ts
+++ b/react/src/cameleon/skins/retro-os/index.ts
@@ -1,0 +1,22 @@
+import type { Skin } from "../../types.js";
+import { retroOsTokens } from "./tokens.js";
+import { retroOsMeta } from "./meta.js";
+import { retroOsRecipes } from "./recipes.js";
+import { buttonTrailing } from "./ornaments.js";
+import "./retro-os.css";
+
+export const retroOsSkin: Skin = {
+	name: "retro-os",
+	label: "Retro OS",
+	colorScheme: "light",
+	tokens: retroOsTokens,
+	meta: retroOsMeta,
+	fonts: [
+		{
+			id: "cam-font-retro-os",
+			href: "https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=IBM+Plex+Mono:wght@400;500;600;700&family=Silkscreen:wght@400;700&display=swap",
+		},
+	],
+	recipes: retroOsRecipes,
+	ornaments: { buttonTrailing },
+};

--- a/react/src/cameleon/skins/retro-os/meta.ts
+++ b/react/src/cameleon/skins/retro-os/meta.ts
@@ -1,0 +1,61 @@
+import type { SkinMeta } from "../../types.js";
+
+/** Retro OS design metadata — the exact values from the design system. */
+export const retroOsMeta: SkinMeta = {
+	palette: [
+		{ name: "Bureau", value: "#E5DCC2", note: "hors fenêtre" },
+		{ name: "Fenêtre", value: "#F1E9D4", note: "papier + scanlines" },
+		{ name: "Panneau", value: "#FAF5E6", note: "menubar · explorer · cartes" },
+		{ name: "Surface", value: "#FDFAF0", note: "champ · scène" },
+		{ name: "Encre", value: "#191308", note: "texte · bordures" },
+		{ name: "Jaune foncé", value: "#7D6414", note: "01 EXP" },
+		{ name: "Rouge", value: "#A0442F", note: "02 PROJ" },
+		{ name: "Bleu", value: "#3F62A7", note: "03 SKILLS" },
+		{ name: "Vert", value: "#3A6B42", note: "04 EDU" },
+		{ name: "Jaune doré", value: "#B8912B", note: "05 LANG" },
+	],
+	type: [
+		{
+			sample: "Rama Herbin",
+			spec: "ARCHIVO 900 · −1.5PX · 44",
+			style: "font-size:40px;font-weight:900;letter-spacing:-1.5px;line-height:1;",
+		},
+		{
+			sample: "TITRE DE FENÊTRE — 12 / 700",
+			spec: "SILKSCREEN 700 CAPS · 10–12 · UI PIXEL",
+			style: "font-family:var(--skin-font-pixel);font-size:12px;font-weight:700;",
+		},
+		{
+			sample: "Entreprise / projet — 16 / 700",
+			spec: "ARCHIVO 700 · 16",
+			style: "font-size:16px;font-weight:700;",
+		},
+		{
+			sample: "Corps — 13 / 400, interligne 1.55. Puces carrées.",
+			spec: "ARCHIVO 400 · 13 · LH 1.55",
+			style: "font-size:13px;font-weight:400;line-height:1.55;max-width:46ch;",
+		},
+		{
+			sample: "DATES — 11 / 600 · STATUT TASKBAR — 12",
+			spec: "IBM PLEX MONO 400–700 · 10.5–12.5 · MÉTA",
+			style: "font-family:var(--skin-font-mono);font-size:11px;font-weight:600;letter-spacing:1px;",
+		},
+	],
+	specs: {
+		radius: [
+			{ size: "8/4px", label: "fenêtre — escalier" },
+			{ size: "4px", label: "boutons fenêtre" },
+			{ size: "0", label: "tout le reste" },
+		],
+		border:
+			"2px encre standard · 3px cadre bureau/barres · 1.5px chips · séparateurs 1px pointillé #B8AC8C",
+		shadowRest: "dures, 0 flou — carte/bouton 3×3 · petit bouton 2×2 · bureau 8×8",
+		shadowHover: "soulève −1,−1 + ombre +1 · actif s'enfonce +2,+2 + ombre 0 · fenêtre hover 5×5",
+		spacing: "grille 4 / 8 / 12 / 16 / 20 / 24",
+	},
+	responsive: [
+		{ label: "Desktop ≥1024", note: "fenêtres tuilées + taskbar fixe · hover lifts on" },
+		{ label: "Tablet 720–1023", note: "fenêtres empilées · menubar sticky · chips wrap" },
+		{ label: "Mobile <720", note: "colonne unique · cibles 44px+ · ombres réduites 2×2" },
+	],
+};

--- a/react/src/cameleon/skins/retro-os/ornaments.tsx
+++ b/react/src/cameleon/skins/retro-os/ornaments.tsx
@@ -1,0 +1,30 @@
+/**
+ * Retro OS ornaments as plain functions returning JSX. The Start-button glyph
+ * is a static 2x2 pixel grid (one of the skin's four accents per cell),
+ * unrelated to the button's variant, so unlike Brutal's arrow it does not
+ * need currentColor.
+ */
+import type { ReactNode } from "react";
+import type { RecipeArgs } from "../../types.js";
+
+export function buttonTrailing(_args: RecipeArgs): ReactNode {
+	return (
+		<span
+			aria-hidden="true"
+			style={{
+				display: "inline-grid",
+				gridTemplateColumns: "6px 6px",
+				gridTemplateRows: "6px 6px",
+				gap: "1.5px",
+				padding: "1.5px",
+				background: "#191308",
+				flex: "none",
+			}}
+		>
+			<span style={{ background: "#B8912B" }} />
+			<span style={{ background: "#A0442F" }} />
+			<span style={{ background: "#3F62A7" }} />
+			<span style={{ background: "#3A6B42" }} />
+		</span>
+	);
+}

--- a/react/src/cameleon/skins/retro-os/recipes.ts
+++ b/react/src/cameleon/skins/retro-os/recipes.ts
@@ -1,0 +1,214 @@
+/**
+ * Retro-OS recipes — the full "Core components" set in a late-90s desktop-OS art
+ * direction: hard square corners (`rounded-none`), thick 2px ink borders, and
+ * zero-blur block shadows that make every control feel like a physical chip.
+ * Motion is a tactile press: hover LIFTS the control (nudge up-left, shadow grows
+ * a pixel), active SINKS it (nudge down-right, shadow collapses to none).
+ *
+ * Static class literals only (Tailwind JIT-safe). Live states are attribute-driven
+ * (disabled / aria-invalid / aria-checked + hover / focus / peer / group variants);
+ * the /skins state-matrix additionally FORCES hover/active/focus statically via
+ * `args.state` (see the FORCE maps below + `demoState` on the primitives). Real
+ * interaction still works — forced classes are additive overrides.
+ *
+ * Palette: desk #F1E9D4, panel #FAF5E6, inner card #FDFAF0, ink #191308,
+ * muted #5C5340, blue #3F62A7, red #A0442F, gold #B8912B, green #3A6B42,
+ * dark-yellow #7D6414, tints yellow-fill #ECD77F / yellow-pale #F7EFD2.
+ * Grammar: border-2 #191308 square; shadow rest 3x3 (sm 2x2), zero blur.
+ * hover = lift (-1px,-1px, shadow +1px); active = sink (+2px,+2px, shadow-none).
+ * disabled = dashed #B8AC8C border + bg #F1E9D4 + text #B8AC8C + shadow-none.
+ * error = border/text #A0442F + bg #F8E8DC. field focus = bg #FAF5E6 + shadow 3x3.
+ * non-field focus = outline-2 offset-2 #3F62A7 (blue). Fonts via CSS vars:
+ * pixel = Silkscreen, mono = IBM Plex Mono, sans = Archivo.
+ */
+import type { PartState, RecipeArgs, RecipeResult, SkinRecipes } from "../../types.js";
+
+const forced = (map: Partial<Record<PartState, string>>, state?: PartState): string =>
+	(state && map[state]) || "";
+
+/* ---- Button ------------------------------------------------------------- */
+const BTN_BASE =
+	"inline-flex items-center justify-center gap-2 rounded-none border-2 border-[#191308] whitespace-nowrap " +
+	"font-[family-name:var(--skin-font-pixel)] font-bold cursor-pointer select-none " +
+	"transition-[transform,box-shadow,background-color] duration-100 " +
+	"hover:-translate-x-px hover:-translate-y-px " +
+	"active:translate-x-[2px] active:translate-y-[2px] active:shadow-none " +
+	"focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#3F62A7] " +
+	"disabled:pointer-events-none disabled:cursor-not-allowed disabled:border-dashed disabled:border-[#B8AC8C] " +
+	"disabled:bg-[#F1E9D4] disabled:text-[#B8AC8C] disabled:shadow-none";
+const BTN_SIZE = {
+	sm: "px-[14px] py-[6px] text-[10px] shadow-[2px_2px_0_#191308] hover:shadow-[3px_3px_0_#191308]",
+	md: "px-4 py-[7px] text-[11px] shadow-[3px_3px_0_#191308] hover:shadow-[4px_4px_0_#191308]",
+	lg: "px-5 py-[9px] text-[12px] shadow-[3px_3px_0_#191308] hover:shadow-[4px_4px_0_#191308]",
+} as const;
+const BTN_VARIANT = {
+	primary: "bg-[#ECD77F] text-[#191308]",
+	secondary: "bg-[#FAF5E6] text-[#191308]",
+	destructive: "bg-[#A0442F] text-[#FAF5E6]",
+} as const;
+const BTN_FORCE: Partial<Record<PartState, string>> = {
+	hover: "-translate-x-px -translate-y-px shadow-[4px_4px_0_#191308]",
+	active: "translate-x-[2px] translate-y-[2px] shadow-none",
+	focus: "outline outline-2 outline-offset-2 outline-[#3F62A7]",
+};
+
+export function retroOsButton(args: RecipeArgs): RecipeResult {
+	const size = BTN_SIZE[(args.size as keyof typeof BTN_SIZE) ?? "md"] ?? BTN_SIZE.md;
+	const variant =
+		BTN_VARIANT[(args.variant as keyof typeof BTN_VARIANT) ?? "primary"] ?? BTN_VARIANT.primary;
+	return { root: `${BTN_BASE} ${size} ${variant} ${forced(BTN_FORCE, args.state)}`, label: "" };
+}
+
+/* ---- Text fields (input / textarea / select) ---------------------------- */
+const FIELD_BASE =
+	"w-full rounded-none border-2 border-[#191308] bg-[#FDFAF0] px-3 py-[9px] " +
+	"font-[family-name:var(--skin-font-mono)] text-[12.5px] text-[#191308] caret-[#191308] outline-none " +
+	"placeholder:text-[#5C5340] transition-[background-color,box-shadow] duration-100 " +
+	"hover:bg-[#F7EFD2] focus:bg-[#FAF5E6] focus:shadow-[3px_3px_0_#191308] " +
+	"disabled:cursor-not-allowed disabled:border-dashed disabled:border-[#B8AC8C] " +
+	"disabled:bg-[#F1E9D4] disabled:text-[#B8AC8C] disabled:shadow-none " +
+	"aria-[invalid=true]:border-[#A0442F] aria-[invalid=true]:bg-[#F8E8DC] aria-[invalid=true]:text-[#A0442F]";
+const FIELD_FORCE: Partial<Record<PartState, string>> = {
+	hover: "bg-[#F7EFD2]",
+	active: "bg-[#FAF5E6]",
+	focus: "bg-[#FAF5E6] shadow-[3px_3px_0_#191308]",
+};
+
+export const retroOsInput = (args: RecipeArgs): RecipeResult => ({
+	root: `${FIELD_BASE} ${forced(FIELD_FORCE, args.state)}`,
+});
+
+export const retroOsTextarea = (args: RecipeArgs): RecipeResult => ({
+	root: `${FIELD_BASE} min-h-[80px] leading-relaxed resize-y ${forced(FIELD_FORCE, args.state)}`,
+});
+
+export const retroOsSelect = (args: RecipeArgs): RecipeResult => ({
+	root: "relative inline-block w-full",
+	field: `${FIELD_BASE} appearance-none pr-9 cursor-pointer ${forced(FIELD_FORCE, args.state)}`,
+	chevron: "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#191308]",
+});
+
+/* ---- Checkbox / Radio (native input + custom box) ----------------------- */
+const CHOICE_ROOT =
+	"inline-flex items-center gap-[10px] cursor-pointer select-none text-[13px] text-[#191308] " +
+	"has-[:disabled]:cursor-not-allowed has-[:disabled]:text-[#B8AC8C]";
+const CHOICE_BOX_BASE =
+	"grid place-items-center h-[18px] w-[18px] shrink-0 border-2 border-[#191308] bg-[#FDFAF0] " +
+	"transition-colors text-transparent " +
+	"peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-[#3F62A7] " +
+	"peer-disabled:border-dashed peer-disabled:border-[#B8AC8C] peer-disabled:bg-[#F1E9D4] " +
+	"peer-aria-[invalid=true]:border-[#A0442F] peer-aria-[invalid=true]:bg-[#F8E8DC] " +
+	"peer-data-[invalid=true]:border-[#A0442F] peer-data-[invalid=true]:bg-[#F8E8DC]";
+const CHOICE_FORCE: Partial<Record<PartState, string>> = {
+	hover: "shadow-[2px_2px_0_#191308]",
+	focus: "outline outline-2 outline-offset-2 outline-[#3F62A7]",
+};
+
+export const retroOsCheckbox = (args: RecipeArgs): RecipeResult => ({
+	root: CHOICE_ROOT,
+	box: `${CHOICE_BOX_BASE} rounded-none peer-checked:bg-[#191308] peer-checked:text-[#FAF5E6] ${forced(CHOICE_FORCE, args.state)}`,
+});
+
+export const retroOsRadio = (args: RecipeArgs): RecipeResult => ({
+	root: CHOICE_ROOT,
+	box: `${CHOICE_BOX_BASE} rounded-full peer-checked:bg-[#191308] peer-checked:shadow-[inset_0_0_0_3px_#FAF5E6] ${forced(CHOICE_FORCE, args.state)}`,
+});
+
+/* ---- Switch (button role=switch) ---------------------------------------- */
+const SWITCH_FORCE: Partial<Record<PartState, string>> = {
+	hover: "shadow-[2px_2px_0_#191308]",
+	focus: "outline outline-2 outline-offset-2 outline-[#3F62A7]",
+};
+
+export const retroOsSwitch = (args: RecipeArgs): RecipeResult => ({
+	root:
+		"group inline-flex h-[22px] w-[42px] shrink-0 items-center rounded-none border-2 border-[#191308] " +
+		"bg-[#F1E9D4] p-px cursor-pointer transition-colors " +
+		"aria-[checked=true]:bg-[#3A6B42] " +
+		"focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#3F62A7] " +
+		"disabled:cursor-not-allowed disabled:border-dashed disabled:border-[#B8AC8C] disabled:bg-[#F1E9D4] disabled:shadow-none " +
+		"aria-[invalid=true]:border-[#A0442F] aria-[invalid=true]:bg-[#F8E8DC] " +
+		forced(SWITCH_FORCE, args.state),
+	thumb:
+		"h-[14px] w-[14px] rounded-none border-2 border-[#191308] bg-[#FAF5E6] " +
+		"transition-transform group-aria-[checked=true]:translate-x-[22px]",
+});
+
+/* ---- Slider (native range; thumb/track in retro-os.css via .cam-range) --- */
+export const retroOsSlider = (): RecipeResult => ({
+	root: "cam-range w-[160px] cursor-pointer appearance-none bg-transparent disabled:cursor-not-allowed disabled:opacity-50",
+});
+
+/* ---- Badge -------------------------------------------------------------- */
+// Flat pixel tags — no leading dot (deliberate divergence from Brutal's before: dot).
+const BADGE_BASE =
+	"inline-flex items-center rounded-none border-2 border-[#191308] px-[7px] py-px " +
+	"font-[family-name:var(--skin-font-mono)] text-[10.5px] font-bold";
+const BADGE_VARIANT = {
+	default: "bg-[#FDFAF0] text-[#191308]",
+	solid: "bg-[#191308] text-[#FAF5E6]",
+	blue: "bg-[#3F62A7] text-[#FAF5E6]",
+	red: "bg-[#A0442F] text-[#FAF5E6]",
+	yellow: "bg-[#B8912B] text-[#191308]",
+	green: "bg-[#3A6B42] text-[#FAF5E6]",
+	purple: "bg-[#7D6414] text-[#FAF5E6]",
+} as const;
+// The badge state row (default variant, 6 states). Forced overrides the resting look.
+const BADGE_FORCE: Partial<Record<PartState, string>> = {
+	hover: "bg-[#ECD77F] text-[#191308]",
+	active: "bg-[#191308] text-[#FAF5E6]",
+	focus: "outline outline-2 outline-offset-2 outline-[#3F62A7]",
+	disabled: "border-dashed border-[#B8AC8C] bg-[#F1E9D4] text-[#B8AC8C]",
+	error: "border-[#A0442F] bg-[#F8E8DC] text-[#A0442F]",
+};
+
+export function retroOsBadge(args: RecipeArgs): RecipeResult {
+	const variant =
+		BADGE_VARIANT[(args.variant as keyof typeof BADGE_VARIANT) ?? "default"] ??
+		BADGE_VARIANT.default;
+	return { root: `${BADGE_BASE} ${variant} ${forced(BADGE_FORCE, args.state)}` };
+}
+
+/* ---- Tooltip ------------------------------------------------------------ */
+// Tooltip has default / focus / error variants (via args.state); no active/disabled.
+const TT_TRIGGER: Partial<Record<PartState, string>> = {
+	focus: "outline outline-2 outline-offset-2 outline-[#3F62A7]",
+	error: "bg-[#A0442F] text-[#FAF5E6]",
+};
+const TT_BUBBLE: Partial<Record<PartState, string>> = {
+	focus: "outline outline-2 outline-offset-2 outline-[#3F62A7]",
+	error: "bg-[#A0442F] after:border-t-[#A0442F]",
+};
+
+export function retroOsTooltip(args: RecipeArgs): RecipeResult {
+	return {
+		root: "relative inline-flex group",
+		trigger:
+			"grid place-items-center h-[22px] w-[22px] rounded-none border-2 border-[#191308] " +
+			"bg-[#ECD77F] text-[#191308] text-[11px] font-bold font-[family-name:var(--skin-font-pixel)] cursor-help " +
+			"focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#3F62A7] " +
+			forced(TT_TRIGGER, args.state),
+		bubble:
+			"pointer-events-none absolute bottom-full left-1/2 mb-[9px] -translate-x-1/2 whitespace-nowrap " +
+			"rounded-none border-2 border-[#191308] bg-[#191308] px-[10px] py-[5px] " +
+			"font-[family-name:var(--skin-font-mono)] text-[11px] text-[#FAF5E6] " +
+			"opacity-0 transition-opacity duration-100 group-hover:opacity-100 group-focus-within:opacity-100 " +
+			"after:content-[''] after:absolute after:top-full after:left-1/2 after:-translate-x-1/2 " +
+			"after:border-x-[6px] after:border-x-transparent after:border-t-[7px] after:border-t-[#191308] " +
+			forced(TT_BUBBLE, args.state),
+	};
+}
+
+/* ---- Skin registration -------------------------------------------------- */
+export const retroOsRecipes: SkinRecipes = {
+	button: retroOsButton,
+	input: retroOsInput,
+	textarea: retroOsTextarea,
+	select: retroOsSelect,
+	checkbox: retroOsCheckbox,
+	radio: retroOsRadio,
+	switch: retroOsSwitch,
+	slider: retroOsSlider,
+	badge: retroOsBadge,
+	tooltip: retroOsTooltip,
+};

--- a/react/src/cameleon/skins/retro-os/retro-os.css
+++ b/react/src/cameleon/skins/retro-os/retro-os.css
@@ -1,0 +1,107 @@
+/* Retro OS skin — pixel-arrow cursor, CRT scanlines, stair-step pixel corners, chunky
+   native range slider. Scoped by data-skin. */
+[data-skin="retro-os"] {
+	position: relative;
+	/* Pixel-art pointer (28×32 PNG, embedded so it needs no static asset and works
+	   on both the docs and /skins). base64 avoids the ;utf8, SVG-cursor rejection in
+	   Chrome/Safari. Hotspot at the arrow tip (2 2). */
+	cursor:
+		url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAgCAYAAAABtRhCAAABIUlEQVR4AbySsW4CQQxEL1elT5UmkfL/3xQJGip6OtArxoUXY/v2OKTRYq89j+Fu/f76vKPloM96EMcwBiQlsps3fTHgm/wHWwOezv8LIiUaJndqGHAnv9RmAJISkRKlDs2BAdjcb4+HQFIiUqK2c7AQAoP56XYKJCUiJZolpsBZgN8vA0mJSIm8UbUuA6uG2VwbSEpESpQB/H0b6A269WYgKREpURW8GVgF+LlpICkRKZEH+Hoa6A2zug38/flbnkkgUiLV/mwDvUG3DoFKERlerrePV4r2QmC0MNsfgEqmX69aIN5IxHNC6lfPAVhd3DpnQCVRsq2G2Z4Bs8G97g0YJVNf/4DAPEfEc0TqZ6cBs8G97lclqBoqqc7u/uEJHwAAAP//CzLSHAAAAAZJREFUAwDGkJNzizebGwAAAABJRU5ErkJggg==")
+			2 2,
+		auto;
+}
+
+/* CRT scanlines overlay — sits above content, below nothing (top layer of the skin).
+   Excluded on the docs shell (.docs-skin): there the skin paints a desk around a
+   window, and a root-level overlay would tint the desk too. The docs site re-declares
+   the very same gradient as the .retro-frame background-image (docs/skins/retro-os/
+   skin-base.css) so the scanlines stay inside the window, exactly like the reference.
+   Every other context (the /skins page, a consumer's <FancyProvider>) keeps the
+   overlay unchanged. */
+[data-skin="retro-os"]:not(.docs-skin)::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	z-index: 40;
+	border-radius: inherit;
+	background: repeating-linear-gradient(0deg, rgba(25, 19, 8, 0.04) 0 2px, transparent 2px 4px);
+}
+
+/* Stair-step pixel corners on cards. box-shadow does not survive clip-path (the clip cuts it
+   off at the box edge), so the drop shadow is done via filter: drop-shadow instead, which
+   applies after clipping. */
+[data-skin="retro-os"] .ds-card {
+	border-radius: 0;
+	border-width: 2px;
+	box-shadow: none;
+	filter: drop-shadow(3px 3px 0 #191308);
+	clip-path: polygon(
+		8px 0,
+		calc(100% - 8px) 0,
+		calc(100% - 8px) 4px,
+		calc(100% - 4px) 4px,
+		calc(100% - 4px) 8px,
+		100% 8px,
+		100% calc(100% - 8px),
+		calc(100% - 4px) calc(100% - 8px),
+		calc(100% - 4px) calc(100% - 4px),
+		calc(100% - 8px) calc(100% - 4px),
+		calc(100% - 8px) 100%,
+		8px 100%,
+		8px calc(100% - 4px),
+		4px calc(100% - 4px),
+		4px calc(100% - 8px),
+		0 calc(100% - 8px),
+		0 8px,
+		4px 8px,
+		4px 4px,
+		8px 4px
+	);
+}
+
+/* Native range slider — chunky square track + thumb, ink border, blue focus ring. */
+[data-skin="retro-os"] .cam-range {
+	height: 22px;
+}
+[data-skin="retro-os"] .cam-range::-webkit-slider-runnable-track {
+	height: 8px;
+	background: #fdfaf0;
+	border: 2px solid #191308;
+	border-radius: 0;
+}
+[data-skin="retro-os"] .cam-range::-webkit-slider-thumb {
+	-webkit-appearance: none;
+	appearance: none;
+	height: 18px;
+	width: 18px;
+	margin-top: -7px;
+	background: #faf5e6;
+	border: 2px solid #191308;
+	border-radius: 0;
+	box-shadow: 2px 2px 0 #191308;
+}
+[data-skin="retro-os"] .cam-range:focus-visible::-webkit-slider-thumb {
+	box-shadow:
+		2px 2px 0 #191308,
+		0 0 0 2px #3f62a7;
+}
+[data-skin="retro-os"] .cam-range::-moz-range-track {
+	height: 8px;
+	background: #fdfaf0;
+	border: 2px solid #191308;
+	border-radius: 0;
+}
+[data-skin="retro-os"] .cam-range::-moz-range-thumb {
+	height: 18px;
+	width: 18px;
+	background: #faf5e6;
+	border: 2px solid #191308;
+	border-radius: 0;
+	box-shadow: 2px 2px 0 #191308;
+}
+[data-skin="retro-os"] .cam-range:focus-visible::-moz-range-thumb {
+	box-shadow:
+		2px 2px 0 #191308,
+		0 0 0 2px #3f62a7;
+}

--- a/react/src/cameleon/skins/retro-os/tokens.ts
+++ b/react/src/cameleon/skins/retro-os/tokens.ts
@@ -1,0 +1,34 @@
+/**
+ * Retro OS skin tokens — "hard-shadow desktop chrome" palette.
+ * Desk/panel/card paper stack, ink borders, five flat accents, Archivo +
+ * IBM Plex Mono + Silkscreen.
+ *
+ * Paper stack note: the desk (#E5DCC2) is the surface OUTSIDE the window; the
+ * window itself is #F1E9D4 (--skin-page-bg / --skin-paper), panels are #FAF5E6
+ * (--skin-card) and inputs/stages are #FDFAF0 (--skin-surface).
+ *
+ * Accent mapping note: the design has exactly five accents and no purple.
+ * --skin-yellow carries the gold accent #B8912B (the lighter #ECD77F is a
+ * fill tint, not an accent, and lives in per-skin CSS instead of tokens).
+ * --skin-purple is filled by the dark-yellow #7D6414 stand-in so consumers
+ * of the shared five-accent contract still get a fifth distinct color.
+ */
+export const retroOsTokens: Record<string, string> = {
+	"--skin-desk": "#E5DCC2",
+	"--skin-page-bg": "#F1E9D4",
+	"--skin-page-fg": "#191308",
+	"--skin-paper": "#F1E9D4",
+	"--skin-card": "#FAF5E6",
+	"--skin-surface": "#FDFAF0",
+	"--skin-ink": "#191308",
+	"--skin-line": "#191308",
+	"--skin-muted": "#5C5340",
+	"--skin-blue": "#3F62A7",
+	"--skin-red": "#A0442F",
+	"--skin-yellow": "#B8912B",
+	"--skin-green": "#3A6B42",
+	"--skin-purple": "#7D6414",
+	"--skin-font-sans": "'Archivo', ui-sans-serif, system-ui, sans-serif",
+	"--skin-font-mono": "'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace",
+	"--skin-font-pixel": "'Silkscreen', 'IBM Plex Mono', monospace",
+};

--- a/react/src/cameleon/skins/terminal/index.ts
+++ b/react/src/cameleon/skins/terminal/index.ts
@@ -1,0 +1,22 @@
+import type { Skin } from "../../types.js";
+import { terminalTokens } from "./tokens.js";
+import { terminalRecipes } from "./recipes.js";
+import { terminalMeta } from "./meta.js";
+import { buttonTrailing } from "./ornaments.js";
+import "./terminal.css";
+
+export const terminalSkin: Skin = {
+	name: "terminal",
+	label: "Terminal",
+	colorScheme: "dark",
+	tokens: terminalTokens,
+	fonts: [
+		{
+			id: "cam-font-terminal",
+			href: "https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap",
+		},
+	],
+	recipes: terminalRecipes,
+	ornaments: { buttonTrailing },
+	meta: terminalMeta,
+};

--- a/react/src/cameleon/skins/terminal/meta.ts
+++ b/react/src/cameleon/skins/terminal/meta.ts
@@ -1,0 +1,74 @@
+import type { SkinMeta } from "../../types.js";
+
+/** Terminal design metadata — CRT green-on-black, monospace everywhere. */
+export const terminalMeta: SkinMeta = {
+	palette: [
+		{ name: "Black", value: "#0a0e0a", note: "page bg · void" },
+		{ name: "Panel", value: "#0d120d", note: "near-black card" },
+		{ name: "Dim green", value: "#14532d", note: "muted border · disabled" },
+		{ name: "Green", value: "#22c55e", note: "border · phosphor" },
+		{ name: "Bright green", value: "#4ade80", note: "text · foreground" },
+		{ name: "Error red", value: "#f87171", note: "aria-invalid" },
+		{ name: "Blue", value: "#38bdf8", note: "accent · info" },
+		{ name: "Amber", value: "#facc15", note: "accent · warn" },
+	],
+	type: [
+		{
+			sample: "DISPLAY",
+			spec: "SPACE MONO 700 CAPS · 56 · +0.02EM",
+			style:
+				"font-family:var(--skin-font-mono);font-size:56px;font-weight:700;letter-spacing:0.02em;line-height:1;text-transform:uppercase;",
+		},
+		{
+			sample: "HEADING — SYSTEM READOUT",
+			spec: "SPACE MONO 700 CAPS · 26 · +0.06EM",
+			style:
+				"font-family:var(--skin-font-mono);font-size:26px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;",
+		},
+		{
+			sample: "Body — phosphor glows on a black tube; the cursor blinks and waits for input.",
+			spec: "SPACE MONO 400 · 14 · 1.6",
+			style:
+				"font-family:var(--skin-font-mono);font-size:14px;font-weight:400;line-height:1.6;max-width:52ch;",
+		},
+		{
+			sample: "$ prompt --input",
+			spec: "SPACE MONO 400 · 13 · caret green",
+			style:
+				"font-family:var(--skin-font-mono);font-size:13px;font-weight:400;letter-spacing:0.01em;",
+		},
+		{
+			sample: "LABEL · STATUS: OK",
+			spec: "SPACE MONO 700 CAPS · 10.5 · +0.14EM",
+			style:
+				"font-family:var(--skin-font-mono);font-size:10.5px;font-weight:700;letter-spacing:0.14em;text-transform:uppercase;",
+		},
+	],
+	specs: {
+		radius: [
+			{ size: "0px", label: "tag" },
+			{ size: "0px", label: "tile" },
+			{ size: "0px", label: "nav" },
+			{ size: "0px", label: "card" },
+			{ size: "0 (square world)", label: "pill" },
+		],
+		border: "1px solid green (#22c55e), everywhere. Dim green #14532d when muted.",
+		shadowRest: "none (flat) · optional phosphor glow via CSS",
+		shadowHover: "none · invert on hover (bg fills green, text goes black)",
+		spacing: "monospace grid · 4 / 8 / 12 / 16 / 24 · character-cell rhythm",
+	},
+	responsive: [
+		{
+			label: "Desktop ≥1024",
+			note: "80-column mainframe · left nav column + fluid readout · hover inverts",
+		},
+		{
+			label: "Tablet 720–1023",
+			note: "narrowed to ~64 cols · top status bar + scroll chips · 2-col grid",
+		},
+		{
+			label: "Mobile <720",
+			note: "single 40-col stack · 44px+ tap targets · caret stays blinking",
+		},
+	],
+};

--- a/react/src/cameleon/skins/terminal/ornaments.tsx
+++ b/react/src/cameleon/skins/terminal/ornaments.tsx
@@ -1,0 +1,14 @@
+/**
+ * Terminal ornaments as plain functions returning JSX. The blinking is driven
+ * by the `cam-blink` keyframes in terminal.css.
+ */
+import type { ReactNode } from "react";
+import type { RecipeArgs } from "../../types.js";
+
+export function buttonTrailing(_args: RecipeArgs): ReactNode {
+	return (
+		<span className="cam-caret" aria-hidden="true">
+			▊
+		</span>
+	);
+}

--- a/react/src/cameleon/skins/terminal/recipes.ts
+++ b/react/src/cameleon/skins/terminal/recipes.ts
@@ -1,0 +1,205 @@
+/**
+ * Terminal recipes — the full "Core components" set in the CRT art direction:
+ * square (`rounded-none`), monospace, uppercase, green-on-black, NO motion
+ * (`transition-none`, except the switch thumb translate). Glow + blinking caret
+ * come from terminal.css / ornaments.
+ *
+ * Static class literals only (Tailwind JIT-safe). States are attribute-driven:
+ * primitives set `disabled`, `aria-invalid`, `aria-checked` and Tailwind's
+ * state variants (hover, focus, peer-, group-, disabled, aria) do the rest.
+ *
+ * Palette: green #22c55e / bright green #4ade80, black bg, dim green #14532d,
+ * error red #f87171. Focus = green outline (not ring). Error = red border/outline.
+ */
+import type { PartState, RecipeArgs, RecipeResult, SkinRecipes } from "../../types.js";
+
+const forced = (map: Partial<Record<PartState, string>>, state?: PartState): string =>
+	(state && map[state]) || "";
+
+/* ---- Button ------------------------------------------------------------- */
+const BTN_BASE =
+	"inline-flex items-center justify-center gap-2 rounded-none border font-mono uppercase " +
+	"tracking-widest whitespace-nowrap cursor-pointer select-none transition-none " +
+	"focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 " +
+	"disabled:opacity-40 disabled:pointer-events-none";
+
+const BTN_SIZE = {
+	sm: "px-3 py-1.5 text-[11px]",
+	md: "px-4 py-2 text-xs",
+	lg: "px-5 py-2.5 text-sm",
+} as const;
+
+const BTN_VARIANT = {
+	primary:
+		"border-[#22c55e] bg-black text-[#4ade80] hover:bg-[#22c55e] hover:text-black " +
+		"focus-visible:outline-[#22c55e]",
+	secondary:
+		"border-[#14532d] bg-transparent text-[#4ade80]/80 hover:border-[#22c55e] hover:text-[#4ade80] " +
+		"focus-visible:outline-[#22c55e]",
+	destructive:
+		"border-[#f87171] bg-black text-[#f87171] hover:bg-[#f87171] hover:text-black " +
+		"focus-visible:outline-[#f87171]",
+} as const;
+
+const BTN_FORCE: Partial<Record<PartState, string>> = {
+	hover: "bg-[#22c55e] text-black",
+	active: "bg-[#4ade80] text-black",
+	focus: "outline outline-1 outline-offset-2 outline-[#22c55e]",
+};
+
+export function terminalButton(args: RecipeArgs): RecipeResult {
+	const size = BTN_SIZE[(args.size as keyof typeof BTN_SIZE) ?? "md"] ?? BTN_SIZE.md;
+	const variant =
+		BTN_VARIANT[(args.variant as keyof typeof BTN_VARIANT) ?? "primary"] ?? BTN_VARIANT.primary;
+	return { root: `${BTN_BASE} ${size} ${variant} ${forced(BTN_FORCE, args.state)}`, label: "" };
+}
+
+/* ---- Text fields (input / textarea / select) ---------------------------- */
+const FIELD_BASE =
+	"w-full rounded-none border border-[#22c55e] bg-black px-3 py-2 " +
+	"text-xs font-mono text-[#4ade80] outline-none transition-none " +
+	"caret-[#22c55e] placeholder:text-[#4ade80]/40 " +
+	"hover:border-[#4ade80] " +
+	"focus:outline focus:outline-1 focus:outline-offset-0 focus:outline-[#22c55e] " +
+	"disabled:opacity-40 disabled:cursor-not-allowed disabled:border-[#14532d] disabled:text-[#4ade80]/40 " +
+	"aria-[invalid=true]:border-[#f87171] aria-[invalid=true]:focus:outline-[#f87171]";
+const FIELD_FORCE: Partial<Record<PartState, string>> = {
+	hover: "border-[#4ade80]",
+	focus: "outline outline-1 outline-offset-0 outline-[#22c55e]",
+};
+
+export const terminalInput = (args: RecipeArgs): RecipeResult => ({
+	root: `${FIELD_BASE} ${forced(FIELD_FORCE, args.state)}`,
+});
+
+export const terminalTextarea = (args: RecipeArgs): RecipeResult => ({
+	root: `${FIELD_BASE} min-h-[80px] leading-relaxed resize-y ${forced(FIELD_FORCE, args.state)}`,
+});
+
+export const terminalSelect = (args: RecipeArgs): RecipeResult => ({
+	root: "relative inline-block w-full",
+	field: `${FIELD_BASE} appearance-none pr-9 cursor-pointer ${forced(FIELD_FORCE, args.state)}`,
+	chevron: "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#22c55e]",
+});
+
+/* ---- Checkbox / Radio (native input + custom box) ----------------------- */
+const CHOICE_ROOT =
+	"inline-flex items-center gap-2 cursor-pointer select-none text-xs font-mono text-[#4ade80] " +
+	"has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-60";
+const CHOICE_BOX_BASE =
+	"grid place-items-center h-[18px] w-[18px] shrink-0 border border-[#22c55e] bg-black " +
+	"transition-none text-transparent " +
+	"peer-focus-visible:outline peer-focus-visible:outline-1 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-[#22c55e] " +
+	"peer-disabled:opacity-40 peer-disabled:border-[#14532d] " +
+	"peer-aria-[invalid=true]:border-[#f87171] " +
+	"peer-data-[invalid=true]:border-[#f87171]";
+const CHOICE_FORCE: Partial<Record<PartState, string>> = {
+	hover: "border-[#4ade80]",
+	focus: "outline outline-1 outline-offset-2 outline-[#22c55e]",
+};
+
+export const terminalCheckbox = (args: RecipeArgs): RecipeResult => ({
+	root: CHOICE_ROOT,
+	box: `${CHOICE_BOX_BASE} rounded-none peer-checked:bg-[#22c55e] peer-checked:text-black ${forced(CHOICE_FORCE, args.state)}`,
+});
+
+export const terminalRadio = (args: RecipeArgs): RecipeResult => ({
+	root: CHOICE_ROOT,
+	box: `${CHOICE_BOX_BASE} rounded-full peer-checked:bg-[#22c55e] ${forced(CHOICE_FORCE, args.state)}`,
+});
+
+/* ---- Switch (button role=switch) ---------------------------------------- */
+const SWITCH_FORCE: Partial<Record<PartState, string>> = {
+	hover: "border-[#4ade80]",
+	focus: "outline outline-1 outline-offset-2 outline-[#22c55e]",
+};
+
+export const terminalSwitch = (args: RecipeArgs): RecipeResult => ({
+	root:
+		"group inline-flex h-[22px] w-[40px] shrink-0 items-center rounded-none border border-[#22c55e] " +
+		"bg-black p-[2px] cursor-pointer transition-none " +
+		"aria-[checked=true]:bg-[#22c55e] " +
+		"focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-[#22c55e] " +
+		"disabled:opacity-40 disabled:cursor-not-allowed " +
+		"aria-[invalid=true]:border-[#f87171] " +
+		forced(SWITCH_FORCE, args.state),
+	thumb:
+		"h-[14px] w-[14px] rounded-none border border-[#22c55e] bg-[#4ade80] " +
+		"transition-transform group-aria-[checked=true]:translate-x-[18px] group-aria-[checked=true]:bg-black group-aria-[checked=true]:border-black",
+});
+
+/* ---- Slider (native range; thumb/track in terminal.css via .cam-range) --- */
+export const terminalSlider = (): RecipeResult => ({
+	root: "cam-range w-[160px] cursor-pointer appearance-none bg-transparent disabled:cursor-not-allowed disabled:opacity-50",
+});
+
+/* ---- Badge -------------------------------------------------------------- */
+const BADGE_BASE =
+	"inline-flex items-center rounded-none border px-[10px] py-[3px] text-[11px] font-mono uppercase tracking-widest " +
+	"before:content-[''] before:mr-[6px] before:h-[7px] before:w-[7px] before:rounded-none before:shrink-0";
+const BADGE_VARIANT = {
+	default: "border-[#22c55e] bg-black text-[#4ade80] before:bg-[#4ade80]",
+	solid: "border-[#22c55e] bg-[#22c55e] text-black before:bg-black",
+	blue: "border-[#38bdf8] bg-black text-[#38bdf8] before:bg-[#38bdf8]",
+	red: "border-[#f87171] bg-black text-[#f87171] before:bg-[#f87171]",
+	yellow: "border-[#facc15] bg-black text-[#facc15] before:bg-[#facc15]",
+	green: "border-[#22c55e] bg-black text-[#4ade80] before:bg-[#22c55e]",
+	purple: "border-[#a78bfa] bg-black text-[#a78bfa] before:bg-[#a78bfa]",
+} as const;
+
+// The badge state row (default variant, 6 states). Forced overrides the resting look.
+const BADGE_FORCE: Partial<Record<PartState, string>> = {
+	hover: "border-[#4ade80] text-[#4ade80] before:bg-[#4ade80]",
+	active: "bg-[#22c55e] text-black before:bg-black",
+	focus: "outline outline-1 outline-offset-2 outline-[#22c55e]",
+	disabled: "border-[#14532d] text-[#4ade80]/40 before:bg-[#14532d]",
+	error: "border-[#f87171] text-[#f87171] before:bg-[#f87171]",
+};
+
+export function terminalBadge(args: RecipeArgs): RecipeResult {
+	const variant =
+		BADGE_VARIANT[(args.variant as keyof typeof BADGE_VARIANT) ?? "default"] ??
+		BADGE_VARIANT.default;
+	return { root: `${BADGE_BASE} ${variant} ${forced(BADGE_FORCE, args.state)}` };
+}
+
+/* ---- Tooltip ------------------------------------------------------------ */
+// Tooltip has default / focus / error variants (via args.state); no active/disabled.
+const TT_TRIGGER: Partial<Record<PartState, string>> = {
+	focus: "outline outline-1 outline-offset-2 outline-[#22c55e]",
+	error: "border-[#f87171] text-[#f87171]",
+};
+const TT_BUBBLE: Partial<Record<PartState, string>> = {
+	focus: "outline outline-1 outline-offset-2 outline-[#22c55e]",
+	error: "border-[#f87171] text-[#f87171]",
+};
+
+export function terminalTooltip(args: RecipeArgs): RecipeResult {
+	return {
+		root: "relative inline-flex group",
+		trigger:
+			"grid place-items-center h-[26px] w-[26px] rounded-none border border-[#22c55e] " +
+			"bg-black text-[#4ade80] text-xs font-mono font-bold cursor-help " +
+			"focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-[#22c55e] " +
+			forced(TT_TRIGGER, args.state),
+		bubble:
+			"pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 whitespace-nowrap " +
+			"rounded-none border border-[#22c55e] bg-black px-3 py-1.5 text-xs font-mono text-[#4ade80] " +
+			"opacity-0 transition-none group-hover:opacity-100 group-focus-within:opacity-100 " +
+			forced(TT_BUBBLE, args.state),
+	};
+}
+
+/* ---- Skin registration -------------------------------------------------- */
+export const terminalRecipes: SkinRecipes = {
+	button: terminalButton,
+	input: terminalInput,
+	textarea: terminalTextarea,
+	select: terminalSelect,
+	checkbox: terminalCheckbox,
+	radio: terminalRadio,
+	switch: terminalSwitch,
+	slider: terminalSlider,
+	badge: terminalBadge,
+	tooltip: terminalTooltip,
+};

--- a/react/src/cameleon/skins/terminal/terminal.css
+++ b/react/src/cameleon/skins/terminal/terminal.css
@@ -1,0 +1,52 @@
+/* Terminal skin — phosphor glow + blinking caret. Scoped by data-skin. */
+[data-skin="terminal"] .cam-btn {
+	text-shadow: 0 0 6px currentColor;
+}
+
+.cam-caret {
+	animation: cam-blink 1s step-end infinite;
+}
+
+@keyframes cam-blink {
+	50% {
+		opacity: 0;
+	}
+}
+
+/* Native range slider — thin green line track + square green thumb, phosphor glow on focus. */
+[data-skin="terminal"] .cam-range {
+	height: 20px;
+}
+[data-skin="terminal"] .cam-range::-webkit-slider-runnable-track {
+	height: 2px;
+	background: #22c55e;
+	border-radius: 0;
+}
+[data-skin="terminal"] .cam-range::-webkit-slider-thumb {
+	-webkit-appearance: none;
+	appearance: none;
+	height: 14px;
+	width: 14px;
+	margin-top: -6px;
+	background: #22c55e;
+	border: 1px solid #4ade80;
+	border-radius: 0;
+}
+[data-skin="terminal"] .cam-range:focus-visible::-webkit-slider-thumb {
+	box-shadow: 0 0 6px #22c55e;
+}
+[data-skin="terminal"] .cam-range::-moz-range-track {
+	height: 2px;
+	background: #22c55e;
+	border-radius: 0;
+}
+[data-skin="terminal"] .cam-range::-moz-range-thumb {
+	height: 14px;
+	width: 14px;
+	background: #22c55e;
+	border: 1px solid #4ade80;
+	border-radius: 0;
+}
+[data-skin="terminal"] .cam-range:focus-visible::-moz-range-thumb {
+	box-shadow: 0 0 6px #22c55e;
+}

--- a/react/src/cameleon/skins/terminal/tokens.ts
+++ b/react/src/cameleon/skins/terminal/tokens.ts
@@ -1,0 +1,18 @@
+/**
+ * Terminal skin tokens — CRT green-on-black, monospace everywhere.
+ * The maximal-divergence proof: square corners, no motion, glow, blinking caret.
+ */
+export const terminalTokens: Record<string, string> = {
+	"--skin-page-bg": "#0a0e0a",
+	"--skin-page-fg": "#4ade80",
+	"--skin-card": "#0d120d",
+	"--skin-surface": "#0a0e0a",
+	"--skin-line": "#22c55e",
+	"--skin-blue": "#38bdf8",
+	"--skin-red": "#f87171",
+	"--skin-yellow": "#facc15",
+	"--skin-green": "#22c55e",
+	"--skin-purple": "#a78bfa",
+	"--skin-font-sans": "'Space Mono', ui-monospace, SFMono-Regular, monospace",
+	"--skin-font-mono": "'Space Mono', ui-monospace, SFMono-Regular, monospace",
+};

--- a/react/src/cameleon/types.ts
+++ b/react/src/cameleon/types.ts
@@ -1,0 +1,125 @@
+/**
+ * Cameleon Engine — the skin contract.
+ *
+ * A "skin" is a complete art direction, not a color theme. It changes
+ * typography, borders, shadows, motion, ornaments, and structure while the
+ * component API stays identical. A skin has three collaborating layers:
+ *
+ *   1. tokens    — CSS custom properties (the shared substrate: color, font,
+ *                  radius, shadow *values*) applied scoped by <FancyProvider>.
+ *   2. recipes   — pure functions returning static Tailwind class strings per
+ *                  component "part" (root, label, field, panel...). This is
+ *                  where structure / motion / hover formulas live.
+ *   3. ornaments — render functions the skin injects into fixed component
+ *                  slots for DOM that differs per skin (Brutal's arrow,
+ *                  Terminal's caret).
+ *
+ * Plus an optional per-skin CSS file (scoped by `[data-skin="<name>"]`) for
+ * pseudo-elements, textures, and keyframes a class cannot express.
+ */
+import type { ReactNode } from "react";
+
+/**
+ * Component state passed to a recipe. "error"/"disabled"/"loading" are real
+ * semantic states (attribute-driven). "hover"/"active"/"focus" are normally CSS
+ * pseudo-states — they appear here only for the /skins state-matrix demo, where a
+ * recipe FORCES that visual statically (see `demoState` on the primitives).
+ */
+export type PartState = "default" | "error" | "disabled" | "loading" | "hover" | "active" | "focus";
+
+/** Inputs to every recipe. Plain object → recipes are pure and unit-testable. */
+export interface RecipeArgs {
+	variant?: string; // "primary" | "destructive" | "secondary" | ...
+	size?: string; // "sm" | "md" | "lg"
+	state?: PartState;
+}
+
+/**
+ * One class string per named PART.
+ * IMPORTANT: values MUST be static class literals (no computed fragments like
+ * `rounded-${r}`) so Tailwind v4's JIT can see them. Build them from `as const`
+ * maps, mirroring src/lib/fancy-ui/book/index.ts.
+ */
+export type RecipeResult = Record<string, string>;
+
+export type RecipeFn = (args: RecipeArgs) => RecipeResult;
+
+/**
+ * The recipes a skin provides — one per primitive. Every skin implements all of
+ * them so components never have to handle a missing recipe. Part names per
+ * recipe (the keys of the returned RecipeResult) are a fixed contract shared by
+ * all skins:
+ *   button   → root, label
+ *   badge    → root                (args.variant: default|blue|red|yellow|green|purple|solid)
+ *   input    → root
+ *   textarea → root
+ *   select   → root, field, chevron
+ *   checkbox → root, box
+ *   radio    → root, box
+ *   switch   → root, thumb
+ *   slider   → root                (thumb/track come from per-skin CSS via .cam-range)
+ *   tooltip  → root, trigger, bubble
+ */
+export interface SkinRecipes {
+	button: RecipeFn;
+	badge: RecipeFn;
+	input: RecipeFn;
+	textarea: RecipeFn;
+	select: RecipeFn;
+	checkbox: RecipeFn;
+	radio: RecipeFn;
+	switch: RecipeFn;
+	slider: RecipeFn;
+	tooltip: RecipeFn;
+}
+
+/** Extra DOM a skin injects into a component's fixed ornament slots. */
+export interface SkinOrnaments {
+	/** Trailing glyph inside Button (Brutal arrow, Terminal caret marker). */
+	buttonTrailing?: (args: RecipeArgs) => ReactNode;
+	/** Eyebrow row at the top of Card (Brutal dot + mono label + / NN index). */
+	cardEyebrow?: (props: { index?: number; label?: string }) => ReactNode;
+}
+
+/** A webfont the skin needs. Injected once (deduped by id) by the provider. */
+export interface SkinFont {
+	id: string;
+	href: string;
+}
+
+/**
+ * Human-readable design metadata for the /skins documentation page (the
+ * design-system.html reproduction). Each skin describes its own palette, type
+ * scale, and specs so sections /01–/03 and /05 reflect the active skin.
+ */
+export interface SkinMeta {
+	/** /01 Color tokens — swatches. */
+	palette: { name: string; value: string; note?: string }[];
+	/** /02 Typography scale — one row per specimen; `style` is inline CSS for the sample. */
+	type: { sample: string; spec: string; style: string }[];
+	/** /03 Grid, radius & borders. */
+	specs: {
+		radius: { size: string; label: string }[];
+		border: string;
+		shadowRest: string;
+		shadowHover: string;
+		spacing: string;
+	};
+	/** /05 Responsive variants — one card per breakpoint. */
+	responsive: { label: string; note: string }[];
+}
+
+export interface Skin {
+	/** Stable id — becomes the `data-skin` attribute value + font dedupe key. */
+	name: string;
+	label: string;
+	/** Drives an optional scoped `.dark` when <FancyProvider manageColorScheme>. */
+	colorScheme: "light" | "dark";
+	/** CSS custom properties applied scoped to the provider's subtree. */
+	tokens: Record<string, string>;
+	fonts?: SkinFont[];
+	recipes: SkinRecipes;
+	ornaments?: SkinOrnaments;
+	/** Design metadata powering the /skins documentation sections. */
+	meta: SkinMeta;
+}

--- a/react/src/components/border-beam/BorderBeam.test.tsx
+++ b/react/src/components/border-beam/BorderBeam.test.tsx
@@ -1,0 +1,72 @@
+import { render, cleanup } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
+import { BorderBeam } from "./BorderBeam.js";
+
+describe("BorderBeam", () => {
+	afterEach(cleanup);
+
+	it("renders a div element", () => {
+		const { container } = render(<BorderBeam />);
+		const div = container.querySelector(".border-beam");
+		expect(div).toBeInTheDocument();
+	});
+
+	it("applies default CSS custom properties", () => {
+		const { container } = render(<BorderBeam />);
+		const div = container.querySelector(".border-beam") as HTMLElement;
+		const style = div.getAttribute("style") ?? "";
+		expect(style).toContain("--border-beam-size: 200");
+		expect(style).toContain("--border-beam-duration: 15s");
+		expect(style).toContain("--border-beam-anchor: 90");
+		expect(style).toContain("--border-beam-border-width: 1.5");
+		expect(style).toContain("--border-beam-color-from: #ffaa40");
+		expect(style).toContain("--border-beam-color-to: #9c40ff");
+		expect(style).toContain("--border-beam-delay: 0s");
+	});
+
+	it("applies custom size", () => {
+		const { container } = render(<BorderBeam size={300} />);
+		const div = container.querySelector(".border-beam") as HTMLElement;
+		expect(div.getAttribute("style")).toContain("--border-beam-size: 300");
+	});
+
+	it("applies custom duration", () => {
+		const { container } = render(<BorderBeam duration={5} />);
+		const div = container.querySelector(".border-beam") as HTMLElement;
+		expect(div.getAttribute("style")).toContain("--border-beam-duration: 5s");
+	});
+
+	it("applies custom colors", () => {
+		const { container } = render(<BorderBeam colorFrom="#ff0000" colorTo="#00ff00" />);
+		const div = container.querySelector(".border-beam") as HTMLElement;
+		const style = div.getAttribute("style") ?? "";
+		expect(style).toContain("--border-beam-color-from: #ff0000");
+		expect(style).toContain("--border-beam-color-to: #00ff00");
+	});
+
+	it("applies custom delay", () => {
+		const { container } = render(<BorderBeam delay={3} />);
+		const div = container.querySelector(".border-beam") as HTMLElement;
+		expect(div.getAttribute("style")).toContain("--border-beam-delay: 3s");
+	});
+
+	it("applies custom borderWidth", () => {
+		const { container } = render(<BorderBeam borderWidth={3} />);
+		const div = container.querySelector(".border-beam") as HTMLElement;
+		expect(div.getAttribute("style")).toContain("--border-beam-border-width: 3");
+	});
+
+	it("applies custom class names", () => {
+		const { container } = render(<BorderBeam className="my-beam" />);
+		const div = container.querySelector(".border-beam");
+		expect(div?.className).toContain("my-beam");
+	});
+
+	it("preserves base classes when custom class is added", () => {
+		const { container } = render(<BorderBeam className="extra" />);
+		const div = container.querySelector(".border-beam");
+		expect(div?.className).toContain("pointer-events-none");
+		expect(div?.className).toContain("absolute");
+		expect(div?.className).toContain("inset-0");
+	});
+});

--- a/react/src/components/border-beam/BorderBeam.tsx
+++ b/react/src/components/border-beam/BorderBeam.tsx
@@ -1,0 +1,67 @@
+import type { CSSProperties } from "react";
+import { cn } from "../../utils.js";
+import "./border-beam.css";
+
+/**
+ * BorderBeam - Animated beam effect that travels around the border
+ *
+ * Place inside a container with `position: relative` and `overflow: hidden`.
+ * The beam will animate around the container's border.
+ */
+export interface BorderBeamProps {
+	/** Additional CSS classes */
+	className?: string;
+	/** Size of the beam in pixels */
+	size?: number;
+	/** Animation duration in seconds */
+	duration?: number;
+	/** Border width in pixels */
+	borderWidth?: number;
+	/** Anchor position (0-100) */
+	anchor?: number;
+	/** Gradient start color */
+	colorFrom?: string;
+	/** Gradient end color */
+	colorTo?: string;
+	/** Animation delay in seconds */
+	delay?: number;
+}
+
+export function BorderBeam({
+	className,
+	size = 200,
+	duration = 15,
+	borderWidth = 1.5,
+	anchor = 90,
+	colorFrom = "#ffaa40",
+	colorTo = "#9c40ff",
+	delay = 0,
+}: BorderBeamProps) {
+	const style = {
+		"--border-beam-size": size,
+		"--border-beam-duration": `${duration}s`,
+		"--border-beam-anchor": anchor,
+		"--border-beam-border-width": borderWidth,
+		"--border-beam-color-from": colorFrom,
+		"--border-beam-color-to": colorTo,
+		"--border-beam-delay": `${delay}s`,
+	} as CSSProperties;
+
+	return (
+		<div
+			className={cn(
+				"border-beam",
+				"pointer-events-none absolute inset-0 rounded-[inherit]",
+				"[border:calc(var(--border-beam-border-width)*1px)_solid_transparent]",
+				"![mask-composite:intersect] ![mask-clip:padding-box,border-box] [mask:linear-gradient(transparent,transparent),linear-gradient(white,white)]",
+				"after:absolute after:aspect-square after:w-[calc(var(--border-beam-size)*1px)]",
+				"after:[animation-delay:var(--border-beam-delay)]",
+				"after:[background:linear-gradient(to_left,var(--border-beam-color-from),var(--border-beam-color-to),transparent)]",
+				"after:[offset-anchor:calc(var(--border-beam-anchor)*1%)_50%]",
+				"after:[offset-path:rect(0_auto_auto_0_round_calc(var(--border-beam-size)*1px))]",
+				className
+			)}
+			style={style}
+		/>
+	);
+}

--- a/react/src/components/border-beam/border-beam.css
+++ b/react/src/components/border-beam/border-beam.css
@@ -1,0 +1,13 @@
+.border-beam::after {
+	content: "";
+	animation: border-beam-animation var(--border-beam-duration) infinite linear;
+}
+
+@keyframes border-beam-animation {
+	0% {
+		offset-distance: 0%;
+	}
+	100% {
+		offset-distance: 100%;
+	}
+}

--- a/react/src/components/border-beam/index.ts
+++ b/react/src/components/border-beam/index.ts
@@ -1,0 +1,2 @@
+export { BorderBeam } from "./BorderBeam.js";
+export type { BorderBeamProps } from "./BorderBeam.js";

--- a/react/src/components/gradient-button/GradientButton.test.tsx
+++ b/react/src/components/gradient-button/GradientButton.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
+import { GradientButton } from "./GradientButton.js";
+
+describe("GradientButton", () => {
+	afterEach(cleanup);
+
+	it("renders a button element", () => {
+		render(<GradientButton />);
+		expect(screen.getByRole("button")).toBeInTheDocument();
+	});
+
+	it("applies default CSS custom properties", () => {
+		render(<GradientButton />);
+		const button = screen.getByRole("button");
+		const style = button.getAttribute("style") ?? "";
+		expect(style).toContain("--gb-duration: 2500ms");
+		expect(style).toContain("--gb-border-width: 2px");
+		expect(style).toContain("--gb-border-radius: 8px");
+		expect(style).toContain("--gb-blur: 4px");
+		expect(style).toContain("--gb-bg-color: #000");
+	});
+
+	it("applies custom colors", () => {
+		render(<GradientButton colors={["#ff0000", "#00ff00"]} />);
+		const button = screen.getByRole("button");
+		expect(button.getAttribute("style")).toContain("--gb-colors: #ff0000, #00ff00");
+	});
+
+	it("applies custom duration", () => {
+		render(<GradientButton duration={5000} />);
+		const button = screen.getByRole("button");
+		expect(button.getAttribute("style")).toContain("--gb-duration: 5000ms");
+	});
+
+	it("applies custom borderWidth", () => {
+		render(<GradientButton borderWidth={4} />);
+		const button = screen.getByRole("button");
+		expect(button.getAttribute("style")).toContain("--gb-border-width: 4px");
+	});
+
+	it("applies custom class names", () => {
+		render(<GradientButton className="my-gradient" />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("my-gradient");
+	});
+
+	it("preserves base classes when custom class is added", () => {
+		render(<GradientButton className="extra" />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("gradient-button");
+		expect(button.className).toContain("overflow-hidden");
+	});
+
+	it("contains gradient-border span", () => {
+		render(<GradientButton />);
+		const button = screen.getByRole("button");
+		const border = button.querySelector(".gradient-border");
+		expect(border).toBeInTheDocument();
+		expect(border).toHaveAttribute("aria-hidden", "true");
+	});
+
+	it("contains gradient-content span", () => {
+		render(<GradientButton />);
+		const button = screen.getByRole("button");
+		const content = button.querySelector(".gradient-content");
+		expect(content).toBeInTheDocument();
+	});
+
+	it("forwards native button attributes", () => {
+		render(<GradientButton disabled type="submit" />);
+		const button = screen.getByRole("button");
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute("type", "submit");
+	});
+});

--- a/react/src/components/gradient-button/GradientButton.tsx
+++ b/react/src/components/gradient-button/GradientButton.tsx
@@ -1,0 +1,84 @@
+import { forwardRef } from "react";
+import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from "react";
+import { cn } from "../../utils.js";
+import "./gradient-button.css";
+
+type BaseProps = {
+	/** Gradient colors for the conic-gradient border */
+	colors?: string[];
+	/** Animation duration in milliseconds */
+	duration?: number;
+	/** Border width in pixels */
+	borderWidth?: number;
+	/** Border radius in pixels */
+	borderRadius?: number;
+	/** Blur amount for the gradient in pixels */
+	blur?: number;
+	/** Background color of the button content area */
+	bgColor?: string;
+	/** Custom CSS class */
+	className?: string;
+	/** Button content */
+	children?: ReactNode;
+};
+
+export type GradientButtonProps = BaseProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>;
+
+const DEFAULT_COLORS = [
+	"#FF0000",
+	"#FFA500",
+	"#FFFF00",
+	"#008000",
+	"#0000FF",
+	"#4B0082",
+	"#EE82EE",
+	"#FF0000",
+];
+
+export const GradientButton = forwardRef<HTMLButtonElement, GradientButtonProps>(
+	(
+		{
+			className,
+			colors = DEFAULT_COLORS,
+			duration = 2500,
+			borderWidth = 2,
+			borderRadius = 8,
+			blur = 4,
+			bgColor = "#000",
+			children,
+			...restProps
+		},
+		ref
+	) => {
+		const styleVars = {
+			"--gb-colors": colors.join(", "),
+			"--gb-duration": `${duration}ms`,
+			"--gb-border-width": `${borderWidth}px`,
+			"--gb-border-radius": `${borderRadius}px`,
+			"--gb-blur": `${blur}px`,
+			"--gb-bg-color": bgColor,
+		} as CSSProperties;
+
+		return (
+			<button
+				ref={ref}
+				className={cn(
+					"gradient-button relative flex min-h-10 min-w-28 cursor-pointer items-center justify-center overflow-hidden",
+					className
+				)}
+				style={styleVars}
+				{...restProps}
+			>
+				{/* Rotating conic-gradient pseudo-element */}
+				<span className="gradient-border" aria-hidden="true" />
+
+				{/* Content area */}
+				<span className="gradient-content inline-flex size-full items-center justify-center px-4 py-2">
+					{children}
+				</span>
+			</button>
+		);
+	}
+);
+
+GradientButton.displayName = "GradientButton";

--- a/react/src/components/gradient-button/GradientButton.tsx
+++ b/react/src/components/gradient-button/GradientButton.tsx
@@ -22,7 +22,9 @@ type BaseProps = {
 	children?: ReactNode;
 };
 
-export type GradientButtonProps = BaseProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>;
+export interface GradientButtonProps
+	extends BaseProps,
+		Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps> {}
 
 const DEFAULT_COLORS = [
 	"#FF0000",

--- a/react/src/components/gradient-button/gradient-button.css
+++ b/react/src/components/gradient-button/gradient-button.css
@@ -1,0 +1,31 @@
+.gradient-button {
+	padding: var(--gb-border-width);
+	border-radius: var(--gb-border-radius);
+	isolation: isolate;
+}
+
+/* Anchored on the root class: the Svelte compiler scoped these rules, plain CSS
+   would leak them into every consumer element sharing the class name. */
+.gradient-button .gradient-border {
+	content: "";
+	position: absolute;
+	inset: -200%;
+	z-index: -1;
+	background: conic-gradient(var(--gb-colors));
+	animation: rotate-gradient var(--gb-duration) linear infinite;
+	filter: blur(var(--gb-blur));
+}
+
+.gradient-button .gradient-content {
+	border-radius: var(--gb-border-radius);
+	background-color: var(--gb-bg-color);
+}
+
+@keyframes rotate-gradient {
+	0% {
+		transform: rotate(0deg);
+	}
+	100% {
+		transform: rotate(360deg);
+	}
+}

--- a/react/src/components/gradient-button/index.ts
+++ b/react/src/components/gradient-button/index.ts
@@ -1,0 +1,2 @@
+export { GradientButton } from "./GradientButton.js";
+export type { GradientButtonProps } from "./GradientButton.js";

--- a/react/src/components/interactive-hover-button/InteractiveHoverButton.test.tsx
+++ b/react/src/components/interactive-hover-button/InteractiveHoverButton.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
+import { InteractiveHoverButton } from "./InteractiveHoverButton.js";
+
+describe("InteractiveHoverButton", () => {
+	afterEach(cleanup);
+
+	it("renders a button element", () => {
+		render(<InteractiveHoverButton />);
+		expect(screen.getByRole("button")).toBeInTheDocument();
+	});
+
+	it('renders default text "Button" when no text prop is provided', () => {
+		render(<InteractiveHoverButton />);
+		const button = screen.getByRole("button");
+		expect(button).toHaveTextContent("Button");
+	});
+
+	it("renders custom text from the text prop", () => {
+		render(<InteractiveHoverButton text="Get Started" />);
+		const button = screen.getByRole("button");
+		expect(button).toHaveTextContent("Get Started");
+	});
+
+	it("displays the text twice (initial + hover overlay)", () => {
+		render(<InteractiveHoverButton text="Subscribe" />);
+		const matches = screen.getAllByText("Subscribe");
+		expect(matches).toHaveLength(2);
+	});
+
+	it("renders the arrow SVG icon", () => {
+		render(<InteractiveHoverButton />);
+		const button = screen.getByRole("button");
+		const svg = button.querySelector("svg");
+		expect(svg).toBeInTheDocument();
+		expect(svg?.querySelectorAll("path")).toHaveLength(2);
+	});
+
+	it("applies custom class names", () => {
+		render(<InteractiveHoverButton className="my-custom-class" />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("my-custom-class");
+	});
+
+	it("preserves base classes when custom class is added", () => {
+		render(<InteractiveHoverButton className="extra" />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("overflow-hidden");
+		expect(button.className).toContain("rounded-full");
+	});
+
+	it("forwards native button attributes", () => {
+		render(<InteractiveHoverButton disabled type="submit" aria-label="Sign up" />);
+		const button = screen.getByRole("button");
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute("type", "submit");
+		expect(button).toHaveAttribute("aria-label", "Sign up");
+	});
+
+	it("contains the dot element with bg-primary class", () => {
+		render(<InteractiveHoverButton />);
+		const button = screen.getByRole("button");
+		const dot = button.querySelector(".bg-primary");
+		expect(dot).toBeInTheDocument();
+	});
+
+	it("has hover overlay with translate and opacity classes", () => {
+		render(<InteractiveHoverButton />);
+		const button = screen.getByRole("button");
+		const overlay = button.querySelector(".translate-x-12.opacity-0");
+		expect(overlay).toBeInTheDocument();
+	});
+});

--- a/react/src/components/interactive-hover-button/InteractiveHoverButton.tsx
+++ b/react/src/components/interactive-hover-button/InteractiveHoverButton.tsx
@@ -1,0 +1,59 @@
+import { forwardRef } from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { cn } from "../../utils.js";
+
+type BaseProps = {
+	/** Button label text */
+	text?: string;
+	/** Custom CSS class */
+	className?: string;
+	/** Button content (overrides text prop) */
+	children?: ReactNode;
+};
+
+export type InteractiveHoverButtonProps = BaseProps &
+	Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>;
+
+export const InteractiveHoverButton = forwardRef<HTMLButtonElement, InteractiveHoverButtonProps>(
+	({ text = "Button", className, children, ...restProps }, ref) => {
+		const label = children ?? text;
+
+		return (
+			<button
+				ref={ref}
+				className={cn(
+					"group bg-background relative w-auto cursor-pointer overflow-hidden rounded-full border p-2 px-6 text-center font-semibold",
+					className
+				)}
+				{...restProps}
+			>
+				<div className="flex items-center gap-2">
+					<div className="bg-primary size-2 rounded-lg transition-all duration-300 group-hover:scale-[100.8]" />
+					<span className="inline-block transition-all duration-300 group-hover:translate-x-12 group-hover:opacity-0">
+						{label}
+					</span>
+				</div>
+
+				<div className="text-primary-foreground absolute top-0 z-10 flex size-full translate-x-12 items-center justify-center gap-2 opacity-0 transition-all duration-300 group-hover:-translate-x-5 group-hover:opacity-100">
+					<span>{label}</span>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="24"
+						height="24"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					>
+						<path d="M5 12h14" />
+						<path d="m12 5 7 7-7 7" />
+					</svg>
+				</div>
+			</button>
+		);
+	}
+);
+
+InteractiveHoverButton.displayName = "InteractiveHoverButton";

--- a/react/src/components/interactive-hover-button/InteractiveHoverButton.tsx
+++ b/react/src/components/interactive-hover-button/InteractiveHoverButton.tsx
@@ -11,8 +11,9 @@ type BaseProps = {
 	children?: ReactNode;
 };
 
-export type InteractiveHoverButtonProps = BaseProps &
-	Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>;
+export interface InteractiveHoverButtonProps
+	extends BaseProps,
+		Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps> {}
 
 export const InteractiveHoverButton = forwardRef<HTMLButtonElement, InteractiveHoverButtonProps>(
 	({ text = "Button", className, children, ...restProps }, ref) => {

--- a/react/src/components/interactive-hover-button/index.ts
+++ b/react/src/components/interactive-hover-button/index.ts
@@ -1,0 +1,2 @@
+export { InteractiveHoverButton } from "./InteractiveHoverButton.js";
+export type { InteractiveHoverButtonProps } from "./InteractiveHoverButton.js";

--- a/react/src/components/marquee/Marquee.test.tsx
+++ b/react/src/components/marquee/Marquee.test.tsx
@@ -1,0 +1,55 @@
+import { render, cleanup } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
+import { Marquee } from "./Marquee.js";
+
+describe("Marquee", () => {
+	afterEach(cleanup);
+
+	it("renders a container div", () => {
+		const { container } = render(<Marquee />);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div).toBeInTheDocument();
+	});
+
+	it("has overflow-hidden class", () => {
+		const { container } = render(<Marquee />);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain("overflow-hidden");
+	});
+
+	it("renders default 4 repeat groups", () => {
+		const { container } = render(<Marquee />);
+		const groups = container.querySelectorAll(".animate-marquee");
+		expect(groups.length).toBe(4);
+	});
+
+	it("renders custom repeat count", () => {
+		const { container } = render(<Marquee repeat={2} />);
+		const groups = container.querySelectorAll(".animate-marquee");
+		expect(groups.length).toBe(2);
+	});
+
+	it("uses vertical animation class when vertical", () => {
+		const { container } = render(<Marquee vertical />);
+		const groups = container.querySelectorAll(".animate-marquee-vertical");
+		expect(groups.length).toBe(4);
+	});
+
+	it("uses flex-col when vertical", () => {
+		const { container } = render(<Marquee vertical />);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain("flex-col");
+	});
+
+	it("sets animation-direction to reverse when reverse prop is true", () => {
+		const { container } = render(<Marquee reverse />);
+		const group = container.querySelector(".animate-marquee") as HTMLElement;
+		expect(group?.style.animationDirection).toBe("reverse");
+	});
+
+	it("applies custom class names", () => {
+		const { container } = render(<Marquee className="my-marquee" />);
+		const div = container.firstElementChild as HTMLElement;
+		expect(div?.className).toContain("my-marquee");
+	});
+});

--- a/react/src/components/marquee/Marquee.tsx
+++ b/react/src/components/marquee/Marquee.tsx
@@ -1,0 +1,51 @@
+import type { CSSProperties, ReactNode } from "react";
+import { cn } from "../../utils.js";
+import "./marquee.css";
+
+export interface MarqueeProps {
+	/** Additional CSS classes */
+	className?: string;
+	/** Reverse the scroll direction */
+	reverse?: boolean;
+	/** Pause the animation on hover */
+	pauseOnHover?: boolean;
+	/** Scroll vertically instead of horizontally */
+	vertical?: boolean;
+	/** Number of times to repeat the children track */
+	repeat?: number;
+	/** Content to repeat and scroll */
+	children?: ReactNode;
+}
+
+export function Marquee({
+	className,
+	reverse = false,
+	pauseOnHover = false,
+	vertical = false,
+	repeat = 4,
+	children,
+}: MarqueeProps) {
+	return (
+		<div
+			className={cn(
+				"group flex [gap:var(--gap)] overflow-hidden p-2 [--duration:40s] [--gap:1rem]",
+				vertical ? "flex-col" : "flex-row",
+				className
+			)}
+		>
+			{Array.from({ length: repeat }, (_, index) => (
+				<div
+					key={index}
+					className={cn(
+						"flex shrink-0 justify-around [gap:var(--gap)]",
+						vertical ? "animate-marquee-vertical flex-col" : "animate-marquee flex-row",
+						pauseOnHover ? "group-hover:[animation-play-state:paused]" : ""
+					)}
+					style={{ animationDirection: reverse ? "reverse" : "normal" } as CSSProperties}
+				>
+					{children}
+				</div>
+			))}
+		</div>
+	);
+}

--- a/react/src/components/marquee/Marquee.tsx
+++ b/react/src/components/marquee/Marquee.tsx
@@ -28,7 +28,7 @@ export function Marquee({
 	return (
 		<div
 			className={cn(
-				"group flex [gap:var(--gap)] overflow-hidden p-2 [--duration:40s] [--gap:1rem]",
+				"fancy-marquee group flex [gap:var(--gap)] overflow-hidden p-2 [--duration:40s] [--gap:1rem]",
 				vertical ? "flex-col" : "flex-row",
 				className
 			)}

--- a/react/src/components/marquee/ReviewCard.tsx
+++ b/react/src/components/marquee/ReviewCard.tsx
@@ -1,0 +1,22 @@
+export interface ReviewCardProps {
+	img: string;
+	name: string;
+	username: string;
+	body: string;
+}
+
+/** A ready-made card for testimonial-style marquees. */
+export function ReviewCard({ img, name, username, body }: ReviewCardProps) {
+	return (
+		<figure className="relative w-64 cursor-pointer overflow-hidden rounded-xl border border-gray-950/[.1] bg-gray-950/[.01] p-4 hover:bg-gray-950/[.05] dark:border-gray-50/[.1] dark:bg-gray-50/[.10] dark:hover:bg-gray-50/[.15]">
+			<div className="flex flex-row items-center gap-2">
+				<img src={img} className="rounded-full" width="32" height="32" alt="" />
+				<div className="flex flex-col">
+					<span className="text-sm font-medium dark:text-white">{name}</span>
+					<p className="text-xs font-medium dark:text-white/40">{username}</p>
+				</div>
+			</div>
+			<blockquote className="mt-2 text-sm">{body}</blockquote>
+		</figure>
+	);
+}

--- a/react/src/components/marquee/index.ts
+++ b/react/src/components/marquee/index.ts
@@ -1,0 +1,4 @@
+export { Marquee } from "./Marquee.js";
+export type { MarqueeProps } from "./Marquee.js";
+export { ReviewCard } from "./ReviewCard.js";
+export type { ReviewCardProps } from "./ReviewCard.js";

--- a/react/src/components/marquee/marquee.css
+++ b/react/src/components/marquee/marquee.css
@@ -1,8 +1,11 @@
-.animate-marquee {
+/* Anchored on the root class (added in the port — the Svelte compiler scoped
+   these rules; as plain CSS they would leak into any consumer element named
+   .animate-marquee). See PORTING.md, styling rule 2. */
+.fancy-marquee .animate-marquee {
 	animation: marquee var(--duration) linear infinite;
 }
 
-.animate-marquee-vertical {
+.fancy-marquee .animate-marquee-vertical {
 	animation: marquee-vertical var(--duration) linear infinite;
 }
 

--- a/react/src/components/marquee/marquee.css
+++ b/react/src/components/marquee/marquee.css
@@ -1,0 +1,25 @@
+.animate-marquee {
+	animation: marquee var(--duration) linear infinite;
+}
+
+.animate-marquee-vertical {
+	animation: marquee-vertical var(--duration) linear infinite;
+}
+
+@keyframes marquee {
+	from {
+		transform: translateX(0);
+	}
+	to {
+		transform: translateX(calc(-100% - var(--gap)));
+	}
+}
+
+@keyframes marquee-vertical {
+	from {
+		transform: translateY(0);
+	}
+	to {
+		transform: translateY(calc(-100% - var(--gap)));
+	}
+}

--- a/react/src/components/meteors/Meteors.test.tsx
+++ b/react/src/components/meteors/Meteors.test.tsx
@@ -1,4 +1,5 @@
 import { render, cleanup } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, it, expect } from "vitest";
 import { Meteors } from "./Meteors.js";
 
@@ -40,6 +41,41 @@ describe("Meteors", () => {
 			expect(style).toContain("animation-delay:");
 			expect(style).toContain("animation-duration:");
 		});
+	});
+
+	// `Math.random()` in the initializer ran once on the server and again
+	// during hydration, so every `left`/delay/duration differed between the
+	// two renders — a hydration mismatch React may resolve by keeping the
+	// SERVER attributes. A seeded PRNG makes both renders agree while keeping
+	// the shower in the server HTML, which generating after mount would not.
+	// Compared as parsed style VALUES rather than raw HTML: jsdom normalises
+	// whitespace and unescapes entities on the client side, so two identical
+	// renders still differ as strings while agreeing on every value React
+	// actually diffs during hydration.
+	function layoutOf(html: string): string[] {
+		const host = document.createElement("div");
+		host.innerHTML = html;
+		return Array.from(host.querySelectorAll<HTMLElement>("span.meteor")).map(
+			(span) =>
+				`${span.style.left}|${span.style.animationDelay}|${span.style.animationDuration}`
+		);
+	}
+
+	it("lays the shower out identically on the server and on the client", () => {
+		const serverLayout = layoutOf(renderToStaticMarkup(<Meteors count={6} />));
+		const { container } = render(<Meteors count={6} />);
+
+		expect(serverLayout).toHaveLength(6);
+		expect(layoutOf(container.innerHTML)).toEqual(serverLayout);
+	});
+
+	it("lays out two showers the same way by default, and differently under different seeds", () => {
+		const first = layoutOf(renderToStaticMarkup(<Meteors count={4} />));
+		const same = layoutOf(renderToStaticMarkup(<Meteors count={4} />));
+		const seeded = layoutOf(renderToStaticMarkup(<Meteors count={4} seed={99} />));
+
+		expect(same).toEqual(first);
+		expect(seeded).not.toEqual(first);
 	});
 
 	it("preserves base classes when custom class is added", () => {

--- a/react/src/components/meteors/Meteors.test.tsx
+++ b/react/src/components/meteors/Meteors.test.tsx
@@ -1,0 +1,51 @@
+import { render, cleanup } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
+import { Meteors } from "./Meteors.js";
+
+describe("Meteors", () => {
+	afterEach(cleanup);
+
+	it("renders the default number of meteor spans (20)", () => {
+		const { container } = render(<Meteors />);
+		const spans = container.querySelectorAll("span.meteor");
+		expect(spans.length).toBe(20);
+	});
+
+	it("renders a custom count of meteors", () => {
+		const { container } = render(<Meteors count={5} />);
+		const spans = container.querySelectorAll("span.meteor");
+		expect(spans.length).toBe(5);
+	});
+
+	it("renders zero meteors when count is 0", () => {
+		const { container } = render(<Meteors count={0} />);
+		const spans = container.querySelectorAll("span.meteor");
+		expect(spans.length).toBe(0);
+	});
+
+	it("applies custom class names to each meteor", () => {
+		const { container } = render(<Meteors count={3} className="my-custom-class" />);
+		const spans = container.querySelectorAll("span.meteor");
+		spans.forEach((span) => {
+			expect(span.className).toContain("my-custom-class");
+		});
+	});
+
+	it("each meteor has a style attribute with left, animation-delay, and animation-duration", () => {
+		const { container } = render(<Meteors count={3} />);
+		const spans = container.querySelectorAll("span.meteor");
+		spans.forEach((span) => {
+			const style = span.getAttribute("style") ?? "";
+			expect(style).toContain("left:");
+			expect(style).toContain("animation-delay:");
+			expect(style).toContain("animation-duration:");
+		});
+	});
+
+	it("preserves base classes when custom class is added", () => {
+		const { container } = render(<Meteors count={1} className="extra" />);
+		const span = container.querySelector("span.meteor")!;
+		expect(span.className).toContain("absolute");
+		expect(span.className).toContain("rounded-full");
+	});
+});

--- a/react/src/components/meteors/Meteors.tsx
+++ b/react/src/components/meteors/Meteors.tsx
@@ -1,0 +1,64 @@
+import { useState, type CSSProperties } from "react";
+import { cn } from "../../utils.js";
+import "./meteors.css";
+
+/**
+ * Meteors - Animated meteor shower effect
+ *
+ * Generates N span elements with randomized positions, delays, and durations
+ * that animate diagonally across the container.
+ */
+export interface MeteorsProps {
+	/** Number of meteors to render */
+	count?: number;
+	/** Additional CSS classes applied to each meteor */
+	className?: string;
+}
+
+interface Meteor {
+	left: string;
+	animationDelay: string;
+	animationDuration: string;
+}
+
+function createMeteors(count: number): Meteor[] {
+	return Array.from({ length: count }, () => ({
+		left: `${Math.floor(Math.random() * 800 - 400)}px`,
+		animationDelay: `${(Math.random() * 0.6 + 0.2).toFixed(2)}s`,
+		animationDuration: `${Math.floor(Math.random() * 8 + 2)}s`,
+	}));
+}
+
+export function Meteors({ count = 20, className }: MeteorsProps) {
+	// Randomized once, then re-randomized only when `count` changes — the same
+	// dependency the Svelte source's $derived tracks. A plain render-time call
+	// would reshuffle on every unrelated re-render and make the shower jump.
+	const [meteors, setMeteors] = useState(() => createMeteors(count));
+	const [renderedCount, setRenderedCount] = useState(count);
+	if (renderedCount !== count) {
+		setRenderedCount(count);
+		setMeteors(createMeteors(count));
+	}
+
+	return (
+		<>
+			{meteors.map((meteor, i) => (
+				<span
+					key={i}
+					className={cn(
+						"meteor pointer-events-none absolute top-0 h-0.5 w-0.5 rounded-full bg-slate-500 opacity-0 shadow-[0_0_0_1px_#ffffff10]",
+						"before:absolute before:top-1/2 before:h-px before:w-[50px] before:-translate-y-1/2 before:bg-gradient-to-r before:from-slate-500 before:to-transparent before:content-['']",
+						className
+					)}
+					style={
+						{
+							left: meteor.left,
+							animationDelay: meteor.animationDelay,
+							animationDuration: meteor.animationDuration,
+						} as CSSProperties
+					}
+				/>
+			))}
+		</>
+	);
+}

--- a/react/src/components/meteors/Meteors.tsx
+++ b/react/src/components/meteors/Meteors.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties } from "react";
+import { useMemo, type CSSProperties } from "react";
 import { cn } from "../../utils.js";
 import "./meteors.css";
 
@@ -13,6 +13,14 @@ export interface MeteorsProps {
 	count?: number;
 	/** Additional CSS classes applied to each meteor */
 	className?: string;
+	/**
+	 * Seed for the meteor layout. The same seed always produces the same
+	 * shower, which is what keeps a server render and its hydration
+	 * identical. Change it to give two showers on one page different
+	 * layouts — the default is shared, so two `<Meteors />` with no seed
+	 * fall the same way.
+	 */
+	seed?: number;
 }
 
 interface Meteor {
@@ -21,24 +29,40 @@ interface Meteor {
 	animationDuration: string;
 }
 
-function createMeteors(count: number): Meteor[] {
+/**
+ * mulberry32 — a tiny deterministic PRNG. `Math.random()` cannot be used
+ * here: the initializer runs once on the server and again during client
+ * hydration, and the two would disagree on every value, which React reports
+ * as a hydration mismatch and may resolve by keeping the SERVER attributes.
+ * Generating after mount instead would fix the mismatch but leave the effect
+ * absent from the server HTML; a seed keeps both renders identical AND keeps
+ * the shower in the markup.
+ */
+function mulberry32(seed: number): () => number {
+	let state = seed >>> 0;
+	return () => {
+		state = (state + 0x6d2b79f5) >>> 0;
+		let t = state;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+function createMeteors(count: number, seed: number): Meteor[] {
+	const random = mulberry32(seed);
 	return Array.from({ length: count }, () => ({
-		left: `${Math.floor(Math.random() * 800 - 400)}px`,
-		animationDelay: `${(Math.random() * 0.6 + 0.2).toFixed(2)}s`,
-		animationDuration: `${Math.floor(Math.random() * 8 + 2)}s`,
+		left: `${Math.floor(random() * 800 - 400)}px`,
+		animationDelay: `${(random() * 0.6 + 0.2).toFixed(2)}s`,
+		animationDuration: `${Math.floor(random() * 8 + 2)}s`,
 	}));
 }
 
-export function Meteors({ count = 20, className }: MeteorsProps) {
-	// Randomized once, then re-randomized only when `count` changes — the same
-	// dependency the Svelte source's $derived tracks. A plain render-time call
-	// would reshuffle on every unrelated re-render and make the shower jump.
-	const [meteors, setMeteors] = useState(() => createMeteors(count));
-	const [renderedCount, setRenderedCount] = useState(count);
-	if (renderedCount !== count) {
-		setRenderedCount(count);
-		setMeteors(createMeteors(count));
-	}
+export function Meteors({ count = 20, className, seed = 1 }: MeteorsProps) {
+	// Recomputed only when `count` or `seed` changes — the same dependencies
+	// the Svelte source's `$derived` tracks. A plain render-time call would
+	// reshuffle on every unrelated re-render and make the shower jump.
+	const meteors = useMemo(() => createMeteors(count, seed), [count, seed]);
 
 	return (
 		<>

--- a/react/src/components/meteors/index.ts
+++ b/react/src/components/meteors/index.ts
@@ -1,0 +1,2 @@
+export { Meteors } from "./Meteors.js";
+export type { MeteorsProps } from "./Meteors.js";

--- a/react/src/components/meteors/meteors.css
+++ b/react/src/components/meteors/meteors.css
@@ -1,0 +1,17 @@
+@keyframes meteor-fall {
+	0% {
+		transform: rotate(215deg) translateX(0);
+		opacity: 1;
+	}
+	70% {
+		opacity: 1;
+	}
+	100% {
+		transform: rotate(215deg) translateX(-500px);
+		opacity: 0;
+	}
+}
+
+.meteor {
+	animation: meteor-fall 5s linear infinite;
+}

--- a/react/src/components/rainbow-button/RainbowButton.test.tsx
+++ b/react/src/components/rainbow-button/RainbowButton.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
+import { RainbowButton } from "./RainbowButton.js";
+
+describe("RainbowButton", () => {
+	afterEach(cleanup);
+
+	it("renders a button element by default", () => {
+		render(<RainbowButton />);
+		expect(screen.getByRole("button")).toBeInTheDocument();
+	});
+
+	it("renders an anchor element when href is provided", () => {
+		render(<RainbowButton href="/test" />);
+		expect(screen.getByRole("link")).toBeInTheDocument();
+	});
+
+	it("applies the href to the anchor element", () => {
+		render(<RainbowButton href="/test" />);
+		expect(screen.getByRole("link")).toHaveAttribute("href", "/test");
+	});
+
+	it("sets the --rainbow-speed CSS custom property", () => {
+		render(<RainbowButton speed={5} />);
+		const button = screen.getByRole("button");
+		expect(button.getAttribute("style")).toContain("--rainbow-speed: 5s");
+	});
+
+	it("uses default speed of 2s", () => {
+		render(<RainbowButton />);
+		const button = screen.getByRole("button");
+		expect(button.getAttribute("style")).toContain("--rainbow-speed: 2s");
+	});
+
+	it("applies custom class names", () => {
+		render(<RainbowButton className="my-custom" />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("my-custom");
+	});
+
+	it("preserves base classes when custom class is added", () => {
+		render(<RainbowButton className="extra" />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("rainbow-button");
+		expect(button.className).toContain("rounded-xl");
+	});
+
+	it("supports disabled state on button", () => {
+		render(<RainbowButton disabled />);
+		expect(screen.getByRole("button")).toBeDisabled();
+	});
+
+	it('sets type="button" by default', () => {
+		render(<RainbowButton />);
+		expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+	});
+
+	it("allows custom type attribute", () => {
+		render(<RainbowButton type="submit" />);
+		expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
+	});
+});

--- a/react/src/components/rainbow-button/RainbowButton.tsx
+++ b/react/src/components/rainbow-button/RainbowButton.tsx
@@ -1,0 +1,72 @@
+import { forwardRef } from "react";
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes, CSSProperties, ReactNode, Ref } from "react";
+import { cn } from "../../utils.js";
+import "./rainbow-button.css";
+
+type BaseProps = {
+	/** Animation speed in seconds */
+	speed?: number;
+	/** Custom CSS class */
+	className?: string;
+	/** Render as anchor element */
+	href?: string;
+	/** Button content */
+	children?: ReactNode;
+};
+
+export type RainbowButtonProps = BaseProps &
+	Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps> &
+	Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps>;
+
+// Note: unlike most components in this package, RainbowButton does not spread
+// rest props onto the rendered element — this mirrors the Svelte source,
+// which only reads class/speed/href/type/disabled/ref/children off $props()
+// and has no ...restProps spread. Attributes typed as valid via the union
+// (e.g. onClick) are accepted by the props type but not forwarded.
+export const RainbowButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, RainbowButtonProps>(
+	({ className, speed = 2, href, type = "button", disabled, children }, ref) => {
+		const speedStyle = { "--rainbow-speed": `${speed}s` } as CSSProperties;
+
+		const baseClasses = cn(
+			"rainbow-button",
+			"group relative inline-flex h-11 cursor-pointer items-center justify-center rounded-xl border-0 bg-[length:200%] px-8 py-2 font-medium transition-colors [background-clip:padding-box,border-box,border-box] [background-origin:border-box] [border:calc(0.08*1rem)_solid_transparent] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+			// Glow effect
+			"before:absolute before:bottom-[-20%] before:left-1/2 before:z-0 before:h-1/5 before:w-3/5 before:-translate-x-1/2 before:animate-rainbow before:bg-[linear-gradient(90deg,var(--rainbow-1),var(--rainbow-5),var(--rainbow-3),var(--rainbow-4),var(--rainbow-2))] before:bg-[length:200%] before:[filter:blur(calc(0.8*1rem))]",
+			// Light mode: dark button with light text
+			"text-white bg-[linear-gradient(#121213,#121213),linear-gradient(#121213_50%,rgba(18,18,19,0.6)_80%,rgba(18,18,19,0)),linear-gradient(90deg,var(--rainbow-1),var(--rainbow-5),var(--rainbow-3),var(--rainbow-4),var(--rainbow-2))]",
+			// Dark mode: light button with dark text
+			"dark:text-black dark:bg-[linear-gradient(#fff,#fff),linear-gradient(#fff_50%,rgba(255,255,255,0.6)_80%,rgba(0,0,0,0)),linear-gradient(90deg,var(--rainbow-1),var(--rainbow-5),var(--rainbow-3),var(--rainbow-4),var(--rainbow-2))]",
+			className
+		);
+
+		if (href) {
+			return (
+				<a
+					ref={ref as Ref<HTMLAnchorElement>}
+					className={baseClasses}
+					style={speedStyle}
+					href={href}
+					aria-disabled={disabled}
+					role={disabled ? "link" : undefined}
+					tabIndex={disabled ? -1 : undefined}
+				>
+					{children}
+				</a>
+			);
+		}
+
+		return (
+			<button
+				ref={ref as Ref<HTMLButtonElement>}
+				className={baseClasses}
+				style={speedStyle}
+				type={type}
+				disabled={disabled}
+			>
+				{children}
+			</button>
+		);
+	}
+);
+
+RainbowButton.displayName = "RainbowButton";

--- a/react/src/components/rainbow-button/RainbowButton.tsx
+++ b/react/src/components/rainbow-button/RainbowButton.tsx
@@ -14,9 +14,18 @@ type BaseProps = {
 	children?: ReactNode;
 };
 
-export type RainbowButtonProps = BaseProps &
-	Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps> &
-	Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps>;
+// The two attribute sets are intersected BEFORE `Omit`, then extended as one:
+// an interface may not extend two types that name the same property with
+// different signatures (`onAbort` and friends differ between button and
+// anchor), while an intersection tolerates it. Same resulting type as the
+// alias this replaces — the interface form is the tooling contract in
+// PORTING.md.
+type RainbowButtonElementProps = Omit<
+	ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement>,
+	keyof BaseProps
+>;
+
+export interface RainbowButtonProps extends BaseProps, RainbowButtonElementProps {}
 
 // Note: unlike most components in this package, RainbowButton does not spread
 // rest props onto the rendered element — this mirrors the Svelte source,

--- a/react/src/components/rainbow-button/index.ts
+++ b/react/src/components/rainbow-button/index.ts
@@ -1,0 +1,2 @@
+export { RainbowButton } from "./RainbowButton.js";
+export type { RainbowButtonProps } from "./RainbowButton.js";

--- a/react/src/components/rainbow-button/rainbow-button.css
+++ b/react/src/components/rainbow-button/rainbow-button.css
@@ -1,0 +1,24 @@
+.rainbow-button {
+	--rainbow-1: hsl(0 100% 63%);
+	--rainbow-2: hsl(270 100% 63%);
+	--rainbow-3: hsl(210 100% 63%);
+	--rainbow-4: hsl(195 100% 63%);
+	--rainbow-5: hsl(90 100% 63%);
+}
+
+@keyframes rainbow {
+	0% {
+		background-position: 0%;
+	}
+	100% {
+		background-position: 200%;
+	}
+}
+
+.animate-rainbow {
+	animation: rainbow var(--rainbow-speed, 2s) infinite linear;
+}
+
+.rainbow-button::before {
+	animation: rainbow var(--rainbow-speed, 2s) infinite linear;
+}

--- a/react/src/components/ripple-button/RippleButton.test.tsx
+++ b/react/src/components/ripple-button/RippleButton.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
+import { RippleButton } from "./RippleButton.js";
+
+describe("RippleButton", () => {
+	afterEach(cleanup);
+
+	it("renders a button element", () => {
+		render(<RippleButton />);
+		expect(screen.getByRole("button")).toBeInTheDocument();
+	});
+
+	it("has overflow-hidden class", () => {
+		render(<RippleButton />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("overflow-hidden");
+	});
+
+	it("has rounded-lg class", () => {
+		render(<RippleButton />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("rounded-lg");
+	});
+
+	it("sets --ripple-duration CSS custom property", () => {
+		render(<RippleButton duration={800} />);
+		const button = screen.getByRole("button");
+		expect(button.getAttribute("style")).toContain("--ripple-duration: 800ms");
+	});
+
+	it("applies custom class names", () => {
+		render(<RippleButton className="my-ripple" />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("my-ripple");
+	});
+
+	it("preserves base classes when custom class is added", () => {
+		render(<RippleButton className="extra" />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("overflow-hidden");
+		expect(button.className).toContain("rounded-lg");
+	});
+
+	it("forwards native button attributes", () => {
+		render(<RippleButton disabled aria-label="Click me" />);
+		const button = screen.getByRole("button");
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute("aria-label", "Click me");
+	});
+});

--- a/react/src/components/ripple-button/RippleButton.tsx
+++ b/react/src/components/ripple-button/RippleButton.tsx
@@ -62,7 +62,7 @@ export const RippleButton = forwardRef<HTMLButtonElement, RippleButtonProps>(
 					assignRef(ref, node);
 				}}
 				className={cn(
-					"relative flex cursor-pointer items-center justify-center overflow-hidden",
+					"ripple-button relative flex cursor-pointer items-center justify-center overflow-hidden",
 					"bg-background text-primary rounded-lg border-2 px-4 py-2 text-center",
 					className
 				)}

--- a/react/src/components/ripple-button/RippleButton.tsx
+++ b/react/src/components/ripple-button/RippleButton.tsx
@@ -1,0 +1,95 @@
+import { forwardRef, useRef, useState } from "react";
+import type { ButtonHTMLAttributes, CSSProperties, MouseEvent, ReactNode, Ref } from "react";
+import { cn } from "../../utils.js";
+import "./ripple-button.css";
+
+export interface RippleButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className"> {
+	/** Additional CSS classes */
+	className?: string;
+	/** Color of the ripple effect */
+	rippleColor?: string;
+	/** Animation duration in milliseconds */
+	duration?: number;
+	/** Button content */
+	children?: ReactNode;
+}
+
+interface RippleState {
+	x: number;
+	y: number;
+	size: number;
+	key: number;
+}
+
+function assignRef<T>(ref: Ref<T> | undefined, node: T | null) {
+	if (typeof ref === "function") ref(node);
+	else if (ref) (ref as { current: T | null }).current = node;
+}
+
+export const RippleButton = forwardRef<HTMLButtonElement, RippleButtonProps>(
+	({ className, rippleColor = "#ADD8E6", duration = 600, children, onClick, ...restProps }, ref) => {
+		const buttonRef = useRef<HTMLButtonElement | null>(null);
+		const [ripples, setRipples] = useState<RippleState[]>([]);
+
+		function createRipple(event: MouseEvent<HTMLButtonElement>) {
+			const button = buttonRef.current;
+			if (!button) return;
+
+			const rect = button.getBoundingClientRect();
+			const size = Math.max(rect.width, rect.height);
+			const x = event.clientX - rect.left - size / 2;
+			const y = event.clientY - rect.top - size / 2;
+
+			const newRipple: RippleState = { x, y, size, key: Date.now() };
+			setRipples((prev) => [...prev, newRipple]);
+
+			// Remove ripple after animation completes
+			setTimeout(() => {
+				setRipples((prev) => prev.filter((r) => r.key !== newRipple.key));
+			}, duration);
+		}
+
+		function handleClick(event: MouseEvent<HTMLButtonElement>) {
+			createRipple(event);
+			// Call the original onClick handler if provided
+			onClick?.(event);
+		}
+
+		return (
+			<button
+				ref={(node) => {
+					buttonRef.current = node;
+					assignRef(ref, node);
+				}}
+				className={cn(
+					"relative flex cursor-pointer items-center justify-center overflow-hidden",
+					"bg-background text-primary rounded-lg border-2 px-4 py-2 text-center",
+					className
+				)}
+				style={{ "--ripple-duration": `${duration}ms` } as CSSProperties}
+				onClick={handleClick}
+				{...restProps}
+			>
+				<div className="relative z-10">{children}</div>
+
+				<span className="pointer-events-none absolute inset-0">
+					{ripples.map((ripple) => (
+						<span
+							key={ripple.key}
+							className="ripple-animation absolute rounded-full opacity-30"
+							style={{
+								width: `${ripple.size}px`,
+								height: `${ripple.size}px`,
+								top: `${ripple.y}px`,
+								left: `${ripple.x}px`,
+								backgroundColor: rippleColor,
+							}}
+						/>
+					))}
+				</span>
+			</button>
+		);
+	}
+);
+
+RippleButton.displayName = "RippleButton";

--- a/react/src/components/ripple-button/index.ts
+++ b/react/src/components/ripple-button/index.ts
@@ -1,0 +1,2 @@
+export { RippleButton } from "./RippleButton.js";
+export type { RippleButtonProps } from "./RippleButton.js";

--- a/react/src/components/ripple-button/ripple-button.css
+++ b/react/src/components/ripple-button/ripple-button.css
@@ -9,6 +9,9 @@
 	}
 }
 
-.ripple-animation {
+/* Anchored on the root class (added in the port — the Svelte compiler scoped
+   this rule; as plain CSS it would leak into any consumer element named
+   .ripple-animation). See PORTING.md, styling rule 2. */
+.ripple-button .ripple-animation {
 	animation: rippling var(--ripple-duration, 600ms) ease-out forwards;
 }

--- a/react/src/components/ripple-button/ripple-button.css
+++ b/react/src/components/ripple-button/ripple-button.css
@@ -1,0 +1,14 @@
+@keyframes rippling {
+	0% {
+		transform: scale(0);
+		opacity: 0.3;
+	}
+	100% {
+		transform: scale(2);
+		opacity: 0;
+	}
+}
+
+.ripple-animation {
+	animation: rippling var(--ripple-duration, 600ms) ease-out forwards;
+}

--- a/react/src/components/shimmer-button/ShimmerButton.test.tsx
+++ b/react/src/components/shimmer-button/ShimmerButton.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
+import { ShimmerButton } from "./ShimmerButton.js";
+
+describe("ShimmerButton", () => {
+	afterEach(cleanup);
+
+	it("renders a button element", () => {
+		render(<ShimmerButton />);
+		expect(screen.getByRole("button")).toBeInTheDocument();
+	});
+
+	it("applies default CSS custom properties", () => {
+		render(<ShimmerButton />);
+		const button = screen.getByRole("button");
+		const style = button.getAttribute("style") ?? "";
+		expect(style).toContain("--shimmer-color: #ffffff");
+		expect(style).toContain("--speed: 3s");
+		expect(style).toContain("--bg: rgba(0, 0, 0, 1)");
+	});
+
+	it("applies custom shimmerColor", () => {
+		render(<ShimmerButton shimmerColor="#ff0000" />);
+		const button = screen.getByRole("button");
+		expect(button.getAttribute("style")).toContain("--shimmer-color: #ff0000");
+	});
+
+	it("applies custom background", () => {
+		render(<ShimmerButton background="rgba(0, 0, 255, 0.5)" />);
+		const button = screen.getByRole("button");
+		expect(button.getAttribute("style")).toContain("--bg: rgba(0, 0, 255, 0.5)");
+	});
+
+	it("applies custom shimmerDuration", () => {
+		render(<ShimmerButton shimmerDuration="5s" />);
+		const button = screen.getByRole("button");
+		expect(button.getAttribute("style")).toContain("--speed: 5s");
+	});
+
+	it("applies custom borderRadius", () => {
+		render(<ShimmerButton borderRadius="8px" />);
+		const button = screen.getByRole("button");
+		expect(button.getAttribute("style")).toContain("--radius: 8px");
+	});
+
+	it("applies custom class names", () => {
+		render(<ShimmerButton className="my-shimmer" />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("my-shimmer");
+	});
+
+	it("preserves base classes when custom class is added", () => {
+		render(<ShimmerButton className="extra" />);
+		const button = screen.getByRole("button");
+		expect(button.className).toContain("shimmer-button");
+		expect(button.className).toContain("overflow-hidden");
+	});
+
+	it("contains shimmer layer div", () => {
+		render(<ShimmerButton />);
+		const button = screen.getByRole("button");
+		const shimmerLayer = button.querySelector(".shimmer-slide");
+		expect(shimmerLayer).toBeInTheDocument();
+	});
+
+	it("contains spin-around element", () => {
+		render(<ShimmerButton />);
+		const button = screen.getByRole("button");
+		const spinAround = button.querySelector(".spin-around");
+		expect(spinAround).toBeInTheDocument();
+	});
+
+	it("forwards native button attributes", () => {
+		render(<ShimmerButton disabled aria-label="Submit" />);
+		const button = screen.getByRole("button");
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute("aria-label", "Submit");
+	});
+});

--- a/react/src/components/shimmer-button/ShimmerButton.tsx
+++ b/react/src/components/shimmer-button/ShimmerButton.tsx
@@ -1,0 +1,87 @@
+import { forwardRef } from "react";
+import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from "react";
+import { cn } from "../../utils.js";
+import "./shimmer-button.css";
+
+type BaseProps = {
+	/** Shimmer highlight color */
+	shimmerColor?: string;
+	/** Thickness of the shimmer border */
+	shimmerSize?: string;
+	/** Button border radius */
+	borderRadius?: string;
+	/** Duration of the shimmer animation cycle */
+	shimmerDuration?: string;
+	/** Button background color */
+	background?: string;
+	/** Custom CSS class */
+	className?: string;
+	/** Button content */
+	children?: ReactNode;
+};
+
+export type ShimmerButtonProps = BaseProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>;
+
+export const ShimmerButton = forwardRef<HTMLButtonElement, ShimmerButtonProps>(
+	(
+		{
+			className,
+			shimmerColor = "#ffffff",
+			shimmerSize = "0.05em",
+			borderRadius = "100px",
+			shimmerDuration = "3s",
+			background = "rgba(0, 0, 0, 1)",
+			children,
+			...restProps
+		},
+		ref
+	) => {
+		const styleVars = {
+			"--spread": "90deg",
+			"--shimmer-color": shimmerColor,
+			"--radius": borderRadius,
+			"--speed": shimmerDuration,
+			"--cut": shimmerSize,
+			"--bg": background,
+		} as CSSProperties;
+
+		return (
+			<button
+				ref={ref}
+				className={cn(
+					"shimmer-button group relative z-0 flex cursor-pointer items-center justify-center overflow-hidden [border-radius:var(--radius)] border border-white/10 px-6 py-3 whitespace-nowrap text-white [background:var(--bg)]",
+					"transform-gpu transition-transform duration-300 ease-in-out active:translate-y-px",
+					className
+				)}
+				style={styleVars}
+				{...restProps}
+			>
+				{/* Shimmer layer */}
+				<div className="[container-type:size] absolute inset-0 -z-30 overflow-visible blur-[2px]">
+					<div className="shimmer-slide absolute inset-0 [aspect-ratio:1] h-[100cqh] [border-radius:0] [mask:none]">
+						<div className="spin-around absolute -inset-full w-auto [translate:0_0] rotate-0 [background:conic-gradient(from_calc(270deg-(var(--spread)*0.5)),transparent_0,var(--shimmer-color)_var(--spread),transparent_var(--spread))]" />
+					</div>
+				</div>
+
+				{/* Content */}
+				{children}
+
+				{/* Inner shadow overlay */}
+				<div
+					className={cn(
+						"insert-0 absolute size-full",
+						"rounded-2xl px-4 py-1.5 text-sm font-medium shadow-[inset_0_-8px_10px_#ffffff1f]",
+						"transform-gpu transition-all duration-300 ease-in-out",
+						"group-hover:shadow-[inset_0_-6px_10px_#ffffff3f]",
+						"group-active:shadow-[inset_0_-10px_10px_#ffffff3f]"
+					)}
+				/>
+
+				{/* Background fill */}
+				<div className="absolute [inset:var(--cut)] -z-20 [border-radius:var(--radius)] [background:var(--bg)]" />
+			</button>
+		);
+	}
+);
+
+ShimmerButton.displayName = "ShimmerButton";

--- a/react/src/components/shimmer-button/ShimmerButton.tsx
+++ b/react/src/components/shimmer-button/ShimmerButton.tsx
@@ -20,7 +20,9 @@ type BaseProps = {
 	children?: ReactNode;
 };
 
-export type ShimmerButtonProps = BaseProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>;
+export interface ShimmerButtonProps
+	extends BaseProps,
+		Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps> {}
 
 export const ShimmerButton = forwardRef<HTMLButtonElement, ShimmerButtonProps>(
 	(

--- a/react/src/components/shimmer-button/index.ts
+++ b/react/src/components/shimmer-button/index.ts
@@ -1,0 +1,2 @@
+export { ShimmerButton } from "./ShimmerButton.js";
+export type { ShimmerButtonProps } from "./ShimmerButton.js";

--- a/react/src/components/shimmer-button/shimmer-button.css
+++ b/react/src/components/shimmer-button/shimmer-button.css
@@ -1,0 +1,32 @@
+@keyframes shimmer-slide {
+	to {
+		transform: translate(calc(100cqw - 100%), 0);
+	}
+}
+
+@keyframes spin-around {
+	0% {
+		transform: translateZ(0) rotate(0);
+	}
+	15%,
+	35% {
+		transform: translateZ(0) rotate(90deg);
+	}
+	65%,
+	85% {
+		transform: translateZ(0) rotate(270deg);
+	}
+	100% {
+		transform: translateZ(0) rotate(360deg);
+	}
+}
+
+/* Anchored on the root class: the Svelte compiler scoped these rules, plain CSS
+   would leak them into every consumer element sharing the class name. */
+.shimmer-button .shimmer-slide {
+	animation: shimmer-slide var(--speed) ease-in-out infinite alternate;
+}
+
+.shimmer-button .spin-around {
+	animation: spin-around calc(var(--speed) * 2) infinite linear;
+}

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -1,0 +1,23 @@
+// fancy-ui-react — public barrel. One export block per component folder,
+// mirroring src/lib/fancy-ui/index.ts on the Svelte side. The cameleon skin
+// engine is deliberately NOT here (parity with the Svelte barrel); it ships
+// through the "fancy-ui-react/cameleon" subpath export instead.
+export { cn } from "./utils.js";
+
+export { RainbowButton } from "./components/rainbow-button/index.js";
+export type { RainbowButtonProps } from "./components/rainbow-button/index.js";
+export { RippleButton } from "./components/ripple-button/index.js";
+export type { RippleButtonProps } from "./components/ripple-button/index.js";
+export { ShimmerButton } from "./components/shimmer-button/index.js";
+export type { ShimmerButtonProps } from "./components/shimmer-button/index.js";
+export { GradientButton } from "./components/gradient-button/index.js";
+export type { GradientButtonProps } from "./components/gradient-button/index.js";
+export { InteractiveHoverButton } from "./components/interactive-hover-button/index.js";
+export type { InteractiveHoverButtonProps } from "./components/interactive-hover-button/index.js";
+
+export { Marquee, ReviewCard } from "./components/marquee/index.js";
+export type { MarqueeProps, ReviewCardProps } from "./components/marquee/index.js";
+export { BorderBeam } from "./components/border-beam/index.js";
+export type { BorderBeamProps } from "./components/border-beam/index.js";
+export { Meteors } from "./components/meteors/index.js";
+export type { MeteorsProps } from "./components/meteors/index.js";

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -1,3 +1,5 @@
+"use client";
+
 // fancy-ui-react — public barrel. One export block per component folder,
 // mirroring src/lib/fancy-ui/index.ts on the Svelte side. The cameleon skin
 // engine is deliberately NOT here (parity with the Svelte barrel); it ships

--- a/react/src/test-setup.ts
+++ b/react/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/react/src/utils.test.ts
+++ b/react/src/utils.test.ts
@@ -1,0 +1,10 @@
+import { cn } from "./utils.js";
+
+describe("cn", () => {
+	it("merges conflicting Tailwind classes, last wins", () => {
+		expect(cn("px-2", "px-4")).toBe("px-4");
+	});
+	it("drops falsy inputs", () => {
+		expect(cn("a", false && "b", undefined, "c")).toBe("a c");
+	});
+});

--- a/react/src/utils.ts
+++ b/react/src/utils.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/** Merge class names with Tailwind-aware conflict resolution. Mirrors src/lib/utils.ts. */
+export function cn(...inputs: ClassValue[]): string {
+	return twMerge(clsx(inputs));
+}

--- a/react/tailwind.css
+++ b/react/tailwind.css
@@ -1,0 +1,12 @@
+/*
+ * Tailwind v4 integration for fancy-ui-react consumers.
+ *
+ * Usage in the consuming app's CSS:
+ *   @import "tailwindcss";
+ *   @import "fancy-ui-react/tailwind.css";
+ *
+ * The @source directive points Tailwind at this package's shipped output so
+ * every utility class the components use is generated in the consumer's build.
+ * Mirrors fancy-ui-svelte/tailwind.css.
+ */
+@source "./dist";

--- a/react/tailwind.css
+++ b/react/tailwind.css
@@ -10,3 +10,49 @@
  * Mirrors fancy-ui-svelte/tailwind.css.
  */
 @source "./dist";
+
+/*
+ * The semantic colour names the components actually spend: `bg-background`,
+ * `bg-primary` / `text-primary`, `text-primary-foreground`, `ring-ring`. None
+ * of these exist in Tailwind's default palette, so without this block the two
+ * documented imports generate the utilities and they resolve to nothing — the
+ * InteractiveHoverButton's hover fill and its contrasting label simply do not
+ * paint unless the consumer happens to run the same custom theme.
+ *
+ * `@theme inline` on purpose: each utility resolves `var(--primary)` at USE
+ * time rather than baking a value in, so an app that already defines the
+ * shadcn token set (the common case, and where these names come from) keeps
+ * its own colours with no configuration here. The defaults below only fill in
+ * when nothing else defines them.
+ */
+@theme inline {
+	--color-background: var(--background);
+	--color-primary: var(--primary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-ring: var(--ring);
+}
+
+/*
+ * Defaults, in `@layer base` rather than a bare `:root`: a consumer's own
+ * token block is almost always unlayered, and unlayered rules beat layered
+ * ones whatever the import order. So these apply when the app defines
+ * nothing, and lose the moment it does — no `!important`, no ordering
+ * requirement in the app's CSS. Values match the shadcn defaults the Svelte
+ * package's own docs site runs on, so the two packages look alike out of the
+ * box. `.dark` mirrors what the docs site switches to.
+ */
+@layer base {
+	:root {
+		--background: oklch(1 0 0);
+		--primary: oklch(0.208 0.042 265.755);
+		--primary-foreground: oklch(0.984 0.003 247.858);
+		--ring: oklch(0.704 0.04 256.788);
+	}
+
+	.dark {
+		--background: oklch(0.05 0 0);
+		--primary: oklch(0.929 0.013 255.508);
+		--primary-foreground: oklch(0.05 0 0);
+		--ring: oklch(0.551 0.027 264.364);
+	}
+}

--- a/react/tsconfig.build.json
+++ b/react/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"emitDeclarationOnly": true,
+		"declaration": true,
+		"outDir": "dist",
+		"rootDir": "src",
+		"types": []
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.tsx", "src/**/*.test.ts", "src/test-setup.ts"]
+}

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"jsx": "react-jsx",
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"verbatimModuleSyntax": true,
+		"isolatedModules": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"types": ["vitest/globals", "@testing-library/jest-dom"]
+	},
+	"include": ["src", "vite.config.ts", "vitest.config.ts"]
+}

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// Library build only — declarations come from `tsc -p tsconfig.build.json`
+// (the build script runs both). CSS from component imports is extracted into a
+// single dist/styles.css; consumers import "fancy-ui-react/styles.css" once.
+export default defineConfig({
+	plugins: [react()],
+	build: {
+		lib: {
+			entry: { index: "src/index.ts", cameleon: "src/cameleon/index.ts" },
+			formats: ["es"],
+			cssFileName: "styles",
+		},
+		rollupOptions: {
+			external: [
+				"react",
+				"react-dom",
+				"react/jsx-runtime",
+				"react/jsx-dev-runtime",
+				"clsx",
+				"tailwind-merge",
+			],
+		},
+	},
+});

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -13,6 +13,18 @@ export default defineConfig({
 			cssFileName: "styles",
 		},
 		rollupOptions: {
+			// Every built entry is a client module. Rollup strips module-level
+			// directives when it bundles, so a `"use client"` written in a
+			// source file would not survive into `dist/` — the banner is what
+			// actually reaches the consumer. Without it an RSC app importing
+			// `fancy-ui-react` classifies the entry as server code and rejects
+			// the `useState`/`useMemo` inside `RippleButton`, `Meteors` and
+			// the cameleon provider. The whole entry is marked rather than
+			// individual components because a single-chunk lib build has no
+			// per-component module boundary left to mark.
+			output: {
+				banner: '"use client";',
+			},
 			external: [
 				"react",
 				"react-dom",

--- a/react/vitest.config.ts
+++ b/react/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+	test: {
+		environment: "jsdom",
+		globals: true,
+		setupFiles: ["src/test-setup.ts"],
+		include: ["src/**/*.test.{ts,tsx}"],
+	},
+});


### PR DESCRIPTION
## Summary

Opening move of the dual-framework effort: **the library becomes consumable from React** without touching anything that ships to Svelte consumers.

- **`react/` is fully standalone** — own `package.json` (`fancy-ui-react`), own lockfile, own `node_modules`, own vite lib build + `tsc` declarations. The SvelteKit app, the packaging boundary and the `fancy-ui-svelte` npm surface are untouched. The repo-root `pnpm-workspace.yaml` is not modified; `react/` carries its own copy doing the same two jobs locally (install-root marker + esbuild build-script allowance — and yes, pnpm tried to inject the historical `set this to true or false` placeholder during setup; it's fixed and documented in the file).
- **The cameleon skin engine, ported**: `FancyProvider`, `useSkin`, all ten primitives, the default/brutal/glass/terminal/retro-os skins — tokens, recipes, meta, ornaments and per-skin CSS **byte-identical** to source. Shipped via the `fancy-ui-react/cameleon` subpath export (the main barrel mirrors the Svelte barrel, which deliberately keeps the engine out).
- **Eight flagship components**: RainbowButton, RippleButton, ShimmerButton, GradientButton, InteractiveHoverButton, Marquee (+ReviewCard), BorderBeam, Meteors.
- **`react/PORTING.md` is the law** for this and every future batch: rune→hook mapping, verbatim Tailwind class strings (the consumer's scanner reads `dist/` via `fancy-ui-react/tailwind.css`), Svelte `<style>` blocks → colocated CSS anchored on the root class, `<Name>Props` interfaces as the tooling contract, forwardRef exactly where the source has `ref = $bindable`.

## Notes for review

**Two-way binding had to become idiomatic React.** `$bindable` props (Input value, Checkbox/Switch checked, Radio group, Slider value) are uncontrolled-by-default and become standard controlled components when the prop is passed. A bare `<Switch />` flips on click, exactly like the Svelte one.

**Scope leaks caught and fixed in review.** Svelte compiler-scoped rules like `.shimmer-slide` / `.gradient-border` would have been global CSS in the port, restyling any consumer element sharing those class names — re-anchored under each component's root class. Also fixed: Switch was omitting `onClick` pass-through (controlled usage would have been deaf), and Meteors now re-randomizes when `count` changes, matching the source's `$derived` tracking.

**Empty changeset on purpose** — `fancy-ui-svelte` is unaffected; the gate requires a file, not a bump.

**Aurora**: that skin lives in the landing PR (#215) and is not on develop yet; it gets ported in a follow-up once #215 merges.

## Test plan

- [x] `pnpm test` (react/) — 104 tests, 14 files: transposed Svelte suites + a new engine suite (the Svelte engine has none)
- [x] `pnpm check` (react/) — tsc clean, strict + noUncheckedIndexedAccess
- [x] `pnpm build` (react/) — `index.js` 13 kB, `cameleon.js` 52 kB, `styles.css`, full `.d.ts` tree with every `<Name>Props`
- [x] Browser smoke on a real Tailwind build: rainbow glow, shimmer sweep, beam travelling the frame, meteor shower, seamless marquee with duplicated track, ripple spawn + self-cleanup, switch toggling `aria-checked`, glass and brutal skins restyling all primitives — brutal's arrow ornament included
- [x] Root CI untouched except the additive `React package` job; root `pnpm-workspace.yaml` byte-identical
- [ ] Reviewer: `cd react && pnpm install && pnpm test` — the install must stay fully isolated (no lockfile churn at repo root)