### PR TITLE
feat(cameleon): publish the engine + retro-os kit foundations (atoms & ornaments)

### DIFF
--- a/.changeset/cameleon-published-retro-kit.md
+++ b/.changeset/cameleon-published-retro-kit.md
@@ -1,0 +1,16 @@
+---
+"fancy-ui-svelte": minor
+---
+
+The cameleon skin engine ships in the npm package. `fancy-ui-svelte/cameleon`
+exports `FancyProvider`, the ten themable primitives and the six skins;
+`fancy-ui-svelte/cameleon/retro-kit` is new — the retro-os skin's own component
+vocabulary, grown out of a real site built on the skin: `RetroButton` (the
+shadow-ladder press key, primary/outline, sm/md), the label kit (`Chip`,
+`NumChip`, `StatusPill`, `RetroTag`, `IconTile`, `InlineIndexLabel`), the
+ornaments (`PixelGlyph`, the `steps(1)`-blinking `Led` — reduced-motion aware,
+it stays lit — and `Swatches`), and the shared accent vocabulary
+(`Accent`, `accentVar`, `accentTint`). The kit's `.r-*` recipe layer and
+`--r-*` tokens load with the kit barrel and scope to `[data-skin="retro-os"]`,
+so a kit component outside a retro-os provider is visibly unpainted rather
+than silently wrong.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	],
 	"files": [
 		"dist/fancy-ui",
+		"dist/cameleon",
 		"dist/utils",
 		"dist/utils.js",
 		"dist/utils.d.ts",
@@ -53,6 +54,16 @@
 			"default": "./dist/fancy-ui/index.js"
 		},
 		"./tailwind.css": "./dist/fancy-ui/tailwind.css",
+		"./cameleon": {
+			"types": "./dist/cameleon/index.d.ts",
+			"svelte": "./dist/cameleon/index.js",
+			"default": "./dist/cameleon/index.js"
+		},
+		"./cameleon/retro-kit": {
+			"types": "./dist/cameleon/skins/retro-os/kit/index.d.ts",
+			"svelte": "./dist/cameleon/skins/retro-os/kit/index.js",
+			"default": "./dist/cameleon/skins/retro-os/kit/index.js"
+		},
 		"./cameleon/*": "./dist/cameleon/*"
 	},
 	"scripts": {

--- a/src/lib/cameleon/index.ts
+++ b/src/lib/cameleon/index.ts
@@ -1,11 +1,14 @@
 /**
  * Cameleon Engine — multi-skin UI primitives for fancy-ui.
  *
- * Same component API, radically different art directions ("skins"). Internal /
- * not published yet: this compiles to dist/cameleon but is not in package.json
- * `files`, so it stays a docs-site subsystem until deliberately promoted.
+ * Same component API, radically different art directions ("skins"): each skin
+ * carries tokens (CSS custom properties), recipes (pure functions returning
+ * class strings per primitive), optional ornaments and per-skin CSS.
  *
- *   import { FancyProvider, Button, brutalSkin } from "$lib/cameleon";
+ * Published as `fancy-ui-svelte/cameleon` (with the retro-os component kit at
+ * `fancy-ui-svelte/cameleon/retro-kit`). Consumers wrap a subtree:
+ *
+ *   import { FancyProvider, Button, brutalSkin } from "fancy-ui-svelte/cameleon";
  *   <FancyProvider skin={brutalSkin}> ... </FancyProvider>
  */
 export { default as FancyProvider, type FancyProviderProps } from "./FancyProvider.svelte";

--- a/src/lib/cameleon/skins/retro-os/kit/Chip.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/Chip.svelte
@@ -1,0 +1,43 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	export interface ChipProps {
+		/** "outline" = paper on ink border · "ink" = inverted · "tint" = a pale accent wash. */
+		tone?: "outline" | "ink" | "tint";
+		/** The tint color when tone="tint", e.g. "var(--r-tint-blue)". */
+		bg?: string;
+		/** Dashed border — the "provisional / not-a-link" signal. */
+		dashed?: boolean;
+		/** Additional CSS classes. */
+		class?: string;
+		children: Snippet;
+		/** data-* / aria-* … forwarded verbatim. */
+		[key: string]: unknown;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { tone = "outline", bg, dashed = false, class: className, children, ...rest }: ChipProps =
+		$props();
+
+	// Deliberately font-agnostic. Chips appear in both typefaces across the
+	// design (pixel for status-ish labels, mono for data-ish ones), and the
+	// choice belongs to the section, not to the chip — pass `.r-pixel` or
+	// `.r-mono` in `class`. Padding and size are Tailwind so cn()/twMerge lets
+	// a caller replace them without an inline-style fight.
+	const background = $derived(
+		tone === "ink" ? "var(--r-ink)" : tone === "tint" ? (bg ?? "var(--r-tint-gold)") : "var(--r-paper)"
+	);
+</script>
+
+<span
+	class={cn("r-border inline-flex items-center px-[8px] py-[2px] text-[11px]", className)}
+	style="background: {background}; color: {tone === 'ink'
+		? 'var(--r-paper)'
+		: 'var(--r-ink)'}; border-style: {dashed ? 'dashed' : 'solid'};"
+	{...rest}
+>
+	{@render children()}
+</span>

--- a/src/lib/cameleon/skins/retro-os/kit/IconTile.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/IconTile.svelte
@@ -1,0 +1,44 @@
+<script lang="ts" module>
+	export interface IconTileProps {
+		/** The mark itself — "W", "</>", "♪"… Decorative, never content. */
+		glyph: string;
+		/** Fill, normally the owning card's tint. */
+		bg: string;
+		/** Tile edge in px. */
+		size?: 30 | 34 | 38;
+		/** Additional CSS classes. */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { glyph, bg, size = 34, class: className }: IconTileProps = $props();
+
+	// Font size tracks the tile, but stays a Tailwind class (not an inline
+	// style) so a caller can dial it down through `class`.
+	const fontClass = $derived(
+		size === 38 ? "text-[11px]" : size === 34 ? "text-[12px]" : "text-[10px]"
+	);
+</script>
+
+<!--
+	The square that opens a card: a pixel monogram on the card's own tint.
+	aria-hidden because the glyph is a picture of the title that follows it.
+
+	box-border is load-bearing, not tidiness: the 2px border must eat INTO the
+	stated size, or a row of 38px tiles measures 42px and stops lining up with
+	the 38px grid it sits on.
+-->
+<span
+	aria-hidden="true"
+	class={cn(
+		"r-border r-pixel box-border inline-flex flex-none items-center justify-center",
+		fontClass,
+		className
+	)}
+	style="width: {size}px; height: {size}px; background: {bg}; color: var(--r-ink);"
+>
+	{glyph}
+</span>

--- a/src/lib/cameleon/skins/retro-os/kit/InlineIndexLabel.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/InlineIndexLabel.svelte
@@ -1,0 +1,27 @@
+<script lang="ts" module>
+	export interface InlineIndexLabelProps {
+		/** e.g. "01" — the ordinal, owned by the layout. */
+		index: string;
+		/** The label text, e.g. "THE BRIEF". */
+		label: string;
+		/** Additional CSS classes. */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { index, label, class: className }: InlineIndexLabelProps = $props();
+</script>
+
+<!--
+	`( 01 ) THE BRIEF` — the column header used where a block has no titlebar
+	of its own to number it, so the index moves inline into the body.
+-->
+<div
+	class={cn("r-mono text-[11px] font-bold tracking-[1px]", className)}
+	style="color: var(--r-muted);"
+>
+	( {index} )&nbsp;<span>{label}</span>
+</div>

--- a/src/lib/cameleon/skins/retro-os/kit/Led.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/Led.svelte
@@ -1,0 +1,29 @@
+<script lang="ts" module>
+	export interface LedProps {
+		/** Lamp color — green reads "online", rust reads "offline". */
+		color?: string;
+		/** Additional CSS classes. */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { color = "var(--r-green)", class: className }: LedProps = $props();
+</script>
+
+<!--
+	The status lamp next to "STATUS: ONLINE". Purely decorative: the state it
+	reports is already in the adjacent text, so announcing a second, wordless
+	copy of it would only add noise.
+
+	The blink is `.r-blink` (kit.css) rather than an inline `animation:` so the
+	prefers-reduced-motion rule can switch it off — an inline animation could
+	only be cancelled with !important.
+-->
+<span
+	aria-hidden="true"
+	class={cn("r-border r-blink inline-block h-[12px] w-[12px] flex-none", className)}
+	style="background: {color};"
+></span>

--- a/src/lib/cameleon/skins/retro-os/kit/NumChip.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/NumChip.svelte
@@ -1,0 +1,25 @@
+<script lang="ts" module>
+	export interface NumChipProps {
+		/** The index itself, e.g. "01" — an ordinal the layout owns, never content. */
+		label: string;
+		/** Additional CSS classes. */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { label, class: className }: NumChipProps = $props();
+</script>
+
+<!--
+	Inverted ink chip carrying a card's ordinal. No border: ink on ink would
+	draw nothing, and the chip is already its own silhouette.
+-->
+<span
+	class={cn("r-pixel inline-flex items-center px-[7px] py-[2px] text-[10px]", className)}
+	style="background: var(--r-ink); color: var(--r-paper);"
+>
+	{label}
+</span>

--- a/src/lib/cameleon/skins/retro-os/kit/PixelGlyph.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/PixelGlyph.svelte
@@ -1,0 +1,38 @@
+<script lang="ts" module>
+	export interface PixelGlyphProps {
+		/** Square edge in px (8 = button suffix, 14 = footer mark). */
+		cell?: number;
+		/** Gutter between the four squares, in px. */
+		gap?: number;
+		/** Ink margin around the grid, in px — what makes the ink read as a frame. */
+		pad?: number;
+		/** Additional CSS classes. */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { cell = 8, gap = 2, pad = 2, class: className }: PixelGlyphProps = $props();
+</script>
+
+<!--
+	The four-color mark: the whole palette compressed into 2×2 pixels.
+	Decorative by construction — aria-hidden, so a screen reader never announces
+	"blue rust green gold" in the middle of a button label.
+
+	Sizes are inline (`{cell}px`) rather than Tailwind arbitrary values because
+	they are props: Tailwind only emits classes it can find as literal strings
+	in the source, so `w-[{cell}px]` would compile to nothing.
+-->
+<span
+	aria-hidden="true"
+	class={cn("inline-grid", className)}
+	style="grid-template-columns: repeat(2, {cell}px); grid-template-rows: repeat(2, {cell}px); gap: {gap}px; padding: {pad}px; background: var(--r-ink);"
+>
+	<span style="background: var(--r-blue);"></span>
+	<span style="background: var(--r-rust);"></span>
+	<span style="background: var(--r-green);"></span>
+	<span style="background: var(--r-gold);"></span>
+</span>

--- a/src/lib/cameleon/skins/retro-os/kit/RetroButton.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/RetroButton.svelte
@@ -1,0 +1,76 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	export interface RetroButtonProps {
+		/** Renders an <a> when set, a <button type="button"> otherwise. */
+		href?: string;
+		/** Open in a new tab (adds rel="noopener noreferrer"). */
+		external?: boolean;
+		/** "primary" = the gold --r-btn key, "outline" = a paper key. */
+		variant?: "primary" | "outline";
+		/** "sm" = 10px key on a 2px shadow; "md" = 12px key on a 3px shadow. */
+		size?: "sm" | "md";
+		/** Append the 2×2 color mark. */
+		pixelGlyph?: boolean;
+		/** Additional CSS classes. */
+		class?: string;
+		children: Snippet;
+		/** aria-* / onclick / data-* … forwarded verbatim to the element. */
+		[key: string]: unknown;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import PixelGlyph from "./PixelGlyph.svelte";
+
+	let {
+		href,
+		external = false,
+		variant = "outline",
+		size = "md",
+		pixelGlyph = false,
+		class: className,
+		children,
+		...rest
+	}: RetroButtonProps = $props();
+
+	// Layout + size in Tailwind, color in a var: the kit's house rule. The
+	// shadow rung is part of the size because it is part of the key's scale —
+	// a 10px label on a 4px shadow reads as a mis-sized button, not a variant.
+	const classes = $derived(
+		cn(
+			"r-border r-pixel r-pressable inline-flex items-center justify-center gap-[10px] text-center",
+			size === "sm"
+				? "r-shadow-2 px-[12px] py-[7px] text-[10px]"
+				: "r-shadow-3 px-[22px] py-[10px] text-[12px]",
+			className
+		)
+	);
+
+	// `color` is set explicitly rather than inherited: many pages give plain
+	// <a> a link color, which is wrong on a key — the label is ink on the key's
+	// own surface, and the surface is what carries the accent.
+	const styles = $derived(
+		`background: ${variant === "primary" ? "var(--r-btn)" : "var(--r-paper)"}; color: var(--r-ink);`
+	);
+</script>
+
+{#if href}
+	<a
+		{href}
+		target={external ? "_blank" : undefined}
+		rel={external ? "noopener noreferrer" : undefined}
+		class={classes}
+		style={styles}
+		{...rest}
+	>
+		{@render children()}
+		{#if pixelGlyph}<PixelGlyph />{/if}
+	</a>
+{:else}
+	<button type="button" class={classes} style={styles} {...rest}>
+		{@render children()}
+		{#if pixelGlyph}<PixelGlyph />{/if}
+	</button>
+{/if}

--- a/src/lib/cameleon/skins/retro-os/kit/RetroTag.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/RetroTag.svelte
@@ -1,0 +1,35 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	export interface RetroTagProps {
+		/** Pill fill, normally the owning card's tint (e.g. "var(--r-tint-blue)"). */
+		bg?: string;
+		/** Additional CSS classes. */
+		class?: string;
+		children: Snippet;
+		/** data-* / aria-* … forwarded verbatim. */
+		[key: string]: unknown;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { bg = "var(--r-paper)", class: className, children, ...rest }: RetroTagProps = $props();
+</script>
+
+<!--
+	The tech-stack pill. Mono, because it labels a tool rather than speaking to
+	the reader; the tint is inherited from the card so a row of tags reads as
+	belonging to it rather than as six separate objects.
+-->
+<span
+	class={cn(
+		"r-border r-mono inline-flex items-center px-[8px] py-[2px] text-[10.5px] font-semibold",
+		className
+	)}
+	style="background: {bg}; color: var(--r-ink);"
+	{...rest}
+>
+	{@render children()}
+</span>

--- a/src/lib/cameleon/skins/retro-os/kit/StatusPill.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/StatusPill.svelte
@@ -1,0 +1,32 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	export interface StatusPillProps {
+		/** Fill — the pill's meaning IS its color (green = live, gold = in progress, …). */
+		bg: string;
+		/** Additional CSS classes. */
+		class?: string;
+		children: Snippet;
+		/** data-* / aria-* … forwarded verbatim. */
+		[key: string]: unknown;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { bg, class: className, children, ...rest }: StatusPillProps = $props();
+</script>
+
+<!--
+	Smallest pixel label in the system (9px): a state stamped on a card. `bg`
+	is required rather than defaulted because a status pill with no color is
+	not a status pill, it is a tag.
+-->
+<span
+	class={cn("r-border r-pixel inline-flex items-center px-[7px] py-[2px] text-[9px]", className)}
+	style="background: {bg}; color: var(--r-ink);"
+	{...rest}
+>
+	{@render children()}
+</span>

--- a/src/lib/cameleon/skins/retro-os/kit/Swatches.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/Swatches.svelte
@@ -1,0 +1,33 @@
+<script lang="ts" module>
+	export interface SwatchesProps {
+		/** Give each square the press physics — visual only, this component never switches anything. */
+		interactive?: boolean;
+		/** Additional CSS classes. */
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { interactive = false, class: className }: SwatchesProps = $props();
+
+	const SWATCHES = ["var(--r-blue)", "var(--r-rust)", "var(--r-gold)", "var(--r-green)"];
+</script>
+
+<!--
+	The palette, stated once: four squares, the whole accent set, no legend.
+	Decorative — it is the design system introducing itself, not a control.
+
+	`interactive` therefore adds hover physics and nothing else. A real skin
+	switcher belongs to the consuming app; keeping the two separate is what
+	stops a decorative row from growing click handlers.
+-->
+<span aria-hidden="true" class={cn("inline-flex gap-[8px]", className)}>
+	{#each SWATCHES as color (color)}
+		<span
+			class={cn("r-border h-[14px] w-[14px]", interactive && "r-pressable")}
+			style="background: {color};"
+		></span>
+	{/each}
+</span>

--- a/src/lib/cameleon/skins/retro-os/kit/accents.ts
+++ b/src/lib/cameleon/skins/retro-os/kit/accents.ts
@@ -1,0 +1,43 @@
+/**
+ * The four accents — the whole color decision surface of the retro-os kit.
+ *
+ * Kit components take an `Accent` rather than a CSS color so the choice stays
+ * nameable ("this section is the blue one") and so a section, its titlebar
+ * dot, its cards' hover shadows and their tag fills cannot drift apart.
+ *
+ * Prefer `import type { Accent }` where only the type is needed — a type-only
+ * import is erased entirely and can never form a module cycle.
+ */
+export type Accent = "blue" | "rust" | "gold" | "green";
+
+/** Accent → the saturated ink used for dots, chips and hover shadows. */
+export const ACCENT_VAR: Record<Accent, string> = {
+	blue: "var(--r-blue)",
+	rust: "var(--r-rust)",
+	gold: "var(--r-gold)",
+	green: "var(--r-green)",
+};
+
+/**
+ * Accent → its pale wash, used for fills large enough that the saturated
+ * value would take over the page (card tints, tag pills, titlebar
+ * backgrounds). Paired 1:1 with ACCENT_VAR on purpose: a tint that does not
+ * belong to the section's accent is the single most visible way this design
+ * goes wrong.
+ */
+export const ACCENT_TINT: Record<Accent, string> = {
+	blue: "var(--r-tint-blue)",
+	rust: "var(--r-tint-rust)",
+	gold: "var(--r-tint-gold)",
+	green: "var(--r-tint-green)",
+};
+
+/** `accentVar("rust")` → `"var(--r-rust)"`. */
+export function accentVar(accent: Accent): string {
+	return ACCENT_VAR[accent];
+}
+
+/** `accentTint("rust")` → `"var(--r-tint-rust)"`. */
+export function accentTint(accent: Accent): string {
+	return ACCENT_TINT[accent];
+}

--- a/src/lib/cameleon/skins/retro-os/kit/index.ts
+++ b/src/lib/cameleon/skins/retro-os/kit/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Retro-OS kit — the skin's own component vocabulary, beyond the shared
+ * primitives.
+ *
+ *   import { RetroButton, Chip, Led, type Accent } from "fancy-ui-svelte/cameleon/retro-kit";
+ *
+ * Two jobs, and they are the reason this barrel exists rather than everyone
+ * importing components by path:
+ *
+ *  1. It imports `./kit.css` — the `--r-*` tokens and `.r-*` recipe layer —
+ *     exactly once. Any consumer that renders a kit component has, by
+ *     construction, already pulled the recipes in. It is deliberately NOT
+ *     imported by the skin itself: using the retro-os skin without the kit
+ *     must not download the kit's CSS.
+ *  2. It names the accent vocabulary, the one piece of shared state between
+ *     otherwise independent components.
+ *
+ * Everything here renders under `<FancyProvider skin={retroOsSkin}>` — the
+ * tokens are scoped to `[data-skin="retro-os"]`, so outside that provider the
+ * components are visibly unpainted rather than silently wrong.
+ */
+
+import "./kit.css";
+
+export {
+	ACCENT_TINT,
+	ACCENT_VAR,
+	accentTint,
+	accentVar,
+	type Accent,
+} from "./accents.js";
+
+export { default as RetroButton, type RetroButtonProps } from "./RetroButton.svelte";
+export { default as Chip, type ChipProps } from "./Chip.svelte";
+export { default as NumChip, type NumChipProps } from "./NumChip.svelte";
+export { default as StatusPill, type StatusPillProps } from "./StatusPill.svelte";
+export { default as RetroTag, type RetroTagProps } from "./RetroTag.svelte";
+export { default as IconTile, type IconTileProps } from "./IconTile.svelte";
+export { default as InlineIndexLabel, type InlineIndexLabelProps } from "./InlineIndexLabel.svelte";
+export { default as PixelGlyph, type PixelGlyphProps } from "./PixelGlyph.svelte";
+export { default as Led, type LedProps } from "./Led.svelte";
+export { default as Swatches, type SwatchesProps } from "./Swatches.svelte";

--- a/src/lib/cameleon/skins/retro-os/kit/kit.css
+++ b/src/lib/cameleon/skins/retro-os/kit/kit.css
@@ -1,0 +1,247 @@
+/* =============================================================================
+   kit.css — the Retro-OS kit's token and recipe layer
+   =============================================================================
+
+   The retro-os KIT (RetroButton, Chip, Led, …) paints roughly a dozen values
+   over and over: a 2px ink border, a hard `Npx Npx 0` shadow, 36px graph
+   paper, two typefaces. They live here once, as `.r-*` recipe classes, so the
+   shapes of the design are named and the components only choose between them.
+
+   TOKENS
+   The `--r-*` vocabulary is declared below, scoped to `[data-skin="retro-os"]`
+   — the attribute FancyProvider stamps on its root. Most values alias the
+   skin's `--skin-*` tokens so the kit follows any token retune; the literals
+   (the button tint, the four pale washes, the prose ink) are kit-only colors
+   that deliberately do NOT exist at token level: `--r-btn` is a fill tint,
+   not an accent, and must not be conflated with `--skin-yellow`.
+
+   The scoping is also the safety: outside a retro-os provider none of these
+   variables exist, so a kit component rendered under another skin shows up
+   visibly unpainted instead of silently wrong.
+
+   WHERE IT IS IMPORTED
+   Once, from `kit/index.ts`, so it arrives with the kit barrel and cannot be
+   forgotten — and so a consumer who uses the retro-os SKIN without the kit
+   never downloads it.
+
+   CASCADE NOTE
+   This file is unlayered, while Tailwind parks its utilities in
+   `@layer utilities`. Unlayered declarations beat every layered one regardless
+   of specificity, so `.r-border` wins over a Tailwind `border-*` utility on
+   the same element no matter the source order. That is intended — the recipe
+   is the authority — but it means "override the recipe with a Tailwind class"
+   does not work. Override with the class the recipe itself provides (see the
+   shadow ladder), or with an inline `style`.
+
+   HOUSE RULE THE KIT COMPONENTS FOLLOW
+   Tailwind for LAYOUT and SIZE (flex/grid/gap/padding/font-size). Color,
+   font-family, border and shadow only ever come from `--r-*` vars or the
+   `.r-*` classes below.
+   ============================================================================= */
+
+[data-skin="retro-os"] {
+	--r-canvas: var(--skin-page-bg, #f1e9d4);
+	--r-paper: var(--skin-card, #faf5e6);
+	--r-ink: var(--skin-ink, #191308);
+	--r-muted: var(--skin-muted, #5c5340);
+	/* Body-copy ink: --r-ink is too heavy and --r-muted too light at 13.5px. */
+	--r-prose: #3d3629;
+	/* The gold KEY fill. A fill tint, not an accent — never --skin-yellow. */
+	--r-btn: #ecd77f;
+	--r-blue: var(--skin-blue, #3f62a7);
+	--r-rust: var(--skin-red, #a0442f);
+	--r-gold: var(--skin-yellow, #b8912b);
+	--r-green: var(--skin-green, #3a6b42);
+	/* The pale washes paired 1:1 with the four accents (see kit/accents.ts). */
+	--r-tint-gold: #f7efd2;
+	--r-tint-blue: #e8edf6;
+	--r-tint-green: #eaf2e4;
+	--r-tint-rust: #f8e8dc;
+	--r-font-pixel: var(--skin-font-pixel, "Silkscreen", "IBM Plex Mono", monospace);
+}
+
+/* -----------------------------------------------------------------------------
+   Shadow ladder
+   -----------------------------------------------------------------------------
+   The hard shadow is not a glow, it is a GAP: the object is a slab of paper
+   floating N pixels above the page and the offset is how far. The rungs are a
+   depth ordering, not a style palette — 2px small keys, 3px cards, 4px section
+   windows, 5px (as a drop-shadow, on the notched frame) the one thing that
+   floats above everything.
+
+   ORDER IS AN API. The rungs are declared ascending, so a component that needs
+   a taller rest shadow may add the taller class ALONGSIDE the shorter one:
+   equal specificity, later declaration wins. The pressable hover ladder below
+   is declared in the same order for the same reason.
+
+   `soft` is the one non-ink shadow: translucent ink for objects meant to read
+   as unselected/at rest among peers. rgba(), not a var(): a color token cannot
+   be given an alpha inside this shorthand without color-mix(), and the literal
+   keeps the value readable.
+   -------------------------------------------------------------------------- */
+
+.r-shadow-2 {
+	box-shadow: 2px 2px 0 var(--r-ink);
+}
+
+.r-shadow-3 {
+	box-shadow: 3px 3px 0 var(--r-ink);
+}
+
+.r-shadow-4 {
+	box-shadow: 4px 4px 0 var(--r-ink);
+}
+
+.r-shadow-soft-3 {
+	box-shadow: 3px 3px 0 rgba(25, 19, 8, 0.35);
+}
+
+.r-shadow-soft-3-weak {
+	box-shadow: 3px 3px 0 rgba(25, 19, 8, 0.25);
+}
+
+/* -----------------------------------------------------------------------------
+   .r-pressable — the press physics
+   -----------------------------------------------------------------------------
+   Every retro affordance behaves like a key on a beige keyboard; the two states
+   are the same object at two heights, not two decorations:
+
+     :hover  → the slab RISES 1px: translate(-1px,-1px), and the shadow grows
+               by 1px because the gap between slab and page just widened.
+     :active → the slab is PRESSED FLAT: translate(2px,2px) with no shadow, so
+               the silhouette lands exactly where its shadow used to be. 2px
+               (not 1px) is what makes it land, given the -1px hover offset.
+
+   The hover shadow is a function of the RESTING shadow, which `.r-pressable`
+   cannot read off the element — so it is spelled out once per rung: 2→3, 3→4,
+   4→5, soft→4 (hovering is what selects the card, so the soft ink hardens).
+   `:active` needs no ladder: one rule at higher specificity than every
+   `.r-shadow-*`, and the pressed value is 0 whatever the rest height was.
+
+   WHY @media (hover: hover): on a touchscreen `:hover` sticks after a tap —
+   the key would stay raised until something else was tapped. Behind the query,
+   a tap gets `:active` only: press, release, done. The `:active` rule is
+   deliberately OUTSIDE the query for exactly that reason.
+
+   Nothing here transitions: the design snaps between states, and that
+   instantaneous 1px jump is the retro feel. A state change with zero duration
+   is not motion, so there is no prefers-reduced-motion escape hatch to write.
+   -------------------------------------------------------------------------- */
+
+.r-pressable {
+	cursor: pointer;
+}
+
+@media (hover: hover) {
+	.r-pressable:hover {
+		transform: translate(-1px, -1px);
+	}
+
+	.r-pressable.r-shadow-2:hover {
+		box-shadow: 3px 3px 0 var(--r-ink);
+	}
+
+	.r-pressable.r-shadow-3:hover {
+		box-shadow: 4px 4px 0 var(--r-ink);
+	}
+
+	.r-pressable.r-shadow-4:hover {
+		box-shadow: 5px 5px 0 var(--r-ink);
+	}
+
+	.r-pressable.r-shadow-soft-3:hover,
+	.r-pressable.r-shadow-soft-3-weak:hover {
+		box-shadow: 4px 4px 0 var(--r-ink);
+	}
+}
+
+.r-pressable:active {
+	transform: translate(2px, 2px);
+	box-shadow: 0 0 0 var(--r-ink);
+}
+
+/* -----------------------------------------------------------------------------
+   Structure — borders and rules
+   -------------------------------------------------------------------------- */
+
+/* The single most repeated declaration in the design. It never scales with the
+   viewport: at 2px it is a drawn line, not a proportion of anything. */
+.r-border {
+	border: 2px solid var(--r-ink);
+}
+
+/* Section-internal divider: a dashed rule above a footnote/credits row. */
+.r-dashed-top {
+	border-top: 2px dashed var(--r-ink);
+}
+
+/* -----------------------------------------------------------------------------
+   Surfaces
+   -------------------------------------------------------------------------- */
+
+/* 36px graph paper. Two repeating gradients, one per axis, each drawing a 1px
+   line then 35px of nothing. The ink is inlined as rgba() because a color
+   token cannot take an alpha inside a gradient stop, and 0.05 ink on cream is
+   the whole point of the effect. */
+.r-grid-bg {
+	background-image:
+		repeating-linear-gradient(0deg, rgba(25, 19, 8, 0.05) 0 1px, transparent 1px 36px),
+		repeating-linear-gradient(90deg, rgba(25, 19, 8, 0.05) 0 1px, transparent 1px 36px);
+}
+
+/* -----------------------------------------------------------------------------
+   Type
+   -----------------------------------------------------------------------------
+   Two families do all the work; body copy is the skin's own --skin-font-sans,
+   so there is no `.r-sans` — not needing a class is the point.
+
+   `.r-pixel` PINS font-weight:700: Silkscreen only ships 400 and 700 and every
+   pixel label in the design is the bold one, so the weight is part of the
+   recipe rather than a separate decision.
+   -------------------------------------------------------------------------- */
+
+.r-pixel {
+	font-family: var(--r-font-pixel);
+	font-weight: 700;
+}
+
+.r-mono {
+	font-family: var(--skin-font-mono, "IBM Plex Mono", monospace);
+}
+
+/* -----------------------------------------------------------------------------
+   Motion
+   -----------------------------------------------------------------------------
+   One animation exists in the whole kit: the status LED. `steps(1)` and the
+   60/61% split are what make it a hard blink (on, off) rather than a pulse —
+   a CRT indicator, not a breathing dot.
+
+   `.r-blink` is a class rather than an inline `animation:` on the component,
+   precisely so the reduced-motion override can reach it: an inline animation
+   could only be cancelled with !important.
+   -------------------------------------------------------------------------- */
+
+@keyframes r-blink {
+	0%,
+	60% {
+		opacity: 1;
+	}
+
+	61%,
+	100% {
+		opacity: 0.25;
+	}
+}
+
+.r-blink {
+	animation: r-blink 1.6s steps(1) infinite;
+}
+
+/* Reduced motion: the LED stays lit. Not dimmed and not hidden — it is a
+   status indicator, and lit is the state it is reporting. */
+@media (prefers-reduced-motion: reduce) {
+	.r-blink {
+		animation: none;
+		opacity: 1;
+	}
+}

--- a/src/lib/cameleon/skins/retro-os/kit/kit.test.ts
+++ b/src/lib/cameleon/skins/retro-os/kit/kit.test.ts
@@ -1,0 +1,143 @@
+import { render, screen, cleanup } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect } from "vitest";
+import RetroButton from "./RetroButton.svelte";
+import Chip from "./Chip.svelte";
+import NumChip from "./NumChip.svelte";
+import StatusPill from "./StatusPill.svelte";
+import RetroTag from "./RetroTag.svelte";
+import IconTile from "./IconTile.svelte";
+import InlineIndexLabel from "./InlineIndexLabel.svelte";
+import PixelGlyph from "./PixelGlyph.svelte";
+import Led from "./Led.svelte";
+import Swatches from "./Swatches.svelte";
+import { ACCENT_TINT, ACCENT_VAR, accentTint, accentVar } from "./accents.js";
+
+const label = (text: string) =>
+	createRawSnippet(() => ({ render: () => `<span>${text}</span>` }));
+
+describe("retro-os kit", () => {
+	afterEach(cleanup);
+
+	describe("RetroButton", () => {
+		it("renders a button by default and an anchor when href is set", () => {
+			render(RetroButton, { children: label("Press") });
+			expect(screen.getByRole("button", { name: "Press" })).toBeInTheDocument();
+			cleanup();
+
+			render(RetroButton, { href: "/docs", children: label("Go") });
+			const link = screen.getByRole("link", { name: "Go" });
+			expect(link).toHaveAttribute("href", "/docs");
+		});
+
+		it("ties the shadow rung to the size, not the variant", () => {
+			render(RetroButton, { size: "sm", children: label("S") });
+			expect(screen.getByRole("button")).toHaveClass("r-shadow-2");
+			cleanup();
+
+			render(RetroButton, { size: "md", variant: "primary", children: label("M") });
+			const md = screen.getByRole("button");
+			expect(md).toHaveClass("r-shadow-3", "r-pressable", "r-border", "r-pixel");
+			// The label is ink on the key's own surface, never the page link color.
+			expect(md.getAttribute("style")).toContain("var(--r-btn)");
+			expect(md.getAttribute("style")).toContain("color: var(--r-ink)");
+		});
+
+		it("appends the pixel glyph only when asked", () => {
+			const { container } = render(RetroButton, { pixelGlyph: true, children: label("CTA") });
+			expect(container.querySelector(".inline-grid")).toBeInTheDocument();
+		});
+
+		it("marks external links as noopener", () => {
+			render(RetroButton, { href: "https://example.com", external: true, children: label("Out") });
+			const link = screen.getByRole("link");
+			expect(link).toHaveAttribute("target", "_blank");
+			expect(link).toHaveAttribute("rel", "noopener noreferrer");
+		});
+	});
+
+	describe("label kit", () => {
+		it("Chip flips ink tone to paper text and honors dashed", () => {
+			const { container } = render(Chip, { tone: "ink", dashed: true, children: label("NDA") });
+			const chip = container.querySelector("span.r-border") as HTMLElement;
+			expect(chip.getAttribute("style")).toContain("var(--r-ink)");
+			expect(chip.getAttribute("style")).toContain("color: var(--r-paper)");
+			expect(chip.getAttribute("style")).toContain("border-style: dashed");
+		});
+
+		it("NumChip renders an inverted, borderless ordinal", () => {
+			render(NumChip, { label: "01" });
+			const chip = screen.getByText("01");
+			expect(chip).toHaveClass("r-pixel");
+			expect(chip).not.toHaveClass("r-border");
+			expect(chip.getAttribute("style")).toContain("var(--r-ink)");
+		});
+
+		it("StatusPill paints its required fill", () => {
+			const { container } = render(StatusPill, { bg: "var(--r-green)", children: label("LIVE") });
+			const pill = container.querySelector(".r-pixel") as HTMLElement;
+			expect(pill.getAttribute("style")).toContain("var(--r-green)");
+		});
+
+		it("RetroTag defaults to paper and stays mono", () => {
+			const { container } = render(RetroTag, { children: label("Svelte 5") });
+			const tag = container.querySelector(".r-mono") as HTMLElement;
+			expect(tag).toHaveClass("r-border");
+			expect(tag.getAttribute("style")).toContain("var(--r-paper)");
+		});
+
+		it("IconTile sizes inline so the border eats into the stated size", () => {
+			const { container } = render(IconTile, { glyph: "W", bg: "var(--r-tint-blue)", size: 38 });
+			const tile = container.querySelector("span") as HTMLElement;
+			expect(tile).toHaveClass("box-border", "text-[11px]");
+			expect(tile.getAttribute("style")).toContain("width: 38px");
+			expect(tile).toHaveAttribute("aria-hidden", "true");
+		});
+
+		it("InlineIndexLabel keeps the ordinal outside the label span", () => {
+			render(InlineIndexLabel, { index: "02", label: "THE BUILD" });
+			expect(screen.getByText(/\(\s*02\s*\)/)).toBeInTheDocument();
+			expect(screen.getByText("THE BUILD")).toBeInTheDocument();
+		});
+	});
+
+	describe("ornaments", () => {
+		it("PixelGlyph is a 2×2 grid sized by props, hidden from the tree", () => {
+			const { container } = render(PixelGlyph, { cell: 14, gap: 3, pad: 4 });
+			const glyph = container.querySelector("span") as HTMLElement;
+			expect(glyph).toHaveAttribute("aria-hidden", "true");
+			expect(glyph.getAttribute("style")).toContain("repeat(2, 14px)");
+			expect(glyph.querySelectorAll("span")).toHaveLength(4);
+		});
+
+		it("Led blinks through the class the reduced-motion rule can reach", () => {
+			const { container } = render(Led, {});
+			const led = container.querySelector("span") as HTMLElement;
+			expect(led).toHaveClass("r-blink", "r-border");
+			expect(led.getAttribute("style")).toContain("var(--r-green)");
+			// No inline animation: cancelling one would need !important.
+			expect(led.getAttribute("style")).not.toContain("animation");
+		});
+
+		it("Swatches shows all four accents and only presses when interactive", () => {
+			const { container } = render(Swatches, {});
+			expect(container.querySelectorAll(".r-border")).toHaveLength(4);
+			expect(container.querySelector(".r-pressable")).not.toBeInTheDocument();
+			cleanup();
+
+			const { container: on } = render(Swatches, { interactive: true });
+			expect(on.querySelectorAll(".r-pressable")).toHaveLength(4);
+		});
+	});
+
+	describe("accent vocabulary", () => {
+		it("pairs every accent with its tint", () => {
+			for (const accent of ["blue", "rust", "gold", "green"] as const) {
+				expect(ACCENT_VAR[accent]).toBe(accentVar(accent));
+				expect(ACCENT_TINT[accent]).toBe(accentTint(accent));
+				expect(accentVar(accent)).toMatch(/^var\(--r-/);
+				expect(accentTint(accent)).toContain("tint");
+			}
+		});
+	});
+});


### PR DESCRIPTION
Closes #206
Closes #209
Closes #210

First of three PRs upstreaming the retro-os component vocabulary proven in the reference portfolio implementation.

## Cameleon goes public

`dist/cameleon` enters the `files` allow-list — `fancy-ui-svelte/cameleon` (engine, primitives, six skins) and the new `fancy-ui-svelte/cameleon/retro-kit` become real npm entry points (explicit `types`/`svelte`/`default` conditions beside the existing wildcard). The "Internal / not published yet" era ends; publint green, tarball verified (111 cameleon files, 1.2 MB packed total).

## The retro-os kit — foundations

`src/lib/cameleon/skins/retro-os/kit/`:

- **kit.css** — the `--r-*` tokens (aliases of `--skin-*` + kit-only literals: the gold key fill `--r-btn`, four pale accent washes, the prose ink) scoped to `[data-skin="retro-os"]`, plus the `.r-*` recipes: 2px ink border, the ascending shadow ladder (declaration order is an API), `.r-pressable` press physics (hover lift behind `@media (hover: hover)`, active press outside it so taps never stick), 36px graph paper, pinned-bold pixel type, and the `steps(1)` LED blink whose reduced-motion override leaves the lamp lit.
- **RetroButton** — shadow-ladder press key: primary (`--r-btn`) / outline, sm/md with the shadow rung tied to the size, optional 2×2 pixel-glyph suffix, `<a>` mode (#206)
- **Label kit** — `Chip` (outline/ink/tint, dashed), `NumChip`, `StatusPill`, `RetroTag`, `IconTile` (30/34/38, `box-border` load-bearing), `InlineIndexLabel` (#209)
- **Ornaments** — `PixelGlyph`, `Led`, `Swatches` (#210)
- **Accent vocabulary** — `Accent`, `accentVar`, `accentTint`: four named accents paired 1:1 with their tints

Port adaptations from the source implementation: content-key props became plain strings; the in-app edit-runtime attributes are gone; everything else — values, physics, scoping decisions — carried over verbatim with its reasoning in comments.

## Tests

14 colocated tests (element roles, shadow-rung/size coupling, tone flips, inline sizing, blink class reachability, accent pairing). Full suite green, `svelte-check` 0 errors, `pnpm package` + publint pass.