### PR TITLE
feat(fancy): hard-edge modes for five components

### DIFF
--- a/.changeset/retro-friendly-variants.md
+++ b/.changeset/retro-friendly-variants.md
@@ -1,0 +1,5 @@
+---
+"fancy-ui-svelte": minor
+---
+
+Add five hard-edge, additive options for existing components — all defaults unchanged, no behavior or visuals change for existing consumers. `InteractiveGridPattern` gains an `interactive` prop (`false` renders a static graph-paper grid with zero per-rect mouse listeners) and a `strokeClassName` prop to recolor the grid lines without overriding the fill logic in `squaresClassName`. `BlurReveal` gains a `mode` prop (`"hard"` drops the blur/translate softening entirely and snaps opacity in via a stepped CSS timing function, keeping the same scroll trigger and stagger). `StaticLogoCloud` gains a `wordmarks` prop that renders a static typographic row of styled text instead of image logos, for brand rows with no logo assets. `LineHoverLink` gains a 12th variant, `"ink"`: a constant underline with the whole link snapping `-1px,-1px` on hover/focus instead of animating the underline in. `ImageTrailCursor` gains a `"pixelated"` trail variant: images pop in and out with no easing tails, styled with `image-rendering: pixelated` and a solid pixel-art border.

--- a/src/lib/components/docs/examples/blur-reveal/HardSnap.svelte
+++ b/src/lib/components/docs/examples/blur-reveal/HardSnap.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { BlurReveal } from "$lib/fancy-ui/blur-reveal";
+	import ReplayButton from "$lib/components/ReplayButton.svelte";
+
+	let replayKey = $state(0);
+</script>
+
+<div class="relative">
+	<ReplayButton onclick={() => replayKey++} />
+	{#key replayKey}
+		<BlurReveal mode="hard">
+			<h3 class="mb-4 text-2xl font-bold">Snaps into place</h3>
+			<p class="text-muted-foreground mb-3">
+				No blur, no translate softening — opacity jumps in via a stepped timing function.
+			</p>
+			<p class="text-muted-foreground">Suited to hard-edge art directions.</p>
+		</BlurReveal>
+	{/key}
+</div>

--- a/src/lib/components/docs/examples/image-trail-cursor/Variants.svelte
+++ b/src/lib/components/docs/examples/image-trail-cursor/Variants.svelte
@@ -20,6 +20,7 @@
 		{ type: "type6", label: "Speed-reactive" },
 		{ type: "type7", label: "Stacking" },
 		{ type: "type8", label: "3D Perspective" },
+		{ type: "pixelated", label: "Pixelated" },
 	];
 
 	let selectedVariant: VariantType = $state("type1");

--- a/src/lib/components/docs/examples/interactive-grid-pattern/StaticGraphPaper.svelte
+++ b/src/lib/components/docs/examples/interactive-grid-pattern/StaticGraphPaper.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { InteractiveGridPattern } from "$lib/fancy-ui/interactive-grid-pattern";
+</script>
+
+<div
+	class="relative flex h-96 w-full items-center justify-center overflow-hidden rounded-lg border bg-white"
+>
+	<InteractiveGridPattern interactive={false} strokeClassName="stroke-black/40" />
+	<p class="z-10 text-lg font-medium text-black">Static graph paper — no hover listeners</p>
+</div>

--- a/src/lib/components/docs/examples/line-hover-link/AllVariants.svelte
+++ b/src/lib/components/docs/examples/line-hover-link/AllVariants.svelte
@@ -14,6 +14,7 @@
 		{ variant: "bounce", label: "Bounce" },
 		{ variant: "arc", label: "Arc" },
 		{ variant: "scribble", label: "Scribble" },
+		{ variant: "ink", label: "Ink" },
 	];
 </script>
 

--- a/src/lib/components/docs/examples/logo-cloud/Wordmarks.svelte
+++ b/src/lib/components/docs/examples/logo-cloud/Wordmarks.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { StaticLogoCloud } from "$lib/fancy-ui/logo-cloud";
+	import type { Wordmark } from "$lib/fancy-ui/logo-cloud";
+
+	const wordmarks: Wordmark[] = [
+		{ name: "Acme Corp", size: 22, weight: 700 },
+		{ name: "Nimbus Labs", size: 20, weight: 400, italic: true },
+		{ name: "FOUNDRY", size: 18, weight: 900, tracking: 2, transform: "uppercase" },
+		{ name: "Cartwright & Sons", size: 20, weight: 400, serif: true },
+		{ name: "Vertex", size: 22, weight: 700, tracking: 1 },
+	];
+</script>
+
+<div class="overflow-hidden rounded-lg border">
+	<StaticLogoCloud title="Trusted by" {wordmarks} />
+</div>

--- a/src/lib/components/docs/examples/registry.ts
+++ b/src/lib/components/docs/examples/registry.ts
@@ -153,6 +153,11 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 			title: "Staggered Cards",
 			description: "Multiple items with stagger.",
 		},
+		{
+			name: "HardSnap",
+			title: "Hard Snap",
+			description: 'mode="hard": no blur or easing, opacity snaps in stepped.',
+		},
 	],
 	focus: [
 		{ name: "BasicUsage", title: "Basic Usage" },
@@ -288,6 +293,11 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 		{ name: "BasicUsage", title: "Basic Usage" },
 		{ name: "IconGrid", title: "Icon Grid" },
 		{ name: "StaticGrid", title: "Static Grid" },
+		{
+			name: "Wordmarks",
+			title: "Wordmarks",
+			description: "Static typographic row instead of image logos — no logo assets needed.",
+		},
 	],
 	"container-scroll": [{ name: "BasicUsage", title: "Basic Usage" }],
 	"bento-grid": [
@@ -367,15 +377,20 @@ export const examplesRegistry: Record<string, ExampleMeta[]> = {
 		{
 			name: "Variants",
 			title: "Animation Variants",
-			description: "8 different trail animation styles.",
+			description: "9 different trail animation styles, including a hard-edge pixelated snap.",
 		},
 	],
 	"interactive-grid-pattern": [
 		{ name: "BasicUsage", title: "Basic Usage" },
 		{ name: "Colored", title: "Colored Variant", description: "Custom hover color." },
+		{
+			name: "StaticGraphPaper",
+			title: "Static Graph Paper",
+			description: "Non-interactive grid with no per-rect listeners, for hard-edge art directions.",
+		},
 	],
 	"line-hover-link": [
-		{ name: "AllVariants", title: "All Variants", description: "11 animated underline effects." },
+		{ name: "AllVariants", title: "All Variants", description: "12 animated underline effects." },
 		{ name: "Navigation", title: "Navigation Example" },
 	],
 	"displacement-text": [

--- a/src/lib/fancy-ui/blur-reveal/BlurReveal.svelte
+++ b/src/lib/fancy-ui/blur-reveal/BlurReveal.svelte
@@ -12,6 +12,8 @@
 		yOffset?: number;
 		/** Additional CSS classes for the container */
 		class?: string;
+		/** Reveal style: "blur" softens in with blur/translate, "hard" snaps opacity with no easing */
+		mode?: "blur" | "hard";
 		/** Content to reveal */
 		children?: Snippet;
 	}
@@ -27,6 +29,7 @@
 		blur = "20px",
 		yOffset = 20,
 		class: className,
+		mode = "blur",
 		children,
 	}: BlurRevealProps = $props();
 
@@ -61,7 +64,7 @@
 	style:--blur-reveal-y="{yOffset}px"
 >
 	{#if children}
-		<div class="blur-reveal-wrapper" class:is-visible={isInView}>
+		<div class="blur-reveal-wrapper" class:is-visible={isInView} class:mode-hard={mode === "hard"}>
 			{@render children()}
 		</div>
 	{/if}
@@ -114,6 +117,18 @@
 	}
 	.blur-reveal-wrapper.is-visible > :global(:nth-child(10)) {
 		transition-delay: calc(var(--blur-reveal-delay, 0.2s) * 9);
+	}
+
+	/* Hard mode: no blur/translate softening, opacity snaps in via a stepped timing function */
+	.blur-reveal-wrapper.mode-hard > :global(*) {
+		opacity: 0;
+		filter: none;
+		transform: none;
+		transition: opacity var(--blur-reveal-duration, 1s) steps(2, jump-none);
+	}
+
+	.blur-reveal-wrapper.mode-hard.is-visible > :global(*) {
+		opacity: 1;
 	}
 
 	/* Respect reduced motion */

--- a/src/lib/fancy-ui/blur-reveal/BlurReveal.test.ts
+++ b/src/lib/fancy-ui/blur-reveal/BlurReveal.test.ts
@@ -51,4 +51,21 @@ describe("BlurReveal", () => {
 		const wrapper = container.querySelector(".blur-reveal-wrapper");
 		expect(wrapper).not.toBeInTheDocument();
 	});
+
+	it("does not apply mode-hard class by default", () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const { container } = render(BlurReveal, { props: { children: (() => {}) as any } });
+		const wrapper = container.querySelector(".blur-reveal-wrapper");
+		expect(wrapper).toBeTruthy();
+		expect(wrapper?.classList.contains("mode-hard")).toBe(false);
+	});
+
+	it('applies mode-hard class when mode="hard"', () => {
+		const { container } = render(BlurReveal, {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			props: { mode: "hard", children: (() => {}) as any },
+		});
+		const wrapper = container.querySelector(".blur-reveal-wrapper");
+		expect(wrapper?.classList.contains("mode-hard")).toBe(true);
+	});
 });

--- a/src/lib/fancy-ui/blur-reveal/README.md
+++ b/src/lib/fancy-ui/blur-reveal/README.md
@@ -11,25 +11,36 @@ A scroll-triggered reveal animation that transitions children from blurred and o
 
 ## Props
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `duration` | `number` | `1` | Animation duration in seconds |
-| `delay` | `number` | `0.2` | Stagger delay between children in seconds |
-| `blur` | `string` | `'20px'` | Initial blur amount (CSS value) |
-| `yOffset` | `number` | `20` | Initial vertical offset in pixels |
-| `class` | `string` | `''` | Additional CSS classes for the container |
+| Prop       | Type               | Default  | Description                                                                                    |
+| ---------- | ------------------ | -------- | ---------------------------------------------------------------------------------------------- |
+| `duration` | `number`           | `1`      | Animation duration in seconds                                                                  |
+| `delay`    | `number`           | `0.2`    | Stagger delay between children in seconds                                                      |
+| `blur`     | `string`           | `'20px'` | Initial blur amount (CSS value)                                                                |
+| `yOffset`  | `number`           | `20`     | Initial vertical offset in pixels                                                              |
+| `class`    | `string`           | `''`     | Additional CSS classes for the container                                                       |
+| `mode`     | `'blur' \| 'hard'` | `'blur'` | Reveal style — `blur` softens in with blur + translate, `hard` snaps opacity in with no easing |
+
+## Hard mode
+
+`mode="hard"` drops the filter/blur and translate softening entirely — children appear with a stepped opacity snap (`transition-timing-function: steps(2, jump-none)`, so opacity jumps from 0 to 1 partway through the duration instead of easing). The scroll trigger and stagger delays are unchanged, for hard-edge art directions where a soft blur-in reads as off-brand:
+
+```svelte
+<BlurReveal mode="hard">
+	<h1>Snaps into place</h1>
+</BlurReveal>
+```
 
 ## Usage
 
 ```svelte
 <script>
-  import { BlurReveal } from '$lib/fancy-ui/blur-reveal';
+	import { BlurReveal } from "$lib/fancy-ui/blur-reveal";
 </script>
 
 <BlurReveal>
-  <h1>This fades in first</h1>
-  <p>This fades in second</p>
-  <p>This fades in third</p>
+	<h1>This fades in first</h1>
+	<p>This fades in second</p>
+	<p>This fades in third</p>
 </BlurReveal>
 ```
 

--- a/src/lib/fancy-ui/image-trail-cursor/ImageTrailCursor.test.ts
+++ b/src/lib/fancy-ui/image-trail-cursor/ImageTrailCursor.test.ts
@@ -66,4 +66,23 @@ describe("ImageTrailCursor", () => {
 		expect(img?.className).toContain("sm:w-[190px]");
 		expect(img?.className).toContain("sm:rounded-[15px]");
 	});
+
+	it("mounts without throwing when variant is pixelated", () => {
+		const { container } = render(ImageTrailCursor, {
+			props: { images: ["/a.jpg", "/b.jpg"], variant: "pixelated" },
+		});
+		const imgs = container.querySelectorAll(".content__img");
+		expect(imgs.length).toBe(2);
+	});
+
+	it("applies pixelated image-rendering and border on mount for the pixelated variant", () => {
+		const { container } = render(ImageTrailCursor, {
+			props: { images: ["/a.jpg"], variant: "pixelated" },
+		});
+		const img = container.querySelector(".content__img") as HTMLElement;
+		expect(img.style.imageRendering).toBe("pixelated");
+		expect(img.style.borderWidth).toBe("2px");
+		expect(img.style.borderStyle).toBe("solid");
+		expect(img.style.borderColor).toBe("rgb(25, 19, 8)"); // #191308
+	});
 });

--- a/src/lib/fancy-ui/image-trail-cursor/README.md
+++ b/src/lib/fancy-ui/image-trail-cursor/README.md
@@ -1,27 +1,28 @@
 # ImageTrailCursor
 
-Cursor-following image trail effect with 8 animation variants. Images appear at the cursor position as you move the mouse, each variant providing a distinct visual style.
+Cursor-following image trail effect with 9 animation variants. Images appear at the cursor position as you move the mouse, each variant providing a distinct visual style.
 
 ## Props
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `images` | `string[]` | `[]` | Array of image URLs for the trail |
-| `variant` | `VariantType` | `'type1'` | Animation variant (`type1` through `type8`) |
-| `class` | `string` | `''` | Additional CSS classes for the container |
+| Prop      | Type          | Default   | Description                                                 |
+| --------- | ------------- | --------- | ----------------------------------------------------------- |
+| `images`  | `string[]`    | `[]`      | Array of image URLs for the trail                           |
+| `variant` | `VariantType` | `'type1'` | Animation variant (`type1` through `type8`, or `pixelated`) |
+| `class`   | `string`      | `''`      | Additional CSS classes for the container                    |
 
 ## Variants
 
-| Variant | Description |
-|---------|-------------|
-| `type1` | Basic fade & scale trail |
-| `type2` | Scale-up with brightness burst |
-| `type3` | Float-up exit with random x drift |
-| `type4` | Momentum-based drift with brightness/contrast |
-| `type5` | Rotation + momentum fling |
-| `type6` | Speed-reactive size, blur, grayscale |
-| `type7` | Stacking trail with visible queue |
-| `type8` | 3D perspective based on cursor position |
+| Variant     | Description                                                                                                              |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `type1`     | Basic fade & scale trail                                                                                                 |
+| `type2`     | Scale-up with brightness burst                                                                                           |
+| `type3`     | Float-up exit with random x drift                                                                                        |
+| `type4`     | Momentum-based drift with brightness/contrast                                                                            |
+| `type5`     | Rotation + momentum fling                                                                                                |
+| `type6`     | Speed-reactive size, blur, grayscale                                                                                     |
+| `type7`     | Stacking trail with visible queue                                                                                        |
+| `type8`     | 3D perspective based on cursor position                                                                                  |
+| `pixelated` | Hard pop-in/pop-out (no easing tails), `image-rendering: pixelated`, 2px `#191308` border — for hard-edge art directions |
 
 ## Dependencies
 
@@ -29,8 +30,9 @@ Cursor-following image trail effect with 8 animation variants. Images appear at 
 
 ## Implementation Notes
 
-- Extracted a `BaseVariant` abstract class to eliminate ~800 lines of duplicated constructor/render/destroy boilerplate across the 8 variant classes.
+- Extracted a `BaseVariant` abstract class to eliminate ~800 lines of duplicated constructor/render/destroy boilerplate across the variant classes.
 - Added proper `destroy()` methods (missing in vendor): cancels RAF, removes event listeners, kills GSAP tweens, cleans up `ImageItem` resize listeners.
 - Fixed `VariantType` to include `type8` (vendor TypeScript type stopped at `type7` but code had 8 variants).
 - Properly typed `variantMap` as `Record<VariantType, ...>` instead of `{ [key: string]: any }`.
-- The Svelte component resets inline styles before re-initializing on variant switch to prevent GSAP style residue.
+- The Svelte component resets inline styles before re-initializing on variant switch to prevent GSAP style residue — this also clears `pixelated`'s inline border/`image-rendering` when switching away from it.
+- `pixelated` uses `gsap.timeline().set(...)` calls (duration 0) instead of `.to()`/`.fromTo()` tweens, so there is no easing curve on either the pop-in or the pop-out; the two `.set()` calls are positioned `HOLD` seconds apart on the timeline to create the hold before the hard snap-out. The border and `image-rendering: pixelated` are applied once, directly on `img.DOM.el`, in the variant's constructor — they are static styling, not animated properties.

--- a/src/lib/fancy-ui/image-trail-cursor/trail-variants.test.ts
+++ b/src/lib/fancy-ui/image-trail-cursor/trail-variants.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { variantMap, ImageTrailVariantPixelated, type VariantType } from "./trail-variants.js";
+
+describe("trail-variants pixelated", () => {
+	it("accepts pixelated as a VariantType", () => {
+		const variant: VariantType = "pixelated";
+		expect(variant).toBe("pixelated");
+	});
+
+	it("has a pixelated entry in variantMap pointing at ImageTrailVariantPixelated", () => {
+		expect(variantMap.pixelated).toBe(ImageTrailVariantPixelated);
+	});
+
+	it("keeps all 9 variant keys in variantMap", () => {
+		expect(Object.keys(variantMap).sort()).toEqual(
+			["type1", "type2", "type3", "type4", "type5", "type6", "type7", "type8", "pixelated"].sort()
+		);
+	});
+});

--- a/src/lib/fancy-ui/image-trail-cursor/trail-variants.ts
+++ b/src/lib/fancy-ui/image-trail-cursor/trail-variants.ts
@@ -12,7 +12,8 @@ export type VariantType =
 	| "type5"
 	| "type6"
 	| "type7"
-	| "type8";
+	| "type8"
+	| "pixelated";
 
 export interface ImageTrailVariant {
 	destroy(): void;
@@ -883,6 +884,47 @@ export class ImageTrailVariant8 extends BaseVariant {
 }
 
 // =============================================================================
+// Variant Pixelated — hard-snap pop-in/pop-out, pixelated + bordered images
+// =============================================================================
+
+export class ImageTrailVariantPixelated extends BaseVariant {
+	private static readonly HOLD = 0.15; // seconds the image stays visible before snapping out
+
+	constructor(container: HTMLDivElement) {
+		super(container);
+		for (const img of this.images) {
+			img.DOM.el.style.imageRendering = "pixelated";
+			img.DOM.el.style.border = "2px solid #191308";
+		}
+	}
+
+	protected showNextImage() {
+		++this.zIndexVal;
+		this.imgPosition = this.imgPosition < this.imagesTotal - 1 ? this.imgPosition + 1 : 0;
+		const img = this.images[this.imgPosition];
+
+		gsap.killTweensOf(img.DOM.el);
+		gsap
+			.timeline({
+				onStart: () => this.onImageActivated(),
+				onComplete: () => this.onImageDeactivated(),
+			})
+			.set(
+				img.DOM.el,
+				{
+					opacity: 1,
+					scale: 1,
+					zIndex: this.zIndexVal,
+					x: this.mousePos.x - (img.rect?.width ?? 0) / 2,
+					y: this.mousePos.y - (img.rect?.height ?? 0) / 2,
+				},
+				0
+			)
+			.set(img.DOM.el, { opacity: 0, scale: 0.2 }, ImageTrailVariantPixelated.HOLD);
+	}
+}
+
+// =============================================================================
 // Variant Map
 // =============================================================================
 
@@ -896,4 +938,5 @@ export const variantMap: Record<VariantType, new (container: HTMLDivElement) => 
 		type6: ImageTrailVariant6,
 		type7: ImageTrailVariant7,
 		type8: ImageTrailVariant8,
+		pixelated: ImageTrailVariantPixelated,
 	};

--- a/src/lib/fancy-ui/interactive-grid-pattern/InteractiveGridPattern.svelte
+++ b/src/lib/fancy-ui/interactive-grid-pattern/InteractiveGridPattern.svelte
@@ -4,12 +4,16 @@
 		class?: string;
 		/** Additional CSS classes for individual squares */
 		squaresClassName?: string;
+		/** Additional CSS classes controlling the square outline color */
+		strokeClassName?: string;
 		/** Width of each square in pixels */
 		width?: number;
 		/** Height of each square in pixels */
 		height?: number;
 		/** Grid dimensions [columns, rows] */
 		squares?: [number, number];
+		/** Whether squares respond to hover. When false, renders a static graph-paper grid with no listeners */
+		interactive?: boolean;
 	}
 </script>
 
@@ -19,9 +23,11 @@
 	let {
 		class: className,
 		squaresClassName,
+		strokeClassName = "stroke-gray-400/30",
 		width = 40,
 		height = 40,
 		squares = [24, 24] as [number, number],
+		interactive = true,
 	}: InteractiveGridPatternProps = $props();
 
 	let hoveredSquare: number | null = $state(null);
@@ -54,12 +60,13 @@
 			{width}
 			{height}
 			class={cn(
-				"interactive-grid-square stroke-gray-400/30 transition-all duration-100 ease-in-out",
+				"interactive-grid-square transition-all duration-100 ease-in-out",
+				strokeClassName,
 				hoveredSquare === index ? "fill-gray-300/30" : "fill-transparent",
 				squaresClassName
 			)}
-			onmouseenter={() => (hoveredSquare = index)}
-			onmouseleave={() => (hoveredSquare = null)}
+			onmouseenter={interactive ? () => (hoveredSquare = index) : undefined}
+			onmouseleave={interactive ? () => (hoveredSquare = null) : undefined}
 		/>
 	{/each}
 </svg>

--- a/src/lib/fancy-ui/interactive-grid-pattern/InteractiveGridPattern.test.ts
+++ b/src/lib/fancy-ui/interactive-grid-pattern/InteractiveGridPattern.test.ts
@@ -1,4 +1,4 @@
-import { render, cleanup } from "@testing-library/svelte";
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
 import { afterEach, describe, it, expect } from "vitest";
 import InteractiveGridPattern from "./InteractiveGridPattern.svelte";
 
@@ -50,5 +50,45 @@ describe("InteractiveGridPattern", () => {
 		const svg = container.querySelector("svg");
 		expect(svg).toHaveAttribute("width", "250");
 		expect(svg).toHaveAttribute("height", "90");
+	});
+
+	it("applies the default stroke class to rects", () => {
+		const { container } = render(InteractiveGridPattern, {
+			props: { squares: [2, 2] },
+		});
+		const rect = container.querySelector("rect");
+		expect(rect?.getAttribute("class")).toContain("stroke-gray-400/30");
+	});
+
+	it("applies a custom strokeClassName to rects", () => {
+		const { container } = render(InteractiveGridPattern, {
+			props: { squares: [2, 2], strokeClassName: "stroke-black/40" },
+		});
+		const rect = container.querySelector("rect");
+		expect(rect?.getAttribute("class")).toContain("stroke-black/40");
+		expect(rect?.getAttribute("class")).not.toContain("stroke-gray-400/30");
+	});
+
+	it("attaches mouseenter/mouseleave listeners by default (interactive)", async () => {
+		const { container } = render(InteractiveGridPattern, {
+			props: { squares: [2, 2] },
+		});
+		const rect = container.querySelector("rect") as SVGRectElement;
+		expect(rect.getAttribute("class")).toContain("fill-transparent");
+		await fireEvent.mouseEnter(rect);
+		expect(rect.getAttribute("class")).toContain("fill-gray-300/30");
+		await fireEvent.mouseLeave(rect);
+		expect(rect.getAttribute("class")).toContain("fill-transparent");
+	});
+
+	it("does not change fill state on hover when interactive is false", async () => {
+		const { container } = render(InteractiveGridPattern, {
+			props: { squares: [2, 2], interactive: false },
+		});
+		const rect = container.querySelector("rect") as SVGRectElement;
+		expect(rect.getAttribute("class")).toContain("fill-transparent");
+		await fireEvent.mouseEnter(rect);
+		expect(rect.getAttribute("class")).toContain("fill-transparent");
+		expect(rect.getAttribute("class")).not.toContain("fill-gray-300/30");
 	});
 });

--- a/src/lib/fancy-ui/interactive-grid-pattern/README.md
+++ b/src/lib/fancy-ui/interactive-grid-pattern/README.md
@@ -6,25 +6,36 @@ SVG grid of squares that highlight on hover with smooth fade transitions.
 
 ```svelte
 <script lang="ts">
-  import { InteractiveGridPattern } from '$lib/fancy-ui/interactive-grid-pattern';
+	import { InteractiveGridPattern } from "$lib/fancy-ui/interactive-grid-pattern";
 </script>
 
 <div class="relative h-96 w-full overflow-hidden">
-  <InteractiveGridPattern />
+	<InteractiveGridPattern />
 </div>
 ```
 
 ## Props
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `class` | `string` | - | Classes on the SVG container |
-| `squaresClassName` | `string` | - | Classes on individual rect elements |
-| `width` | `number` | `40` | Square width in pixels |
-| `height` | `number` | `40` | Square height in pixels |
-| `squares` | `[number, number]` | `[24, 24]` | Grid dimensions `[columns, rows]` |
+| Prop               | Type               | Default                | Description                                                                                  |
+| ------------------ | ------------------ | ---------------------- | -------------------------------------------------------------------------------------------- |
+| `class`            | `string`           | -                      | Classes on the SVG container                                                                 |
+| `squaresClassName` | `string`           | -                      | Classes on individual rect elements                                                          |
+| `strokeClassName`  | `string`           | `'stroke-gray-400/30'` | Classes controlling the square outline color                                                 |
+| `width`            | `number`           | `40`                   | Square width in pixels                                                                       |
+| `height`           | `number`           | `40`                   | Square height in pixels                                                                      |
+| `squares`          | `[number, number]` | `[24, 24]`             | Grid dimensions `[columns, rows]`                                                            |
+| `interactive`      | `boolean`          | `true`                 | When `false`, renders a static graph-paper grid: no per-rect mouse listeners, no hover state |
+
+## Static graph-paper mode
+
+Set `interactive={false}` for a plain grid backdrop with zero per-rect event listeners — useful for a print/graph-paper look behind static content, or when the hover cost of hundreds of rects isn't wanted. Combine with `strokeClassName` to recolor the lines without overriding `squaresClassName` (which also carries the fill logic):
+
+```svelte
+<InteractiveGridPattern interactive={false} strokeClassName="stroke-black/40" />
+```
 
 ## Implementation Notes
 
 - Uses `$state` for hover tracking, Svelte 5 `onmouseenter`/`onmouseleave` handlers
 - CSS transition: 100ms on hover-in, 1000ms on hover-out via `:not(:hover)` selector
+- When `interactive` is `false`, the `onmouseenter`/`onmouseleave` handlers are `undefined` rather than no-ops, so no listeners are attached to the DOM at all

--- a/src/lib/fancy-ui/line-hover-link/LineHoverLink.svelte
+++ b/src/lib/fancy-ui/line-hover-link/LineHoverLink.svelte
@@ -15,6 +15,7 @@
 	 * bounce   - Bouncy squish animation
 	 * arc      - SVG arc stroke draws in
 	 * scribble - SVG scribble stroke draws in
+	 * ink      - Constant underline; whole link snaps (-1px,-1px) on hover
 	 */
 	export type LineHoverVariant =
 		| "slide"
@@ -27,7 +28,8 @@
 		| "sweep"
 		| "bounce"
 		| "arc"
-		| "scribble";
+		| "scribble"
+		| "ink";
 
 	export interface LineHoverLinkProps {
 		/** The animation variant */
@@ -446,5 +448,20 @@
 	.link-hover:is(:hover, :focus-visible) .link-hover__graphic--scribble :global(path) {
 		transition-timing-function: cubic-bezier(0.8, 1, 0.7, 1);
 		transition-duration: 0.3s;
+	}
+
+	/* Ink */
+	.link-hover--ink::before {
+		height: 2px;
+	}
+
+	.link-hover--ink:focus-visible {
+		transform: translate3d(-1px, -1px, 0);
+	}
+
+	@media (hover: hover) {
+		.link-hover--ink:hover {
+			transform: translate3d(-1px, -1px, 0);
+		}
 	}
 </style>

--- a/src/lib/fancy-ui/line-hover-link/LineHoverLink.test.ts
+++ b/src/lib/fancy-ui/line-hover-link/LineHoverLink.test.ts
@@ -63,4 +63,19 @@ describe("LineHoverLink", () => {
 		});
 		expect(container.querySelector("a.text-xl")).toBeTruthy();
 	});
+
+	it("applies the ink variant class", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "ink", href: "#" } });
+		expect(container.querySelector("a.link-hover--ink")).toBeTruthy();
+	});
+
+	it("does not wrap children in a span for the ink variant", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "ink", href: "#" } });
+		expect(container.querySelector("a.link-hover--ink span")).toBeNull();
+	});
+
+	it("does not render an SVG for the ink variant", () => {
+		const { container } = render(LineHoverLink, { props: { variant: "ink", href: "#" } });
+		expect(container.querySelector("svg")).toBeNull();
+	});
 });

--- a/src/lib/fancy-ui/line-hover-link/README.md
+++ b/src/lib/fancy-ui/line-hover-link/README.md
@@ -1,6 +1,6 @@
 # LineHoverLink
 
-An anchor with a pure-CSS underline hover effect, selectable from 11 variants. No JavaScript runs on hover — every variant is `::before`/`::after` pseudo-elements or an inline SVG stroke animated with CSS `transition`/`transform`/`stroke-dashoffset`, triggered by `:hover`/`:focus-visible`.
+An anchor with a pure-CSS underline hover effect, selectable from 12 variants. No JavaScript runs on hover — every variant is `::before`/`::after` pseudo-elements or an inline SVG stroke animated with CSS `transition`/`transform`/`stroke-dashoffset`, triggered by `:hover`/`:focus-visible`.
 
 ## Usage
 
@@ -26,12 +26,13 @@ An anchor with a pure-CSS underline hover effect, selectable from 11 variants. N
 
 Children (slot content) are the link's visible text/label.
 
-`LineHoverVariant` is one of: `"slide" | "double" | "grow" | "strike" | "fade" | "pulse" | "swap" | "sweep" | "bounce" | "arc" | "scribble"`.
+`LineHoverVariant` is one of: `"slide" | "double" | "grow" | "strike" | "fade" | "pulse" | "swap" | "sweep" | "bounce" | "arc" | "scribble" | "ink"`.
 
 ## Implementation notes
 
 - The component has no `<script>`-side reactive state beyond two `$derived` values — everything visual is CSS selected by a `link-hover--<variant>` class.
 - `arc` and `scribble` render an inline `<svg>` with a single `<path pathLength="1">` instead of a pseudo-element underline; both use the same technique (`stroke-dasharray: 1; stroke-dashoffset: 1` at rest, animated to `0` on hover/focus via `transition: stroke-dashoffset`).
 - `strike`, `bounce`, `arc`, and `scribble` wrap the link text in an inner `<span>` (via the `needsSpan` derived flag) because those variants also transform the text itself (scale for `strike`, translate for `bounce`) independently of the underline graphic.
+- `ink` is the odd one out: the underline is a constant 2px `::before` — not animated in — and instead the whole link snaps `translate3d(-1px, -1px, 0)` on interaction, for a hard-edge, ink-stamp feel. The hover half of the rule is gated behind `@media (hover: hover)` so touch devices don't get a stuck translated state; `:focus-visible` still applies unconditionally for keyboard users.
 - `rel` defaults to `"noopener noreferrer"` automatically when `target="_blank"` and no explicit `rel` was passed, via the `relValue` derived value — an explicit `rel` prop is never overridden.
 - All variants respond to both `:hover` and `:focus-visible`, so the effect is keyboard-navigable, not mouse-only.

--- a/src/lib/fancy-ui/logo-cloud/README.md
+++ b/src/lib/fancy-ui/logo-cloud/README.md
@@ -6,12 +6,12 @@ Logo display components in three variants: animated marquee, static grid, and co
 
 ```svelte
 <script lang="ts">
-  import { AnimatedLogoCloud, StaticLogoCloud, IconLogoCloud } from '$lib/fancy-ui/logo-cloud';
+	import { AnimatedLogoCloud, StaticLogoCloud, IconLogoCloud } from "$lib/fancy-ui/logo-cloud";
 
-  const logos = [
-    { name: 'Vercel', path: '/logos/vercel.svg' },
-    { name: 'Next.js', path: '/logos/nextjs.svg' },
-  ];
+	const logos = [
+		{ name: "Vercel", path: "/logos/vercel.svg" },
+		{ name: "Next.js", path: "/logos/nextjs.svg" },
+	];
 </script>
 
 <AnimatedLogoCloud title="Trusted by" {logos} />
@@ -21,21 +21,54 @@ Logo display components in three variants: animated marquee, static grid, and co
 
 ## Variants
 
-| Component | Description |
-|-----------|-------------|
+| Component           | Description                               |
+| ------------------- | ----------------------------------------- |
 | `AnimatedLogoCloud` | Infinite horizontal scroll with fade mask |
-| `StaticLogoCloud` | Responsive grid layout |
-| `IconLogoCloud` | Compact icon-sized grid |
+| `StaticLogoCloud`   | Responsive grid layout                    |
+| `IconLogoCloud`     | Compact icon-sized grid                   |
 
 ## Props (shared)
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `class` | `string` | - | Classes on the container |
-| `title` | `string` | - | Optional heading text |
-| `logos` | `Logo[]` | `[]` | Array of `{ name, path }` objects |
+| Prop        | Type         | Default | Description                                                                        |
+| ----------- | ------------ | ------- | ---------------------------------------------------------------------------------- |
+| `class`     | `string`     | -       | Classes on the container                                                           |
+| `title`     | `string`     | -       | Optional heading text                                                              |
+| `logos`     | `Logo[]`     | `[]`    | Array of `{ name, path }` objects                                                  |
+| `wordmarks` | `Wordmark[]` | -       | `StaticLogoCloud` only — static typographic row instead of image logos (see below) |
+
+## Wordmarks (StaticLogoCloud only)
+
+Pass `wordmarks` instead of `logos` to render brand names as styled text rather than images — no logo assets needed:
+
+```svelte
+<script lang="ts">
+	import { StaticLogoCloud } from "$lib/fancy-ui/logo-cloud";
+	import type { Wordmark } from "$lib/fancy-ui/logo-cloud";
+
+	const wordmarks: Wordmark[] = [
+		{ name: "Acme Corp", size: 22, weight: 700 },
+		{ name: "Nimbus Labs", size: 20, weight: 400, italic: true },
+		{ name: "FOUNDRY", size: 18, weight: 900, tracking: 2, transform: "uppercase" },
+	];
+</script>
+
+<StaticLogoCloud title="Our partners" {wordmarks} />
+```
+
+| `Wordmark` field | Type                         | Description                                                               |
+| ---------------- | ---------------------------- | ------------------------------------------------------------------------- |
+| `name`           | `string`                     | The brand/wordmark text                                                   |
+| `size`           | `number`                     | Font size in pixels                                                       |
+| `weight`         | `400 \| 700 \| 900`          | Font weight                                                               |
+| `tracking`       | `number`                     | Letter-spacing in pixels                                                  |
+| `italic`         | `boolean`                    | Render in italic                                                          |
+| `serif`          | `boolean`                    | Use `Georgia, "Times New Roman", serif` instead of the default font stack |
+| `transform`      | `'uppercase' \| 'lowercase'` | CSS `text-transform`                                                      |
+
+Each mark renders at `opacity: .85`. When `wordmarks` is provided, `logos` is ignored.
 
 ## Implementation Notes
 
 - Images use `brightness-0 dark:invert` for monochrome display that adapts to theme
 - Animated variant duplicates logos 5x for seamless infinite scroll
+- `wordmarks` is only read by `StaticLogoCloud`; `AnimatedLogoCloud` and `IconLogoCloud` remain image-only

--- a/src/lib/fancy-ui/logo-cloud/StaticLogoCloud.svelte
+++ b/src/lib/fancy-ui/logo-cloud/StaticLogoCloud.svelte
@@ -1,4 +1,21 @@
 <script lang="ts" module>
+	export interface Wordmark {
+		/** The brand/wordmark text */
+		name: string;
+		/** Font size in pixels */
+		size: number;
+		/** Font weight */
+		weight: 400 | 700 | 900;
+		/** Letter-spacing in pixels */
+		tracking?: number;
+		/** Render in italic */
+		italic?: boolean;
+		/** Use a serif font stack instead of the default */
+		serif?: boolean;
+		/** CSS text-transform */
+		transform?: "uppercase" | "lowercase";
+	}
+
 	export interface StaticLogoCloudProps {
 		/** Additional CSS classes for the grid container */
 		class?: string;
@@ -6,13 +23,15 @@
 		title?: string;
 		/** Array of logos with name and image path */
 		logos?: import("./AnimatedLogoCloud.svelte").Logo[];
+		/** When provided, renders a static typographic row of wordmarks instead of image logos */
+		wordmarks?: Wordmark[];
 	}
 </script>
 
 <script lang="ts">
 	import { cn } from "$lib/utils.js";
 
-	let { class: className, title, logos = [] }: StaticLogoCloudProps = $props();
+	let { class: className, title, logos = [], wordmarks }: StaticLogoCloudProps = $props();
 </script>
 
 <div class="w-full py-12">
@@ -22,10 +41,28 @@
 				{title}
 			</div>
 		{/if}
-		<div class={cn("grid grid-cols-3 gap-x-4 md:grid-cols-5 lg:grid-cols-8", className)}>
-			{#each logos as logo}
-				<img src={logo.path} alt={logo.name} class="h-10 w-28 px-2 brightness-0 dark:invert" />
-			{/each}
-		</div>
+		{#if wordmarks}
+			<div class={cn("flex flex-wrap items-center justify-around gap-x-9 gap-y-5", className)}>
+				{#each wordmarks as mark}
+					<span
+						style:font-size="{mark.size}px"
+						style:font-weight={mark.weight}
+						style:letter-spacing={mark.tracking !== undefined ? `${mark.tracking}px` : undefined}
+						style:font-style={mark.italic ? "italic" : undefined}
+						style:font-family={mark.serif ? 'Georgia, "Times New Roman", serif' : undefined}
+						style:text-transform={mark.transform}
+						style:opacity="0.85"
+					>
+						{mark.name}
+					</span>
+				{/each}
+			</div>
+		{:else}
+			<div class={cn("grid grid-cols-3 gap-x-4 md:grid-cols-5 lg:grid-cols-8", className)}>
+				{#each logos as logo}
+					<img src={logo.path} alt={logo.name} class="h-10 w-28 px-2 brightness-0 dark:invert" />
+				{/each}
+			</div>
+		{/if}
 	</div>
 </div>

--- a/src/lib/fancy-ui/logo-cloud/StaticLogoCloud.test.ts
+++ b/src/lib/fancy-ui/logo-cloud/StaticLogoCloud.test.ts
@@ -1,0 +1,67 @@
+import { render, cleanup } from "@testing-library/svelte";
+import { afterEach, describe, it, expect } from "vitest";
+import { StaticLogoCloud } from "./index";
+import type { Wordmark } from "./index";
+
+const mockLogos = [
+	{ name: "Svelte", path: "/svelte.svg" },
+	{ name: "React", path: "/react.svg" },
+];
+
+const mockWordmarks: Wordmark[] = [
+	{ name: "Acme Corp", size: 22, weight: 700 },
+	{ name: "Nimbus Labs", size: 20, weight: 400, italic: true, tracking: 1 },
+	{ name: "FOUNDRY", size: 18, weight: 900, transform: "uppercase", serif: true },
+];
+
+describe("StaticLogoCloud", () => {
+	afterEach(cleanup);
+
+	it("renders logo images when logos is provided without wordmarks", () => {
+		const { container } = render(StaticLogoCloud, { props: { logos: mockLogos } });
+		const imgs = container.querySelectorAll("img");
+		expect(imgs.length).toBe(2);
+	});
+
+	it("renders wordmark spans instead of images when wordmarks is provided", () => {
+		const { container } = render(StaticLogoCloud, {
+			props: { logos: mockLogos, wordmarks: mockWordmarks },
+		});
+		expect(container.querySelectorAll("img").length).toBe(0);
+		const spans = container.querySelectorAll("span");
+		expect(spans.length).toBe(3);
+		expect(spans[0].textContent?.trim()).toBe("Acme Corp");
+	});
+
+	it("applies inline font styles from wordmark data", () => {
+		const { container } = render(StaticLogoCloud, { props: { wordmarks: mockWordmarks } });
+		const span = container.querySelector("span") as HTMLElement;
+		expect(span.style.fontSize).toBe("22px");
+		expect(span.style.fontWeight).toBe("700");
+		expect(span.style.opacity).toBe("0.85");
+	});
+
+	it("applies italic and tracking to the relevant mark", () => {
+		const { container } = render(StaticLogoCloud, { props: { wordmarks: mockWordmarks } });
+		const spans = container.querySelectorAll("span");
+		const nimbus = spans[1] as HTMLElement;
+		expect(nimbus.style.fontStyle).toBe("italic");
+		expect(nimbus.style.letterSpacing).toBe("1px");
+	});
+
+	it("applies serif font stack and uppercase transform to the relevant mark", () => {
+		const { container } = render(StaticLogoCloud, { props: { wordmarks: mockWordmarks } });
+		const spans = container.querySelectorAll("span");
+		const foundry = spans[2] as HTMLElement;
+		expect(foundry.style.fontFamily).toContain("Georgia");
+		expect(foundry.style.textTransform).toBe("uppercase");
+	});
+
+	it("applies custom class names to the wordmark row", () => {
+		const { container } = render(StaticLogoCloud, {
+			props: { wordmarks: mockWordmarks, class: "custom-wordmarks" },
+		});
+		const row = container.querySelector(".custom-wordmarks");
+		expect(row).toBeTruthy();
+	});
+});

--- a/src/lib/fancy-ui/logo-cloud/index.ts
+++ b/src/lib/fancy-ui/logo-cloud/index.ts
@@ -2,7 +2,10 @@ import AnimatedLogoCloud, {
 	type AnimatedLogoCloudProps,
 	type Logo,
 } from "./AnimatedLogoCloud.svelte";
-import StaticLogoCloud, { type StaticLogoCloudProps } from "./StaticLogoCloud.svelte";
+import StaticLogoCloud, {
+	type StaticLogoCloudProps,
+	type Wordmark,
+} from "./StaticLogoCloud.svelte";
 import IconLogoCloud, { type IconLogoCloudProps } from "./IconLogoCloud.svelte";
 
 export {
@@ -13,4 +16,5 @@ export {
 	type StaticLogoCloudProps,
 	type IconLogoCloudProps,
 	type Logo,
+	type Wordmark,
 };

--- a/src/lib/fancy-ui/registry.ts
+++ b/src/lib/fancy-ui/registry.ts
@@ -335,6 +335,13 @@ export const registry: Record<string, ComponentMeta> = {
 				default: "20",
 				description: "Initial vertical offset in pixels",
 			},
+			{
+				name: "mode",
+				type: '"blur" | "hard"',
+				default: '"blur"',
+				description:
+					"Reveal style: blur softens in with blur/translate, hard snaps opacity with no easing",
+			},
 		],
 		slots: [
 			{ name: "children", description: "Content elements to reveal with staggered animation" },
@@ -471,7 +478,7 @@ export const registry: Record<string, ComponentMeta> = {
 		name: "ImageTrailCursor",
 		slug: "image-trail-cursor",
 		description:
-			"Trail of images that spawn and animate along the cursor's path, powered by GSAP timelines, with 8 selectable variants spanning simple fades, momentum drift, rotation flings, and 3D perspective tilt",
+			"Trail of images that spawn and animate along the cursor's path, powered by GSAP timelines, with 9 selectable variants spanning simple fades, momentum drift, rotation flings, 3D perspective tilt, and a hard-edge pixelated snap",
 		category: "effects",
 		group: "fancy",
 		status: "done",
@@ -485,7 +492,7 @@ export const registry: Record<string, ComponentMeta> = {
 			},
 			{
 				name: "variant",
-				type: '"type1" | "type2" | ... | "type8"',
+				type: '"type1" | "type2" | ... | "type8" | "pixelated"',
 				default: '"type1"',
 				description: "Animation variant controlling how images appear and move",
 			},
@@ -513,6 +520,12 @@ export const registry: Record<string, ComponentMeta> = {
 				description: "Additional CSS classes for individual squares",
 			},
 			{
+				name: "strokeClassName",
+				type: "string",
+				default: '"stroke-gray-400/30"',
+				description: "Additional CSS classes controlling the square outline color",
+			},
+			{
 				name: "width",
 				type: "number",
 				default: "40",
@@ -530,6 +543,13 @@ export const registry: Record<string, ComponentMeta> = {
 				default: "[24, 24]",
 				description: "Grid dimensions as [columns, rows]",
 			},
+			{
+				name: "interactive",
+				type: "boolean",
+				default: "true",
+				description:
+					"Whether squares respond to hover; when false, renders a static graph-paper grid with no per-rect listeners",
+			},
 		],
 	},
 
@@ -537,7 +557,7 @@ export const registry: Record<string, ComponentMeta> = {
 		name: "LineHoverLink",
 		slug: "line-hover-link",
 		description:
-			"Link component with 11 animated underline hover effects — pure CSS, no JS on hover",
+			"Link component with 12 animated underline hover effects — pure CSS, no JS on hover",
 		category: "navigation",
 		group: "fancy",
 		status: "done",
@@ -546,7 +566,7 @@ export const registry: Record<string, ComponentMeta> = {
 		props: [
 			{
 				name: "variant",
-				type: '"slide" | "double" | "grow" | "strike" | "fade" | "pulse" | "swap" | "sweep" | "bounce" | "arc" | "scribble"',
+				type: '"slide" | "double" | "grow" | "strike" | "fade" | "pulse" | "swap" | "sweep" | "bounce" | "arc" | "scribble" | "ink"',
 				default: '"slide"',
 				description: "The animation variant",
 			},
@@ -662,6 +682,12 @@ export const registry: Record<string, ComponentMeta> = {
 				type: "Logo[]",
 				default: "[]",
 				description: "Array of logos with name and image path",
+			},
+			{
+				name: "wordmarks",
+				type: "Wordmark[]",
+				description:
+					"StaticLogoCloud only: when provided, renders a static typographic row of wordmarks instead of image logos",
 			},
 		],
 	},


### PR DESCRIPTION
Closes #197
Closes #198
Closes #200
Closes #201
Closes #203

Third PR of the retro-os upstreaming batch: additive hard-edge modes on five existing components. Every default is unchanged — zero visual or behavioral change for existing consumers.

- **InteractiveGridPattern** — `interactive` prop (`false` renders a static graph-paper grid with no per-rect listeners) + `strokeClassName` to tint the lines without fighting `squaresClassName`'s fill logic (#197)
- **BlurReveal** — `mode: "blur" | "hard"`; hard drops blur/translate softening and snaps opacity in via a stepped timing function, same scroll trigger, and the nth-child stagger survives by specificity (#198)
- **StaticLogoCloud** — `wordmarks` prop renders a static typographic row (per-mark size/weight/tracking/italic/serif/transform) instead of image logos; `Wordmark` type exported (#200)
- **LineHoverLink** — 12th variant `"ink"`: constant 2px underline, the whole link snaps (-1px,-1px) on hover (behind `@media (hover: hover)`) and on `:focus-visible` (#201)
- **ImageTrailCursor** — `"pixelated"` trail variant: hard pop-in/hold/pop-out with zero-duration tweens, `image-rendering: pixelated`, solid ink border (#203)

Registry props, READMEs and docs examples updated for all five (fictional brand names in the wordmarks example). StaticLogoCloud gains its first test file.

Tests: 56 across the five components (7 files), full suite 3074 green, `svelte-check` 0 errors, registry parity OK at 132.