### PR TITLE
feat(cameleon): retro-os kit — windows, media and chrome

### DIFF
--- a/.changeset/cameleon-published-retro-kit.md
+++ b/.changeset/cameleon-published-retro-kit.md
@@ -14,3 +14,13 @@ it stays lit — and `Swatches`), and the shared accent vocabulary
 `--r-*` tokens load with the kit barrel and scope to `[data-skin="retro-os"]`,
 so a kit component outside a retro-os provider is visibly unpainted rather
 than silently wrong.
+
+The kit also grows its windows, media and chrome vocabulary, ported from the
+reference portfolio implementation that grew the retro-os language in the
+first place: `SectionWindow` and `AppWindow` (the two DOS-titlebar window
+grammars), `NotchedFrame` (the three-layer chamfered-corner hero frame) and
+`RetroCard` (the accent-aware hover card); `VideoFrame`, `PlayBadge` and
+`EmptyMediaFrame` for poster-and-play video staging with a dashed-border
+placeholder for demos not yet recorded; and `HeaderBar`, the page-header
+shell — ink tile, clamp()'d title/subtitle, and a slot on the right for a
+consumer's own navigation or skin controls.

--- a/src/lib/cameleon/skins/retro-os/kit/AppWindow.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/AppWindow.svelte
@@ -1,0 +1,88 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	export interface AppWindowProps {
+		/** titlebar filename, e.g. "photo.jpg" */
+		filename: string;
+		class?: string;
+		children: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { filename, class: className, children }: AppWindowProps = $props();
+</script>
+
+<!--
+	Grammar C — the little "application window" (home: photo.jpg).
+
+	NO SHADOW BY DEFAULT, on purpose: in the mockup the drop-shadow carrier is a
+	div *around* this window, and grammar C is used both standalone (needs the 4px
+	shadow) and nested inside a slab that already casts one. Callers add it —
+	either `class="r-shadow-4"` or their own `filter: drop-shadow(4px 4px 0
+	var(--r-ink))` wrapper.
+
+	The `_` and `✕` boxes are inert decoration — a minimise/close affordance that
+	does nothing would be a lie to assistive tech, so they are aria-hidden spans,
+	never buttons.
+-->
+<div class={cn("r-app r-border", className)}>
+	<div class="r-app-bar">
+		<span class="r-mono r-app-name">{filename}</span>
+		<span class="r-border r-app-btn r-app-btn-min" aria-hidden="true">_</span>
+		<span class="r-border r-app-btn" aria-hidden="true">✕</span>
+	</div>
+	<div class="r-app-body">
+		{@render children()}
+	</div>
+</div>
+
+<style>
+	/* border comes from the .r-border recipe (kit.css) */
+	.r-app {
+		background: var(--r-paper);
+	}
+
+	.r-app-bar {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 7px 10px;
+		border-bottom: 2px solid var(--r-ink);
+		background: var(--r-tint-gold);
+	}
+
+	.r-app-name {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: 11px;
+		font-weight: 700;
+	}
+
+	.r-app-btn {
+		display: inline-flex;
+		width: 20px;
+		height: 20px;
+		flex: none;
+		align-items: center;
+		justify-content: center;
+		background: var(--r-paper);
+		box-sizing: border-box;
+		font-size: 10px;
+	}
+
+	/* the underscore sits on the baseline of its own box, like a minimise glyph */
+	.r-app-btn-min {
+		align-items: flex-end;
+		line-height: 1.4;
+	}
+
+	.r-app-body {
+		padding: 8px;
+	}
+</style>

--- a/src/lib/cameleon/skins/retro-os/kit/EmptyMediaFrame.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/EmptyMediaFrame.svelte
@@ -1,0 +1,56 @@
+<script lang="ts" module>
+	export interface EmptyMediaFrameProps {
+		/** the Silkscreen label */
+		label: string;
+		/** decorative glyph in the icon box — a prop, never content */
+		glyph?: string;
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { label, glyph = "⏳", class: className }: EmptyMediaFrameProps = $props();
+</script>
+
+<!--
+	The "no demo yet" stand-in that takes a VideoFrame's place. Dashed border =
+	the retro language's "not real content" marker, same as the NDA badge on
+	the home work card.
+-->
+<div class={cn("r-empty", className)}>
+	<span class="r-border r-empty-icon" aria-hidden="true">{glyph}</span>
+	<span class="r-pixel r-empty-label">{label}</span>
+</div>
+
+<style>
+	.r-empty {
+		display: flex;
+		min-height: 200px;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 10px;
+		border: 2px dashed var(--r-ink);
+		background: var(--r-tint-gold);
+		padding: 16px;
+		text-align: center;
+	}
+
+	.r-empty-icon {
+		display: inline-flex;
+		width: 38px;
+		height: 38px;
+		flex: none;
+		align-items: center;
+		justify-content: center;
+		box-sizing: border-box;
+		background: var(--r-paper);
+		font-size: 14px;
+	}
+
+	.r-empty-label {
+		font-size: 10px;
+	}
+</style>

--- a/src/lib/cameleon/skins/retro-os/kit/HeaderBar.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/HeaderBar.svelte
@@ -1,0 +1,62 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	export interface HeaderBarProps {
+		/** the header's main title */
+		title: string;
+		/** the header's subtitle */
+		subtitle?: string;
+		/** the 44px ink tile's glyph — a wordmark, not prose */
+		tile?: string;
+		class?: string;
+		/** rendered on the right, where a skin switcher or nav would sit */
+		children?: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { title, subtitle, tile = "✦", class: className, children }: HeaderBarProps = $props();
+</script>
+
+<!--
+	Header bar shell: ink tile · title + subtitle · right-side slot.
+
+	This is the SHELL only — the reference portfolio implementation's header
+	also hosted a skin switcher in the right-hand slot; that piece is
+	app-specific navigation, not kit vocabulary, so it is a `children` snippet
+	here instead. The two titles absorb the narrow end via clamp() rather than
+	the shell itself shrinking, since the tile and border never scale.
+-->
+<header
+	class={cn(
+		"r-border r-shadow-4 flex items-center gap-4 bg-[var(--r-paper)] px-5 py-[14px]",
+		className
+	)}
+>
+	<span
+		class="r-pixel inline-flex h-11 w-11 flex-none items-center justify-center bg-[var(--r-ink)] text-[14px] text-[var(--r-paper)]"
+	>
+		{tile}
+	</span>
+
+	<div class="flex min-w-0 flex-1 flex-col gap-[3px]">
+		<span
+			class="text-[clamp(15px,3.6vw,22px)] leading-tight font-black tracking-[-0.3px] text-[var(--r-ink)]"
+		>
+			{title}
+		</span>
+		{#if subtitle}
+			<span
+				class="r-mono text-[clamp(9px,2.1vw,11px)] font-semibold tracking-[1px] text-[var(--r-muted)]"
+			>
+				{subtitle}
+			</span>
+		{/if}
+	</div>
+
+	{#if children}
+		{@render children()}
+	{/if}
+</header>

--- a/src/lib/cameleon/skins/retro-os/kit/NotchedFrame.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/NotchedFrame.svelte
@@ -1,0 +1,83 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+
+	export interface NotchedFrameProps {
+		/** drop-shadow offset in px — 5 = hero (grammar B), 4 = tighter nested use */
+		shadow?: 4 | 5;
+		/** extra classes for the PAPER layer (the one that wraps `children`) */
+		class?: string;
+		children: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let { shadow = 5, class: className, children }: NotchedFrameProps = $props();
+</script>
+
+<!--
+	Grammar B — the notched "chamfered pixel corner" frame (hero + case heroes).
+
+	Three nested layers, and all three are load-bearing:
+
+	  1. carrier   `filter: drop-shadow(Npx Npx 0 ink)`. A `box-shadow` here would
+	               draw the UNCLIPPED rectangle and the notches would be ghosted by
+	               a square shadow, so the hard offset shadow has to be a
+	               drop-shadow following the alpha silhouette of the clipped stack.
+	  2. ink slab  2.5px of ink showing through as the "border" — a real `border`
+	               cannot follow a clip-path, so the border is a painted padding.
+	  3. paper     the same polygon again, inset by the slab's padding.
+
+	THE POLYGON IS DECLARED ONCE, here, as `--r-notch` on the carrier, and inherited
+	by both clipped layers. It is the single source of truth for the notch shape in
+	the whole retro-os kit (copied verbatim from the reference portfolio
+	implementation): 8px chamfer with a 4px stair step on every corner. Never
+	re-type it elsewhere — import this component instead.
+-->
+<div class="r-notched" style="--r-notch-shadow: {shadow}px">
+	<div class="r-notched-ink">
+		<div class={cn("r-notched-paper", className)}>
+			{@render children()}
+		</div>
+	</div>
+</div>
+
+<style>
+	.r-notched {
+		--r-notch: polygon(
+			8px 0,
+			calc(100% - 8px) 0,
+			calc(100% - 8px) 4px,
+			calc(100% - 4px) 4px,
+			calc(100% - 4px) 8px,
+			100% 8px,
+			100% calc(100% - 8px),
+			calc(100% - 4px) calc(100% - 8px),
+			calc(100% - 4px) calc(100% - 4px),
+			calc(100% - 8px) calc(100% - 4px),
+			calc(100% - 8px) 100%,
+			8px 100%,
+			8px calc(100% - 4px),
+			4px calc(100% - 4px),
+			4px calc(100% - 8px),
+			0 calc(100% - 8px),
+			0 8px,
+			4px 8px,
+			4px 4px,
+			8px 4px
+		);
+		filter: drop-shadow(var(--r-notch-shadow) var(--r-notch-shadow) 0 var(--r-ink));
+	}
+
+	.r-notched-ink {
+		background: var(--r-ink);
+		padding: 2.5px;
+		clip-path: var(--r-notch);
+	}
+
+	.r-notched-paper {
+		background: var(--r-paper);
+		clip-path: var(--r-notch);
+	}
+</style>

--- a/src/lib/cameleon/skins/retro-os/kit/PlayBadge.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/PlayBadge.svelte
@@ -1,0 +1,46 @@
+<script lang="ts" module>
+	export interface PlayBadgeProps {
+		/** 44 = ProductionRow thumbnails (3px shadow), 60 = the full demo (4px) */
+		size?: 44 | 60;
+	}
+</script>
+
+<script lang="ts">
+	let { size = 44 }: PlayBadgeProps = $props();
+
+	const shadow = $derived(size === 60 ? 4 : 3);
+	const glyph = $derived(size === 60 ? 20 : 15);
+</script>
+
+<!--
+	The paper play box that sits dead-centre on a video stage. It is pure
+	decoration: the whole stage is the real control (see VideoFrame), so this
+	carries no role and is hidden from assistive tech.
+-->
+<span
+	class="r-play"
+	aria-hidden="true"
+	style="--r-play-size:{size}px;--r-play-shadow:{shadow}px;--r-play-glyph:{glyph}px">▶</span
+>
+
+<style>
+	.r-play {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		display: inline-flex;
+		width: var(--r-play-size);
+		height: var(--r-play-size);
+		align-items: center;
+		justify-content: center;
+		box-sizing: border-box;
+		border: 2px solid var(--r-ink);
+		background: var(--r-paper);
+		box-shadow: var(--r-play-shadow) var(--r-play-shadow) 0 var(--r-ink);
+		color: var(--r-ink);
+		font-size: var(--r-play-glyph);
+		/* nudge the optical centre of ▶ back onto the box centre */
+		padding-left: 2px;
+	}
+</style>

--- a/src/lib/cameleon/skins/retro-os/kit/RetroCard.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/RetroCard.svelte
@@ -1,0 +1,92 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { Accent } from "./accents.js";
+
+	export interface RetroCardProps extends HTMLAttributes<HTMLElement> {
+		/** renders an <a> instead of a <div> */
+		href?: string;
+		/** when set, the hover shadow recolours from ink to this accent */
+		accent?: Accent;
+		/** card background — any CSS colour value, normally a --r-tint-* var */
+		bg?: string;
+		class?: string;
+		children: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { accentVar } from "./accents.js";
+
+	let {
+		href,
+		accent,
+		bg = "var(--r-paper)",
+		class: className,
+		style,
+		children,
+		...rest
+	}: RetroCardProps = $props();
+
+	// Both hooks are custom properties so the single .r-card rule below can stay
+	// static — Svelte scopes it once and the dynamic part never touches the CSS.
+	// A caller's own `style` is appended rather than dropped: it is pulled out of
+	// `rest` on purpose, because spreading it would silently erase these two.
+	const cardStyle = $derived(
+		`--r-card-bg:${bg};--r-card-hover:${accent ? accentVar(accent) : "var(--r-ink)"};${style ?? ""}`
+	);
+</script>
+
+<!--
+	Grammar D — the generic retro card (work cards, testimonials, gear, projects,
+	prev/next). 2px ink border, 3px hard shadow, 20px padding, column flow.
+
+	Hover physics live behind @media (hover:hover) so a touch device never gets a
+	stuck :hover state, and there is no transition — the retro language cuts hard
+	rather than easing. `accent` recolours the grown shadow (the perso project
+	cards' signature move); without it the shadow just grows in ink.
+
+	The RESTING shadow is `.r-shadow-3`. A caller that needs another rung (the
+	inactive testimonial card's soft ink, the active one's hard 4px) adds the
+	matching `.r-shadow-*` class through `class` — kit.css declares the ladder
+	in ascending order precisely so the later class wins at equal specificity.
+-->
+{#if href}
+	<a {...rest} {href} class={cn("r-card r-border r-shadow-3", className)} style={cardStyle}>
+		{@render children()}
+	</a>
+{:else}
+	<div {...rest} class={cn("r-card r-border r-shadow-3", className)} style={cardStyle}>
+		{@render children()}
+	</div>
+{/if}
+
+<style>
+	/* border + resting shadow come from the .r-border / .r-shadow-3 recipes.
+	   .r-pressable is deliberately NOT used: it ladders the hover shadow in ink,
+	   and this card may recolour it — so it owns both interaction states below. */
+	.r-card {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		padding: 20px;
+		background: var(--r-card-bg);
+		color: var(--r-ink);
+		text-decoration: none;
+	}
+
+	@media (hover: hover) {
+		.r-card:hover {
+			transform: translate(-1px, -1px);
+			box-shadow: 4px 4px 0 var(--r-card-hover);
+		}
+	}
+
+	/* press feedback only on the linked form — a plain content card has nothing
+	   to press, and the mockup's non-link cards have no active state either */
+	a.r-card:active {
+		transform: translate(2px, 2px);
+		box-shadow: 0 0 0 var(--r-ink);
+	}
+</style>

--- a/src/lib/cameleon/skins/retro-os/kit/SectionWindow.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/SectionWindow.svelte
@@ -1,0 +1,125 @@
+<script lang="ts" module>
+	import type { Snippet } from "svelte";
+	import type { Accent } from "./accents.js";
+
+	export interface SectionWindowProps {
+		/** DOM id — callers pass the already `retro-`prefixed form (e.g. "retro-connect") */
+		id?: string;
+		/** two-digit section index ("01"). Omit for an index-less titlebar (BnF brief). */
+		index?: string;
+		/** "/ 01" on the home page, "( 01 )" on the case pages */
+		indexStyle?: "slash" | "paren";
+		/** the Silkscreen title */
+		title: string;
+		/** the right-aligned DOS filename label, e.g. "SUMMARY.EXE" */
+		dosLabel: string;
+		/** colour of the 12px titlebar dot */
+		accent: Accent;
+		/** optional centered caption row under the titlebar */
+		caption?: string;
+		class?: string;
+		children: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { accentVar } from "./accents.js";
+
+	let {
+		id,
+		index,
+		indexStyle = "slash",
+		title,
+		dosLabel,
+		accent,
+		caption,
+		class: className,
+		children,
+	}: SectionWindowProps = $props();
+
+	// The index is structural chrome, not content — it never gets a data-edit.
+	const indexLabel = $derived(
+		index === undefined ? "" : indexStyle === "paren" ? `( ${index} )` : `/ ${index}`
+	);
+</script>
+
+<!--
+	Grammar A — the section window: bordered paper slab, 4px hard shadow, DOS
+	titlebar. Home and case pages share one component; the ONLY difference is the
+	index format ("/ 01" vs "( 01 )"), hence `indexStyle`.
+
+	The titlebar is allowed to wrap: Silkscreen is a wide face and the DOS label
+	would otherwise force a horizontal scroll on narrow screens. Borders and the
+	shadow never scale.
+-->
+<section {id} class={cn("r-window r-border r-shadow-4", className)}>
+	<div class="r-window-bar">
+		<span class="r-border r-window-dot" style="background: {accentVar(accent)}"></span>
+		{#if indexLabel}
+			<span class="r-mono r-window-index">{indexLabel}</span>
+		{/if}
+		<h2 class="r-pixel r-window-title">{title}</h2>
+		<span class="r-window-spacer"></span>
+		<span class="r-mono r-window-dos">{dosLabel}</span>
+	</div>
+
+	{#if caption}
+		<div class="r-mono r-window-caption">{caption}</div>
+	{/if}
+
+	{@render children()}
+</section>
+
+<style>
+	/* border + shadow come from the .r-border / .r-shadow-4 recipes (kit.css) */
+	.r-window {
+		background: var(--r-paper);
+	}
+
+	.r-window-bar {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 10px;
+		padding: 12px 18px;
+		border-bottom: 2px solid var(--r-ink);
+	}
+
+	.r-window-dot {
+		width: 12px;
+		height: 12px;
+		flex: none;
+		box-sizing: border-box;
+	}
+
+	.r-window-index {
+		font-size: 11px;
+		font-weight: 700;
+		color: var(--r-muted);
+	}
+
+	.r-window-title {
+		margin: 0;
+		font-size: 12px;
+		text-transform: uppercase;
+	}
+
+	.r-window-spacer {
+		flex: 1;
+	}
+
+	.r-window-dos {
+		font-size: 10.5px;
+		font-weight: 600;
+		letter-spacing: 1px;
+		color: var(--r-muted);
+	}
+
+	.r-window-caption {
+		padding: 18px 20px 0;
+		text-align: center;
+		font-size: 12px;
+		color: var(--r-muted);
+	}
+</style>

--- a/src/lib/cameleon/skins/retro-os/kit/VideoFrame.svelte
+++ b/src/lib/cameleon/skins/retro-os/kit/VideoFrame.svelte
@@ -1,0 +1,177 @@
+<script lang="ts" module>
+	export interface VideoFrameProps {
+		/** poster still, e.g. /videos/demo/poster.jpg */
+		poster: string;
+		/** titlebar filename from the frozen production data, e.g. "DEMO.MP4" */
+		fileLabel: string;
+		/** clip length, e.g. "01:31" — frozen data, not content */
+		duration: string;
+		/** "sm" = 200px stage inside a row, "lg" = 420px standalone hero demo */
+		size?: "sm" | "lg";
+		/** the lg titlebar badge, e.g. "FULL DEMO" */
+		badge?: string;
+		/** poster alt text; falls back to the file label */
+		alt?: string;
+		/** when set the whole stage becomes the play control */
+		onOpen?: () => void;
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import PlayBadge from "./PlayBadge.svelte";
+
+	let {
+		poster,
+		fileLabel,
+		duration,
+		size = "sm",
+		badge,
+		alt,
+		onOpen,
+		class: className,
+	}: VideoFrameProps = $props();
+
+	const lg = $derived(size === "lg");
+	const posterAlt = $derived(alt ?? fileLabel);
+</script>
+
+<!--
+	The retro video frame: DOS titlebar + poster stage + centred PlayBadge.
+
+	DEVIATION FROM SPEC-CASES (deliberate): the sm stage is a real <img> with
+	object-fit:cover rather than a background-image. Pixel-identical, but it keeps
+	the house rule that every image is `loading="lazy"` with a real alt — a CSS
+	background can be neither lazy nor described.
+
+	The lg variant's shadow is `.r-shadow-4` rather than the spec's
+	`drop-shadow(4px 4px 0)`: the frame has square corners, so the two render
+	identically, and a box-shadow avoids a filter containing-block on an element
+	that hosts an absolutely positioned badge.
+
+	When `onOpen` is given the STAGE is the button (not a floating overlay
+	control), so the click target matches the affordance and keyboard users get
+	the same one focus stop. The PlayBadge inside stays aria-hidden.
+-->
+<div class={cn("r-vframe r-border", lg && "r-vframe-lg r-shadow-4", className)}>
+	<div class="r-vframe-bar">
+		<span class="r-border r-vframe-dot"></span>
+		<span class="r-mono r-vframe-file">{fileLabel}</span>
+		{#if lg && badge}
+			<span class="r-pixel r-border r-vframe-badge">{badge}</span>
+		{/if}
+		<span class="r-mono r-vframe-time">{duration}</span>
+	</div>
+
+	{#if onOpen}
+		<button type="button" class="r-vframe-stage" onclick={onOpen} aria-label="Play {fileLabel}">
+			<img src={poster} alt={posterAlt} loading="lazy" class="r-vframe-poster" />
+			<PlayBadge size={lg ? 60 : 44} />
+		</button>
+	{:else}
+		<div class="r-vframe-stage">
+			<img src={poster} alt={posterAlt} loading="lazy" class="r-vframe-poster" />
+			<PlayBadge size={lg ? 60 : 44} />
+		</div>
+	{/if}
+</div>
+
+<style>
+	/* border comes from .r-border; the lg variant adds .r-shadow-4 in the markup —
+	   the sm frame sits inside a row that already casts a shadow */
+	.r-vframe {
+		background: var(--r-paper);
+	}
+
+	.r-vframe-bar {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 6px 10px;
+		border-bottom: 2px solid var(--r-ink);
+		background: var(--r-tint-gold);
+	}
+
+	.r-vframe-lg .r-vframe-bar {
+		padding: 8px 12px;
+	}
+
+	.r-vframe-dot {
+		width: 8px;
+		height: 8px;
+		flex: none;
+		box-sizing: border-box;
+		background: var(--r-rust);
+	}
+
+	.r-vframe-file {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: 10px;
+		font-weight: 700;
+	}
+
+	.r-vframe-badge {
+		flex: none;
+		font-size: 9px;
+		background: var(--r-btn);
+		padding: 2px 7px;
+	}
+
+	.r-vframe-time {
+		flex: none;
+		font-size: 10px;
+		font-weight: 600;
+		color: var(--r-muted);
+	}
+
+	.r-vframe-lg .r-vframe-time {
+		font-size: 11px;
+	}
+
+	.r-vframe-stage {
+		position: relative;
+		display: block;
+		width: 100%;
+		height: 200px;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		background: none;
+		appearance: none;
+		font: inherit;
+		color: inherit;
+	}
+
+	.r-vframe-lg .r-vframe-stage {
+		height: 420px;
+	}
+
+	/* 420px is a portrait slab on a phone; crop it back to a landscape band */
+	@media (max-width: 640px) {
+		.r-vframe-lg .r-vframe-stage {
+			height: 260px;
+		}
+	}
+
+	button.r-vframe-stage {
+		cursor: pointer;
+	}
+
+	button.r-vframe-stage:focus-visible {
+		outline: 2px solid var(--r-blue);
+		outline-offset: -4px;
+	}
+
+	.r-vframe-poster {
+		display: block;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		object-position: center;
+	}
+</style>

--- a/src/lib/cameleon/skins/retro-os/kit/index.ts
+++ b/src/lib/cameleon/skins/retro-os/kit/index.ts
@@ -22,13 +22,7 @@
 
 import "./kit.css";
 
-export {
-	ACCENT_TINT,
-	ACCENT_VAR,
-	accentTint,
-	accentVar,
-	type Accent,
-} from "./accents.js";
+export { ACCENT_TINT, ACCENT_VAR, accentTint, accentVar, type Accent } from "./accents.js";
 
 export { default as RetroButton, type RetroButtonProps } from "./RetroButton.svelte";
 export { default as Chip, type ChipProps } from "./Chip.svelte";
@@ -40,3 +34,14 @@ export { default as InlineIndexLabel, type InlineIndexLabelProps } from "./Inlin
 export { default as PixelGlyph, type PixelGlyphProps } from "./PixelGlyph.svelte";
 export { default as Led, type LedProps } from "./Led.svelte";
 export { default as Swatches, type SwatchesProps } from "./Swatches.svelte";
+
+export { default as SectionWindow, type SectionWindowProps } from "./SectionWindow.svelte";
+export { default as AppWindow, type AppWindowProps } from "./AppWindow.svelte";
+export { default as NotchedFrame, type NotchedFrameProps } from "./NotchedFrame.svelte";
+export { default as RetroCard, type RetroCardProps } from "./RetroCard.svelte";
+
+export { default as VideoFrame, type VideoFrameProps } from "./VideoFrame.svelte";
+export { default as PlayBadge, type PlayBadgeProps } from "./PlayBadge.svelte";
+export { default as EmptyMediaFrame, type EmptyMediaFrameProps } from "./EmptyMediaFrame.svelte";
+
+export { default as HeaderBar, type HeaderBarProps } from "./HeaderBar.svelte";

--- a/src/lib/cameleon/skins/retro-os/kit/kit-windows.test.ts
+++ b/src/lib/cameleon/skins/retro-os/kit/kit-windows.test.ts
@@ -1,0 +1,175 @@
+import { render, screen, cleanup } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, it, expect } from "vitest";
+import SectionWindow from "./SectionWindow.svelte";
+import AppWindow from "./AppWindow.svelte";
+import NotchedFrame from "./NotchedFrame.svelte";
+import RetroCard from "./RetroCard.svelte";
+import VideoFrame from "./VideoFrame.svelte";
+import PlayBadge from "./PlayBadge.svelte";
+import EmptyMediaFrame from "./EmptyMediaFrame.svelte";
+import HeaderBar from "./HeaderBar.svelte";
+
+const text = (t: string) => createRawSnippet(() => ({ render: () => `<span>${t}</span>` }));
+
+describe("retro-os kit — windows, media, chrome", () => {
+	afterEach(cleanup);
+
+	describe("SectionWindow", () => {
+		it("renders the title, index and DOS label, and paints the accent dot", () => {
+			const { container } = render(SectionWindow, {
+				index: "01",
+				title: "CONNECT",
+				dosLabel: "SUMMARY.EXE",
+				accent: "blue",
+				children: text("body"),
+			});
+			expect(screen.getByText("CONNECT")).toBeInTheDocument();
+			expect(screen.getByText("/ 01")).toBeInTheDocument();
+			expect(screen.getByText("SUMMARY.EXE")).toBeInTheDocument();
+			const dot = container.querySelector(".r-window-dot") as HTMLElement;
+			expect(dot.getAttribute("style")).toContain("var(--r-blue)");
+		});
+
+		it("formats the index in parens when indexStyle is paren", () => {
+			render(SectionWindow, {
+				index: "02",
+				indexStyle: "paren",
+				title: "BRIEF",
+				dosLabel: "BRIEF.EXE",
+				accent: "rust",
+				children: text("body"),
+			});
+			expect(screen.getByText("( 02 )")).toBeInTheDocument();
+		});
+	});
+
+	describe("AppWindow", () => {
+		it("renders the filename and two aria-hidden control boxes with no shadow class by default", () => {
+			const { container } = render(AppWindow, { filename: "photo.jpg", children: text("body") });
+			expect(screen.getByText("photo.jpg")).toBeInTheDocument();
+			const controls = container.querySelectorAll(".r-app-btn[aria-hidden='true']");
+			expect(controls).toHaveLength(2);
+			const win = container.querySelector(".r-app") as HTMLElement;
+			expect(win).not.toHaveClass("r-shadow-4");
+		});
+	});
+
+	describe("NotchedFrame", () => {
+		it("builds the three nested layers and passes shadow into the inline custom property", () => {
+			const { container } = render(NotchedFrame, { shadow: 4, children: text("body") });
+			const carrier = container.querySelector(".r-notched") as HTMLElement;
+			const ink = carrier.querySelector(".r-notched-ink") as HTMLElement;
+			const paper = ink.querySelector(".r-notched-paper") as HTMLElement;
+			expect(carrier).toBeInTheDocument();
+			expect(ink).toBeInTheDocument();
+			expect(paper).toBeInTheDocument();
+			expect(carrier.getAttribute("style")).toContain("--r-notch-shadow: 4px");
+		});
+	});
+
+	describe("RetroCard", () => {
+		it("becomes an <a> with href, carries both custom properties and preserves caller style", () => {
+			const { container } = render(RetroCard, {
+				href: "/work/x",
+				accent: "gold",
+				bg: "var(--r-tint-gold)",
+				style: "margin-top: 4px;",
+				children: text("body"),
+			});
+			const card = container.querySelector("a.r-card") as HTMLElement;
+			expect(card).toHaveAttribute("href", "/work/x");
+			const style = card.getAttribute("style") ?? "";
+			expect(style).toContain("--r-card-bg: var(--r-tint-gold)");
+			expect(style).toContain("--r-card-hover: var(--r-gold)");
+			expect(style).toContain("margin-top: 4px");
+		});
+
+		it("renders a <div> when href is absent", () => {
+			const { container } = render(RetroCard, { children: text("body") });
+			expect(container.querySelector("div.r-card")).toBeInTheDocument();
+			expect(container.querySelector("a.r-card")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("VideoFrame", () => {
+		it("renders a button when onOpen is set, and a plain stage otherwise", () => {
+			const { container } = render(VideoFrame, {
+				poster: "/poster.jpg",
+				fileLabel: "DEMO.MP4",
+				duration: "01:31",
+				onOpen: () => {},
+			});
+			expect(container.querySelector("button.r-vframe-stage")).toBeInTheDocument();
+			cleanup();
+
+			const { container: c2 } = render(VideoFrame, {
+				poster: "/poster.jpg",
+				fileLabel: "DEMO.MP4",
+				duration: "01:31",
+			});
+			expect(c2.querySelector("button.r-vframe-stage")).not.toBeInTheDocument();
+			expect(c2.querySelector("div.r-vframe-stage")).toBeInTheDocument();
+		});
+
+		it("applies the lg stage/shadow classes only for size='lg'", () => {
+			const { container } = render(VideoFrame, {
+				poster: "/poster.jpg",
+				fileLabel: "DEMO.MP4",
+				duration: "01:31",
+				size: "sm",
+			});
+			const sm = container.querySelector(".r-vframe") as HTMLElement;
+			expect(sm).not.toHaveClass("r-vframe-lg", "r-shadow-4");
+			cleanup();
+
+			const { container: c2 } = render(VideoFrame, {
+				poster: "/poster.jpg",
+				fileLabel: "DEMO.MP4",
+				duration: "01:31",
+				size: "lg",
+				badge: "FULL DEMO",
+			});
+			const lg = c2.querySelector(".r-vframe") as HTMLElement;
+			expect(lg).toHaveClass("r-vframe-lg", "r-shadow-4");
+			expect(screen.getByText("FULL DEMO")).toBeInTheDocument();
+		});
+	});
+
+	describe("PlayBadge", () => {
+		it("scales the shadow rung and glyph size with size=60", () => {
+			const { container } = render(PlayBadge, { size: 60 });
+			const badge = container.querySelector(".r-play") as HTMLElement;
+			const style = badge.getAttribute("style") ?? "";
+			expect(style).toContain("--r-play-size: 60px");
+			expect(style).toContain("--r-play-shadow: 4px");
+			expect(style).toContain("--r-play-glyph: 20px");
+		});
+
+		it("defaults to the 44px/3px rung", () => {
+			const { container } = render(PlayBadge, {});
+			const badge = container.querySelector(".r-play") as HTMLElement;
+			const style = badge.getAttribute("style") ?? "";
+			expect(style).toContain("--r-play-size: 44px");
+			expect(style).toContain("--r-play-shadow: 3px");
+		});
+	});
+
+	describe("EmptyMediaFrame", () => {
+		it("renders a dashed frame and the label", () => {
+			const { container } = render(EmptyMediaFrame, { label: "DEMO IN PREPARATION" });
+			const frame = container.querySelector(".r-empty") as HTMLElement;
+			expect(frame).toBeInTheDocument();
+			expect(screen.getByText("DEMO IN PREPARATION")).toBeInTheDocument();
+		});
+	});
+
+	describe("HeaderBar", () => {
+		it("renders the title and the children slot content on the right", () => {
+			render(HeaderBar, { title: "Retro OS", subtitle: "kit demo", children: text("Switch") });
+			expect(screen.getByText("Retro OS")).toBeInTheDocument();
+			expect(screen.getByText("kit demo")).toBeInTheDocument();
+			expect(screen.getByText("Switch")).toBeInTheDocument();
+		});
+	});
+});

--- a/src/lib/fancy-ui/liquid-glass/README.md
+++ b/src/lib/fancy-ui/liquid-glass/README.md
@@ -35,6 +35,10 @@ A glass-like visual effect using SVG filters for chromatic displacement, creatin
 
 **Note**: This component uses `position: relative` and `backdrop-filter` with SVG filters. Place it over content to see the refraction effect.
 
+## Skin compatibility
+
+Glass morphism depends on `backdrop-filter` blur and translucency reading against whatever sits behind it — there has to be something soft and layered underneath for the refraction to register. Flat paper/ink art directions have neither: cameleon's `retro-os` skin, for one, paints opaque paper on a hard ink border with no blur anywhere in its language, so `LiquidGlass` cannot render there in any recognizable form. Under such skins, cover the navigation/chrome use case with the retro kit's `HeaderBar` instead.
+
 ## Browser support
 
 Safari (WebKit) cannot resolve an SVG `url(#…)` filter reference inside `backdrop-filter`, so the chromatic displacement silently disappears there. To keep the component usable, LiquidGlass automatically detects Safari (via a WebKit-only `@supports` feature query) and falls back to a plain frosted `blur()` + `saturate()` (both `-webkit-` prefixed and unprefixed), tunable via the `fallbackBlur` and `fallbackSaturation` props. Chromium and Firefox get the full chromatic refraction.


### PR DESCRIPTION
Closes #204
Closes #205
Closes #207
Closes #208
Closes #202

Second PR of the retro-os batch, stacked on #220 (merge that first; this retargets to develop automatically).

## Windows

- **SectionWindow** — the numbered section grammar: accent dot, `/ 01` or `( 01 )` index styles, pixel title, DOS-filename right label, optional caption (#204)
- **AppWindow** — filename titlebar on the gold tint with inert aria-hidden `_`/`✕` boxes; no shadow by default, callers add a rung (#204)
- **NotchedFrame** — the 3-layer stair-step frame: drop-shadow carrier (a box-shadow would ghost the unclipped rectangle), 2.5px ink slab as painted padding (a real border cannot follow a clip-path), clipped paper. The 20-vertex polygon is declared once and documented as the single source of truth (#205)
- **RetroCard** — 2px border, 3px shadow, hover lift with the shadow recoloring to the card's accent via `--r-card-hover`; caller `style` extracted from rest and appended, never spread away; `:active` press only on the linked form (#207)

## Media & chrome

- **VideoFrame** (sm 200px / lg 420px→260px stage, filename bar, whole stage becomes the button when `onOpen` is set, inset focus outline) + **PlayBadge** (44/60 with matched shadow, optically centered ▶) + **EmptyMediaFrame** (dashed border = "not real content", pixel label) (#208)
- **HeaderBar** — shell only: 44px ink tile, clamp()-sized title/subtitle, `children` slot where app chrome (nav, skin switcher) belongs (#202)
- **LiquidGlass README** gains a "Skin compatibility" section: glass morphism cannot render in flat paper/ink art directions — under such skins, cover the chrome use case with `HeaderBar` (#202)

Porting adaptations: content-key props became plain strings, edit-runtime attributes dropped, accent imports repointed to the kit's own vocabulary. Everything else verbatim, reasoning kept in comments.

Tests: 12 new (26 total in the kit), `svelte-check` 0 errors. Changeset extended on the shared minor bump.