### PR TITLE
fix(package): add dist/cameleon to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	],
 	"files": [
 		"dist/fancy-ui",
+		"dist/cameleon",
 		"dist/utils",
 		"dist/utils.js",
 		"dist/utils.d.ts",


### PR DESCRIPTION
## What failed

Nightly CI (`pnpm package` → `publint`) reported:

```
Warnings:
1. pkg.exports["./cameleon/*"] is ./dist/cameleon/* but does not match any files.
```

## Root cause

Commit b619168 ("feat(exports): expose the cameleon engine to link: consumers") added:

```json
"./cameleon/*": "./dist/cameleon/*"
```

to `exports` in `package.json`, but never added `dist/cameleon` to the `files` array. `pnpm pack` therefore excluded the entire cameleon directory from the tarball, leaving the export path pointing at files that consumers could never receive.

## Fix

One-line addition to the `files` array:

```json
"dist/cameleon",
```

Verified green: `pnpm check` (0 errors, 42 warnings), `pnpm test` (3054 tests passed across 186 files), `pnpm package` (publint: **All good!**).

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2dizTz9p3t84kWkk6x723)_